### PR TITLE
Add config constructor

### DIFF
--- a/src/androidTest/java/com/bugsnag/android/AppDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/AppDataTest.java
@@ -22,7 +22,7 @@ public class AppDataTest extends BugsnagTestCase {
 
     public void testAppVersionOverride() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
-        config.appVersion = "1.2.3";
+        config.setAppVersion("1.2.3");
 
         AppData appData = new AppData(getContext(), config);
         JSONObject appDataJson = streamableToJson(appData);
@@ -32,7 +32,7 @@ public class AppDataTest extends BugsnagTestCase {
 
     public void testReleaseStageOverride() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
-        config.releaseStage = "test-stage";
+        config.setReleaseStage("test-stage");
 
         AppData appData = new AppData(getContext(), config);
         JSONObject appDataJson = streamableToJson(appData);

--- a/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -10,7 +10,7 @@ public class ClientTest extends BugsnagTestCase {
 
     public void testNullApiKey() {
         try {
-            Client client = new Client(getContext(), null);
+            Client client = new Client(getContext(), null, true);
             fail("Should throw for null Contexts");
         } catch(NullPointerException e) { }
     }

--- a/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -20,4 +20,15 @@ public class ClientTest extends BugsnagTestCase {
         Client client = new Client(getContext(), "api-key");
         client.notify(new RuntimeException("Testing"));
     }
+
+    public void testConfig() {
+        Configuration config = new Configuration("api-key");
+        config.setEndpoint("new-endpoint");
+
+        Client client = new Client(getContext(), config);
+
+        // Notify should not crash
+        client.notify(new RuntimeException("Testing"));
+    }
+
 }

--- a/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
@@ -5,11 +5,11 @@ public class ConfigurationTest extends BugsnagTestCase {
         Configuration config = new Configuration("api-key");
 
         // Default endpoints
-        assertEquals("https://notify.bugsnag.com", config.getNotifyEndpoint());
+        assertEquals("https://notify.bugsnag.com", config.getEndpoint());
 
         // Setting an endpoint
-        config.endpoint = "http://localhost:8000";
-        assertEquals("http://localhost:8000", config.getNotifyEndpoint());
+        config.setEndpoint("http://localhost:8000");
+        assertEquals("http://localhost:8000", config.getEndpoint());
     }
 
     public void testShouldNotify() {
@@ -19,15 +19,15 @@ public class ConfigurationTest extends BugsnagTestCase {
         assertTrue(config.shouldNotifyForReleaseStage("development"));
 
         // Shouldn't notify if notifyReleaseStages is set and releaseStage is null
-        config.notifyReleaseStages = new String[] {"example"};
+        config.setNotifyReleaseStages(new String[] {"example"});
         assertFalse(config.shouldNotifyForReleaseStage(null));
 
         // Shouldn't notify if releaseStage not in notifyReleaseStages
-        config.notifyReleaseStages = new String[] {"production"};
+        config.setNotifyReleaseStages(new String[] {"production"});
         assertFalse(config.shouldNotifyForReleaseStage("not-production"));
 
         // Should notify if releaseStage in notifyReleaseStages
-        config.notifyReleaseStages = new String[] {"production"};
+        config.setNotifyReleaseStages(new String[] {"production"});
         assertTrue(config.shouldNotifyForReleaseStage("production"));
     }
 
@@ -38,7 +38,7 @@ public class ConfigurationTest extends BugsnagTestCase {
         assertFalse(config.shouldIgnoreClass("java.io.IOException"));
 
         // Should ignore when added to ignoreClasses
-        config.ignoreClasses = new String[] {"java.io.IOException"};
+        config.setIgnoreClasses(new String[] {"java.io.IOException"});
         assertTrue(config.shouldIgnoreClass("java.io.IOException"));
     }
 
@@ -49,11 +49,11 @@ public class ConfigurationTest extends BugsnagTestCase {
         assertFalse(config.inProject("com.bugsnag.android.Example"));
 
         // Should be inProject if class in projectPackages
-        config.projectPackages = new String[] {"com.bugsnag.android"};
+        config.setProjectPackages(new String[] {"com.bugsnag.android"});
         assertTrue(config.inProject("com.bugsnag.android.Example"));
 
         // Shouldn't be inProject if class not in projectPackages
-        config.projectPackages = new String[] {"com.bugsnag.android"};
+        config.setProjectPackages(new String[] {"com.bugsnag.android"});
         assertFalse(config.inProject("java.io.IOException"));
     }
 }

--- a/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -8,7 +8,7 @@ import org.json.JSONObject;
 public class ErrorTest extends BugsnagTestCase {
     public void testShouldIgnoreClass() {
         Configuration config = new Configuration("api-key");
-        config.ignoreClasses = new String[] {"java.io.IOException"};
+        config.setIgnoreClasses(new String[] {"java.io.IOException"});
 
         // Shouldn't ignore classes not in ignoreClasses
         Error error = new Error(config, new RuntimeException("Test"));

--- a/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
+++ b/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
@@ -22,7 +22,7 @@ public class StacktraceTest extends BugsnagTestCase {
 
     public void testInProject() throws JSONException, IOException {
         Configuration config = new Configuration("api-key");
-        config.projectPackages = new String[] {"com.bugsnag.android"};
+        config.setProjectPackages(new String[] {"com.bugsnag.android"});
 
         Throwable exception = new RuntimeException("oops");
         Stacktrace stacktrace = new Stacktrace(config, exception.getStackTrace());

--- a/src/main/java/com/bugsnag/android/AppData.java
+++ b/src/main/java/com/bugsnag/android/AppData.java
@@ -42,7 +42,7 @@ class AppData implements JsonStream.Streamable {
         writer.name("packageName").value(packageName);
         writer.name("versionName").value(versionName);
         writer.name("versionCode").value(versionCode);
-        writer.name("buildUUID").value(config.buildUUID);
+        writer.name("buildUUID").value(config.getBuildUUID());
 
         // Prefer user-configured appVersion + releaseStage
         writer.name("version").value(getAppVersion());
@@ -53,8 +53,8 @@ class AppData implements JsonStream.Streamable {
 
     @NonNull
     public String getReleaseStage() {
-        if (config.releaseStage != null) {
-            return config.releaseStage;
+        if (config.getReleaseStage() != null) {
+            return config.getReleaseStage();
         } else {
             return guessedReleaseStage;
         }
@@ -62,8 +62,8 @@ class AppData implements JsonStream.Streamable {
 
     @Nullable
     public String getAppVersion() {
-        if (config.appVersion != null) {
-            return config.appVersion;
+        if (config.getAppVersion() != null) {
+            return config.getAppVersion();
         } else {
             return versionName;
         }

--- a/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -97,7 +97,7 @@ public final class Bugsnag {
      * endpoint.
      *
      * @param  endpoint  the custom endpoint to send notifications to
-     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoint()} instead.
+     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoint(String)} instead.
      */
     @Deprecated
     public static void setEndpoint(final String endpoint) {

--- a/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -51,6 +51,17 @@ public final class Bugsnag {
     }
 
     /**
+     * Initialize the static Bugsnag client
+     *
+     * @param androidContext an Android context, usually <code>this</code>
+     * @param config         a configuration for the Client
+     */
+    public static Client init(Context androidContext, Configuration config) {
+        client = new Client(androidContext, config);
+        return client;
+    }
+
+    /**
      * Set the application version sent to Bugsnag. By default we'll pull this
      * from your AndroidManifest.xml
      *
@@ -86,7 +97,9 @@ public final class Bugsnag {
      * endpoint.
      *
      * @param  endpoint  the custom endpoint to send notifications to
+     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoint()} instead.
      */
+    @Deprecated
     public static void setEndpoint(final String endpoint) {
         getClient().setEndpoint(endpoint);
     }

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -539,7 +539,7 @@ public class Client {
      * @param value the contents of the diagnostic information
      */
     public void addToTab(String tab, String key, Object value) {
-        config.metaData.addToTab(tab, key, value);
+        config.getMetaData().addToTab(tab, key, value);
     }
 
     /**
@@ -548,7 +548,7 @@ public class Client {
      * @param tabName the dashboard tab to remove diagnostic data from
      */
     public void clearTab(String tabName) {
-        config.metaData.clearTab(tabName);
+        config.getMetaData().clearTab(tabName);
     }
 
     /**
@@ -557,7 +557,7 @@ public class Client {
      * @see MetaData
      */
     public MetaData getMetaData() {
-        return config.metaData;
+        return config.getMetaData();
     }
 
     /**
@@ -566,7 +566,7 @@ public class Client {
      * @see MetaData
      */
     public void setMetaData(MetaData metaData) {
-        config.metaData = metaData;
+        config.setMetaData(metaData);
     }
 
     /**
@@ -682,7 +682,7 @@ public class Client {
     }
 
     private boolean runBeforeNotifyTasks(Error error) {
-        for (BeforeNotify beforeNotify : config.beforeNotifyTasks) {
+        for (BeforeNotify beforeNotify : config.getBeforeNotifyTasks()) {
             try {
                 if (!beforeNotify.run(error)) {
                     return false;

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+
 import java.util.Locale;
 import java.util.Collections;
 import java.util.Map;
@@ -37,7 +38,7 @@ public class Client {
      * @param androidContext an Android context, usually <code>this</code>
      */
     public Client(@NonNull Context androidContext) {
-        this(androidContext, null);
+        this(androidContext, null, true);
     }
 
     /**
@@ -58,31 +59,29 @@ public class Client {
      * @param enableExceptionHandler should we automatically handle uncaught exceptions?
      */
     public Client(@NonNull Context androidContext, @Nullable String apiKey, boolean enableExceptionHandler) {
+        this(androidContext, createNewConfiguration(androidContext, apiKey, enableExceptionHandler));
+    }
 
-        // Get the application context, many things need this
+    /**
+     * Initialize a Bugsnag client
+     *
+     * @param androidContext an Android context, usually <code>this</code>
+     * @param config         a configuration for the Client
+     */
+    public Client(@NonNull Context androidContext, @NonNull Configuration config) {
+
         appContext = androidContext.getApplicationContext();
 
+        this.config = config;
+
         String buildUUID = null;
-
-        // Attempt to load API key from AndroidManifest.xml if not passed in
-        if (TextUtils.isEmpty(apiKey)) {
-            try {
-                ApplicationInfo ai = appContext.getPackageManager().getApplicationInfo(appContext.getPackageName(), PackageManager.GET_META_DATA);
-                apiKey = ai.metaData.getString("com.bugsnag.android.API_KEY");
-                buildUUID = ai.metaData.getString("com.bugsnag.android.BUILD_UUID");
-            } catch (Exception ignore) {
-            }
+        try {
+            ApplicationInfo ai = appContext.getPackageManager().getApplicationInfo(appContext.getPackageName(), PackageManager.GET_META_DATA);
+            buildUUID = ai.metaData.getString("com.bugsnag.android.BUILD_UUID");
+        } catch (Exception ignore) {
         }
-
-        if (apiKey == null) {
-            throw new NullPointerException("You must provide a Bugsnag API key");
-        }
-
-        // Build a configuration object
-        config = new Configuration(apiKey);
-
         if (buildUUID != null) {
-            config.buildUUID = buildUUID;
+            config.setBuildUUID(buildUUID);
         }
 
         // Set up and collect constant app and device diagnostics
@@ -101,12 +100,45 @@ public class Client {
         errorStore = new ErrorStore(config, appContext);
 
         // Install a default exception handler with this client
-        if (enableExceptionHandler) {
+        if (config.getEnableExceptionHandler()) {
             enableExceptionHandler();
         }
 
         // Flush any on-disk errors
         errorStore.flush();
+    }
+
+    /**
+     * Creates a new configuration object based on the provided parameters
+     * will read the API key from the manifest file if it is not provided
+     *
+     * @param androidContext         The context of the application
+     * @param apiKey                 The API key to use
+     * @param enableExceptionHandler should we automatically handle uncaught exceptions?
+     * @return The created config
+     */
+    private static Configuration createNewConfiguration(@NonNull Context androidContext, String apiKey, boolean enableExceptionHandler) {
+        Context appContext = androidContext.getApplicationContext();
+
+        // Attempt to load API key from AndroidManifest.xml if not passed in
+        if (TextUtils.isEmpty(apiKey)) {
+            try {
+                ApplicationInfo ai = appContext.getPackageManager().getApplicationInfo(appContext.getPackageName(), PackageManager.GET_META_DATA);
+                apiKey = ai.metaData.getString("com.bugsnag.android.API_KEY");
+            } catch (Exception ignore) {
+            }
+        }
+
+        if (apiKey == null) {
+            throw new NullPointerException("You must provide a Bugsnag API key");
+        }
+
+        // Build a configuration object
+        Configuration newConfig = new Configuration(apiKey);
+
+        newConfig.setEnableExceptionHandler(enableExceptionHandler);
+
+        return newConfig;
     }
 
     /**
@@ -116,15 +148,16 @@ public class Client {
      * @param appVersion the app version to send
      */
     public void setAppVersion(String appVersion) {
-        config.appVersion = appVersion;
+        config.setAppVersion(appVersion);
     }
 
     /**
      * Gets the context to be sent to Bugsnag.
+     *
      * @return Context
      */
     public String getContext() {
-        return config.context;
+        return config.getContext();
     }
 
     /**
@@ -135,7 +168,7 @@ public class Client {
      * @param context set what was happening at the time of a crash
      */
     public void setContext(String context) {
-        config.context = context;
+        config.setContext(context);
     }
 
     /**
@@ -147,7 +180,7 @@ public class Client {
      * @param endpoint the custom endpoint to send notifications to
      */
     public void setEndpoint(String endpoint) {
-        config.endpoint = endpoint;
+        config.setEndpoint(endpoint);
     }
 
     /**
@@ -159,7 +192,7 @@ public class Client {
      * @param buildUUID the buildUUID.
      */
     public void setBuildUUID(final String buildUUID) {
-        config.buildUUID = buildUUID;
+        config.setBuildUUID(buildUUID);
     }
 
 
@@ -177,7 +210,7 @@ public class Client {
      * @param filters a list of keys to filter from metaData
      */
     public void setFilters(String... filters) {
-        config.filters = filters;
+        config.setFilters(filters);
     }
 
     /**
@@ -190,7 +223,7 @@ public class Client {
      * @param ignoreClasses a list of exception classes to ignore
      */
     public void setIgnoreClasses(String... ignoreClasses) {
-        config.ignoreClasses = ignoreClasses;
+        config.setIgnoreClasses(ignoreClasses);
     }
 
     /**
@@ -205,7 +238,7 @@ public class Client {
      * @see #setReleaseStage
      */
     public void setNotifyReleaseStages(String... notifyReleaseStages) {
-        config.notifyReleaseStages = notifyReleaseStages;
+        config.setNotifyReleaseStages(notifyReleaseStages);
     }
 
     /**
@@ -221,7 +254,7 @@ public class Client {
      * @param projectPackages a list of package names
      */
     public void setProjectPackages(String... projectPackages) {
-        config.projectPackages = projectPackages;
+        config.setProjectPackages(projectPackages);
     }
 
     /**
@@ -233,7 +266,7 @@ public class Client {
      * @see #setNotifyReleaseStages
      */
     public void setReleaseStage(String releaseStage) {
-        config.releaseStage = releaseStage;
+        config.setReleaseStage(releaseStage);
     }
 
     /**
@@ -243,7 +276,7 @@ public class Client {
      * @param sendThreads should we send thread-state with notifications?
      */
     public void setSendThreads(boolean sendThreads) {
-        config.sendThreads = sendThreads;
+        config.setSendThreads(sendThreads);
     }
 
     /**

--- a/src/main/java/com/bugsnag/android/Configuration.java
+++ b/src/main/java/com/bugsnag/android/Configuration.java
@@ -25,8 +25,8 @@ public class Configuration {
     private boolean sendThreads = true;
     private boolean enableExceptionHandler = true;
 
-    protected MetaData metaData = new MetaData();
-    protected final Collection<BeforeNotify> beforeNotifyTasks = new LinkedList<BeforeNotify>();
+    private MetaData metaData = new MetaData();
+    private final Collection<BeforeNotify> beforeNotifyTasks = new LinkedList<BeforeNotify>();
 
     /**
      * Construct a new Bugsnag configuration object
@@ -280,6 +280,33 @@ public class Configuration {
      */
     public void setEnableExceptionHandler(boolean enableExceptionHandler) {
         this.enableExceptionHandler = enableExceptionHandler;
+    }
+
+    /**
+     * Gets any meta data associated with the error
+     *
+     * @return meta data
+     */
+    protected MetaData getMetaData() {
+        return metaData;
+    }
+
+    /**
+     * Sets any meta data associated with the error
+     *
+     * @param metaData meta data
+     */
+    protected void setMetaData(MetaData metaData) {
+        this.metaData = metaData;
+    }
+
+    /**
+     * Gets any before notify tasks to run
+     *
+     * @return the before notify tasks
+     */
+    protected Collection<BeforeNotify> getBeforeNotifyTasks() {
+        return beforeNotifyTasks;
     }
 
     /**

--- a/src/main/java/com/bugsnag/android/Configuration.java
+++ b/src/main/java/com/bugsnag/android/Configuration.java
@@ -9,33 +9,286 @@ import java.util.List;
  * User-specified configuration storage object, contains information
  * specified at the client level, api-key and endpoint configuration.
  */
-class Configuration {
+public class Configuration {
     static final String DEFAULT_ENDPOINT = "https://notify.bugsnag.com";
 
-    final String apiKey;
-    String buildUUID;
-    String appVersion;
-    String context;
-    String endpoint = DEFAULT_ENDPOINT;
-    String[] filters = new String[]{"password"};
-    String[] ignoreClasses;
-    String[] notifyReleaseStages = null;
-    String[] projectPackages;
-    String releaseStage;
-    boolean sendThreads = true;
+    private final String apiKey;
+    private String buildUUID;
+    private String appVersion;
+    private String context;
+    private String endpoint = DEFAULT_ENDPOINT;
+    private String[] filters = new String[]{"password"};
+    private String[] ignoreClasses;
+    private String[] notifyReleaseStages = null;
+    private String[] projectPackages;
+    private String releaseStage;
+    private boolean sendThreads = true;
+    private boolean enableExceptionHandler = true;
 
-    MetaData metaData = new MetaData();
-    final Collection<BeforeNotify> beforeNotifyTasks = new LinkedList<BeforeNotify>();
+    protected MetaData metaData = new MetaData();
+    protected final Collection<BeforeNotify> beforeNotifyTasks = new LinkedList<BeforeNotify>();
 
-    Configuration(String apiKey) {
+    /**
+     * Construct a new Bugsnag configuration object
+     *
+     * @param apiKey The API key to send reports to
+     */
+    public Configuration(String apiKey) {
         this.apiKey = apiKey;
     }
 
-    String getNotifyEndpoint() {
+    /**
+     * Gets the API key to send reports to
+     *
+     * @return API key
+     */
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    /**
+     * Gets the application version sent to Bugsnag.
+     *
+     * @return App Version
+     */
+    public String getAppVersion() {
+        return appVersion;
+    }
+
+    /**
+     * Set the application version sent to Bugsnag. By default we'll pull this
+     * from your AndroidManifest.xml
+     *
+     * @param appVersion the app version to send
+     */
+    public void setAppVersion(String appVersion) {
+        this.appVersion = appVersion;
+    }
+
+    /**
+     * Gets the context to be sent to Bugsnag.
+     *
+     * @return Context
+     */
+    public String getContext() {
+        return context;
+    }
+
+    /**
+     * Set the context sent to Bugsnag. By default we'll attempt to detect the
+     * name of the top-most activity at the time of a notification, and use this
+     * as the context, but sometime this is not possible.
+     *
+     * @param context set what was happening at the time of a crash
+     */
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    /**
+     * Get the endpoint to send data
+     *
+     * @return Endpoint
+     */
+    public String getEndpoint() {
         return endpoint;
     }
 
-    boolean shouldNotifyForReleaseStage(String releaseStage) {
+    /**
+     * Set the endpoint to send data to. By default we'll send reports to
+     * the standard https://notify.bugsnag.com endpoint, but you can override
+     * this if you are using Bugsnag Enterprise to point to your own Bugsnag
+     * endpoint.
+     *
+     * @param endpoint the custom endpoint to send notifications to
+     */
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    /**
+     * Get the buildUUID.
+     *
+     * @return build UUID
+     */
+    public String getBuildUUID() {
+        return buildUUID;
+    }
+
+    /**
+     * Set the buildUUID to your own value. This is used to identify proguard
+     * mapping files in the case that you publish multiple different apps with
+     * the same appId and versionCode. The default value is read from the
+     * com.bugsnag.android.BUILD_UUID meta-data field in your app manifest.
+     *
+     * @param buildUUID the buildUUID.
+     */
+    public void setBuildUUID(String buildUUID) {
+        this.buildUUID = buildUUID;
+    }
+
+    /**
+     * Get which keys should be filtered when sending metaData to Bugsnag
+     *
+     * @return Filters
+     */
+    public String[] getFilters() {
+        return filters;
+    }
+
+    /**
+     * Set which keys should be filtered when sending metaData to Bugsnag.
+     * Use this when you want to ensure sensitive information, such as passwords
+     * or credit card information is stripped from metaData you send to Bugsnag.
+     * Any keys in metaData which contain these strings will be marked as
+     * [FILTERED] when send to Bugsnag.
+     * <p/>
+     * For example:
+     * <p/>
+     * client.setFilters("password", "credit_card");
+     *
+     * @param filters a list of keys to filter from metaData
+     */
+    public void setFilters(String[] filters) {
+        this.filters = filters;
+    }
+
+    /**
+     * Get which exception classes should be ignored (not sent) by Bugsnag.
+     *
+     * @return Ignore classes
+     */
+    public String[] getIgnoreClasses() {
+        return ignoreClasses;
+    }
+
+    /**
+     * Set which exception classes should be ignored (not sent) by Bugsnag.
+     * <p/>
+     * For example:
+     * <p/>
+     * client.setIgnoreClasses("java.lang.RuntimeException");
+     *
+     * @param ignoreClasses a list of exception classes to ignore
+     */
+    public void setIgnoreClasses(String[] ignoreClasses) {
+        this.ignoreClasses = ignoreClasses;
+    }
+
+    /**
+     * Get for which releaseStages errors should be sent to Bugsnag.
+     *
+     * @return Notify release stages
+     */
+    public String[] getNotifyReleaseStages() {
+        return notifyReleaseStages;
+    }
+
+    /**
+     * Set for which releaseStages errors should be sent to Bugsnag.
+     * Use this to stop errors from development builds being sent.
+     * <p/>
+     * For example:
+     * <p/>
+     * client.setNotifyReleaseStages("production");
+     *
+     * @param notifyReleaseStages a list of releaseStages to notify for
+     * @see #setReleaseStage
+     */
+    public void setNotifyReleaseStages(String[] notifyReleaseStages) {
+        this.notifyReleaseStages = notifyReleaseStages;
+    }
+
+    /**
+     * Get which packages should be considered part of your application.
+     *
+     * @return packages
+     */
+    public String[] getProjectPackages() {
+        return projectPackages;
+    }
+
+    /**
+     * Set which packages should be considered part of your application.
+     * Bugsnag uses this to help with error grouping, and stacktrace display.
+     * <p/>
+     * For example:
+     * <p/>
+     * client.setProjectPackages("com.example.myapp");
+     * <p/>
+     * By default, we'll mark the current package name as part of you app.
+     *
+     * @param projectPackages a list of package names
+     */
+    public void setProjectPackages(String[] projectPackages) {
+        this.projectPackages = projectPackages;
+    }
+
+    /**
+     * Get the current "release stage" of your application.
+     *
+     * @return release stage
+     */
+    public String getReleaseStage() {
+        return releaseStage;
+    }
+
+    /**
+     * Set the current "release stage" of your application.
+     * By default, we'll set this to "development" for debug builds and
+     * "production" for non-debug builds.
+     *
+     * @param releaseStage the release stage of the app
+     * @see #setNotifyReleaseStages
+     */
+    public void setReleaseStage(String releaseStage) {
+        this.releaseStage = releaseStage;
+    }
+
+    /**
+     * Get whether to send thread-state with notifications.
+     *
+     * @return send threads
+     */
+    public boolean getSendThreads() {
+        return sendThreads;
+    }
+
+    /**
+     * Set whether to send thread-state with notifications.
+     * By default, this will be true.
+     *
+     * @param sendThreads should we send thread-state with notifications?
+     */
+    public void setSendThreads(boolean sendThreads) {
+        this.sendThreads = sendThreads;
+    }
+
+    /**
+     * Get whether or not Bugsnag should automatically handle uncaught exceptions
+     *
+     * @return should Bugsnag automatically handle uncaught exceptions
+     */
+    public boolean getEnableExceptionHandler() {
+        return enableExceptionHandler;
+    }
+
+    /**
+     * Set whether or not Bugsnag should automatically handle uncaught exceptions
+     *
+     * @param enableExceptionHandler should Bugsnag automatically handle uncaught exceptions
+     */
+    public void setEnableExceptionHandler(boolean enableExceptionHandler) {
+        this.enableExceptionHandler = enableExceptionHandler;
+    }
+
+    /**
+     * Checks if the given release stage should be notified or not
+     *
+     * @param releaseStage the release stage to check
+     * @return true if the release state should be notified else false
+     */
+    protected boolean shouldNotifyForReleaseStage(String releaseStage) {
         if(this.notifyReleaseStages == null)
             return true;
 
@@ -43,7 +296,13 @@ class Configuration {
         return stages.contains(releaseStage);
     }
 
-    boolean shouldIgnoreClass(String className) {
+    /**
+     * Checks if the given exception class should be ignored or not
+     *
+     * @param className the exception class to check
+     * @return true if the exception class should be ignored else false
+     */
+    protected boolean shouldIgnoreClass(String className) {
         if(this.ignoreClasses == null)
             return false;
 
@@ -51,11 +310,22 @@ class Configuration {
         return classes.contains(className);
     }
 
-    void beforeNotify(BeforeNotify beforeNotify) {
+    /**
+     * Adds a new before notify task
+     *
+     * @param beforeNotify the new before notify task
+     */
+    protected void beforeNotify(BeforeNotify beforeNotify) {
         this.beforeNotifyTasks.add(beforeNotify);
     }
 
-    boolean inProject(String className) {
+    /**
+     * Checks if the given class name should be marked as in the project or not
+     *
+     * @param className the class to check
+     * @return true if the class should be considered in the project else false
+     */
+    protected boolean inProject(String className) {
         if(projectPackages != null) {
             for(String packageName : projectPackages) {
                 if(packageName != null && className.startsWith(packageName)) {

--- a/src/main/java/com/bugsnag/android/Error.java
+++ b/src/main/java/com/bugsnag/android/Error.java
@@ -45,7 +45,7 @@ public class Error implements JsonStream.Streamable {
     public void toStream(@NonNull JsonStream writer) throws IOException {
         // Merge error metaData into global metadata and apply filters
         MetaData mergedMetaData = MetaData.merge(config.metaData, metaData);
-        mergedMetaData.setFilters(config.filters);
+        mergedMetaData.setFilters(config.getFilters());
 
         // Write error basics
         writer.beginObject();
@@ -54,9 +54,9 @@ public class Error implements JsonStream.Streamable {
             writer.name("severity").value(severity);
             writer.name("metaData").value(mergedMetaData);
 
-            if(config.projectPackages != null) {
+            if(config.getProjectPackages() != null) {
                 writer.name("projectPackages").beginArray();
-                    for (String projectPackage : config.projectPackages) {
+                    for (String projectPackage : config.getProjectPackages()) {
                         writer.value(projectPackage);
                     }
                 writer.endArray();
@@ -75,7 +75,7 @@ public class Error implements JsonStream.Streamable {
             writer.name("deviceState").value(deviceState);
             writer.name("breadcrumbs").value(breadcrumbs);
             writer.name("groupingHash").value(groupingHash);
-            if(config.sendThreads) {
+            if(config.getSendThreads()) {
                 writer.name("threads").value(new ThreadState(config));
             }
 
@@ -101,8 +101,8 @@ public class Error implements JsonStream.Streamable {
     public String getContext() {
         if(context != null && !TextUtils.isEmpty(context)) {
             return context;
-        } else if (config.context != null) {
-            return config.context;
+        } else if (config.getContext() != null) {
+            return config.getContext();
         } else if (appState != null){
             return AppState.getActiveScreenClass(context);
         } else {

--- a/src/main/java/com/bugsnag/android/Error.java
+++ b/src/main/java/com/bugsnag/android/Error.java
@@ -44,7 +44,7 @@ public class Error implements JsonStream.Streamable {
 
     public void toStream(@NonNull JsonStream writer) throws IOException {
         // Merge error metaData into global metadata and apply filters
-        MetaData mergedMetaData = MetaData.merge(config.metaData, metaData);
+        MetaData mergedMetaData = MetaData.merge(config.getMetaData(), metaData);
         mergedMetaData.setFilters(config.getFilters());
 
         // Write error basics

--- a/src/main/java/com/bugsnag/android/Notification.java
+++ b/src/main/java/com/bugsnag/android/Notification.java
@@ -29,7 +29,7 @@ class Notification implements JsonStream.Streamable {
         writer.beginObject();
 
             // Write the API key
-            writer.name("apiKey").value(config.apiKey);
+            writer.name("apiKey").value(config.getApiKey());
 
             // Write the notifier info
             writer.name("notifier").value(Notifier.getInstance());
@@ -63,7 +63,7 @@ class Notification implements JsonStream.Streamable {
     }
 
     int deliver() throws HttpClient.NetworkException, HttpClient.BadResponseException {
-        HttpClient.post(config.getNotifyEndpoint(), this);
+        HttpClient.post(config.getEndpoint(), this);
         return errors.size() + errorFiles.size();
     }
 }


### PR DESCRIPTION
Currently it is not possible to create a Bugsnag client passing in any additional config. This causes a potential bug related to setting the endpoint and also makes it difficult to add new config settings.

This PR adds a new constructor for the Client which takes a config object, and exposes the Config as public.