### PR TITLE
Limit number of stored errors

### DIFF
--- a/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -12,6 +12,7 @@ import android.content.Context;
  */
 class ErrorStore {
     private static final String UNSENT_ERROR_PATH = "/bugsnag-errors/";
+    private static final int MAX_STORED_ERRORS = 100;
 
     final Configuration config;
     final String path;
@@ -76,6 +77,13 @@ class ErrorStore {
     // Write an error to disk, for later sending
     void write(Error error) {
         if(path == null) return;
+
+        // Limit number of saved errors to prevent disk space issues
+        File exceptionDir = new File(path);
+        if (exceptionDir.isDirectory() && exceptionDir.listFiles().length >= MAX_STORED_ERRORS) {
+            Logger.warn("Discarding error without saving to disk as stored error limit reached");
+            return;
+        }
 
         String filename = String.format("%s%d.json", path, System.currentTimeMillis());
         Writer out = null;

--- a/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -3,6 +3,8 @@ package com.bugsnag.android;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
+import java.util.Arrays;
+import java.util.List;
 
 import android.content.Context;
 
@@ -80,9 +82,16 @@ class ErrorStore {
 
         // Limit number of saved errors to prevent disk space issues
         File exceptionDir = new File(path);
-        if (exceptionDir.isDirectory() && exceptionDir.listFiles().length >= MAX_STORED_ERRORS) {
-            Logger.warn("Discarding error without saving to disk as stored error limit reached");
-            return;
+        if (exceptionDir.isDirectory()) {
+            File[] files = exceptionDir.listFiles();
+            if (files.length >= MAX_STORED_ERRORS) {
+                // Sort files then delete the first one (oldest timestamp)
+                Arrays.sort(files);
+                Logger.warn(String.format("Discarding oldest error as stored error limit reached (%s)", files[0].getPath()));
+                if (!files[0].delete()) {
+                    files[0].deleteOnExit();
+                }
+            }
         }
 
         String filename = String.format("%s%d.json", path, System.currentTimeMillis());


### PR DESCRIPTION
Limit the number of errors stored for later sending to prevent possible disk space issues (see #23).

Stores up to 100 errors and discards any subsequent errors.  First 100 errors are stored on the basis that they are likely to be the most interesting.  Is this sensible?