### PR TITLE
Allow customized Throwable serialization

### DIFF
--- a/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/src/main/java/com/bugsnag/android/Exceptions.java
@@ -22,7 +22,11 @@ class Exceptions implements JsonStream.Streamable {
         // Unwrap any "cause" exceptions
         Throwable currentEx = exception;
         while(currentEx != null) {
-            exceptionToStream(writer, getExceptionName(currentEx), currentEx.getLocalizedMessage(), currentEx.getStackTrace());
+            if(currentEx instanceof JsonStream.Streamable) {
+                ((JsonStream.Streamable)currentEx).toStream(writer);
+            } else {
+                exceptionToStream(writer, getExceptionName(currentEx), currentEx.getLocalizedMessage(), currentEx.getStackTrace());
+            }
             currentEx = currentEx.getCause();
         }
 

--- a/src/main/java/com/bugsnag/android/JsonStream.java
+++ b/src/main/java/com/bugsnag/android/JsonStream.java
@@ -7,8 +7,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Writer;
 
-class JsonStream extends JsonWriter {
-    interface Streamable {
+public class JsonStream extends JsonWriter {
+    public interface Streamable {
         void toStream(@NonNull JsonStream stream) throws IOException;
     }
 

--- a/src/main/java/com/bugsnag/android/JsonWriter.java
+++ b/src/main/java/com/bugsnag/android/JsonWriter.java
@@ -120,7 +120,7 @@ import java.util.List;
  * @author Jesse Wilson
  * @since 1.6
  */
-class JsonWriter implements Closeable {
+public class JsonWriter implements Closeable {
 
     /**
     * Lexical scoping elements within a JSON reader or writer.


### PR DESCRIPTION
This changeset allows for customizing the serialization of Throwables within payloads sent to Bugsnag. It allows integrations to attach additional stacktrace information or interact with the `inProject` property of the stacktrace. 