### PR TITLE
Remove duplicate fields

### DIFF
--- a/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
@@ -44,7 +44,8 @@ public class ExceptionsTest extends BugsnagTestCase {
 
         StackTraceElement element = new StackTraceElement("Class", "method", "Class.java", 123);
         StackTraceElement[] frames = new StackTraceElement[] { element };
-        Exceptions exceptions = new Exceptions(config, "RuntimeException", "Example message", frames);
+        Error error = new Error(config, "RuntimeException", "Example message", frames);
+        Exceptions exceptions = new Exceptions(config, error.getException());
 
         JSONObject exceptionJson = streamableToJsonArray(exceptions).getJSONObject(0);
         assertEquals("RuntimeException", exceptionJson.get("errorClass"));

--- a/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
@@ -9,7 +9,7 @@ import org.json.JSONObject;
 public class ExceptionsTest extends BugsnagTestCase {
     public void testBasicException() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
-        Exceptions exceptions = new Exceptions(config, new BugsnagException(new RuntimeException("oops")));
+        Exceptions exceptions = new Exceptions(config, new RuntimeException("oops"));
         JSONArray exceptionsJson = streamableToJsonArray(exceptions);
 
         assertEquals(1, exceptionsJson.length());
@@ -23,7 +23,7 @@ public class ExceptionsTest extends BugsnagTestCase {
     public void testCauseException() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Throwable ex = new RuntimeException("oops", new Exception("cause"));
-        Exceptions exceptions = new Exceptions(config, new BugsnagException(ex));
+        Exceptions exceptions = new Exceptions(config, ex);
         JSONArray exceptionsJson = streamableToJsonArray(exceptions);
 
         assertEquals(2, exceptionsJson.length());

--- a/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
@@ -9,7 +9,7 @@ import org.json.JSONObject;
 public class ExceptionsTest extends BugsnagTestCase {
     public void testBasicException() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
-        Exceptions exceptions = new Exceptions(config, new RuntimeException("oops"));
+        Exceptions exceptions = new Exceptions(config, new BugsnagException(new RuntimeException("oops")));
         JSONArray exceptionsJson = streamableToJsonArray(exceptions);
 
         assertEquals(1, exceptionsJson.length());
@@ -23,7 +23,7 @@ public class ExceptionsTest extends BugsnagTestCase {
     public void testCauseException() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
         Throwable ex = new RuntimeException("oops", new Exception("cause"));
-        Exceptions exceptions = new Exceptions(config, ex);
+        Exceptions exceptions = new Exceptions(config, new BugsnagException(ex));
         JSONArray exceptionsJson = streamableToJsonArray(exceptions);
 
         assertEquals(2, exceptionsJson.length());

--- a/src/main/java/com/bugsnag/android/BugsnagException.java
+++ b/src/main/java/com/bugsnag/android/BugsnagException.java
@@ -1,0 +1,30 @@
+package com.bugsnag.android;
+
+/**
+ * Used to store information about an exception that was not provided with an exception object
+ */
+public class BugsnagException extends Throwable {
+
+    /** The name of the exception (used instead of the exception class) */
+    private String name;
+
+    /**
+     * Constructor
+     * @param name The name of the exception (used instead of the exception class)
+     * @param message The exception message
+     * @param frames The exception stack trace
+     */
+    public BugsnagException(String name, String message, StackTraceElement[] frames) {
+        super(message);
+
+        super.setStackTrace(frames);
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the exception (used instead of the exception class)
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/bugsnag/android/BugsnagException.java
+++ b/src/main/java/com/bugsnag/android/BugsnagException.java
@@ -22,6 +22,17 @@ public class BugsnagException extends Throwable {
     }
 
     /**
+     * Constructor
+     * @param t Any throwable passed in, used to get the class name to use as the name
+     */
+    public BugsnagException(Throwable t) {
+        super(t.getLocalizedMessage(), t.getCause());
+
+        super.setStackTrace(t.getStackTrace());
+        this.name = t.getClass().getName();
+    }
+
+    /**
      * @return The name of the exception (used instead of the exception class)
      */
     public String getName() {

--- a/src/main/java/com/bugsnag/android/BugsnagException.java
+++ b/src/main/java/com/bugsnag/android/BugsnagException.java
@@ -22,17 +22,6 @@ public class BugsnagException extends Throwable {
     }
 
     /**
-     * Constructor
-     * @param t Any throwable passed in, used to get the class name to use as the name
-     */
-    public BugsnagException(Throwable t) {
-        super(t.getLocalizedMessage(), t.getCause());
-
-        super.setStackTrace(t.getStackTrace());
-        this.name = t.getClass().getName();
-    }
-
-    /**
      * @return The name of the exception (used instead of the exception class)
      */
     public String getName() {

--- a/src/main/java/com/bugsnag/android/Error.java
+++ b/src/main/java/com/bugsnag/android/Error.java
@@ -25,7 +25,7 @@ public class Error implements JsonStream.Streamable {
     private DeviceState deviceState;
     private Breadcrumbs breadcrumbs;
     private User user;
-    private Throwable exception;
+    private BugsnagException exception;
     private Severity severity = Severity.WARNING;
     private MetaData metaData = new MetaData();
     private String groupingHash;
@@ -33,12 +33,11 @@ public class Error implements JsonStream.Streamable {
 
     Error(Configuration config, Throwable exception) {
         this.config = config;
-        this.exception = exception;
+        this.exception = new BugsnagException(exception);
     }
 
     Error(Configuration config, String name, String message, StackTraceElement[] frames) {
         this.config = config;
-
         this.exception = new BugsnagException(name, message, frames);
     }
 
@@ -244,11 +243,7 @@ public class Error implements JsonStream.Streamable {
      * Get the class name from the exception contained in this Error report.
      */
     public String getExceptionName() {
-        if(exception instanceof BugsnagException) {
-            return ((BugsnagException)exception).getName();
-        } else {
-            return exception.getClass().getName();
-        }
+        return exception.getName();
     }
 
     /**
@@ -261,7 +256,7 @@ public class Error implements JsonStream.Streamable {
     /**
      * The {@linkplain Throwable exception} which triggered this Error report.
      */
-    public Throwable getException() {
+    public BugsnagException getException() {
         return exception;
     }
 

--- a/src/main/java/com/bugsnag/android/Error.java
+++ b/src/main/java/com/bugsnag/android/Error.java
@@ -25,7 +25,7 @@ public class Error implements JsonStream.Streamable {
     private DeviceState deviceState;
     private Breadcrumbs breadcrumbs;
     private User user;
-    private BugsnagException exception;
+    private Throwable exception;
     private Severity severity = Severity.WARNING;
     private MetaData metaData = new MetaData();
     private String groupingHash;
@@ -33,11 +33,12 @@ public class Error implements JsonStream.Streamable {
 
     Error(Configuration config, Throwable exception) {
         this.config = config;
-        this.exception = new BugsnagException(exception);
+        this.exception = exception;
     }
 
     Error(Configuration config, String name, String message, StackTraceElement[] frames) {
         this.config = config;
+
         this.exception = new BugsnagException(name, message, frames);
     }
 
@@ -243,7 +244,11 @@ public class Error implements JsonStream.Streamable {
      * Get the class name from the exception contained in this Error report.
      */
     public String getExceptionName() {
-        return exception.getName();
+        if(exception instanceof BugsnagException) {
+            return ((BugsnagException)exception).getName();
+        } else {
+            return exception.getClass().getName();
+        }
     }
 
     /**
@@ -256,7 +261,7 @@ public class Error implements JsonStream.Streamable {
     /**
      * The {@linkplain Throwable exception} which triggered this Error report.
      */
-    public BugsnagException getException() {
+    public Throwable getException() {
         return exception;
     }
 

--- a/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/src/main/java/com/bugsnag/android/Exceptions.java
@@ -9,9 +9,9 @@ import java.io.IOException;
  */
 class Exceptions implements JsonStream.Streamable {
     private final Configuration config;
-    private Throwable exception;
+    private BugsnagException exception;
 
-    Exceptions(Configuration config, Throwable exception) {
+    Exceptions(Configuration config, BugsnagException exception) {
         this.config = config;
         this.exception = exception;
     }

--- a/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/src/main/java/com/bugsnag/android/Exceptions.java
@@ -9,9 +9,9 @@ import java.io.IOException;
  */
 class Exceptions implements JsonStream.Streamable {
     private final Configuration config;
-    private BugsnagException exception;
+    private Throwable exception;
 
-    Exceptions(Configuration config, BugsnagException exception) {
+    Exceptions(Configuration config, Throwable exception) {
         this.config = config;
         this.exception = exception;
     }


### PR DESCRIPTION
Currently there are a couple of constructors for the Error object, one takes and exception and the other takes a name, message and stacktrace.

These fields are store separately and every time the details are accessed we have to check which one to use.

This PR adds a new BugsnagException class used to wrap the name, message and stacktrace so that can store them in the exception field.