### PR TITLE
Leave breadrumb for the current error after notifying

### DIFF
--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -594,9 +594,6 @@ public class Client {
             return;
         }
 
-        // Add a breadcrumb for this error occurring
-        breadcrumbs.add(error.getExceptionName(), BreadcrumbType.ERROR, Collections.singletonMap("message", error.getExceptionMessage()));
-
         // Capture the state of the app and device and attach diagnostics to the error
         error.setAppData(appData);
         error.setDeviceData(deviceData);
@@ -630,6 +627,9 @@ public class Client {
                 }
             });
         }
+
+        // Add a breadcrumb for this error occurring
+        breadcrumbs.add(error.getExceptionName(), BreadcrumbType.ERROR, Collections.singletonMap("message", error.getExceptionMessage()));
     }
 
     void deliver(Notification notification, Error error) {


### PR DESCRIPTION
This avoids having the error showing up twice in the breadcrumbs.

For reference, this is the PHP implementation: https://github.com/bugsnag/bugsnag-php/blob/v3.4.0/src/Client.php#L258-L283.

Maybe I should move this leaveBreadcrumb line above the code that sends the error to be identical to the PHP implementation?