### PR TITLE
make setting and clearing of max breadcrumbs static methods

### DIFF
--- a/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -379,14 +379,14 @@ public final class Bugsnag {
      *
      * @param  numBreadcrumbs  number of breadcrumb log messages to send
      */
-    public void setMaxBreadcrumbs(int numBreadcrumbs) {
+    public static void setMaxBreadcrumbs(int numBreadcrumbs) {
         getClient().setMaxBreadcrumbs(numBreadcrumbs);
     }
 
     /**
      * Clear any breadcrumbs that have been left so far.
      */
-    public void clearBreadcrumbs() {
+    public static void clearBreadcrumbs() {
         getClient().clearBreadcrumbs();
     }
 


### PR DESCRIPTION
The setting and clearing of max breadcrumbs are currently not static methods and hence can never be called.  This pull request corrects the error.