### PR TITLE
Add blocking API

### DIFF
--- a/src/main/java/com/bugsnag/android/Async.java
+++ b/src/main/java/com/bugsnag/android/Async.java
@@ -1,15 +1,13 @@
 package com.bugsnag.android;
 
-import android.os.AsyncTask;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 class Async {
-    static void run(final Runnable task) {
-        new AsyncTask <Void, Void, Void>() {
-            @Override
-            protected Void doInBackground(Void... voi) {
-                task.run();
-                return null;
-            }
-        }.execute();
+
+    private static final Executor executor = Executors.newCachedThreadPool();
+
+    static void run(Runnable task) {
+        executor.execute(task);
     }
 }


### PR DESCRIPTION
When uploading a crash, it makes sense to do it from the crashing thread before delegating to the default handler, to guarantee that the crash is either uploaded or saved before the process is killed.

* This change introduces an API that allows one to write a blocking `UncaughtExceptionHandler`.
* I did not change the default exception handler, because this change might slightly delay the appearance of the crash dialog.
* Also fixed `Async` to use a Java Executor instead of the `AsyncTask` garbage. `AsyncTask` should be burnt to the ground.
* The async API is still needed when you want to log a non crashing throwable.

Fixes #63