### PR TITLE
Fix for when no project packages are found

### DIFF
--- a/src/androidTest/java/com/bugsnag/android/AppDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/AppDataTest.java
@@ -1,10 +1,12 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class AppDataTest extends BugsnagTestCase {
-    public void testManifestData() throws JSONException {
+    public void testManifestData() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
         AppData appData = new AppData(getContext(), config);
         JSONObject appDataJson = streamableToJson(appData);
@@ -18,7 +20,7 @@ public class AppDataTest extends BugsnagTestCase {
         assertEquals("development", appDataJson.get("releaseStage"));
     }
 
-    public void testAppVersionOverride() throws JSONException {
+    public void testAppVersionOverride() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
         config.appVersion = "1.2.3";
 
@@ -28,7 +30,7 @@ public class AppDataTest extends BugsnagTestCase {
         assertEquals("1.2.3", appDataJson.get("version"));
     }
 
-    public void testReleaseStageOverride() throws JSONException {
+    public void testReleaseStageOverride() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
         config.releaseStage = "test-stage";
 

--- a/src/androidTest/java/com/bugsnag/android/AppStateTest.java
+++ b/src/androidTest/java/com/bugsnag/android/AppStateTest.java
@@ -1,10 +1,12 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class AppStateTest extends BugsnagTestCase {
-    public void testSaneValues() throws JSONException {
+    public void testSaneValues() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
         AppState appState = new AppState(getContext());
         JSONObject appStateJson = streamableToJson(appState);

--- a/src/androidTest/java/com/bugsnag/android/BreadcrumbsTest.java
+++ b/src/androidTest/java/com/bugsnag/android/BreadcrumbsTest.java
@@ -1,10 +1,12 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONException;
 import org.json.JSONArray;
 
 public class BreadcrumbsTest extends BugsnagTestCase {
-    public void testSerialization() throws JSONException {
+    public void testSerialization() throws JSONException, IOException {
         Breadcrumbs breadcrumbs = new Breadcrumbs();
         breadcrumbs.add("Started app");
         breadcrumbs.add("Clicked a button");
@@ -15,7 +17,7 @@ public class BreadcrumbsTest extends BugsnagTestCase {
         assertEquals("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim", breadcrumbsJson.getJSONArray(2).get(1));
     }
 
-    public void testSizeLimit() throws JSONException {
+    public void testSizeLimit() throws JSONException, IOException {
         Breadcrumbs breadcrumbs = new Breadcrumbs();
         breadcrumbs.setSize(5);
         breadcrumbs.add("1");
@@ -31,7 +33,7 @@ public class BreadcrumbsTest extends BugsnagTestCase {
         assertEquals("6", breadcrumbsJson.getJSONArray(4).get(1));
     }
 
-    public void testResize() throws JSONException {
+    public void testResize() throws JSONException, IOException {
         Breadcrumbs breadcrumbs = new Breadcrumbs();
         breadcrumbs.add("1");
         breadcrumbs.add("2");
@@ -47,7 +49,7 @@ public class BreadcrumbsTest extends BugsnagTestCase {
         assertEquals("6", breadcrumbsJson.getJSONArray(4).get(1));
     }
 
-    public void testClear() throws JSONException {
+    public void testClear() throws JSONException, IOException {
         Breadcrumbs breadcrumbs = new Breadcrumbs();
         breadcrumbs.add("1");
         breadcrumbs.add("2");

--- a/src/androidTest/java/com/bugsnag/android/BugsnagTestCase.java
+++ b/src/androidTest/java/com/bugsnag/android/BugsnagTestCase.java
@@ -18,27 +18,11 @@ public class BugsnagTestCase extends AndroidTestCase {
         return writer.toString();
     }
 
-    protected JSONObject streamableToJson(JsonStream.Streamable streamable) {
-        JSONObject json = null;
-
-        try {
-            return new JSONObject(streamableToString(streamable));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        return json;
+    protected JSONObject streamableToJson(JsonStream.Streamable streamable) throws JSONException, IOException {
+        return new JSONObject(streamableToString(streamable));
     }
 
-    protected JSONArray streamableToJsonArray(JsonStream.Streamable streamable) {
-        JSONArray json = null;
-
-        try {
-            return new JSONArray(streamableToString(streamable));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        return json;
+    protected JSONArray streamableToJsonArray(JsonStream.Streamable streamable) throws JSONException, IOException  {
+        return new JSONArray(streamableToString(streamable));
     }
 }

--- a/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -1,12 +1,14 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.util.DisplayMetrics;
 
 public class DeviceDataTest extends BugsnagTestCase {
-    public void testSaneValues() throws JSONException {
+    public void testSaneValues() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
         DeviceData deviceData = new DeviceData(getContext());
         JSONObject deviceDataJson = streamableToJson(deviceData);

--- a/src/androidTest/java/com/bugsnag/android/DeviceStateTest.java
+++ b/src/androidTest/java/com/bugsnag/android/DeviceStateTest.java
@@ -1,10 +1,12 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class DeviceStateTest extends BugsnagTestCase {
-    public void testSaneValues() throws JSONException {
+    public void testSaneValues() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
         DeviceState deviceState = new DeviceState(getContext());
         JSONObject deviceStateJson = streamableToJson(deviceState);

--- a/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -31,7 +33,7 @@ public class ErrorTest extends BugsnagTestCase {
         assertEquals("Example message", error.getExceptionMessage());
     }
 
-    public void testBasicSerialization() throws JSONException {
+    public void testBasicSerialization() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Error error = new Error(config, new RuntimeException("Example message"));
 
@@ -43,7 +45,7 @@ public class ErrorTest extends BugsnagTestCase {
         assertNotNull(errorJson.get("threads"));
     }
 
-    public void testSetContext() throws JSONException {
+    public void testSetContext() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Error error = new Error(config, new RuntimeException("Example message"));
         error.setContext("ExampleContext");
@@ -52,7 +54,7 @@ public class ErrorTest extends BugsnagTestCase {
         assertEquals("ExampleContext", errorJson.get("context"));
     }
 
-    public void testSetGroupingHash() throws JSONException {
+    public void testSetGroupingHash() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Error error = new Error(config, new RuntimeException("Example message"));
         error.setGroupingHash("herpderp");
@@ -61,7 +63,7 @@ public class ErrorTest extends BugsnagTestCase {
         assertEquals("herpderp", errorJson.get("groupingHash"));
     }
 
-    public void testSetSeverity() throws JSONException {
+    public void testSetSeverity() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Error error = new Error(config, new RuntimeException("Example message"));
         error.setSeverity(Severity.INFO);

--- a/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
@@ -1,11 +1,13 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class ExceptionsTest extends BugsnagTestCase {
-    public void testBasicException() throws JSONException {
+    public void testBasicException() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Exceptions exceptions = new Exceptions(config, new RuntimeException("oops"));
         JSONArray exceptionsJson = streamableToJsonArray(exceptions);
@@ -18,7 +20,7 @@ public class ExceptionsTest extends BugsnagTestCase {
         assertNotNull(firstException.get("stacktrace"));
     }
 
-    public void testCauseException() throws JSONException {
+    public void testCauseException() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Throwable ex = new RuntimeException("oops", new Exception("cause"));
         Exceptions exceptions = new Exceptions(config, ex);
@@ -37,7 +39,7 @@ public class ExceptionsTest extends BugsnagTestCase {
         assertNotNull(causeException.get("stacktrace"));
     }
 
-    public void testNamedException() throws JSONException {
+    public void testNamedException() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
 
         StackTraceElement element = new StackTraceElement("Class", "method", "Class.java", 123);

--- a/src/androidTest/java/com/bugsnag/android/MetaDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/MetaDataTest.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -11,7 +13,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class MetaDataTest extends BugsnagTestCase {
-    public void testBasicSerialization() throws JSONException {
+    public void testBasicSerialization() throws JSONException, IOException {
         MetaData metaData = new MetaData();
         metaData.addToTab("example", "string", "value");
         metaData.addToTab("example", "integer", 123);
@@ -49,7 +51,7 @@ public class MetaDataTest extends BugsnagTestCase {
         assertEquals("value", mapJson.getString("key"));
     }
 
-    public void testNestedMapSerialization() throws JSONException {
+    public void testNestedMapSerialization() throws JSONException, IOException {
         Map<String, String> childMap = new HashMap<String, String>();
         childMap.put("key", "value");
 
@@ -66,7 +68,7 @@ public class MetaDataTest extends BugsnagTestCase {
         assertEquals("value", childMapJson.getString("key"));
     }
 
-    public void testNestedCollectionSerialization() throws JSONException {
+    public void testNestedCollectionSerialization() throws JSONException, IOException {
         Collection childList = new LinkedList<String>();
         childList.add("james");
         childList.add("test");
@@ -132,7 +134,7 @@ public class MetaDataTest extends BugsnagTestCase {
         assertEquals("fromOverrides", mergedMap.get("key"));
     }
 
-    public void testBasicFiltering() throws JSONException {
+    public void testBasicFiltering() throws JSONException, IOException {
         MetaData metaData = new MetaData();
         metaData.setFilters("password");
         metaData.addToTab("example", "password", "p4ssw0rd");
@@ -148,7 +150,7 @@ public class MetaDataTest extends BugsnagTestCase {
         assertEquals("safe", tabJson.getString("normal"));
     }
 
-    public void testNestedFiltering() throws JSONException  {
+    public void testNestedFiltering() throws JSONException, IOException  {
         Map<String, String> sensitiveMap = new HashMap<String, String>();
         sensitiveMap.put("password", "p4ssw0rd");
         sensitiveMap.put("confirm_password", "p4ssw0rd");

--- a/src/androidTest/java/com/bugsnag/android/NotificationTest.java
+++ b/src/androidTest/java/com/bugsnag/android/NotificationTest.java
@@ -1,10 +1,12 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class NotificationTest extends BugsnagTestCase {
-    public void testInMemoryError() throws JSONException {
+    public void testInMemoryError() throws JSONException, IOException {
         Configuration config = new Configuration("example-api-key");
         Notification notif = new Notification(config);
         notif.addError(new Error(config, new RuntimeException("Something broke")));

--- a/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
+++ b/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
@@ -1,24 +1,26 @@
 package com.bugsnag.android;
 
+import java.io.IOException;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public class StacktraceTest extends BugsnagTestCase {
-    public void testBasicException() throws JSONException {
+    public void testBasicException() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Throwable exception = new RuntimeException("oops");
         Stacktrace stacktrace = new Stacktrace(config, exception.getStackTrace());
         JSONArray stacktraceJson = streamableToJsonArray(stacktrace);
 
         JSONObject firstFrame = (JSONObject)stacktraceJson.get(0);
-        assertEquals(10, firstFrame.get("lineNumber"));
+        assertEquals(12, firstFrame.get("lineNumber"));
         assertEquals("com.bugsnag.android.StacktraceTest.testBasicException", firstFrame.get("method"));
         assertEquals("StacktraceTest.java", firstFrame.get("file"));
         assertFalse(firstFrame.has("inProject"));
     }
 
-    public void testInProject() throws JSONException {
+    public void testInProject() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         config.projectPackages = new String[] {"com.bugsnag.android"};
 

--- a/src/main/java/com/bugsnag/android/Error.java
+++ b/src/main/java/com/bugsnag/android/Error.java
@@ -54,11 +54,13 @@ public class Error implements JsonStream.Streamable {
             writer.name("severity").value(severity);
             writer.name("metaData").value(mergedMetaData);
 
-            writer.name("projectPackages").beginArray();
-                for (String projectPackage : config.projectPackages) {
-                    writer.value(projectPackage);
-                }
-            writer.endArray();
+            if(config.projectPackages != null) {
+                writer.name("projectPackages").beginArray();
+                    for (String projectPackage : config.projectPackages) {
+                        writer.value(projectPackage);
+                    }
+                writer.endArray();
+            }
 
             // Write exception info
             if(exception != null) {


### PR DESCRIPTION
The tests were failing because of projectPackages was null (only likely to ever occur in the tests). I also improved the tests to not swallow exceptions so that you can see the true failures rather than an NPE in the tests.