### PR TITLE
Restore ability to access underlying Throwable.

### DIFF
--- a/src/main/java/com/bugsnag/android/Error.java
+++ b/src/main/java/com/bugsnag/android/Error.java
@@ -239,6 +239,13 @@ public class Error implements JsonStream.Streamable {
     public String getExceptionMessage() {
         return exception.getLocalizedMessage();
     }
+    
+    /**
+     * The {@linkplain Throwable exception} which triggered this Error report.
+     */
+    public Throwable getException() {
+        return exception;
+    }
 
     void setAppData(AppData appData) {
         this.appData = appData;


### PR DESCRIPTION
This is essential for `instanceof` checks and pulling metadata from the instance.
