### PR TITLE
Add cpu abi to device information

### DIFF
--- a/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -24,6 +24,7 @@ public class DeviceDataTest extends BugsnagTestCase {
         assertTrue(deviceDataJson.getLong("totalMemory") > 0);
         assertNotNull(deviceDataJson.getBoolean("jailbroken"));
         assertNotNull(deviceDataJson.getString("locale"));
+        assertNotNull(deviceDataJson.getString("cpuAbi"));
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.FROYO) {
             // Emulators returned null for android id before android 2.2

--- a/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/src/main/java/com/bugsnag/android/DeviceData.java
@@ -31,7 +31,7 @@ class DeviceData implements JsonStream.Streamable {
     private final Boolean rooted;
     private final String locale;
     private final String id;
-    private final String cpuAbi;
+    private final String[] cpuAbi;
 
     DeviceData(@NonNull Context appContext) {
         screenDensity = getScreenDensity(appContext);
@@ -63,7 +63,12 @@ class DeviceData implements JsonStream.Streamable {
         writer.name("screenDensity").value(screenDensity);
         writer.name("dpi").value(dpi);
         writer.name("screenResolution").value(screenResolution);
-        writer.name("cpuAbi").value(cpuAbi);
+
+        writer.name("cpuAbi").beginArray();
+        for (String s : cpuAbi) {
+            writer.value(s);
+        }
+        writer.endArray();
 
         writer.endObject();
     }
@@ -172,16 +177,14 @@ class DeviceData implements JsonStream.Streamable {
      * Gets information about the CPU / API
      */
     @NonNull
-    private static String getCpuAbi() {
-        String cpuAbi = Build.CPU_ABI;
-
+    private static String[] getCpuAbi() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            cpuAbi = SupportedAbiWrapper.getSupportedAbis();
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
-            cpuAbi = Abi2Wrapper.getAbi1andAbi2();
+            return SupportedAbiWrapper.getSupportedAbis();
         }
-
-        return cpuAbi;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
+            return Abi2Wrapper.getAbi1andAbi2();
+        }
+        return new String[]{Build.CPU_ABI};
     }
 
     /**
@@ -189,8 +192,8 @@ class DeviceData implements JsonStream.Streamable {
      */
     private static class SupportedAbiWrapper {
         @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-        public static String getSupportedAbis() {
-            return Arrays.toString(Build.SUPPORTED_ABIS);
+        public static String[] getSupportedAbis() {
+            return Build.SUPPORTED_ABIS;
         }
     }
 
@@ -199,8 +202,8 @@ class DeviceData implements JsonStream.Streamable {
      */
     private static class Abi2Wrapper {
         @TargetApi(Build.VERSION_CODES.FROYO)
-        public static String getAbi1andAbi2() {
-            return Arrays.toString(new String[]{Build.CPU_ABI, Build.CPU_ABI2});
+        public static String[] getAbi1andAbi2() {
+            return new String[]{Build.CPU_ABI, Build.CPU_ABI2};
         }
     }
 }

--- a/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/src/main/java/com/bugsnag/android/DeviceData.java
@@ -1,8 +1,10 @@
 package com.bugsnag.android;
 
+import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Resources;
+import android.os.Build;
 import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -10,6 +12,7 @@ import android.util.DisplayMetrics;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Locale;
 
 /**
@@ -28,6 +31,7 @@ class DeviceData implements JsonStream.Streamable {
     private final Boolean rooted;
     private final String locale;
     private final String id;
+    private final String cpuAbi;
 
     DeviceData(@NonNull Context appContext) {
         screenDensity = getScreenDensity(appContext);
@@ -37,6 +41,7 @@ class DeviceData implements JsonStream.Streamable {
         rooted = isRooted();
         locale = getLocale();
         id = getAndroidId(appContext);
+        cpuAbi = getCpuAbi();
     }
 
     public void toStream(@NonNull JsonStream writer) throws IOException {
@@ -58,6 +63,7 @@ class DeviceData implements JsonStream.Streamable {
         writer.name("screenDensity").value(screenDensity);
         writer.name("dpi").value(dpi);
         writer.name("screenResolution").value(screenResolution);
+        writer.name("cpuAbi").value(cpuAbi);
 
         writer.endObject();
     }
@@ -160,5 +166,41 @@ class DeviceData implements JsonStream.Streamable {
     private static String getAndroidId(Context appContext) {
         ContentResolver cr = appContext.getContentResolver();
         return Settings.Secure.getString(cr, Settings.Secure.ANDROID_ID);
+    }
+
+    /**
+     * Gets information about the CPU / API
+     */
+    @NonNull
+    private static String getCpuAbi() {
+        String cpuAbi = Build.CPU_ABI;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            cpuAbi = SupportedAbiWrapper.getSupportedAbis();
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.FROYO) {
+            cpuAbi = Abi2Wrapper.getAbi1andAbi2();
+        }
+
+        return cpuAbi;
+    }
+
+    /**
+     * Wrapper class to allow the test framework to use the correct version of the CPU / ABI
+     */
+    private static class SupportedAbiWrapper {
+        @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+        public static String getSupportedAbis() {
+            return Arrays.toString(Build.SUPPORTED_ABIS);
+        }
+    }
+
+    /**
+     * Wrapper class to allow the test framework to use the correct version of the CPU / ABI
+     */
+    private static class Abi2Wrapper {
+        @TargetApi(Build.VERSION_CODES.FROYO)
+        public static String getAbi1andAbi2() {
+            return Arrays.toString(new String[]{Build.CPU_ABI, Build.CPU_ABI2});
+        }
     }
 }


### PR DESCRIPTION
This PR adds the CPU/ABI information to the device information as suggested in https://github.com/bugsnag/bugsnag-android/pull/109

This is done slightly differently to ensure that the tests pass on android v4