### PR TITLE
Remove the need for synthetic methods.

### DIFF
--- a/src/main/java/com/bugsnag/android/Breadcrumbs.java
+++ b/src/main/java/com/bugsnag/android/Breadcrumbs.java
@@ -8,8 +8,8 @@ import java.util.List;
 class Breadcrumbs implements JsonStream.Streamable {
     private static class Breadcrumb {
         private static final int MAX_MESSAGE_LENGTH = 140;
-        private String timestamp;
-        private String message;
+        String timestamp;
+        String message;
 
         Breadcrumb(String message) {
             this.timestamp = DateUtils.toISO8601(new Date());

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -614,7 +614,7 @@ public class Client {
         }
     }
 
-    private void deliver(Notification notification, Error error) {
+    void deliver(Notification notification, Error error) {
         try {
             int errorCount = notification.deliver();
             Logger.info(String.format("Sent %d new error(s) to Bugsnag", errorCount));

--- a/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -13,8 +13,8 @@ import android.content.Context;
 class ErrorStore {
     private static final String UNSENT_ERROR_PATH = "/bugsnag-errors/";
 
-    private final Configuration config;
-    private final String path;
+    final Configuration config;
+    final String path;
 
     ErrorStore(Configuration config, Context appContext) {
         this.config = config;


### PR DESCRIPTION
`javac` generates package-scoped methods when you access private fields and methods from inner to outer classes (and vise-versa).

```
$ dex-method-count before.dex
443

$ dex-method-count after.dex
436
```

Every bit counts for libraries!