### PR TITLE
Jailbreak detection improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ proguard/
 
 # Log Files
 *.log
+
+# Android Studio #
+.idea
+*.iml


### PR DESCRIPTION
While just checking for the existence of certain files does not guarantee a device is rooted, it's something we can check with virtually no impact on the user.

I've extended the current type of check with a few more locations.
The previous check only worked if the device was using a specific superuser app.

Additionally, on newer Android versions the app folder hierarchy changed.