### PR TITLE
Fixes NPE at com.bugsnag.android.ErrorStore$1.run(ErrorStore.java:49)

### DIFF
--- a/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -46,7 +46,7 @@ class ErrorStore {
                 if(!exceptionDir.exists() || !exceptionDir.isDirectory()) return;
 
                 File[] errorFiles = exceptionDir.listFiles();
-                if(errorFiles.length > 0) {
+                if(errorFiles != null && errorFiles.length > 0) {
                     Logger.info(String.format("Sending %d saved error(s) to Bugsnag", errorFiles.length));
 
                     for(File errorFile : errorFiles) {


### PR DESCRIPTION
We got this error in a tablet 3Q TS1003T on Android 2.2
I think it's a firmware bug, there must be no NPE because isDirectory() is true