### PR TITLE
Updates to allow Android NDK plugin to work

### DIFF
--- a/src/main/java/com/bugsnag/android/AppData.java
+++ b/src/main/java/com/bugsnag/android/AppData.java
@@ -18,11 +18,11 @@ import java.io.IOException;
 class AppData implements JsonStream.Streamable {
     private final Configuration config;
 
-    private final String packageName;
-    private final String appName;
-    private final Integer versionCode;
-    private final String versionName;
-    private final String guessedReleaseStage;
+    protected final String packageName;
+    protected final String appName;
+    protected final Integer versionCode;
+    protected final String versionName;
+    protected final String guessedReleaseStage;
 
     AppData(@NonNull Context appContext, @NonNull Configuration config) {
         this.config = config;

--- a/src/main/java/com/bugsnag/android/Breadcrumbs.java
+++ b/src/main/java/com/bugsnag/android/Breadcrumbs.java
@@ -64,7 +64,7 @@ class Breadcrumbs implements JsonStream.Streamable {
 
     private static final int DEFAULT_MAX_SIZE = 20;
     private static final int MAX_PAYLOAD_SIZE = 4096;
-    private final Queue<Breadcrumb> store = new ConcurrentLinkedQueue<>();
+    final Queue<Breadcrumb> store = new ConcurrentLinkedQueue<>();
     private int maxSize = DEFAULT_MAX_SIZE;
 
     public void toStream(@NonNull JsonStream writer) throws IOException {

--- a/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -25,7 +25,7 @@ public final class Bugsnag {
      */
     public static Client init(Context androidContext) {
         client = new Client(androidContext);
-        configureClientObservers();
+        NativeInterface.configureClientObservers(client);
         return client;
     }
 
@@ -37,7 +37,7 @@ public final class Bugsnag {
      */
     public static Client init(Context androidContext, String apiKey) {
         client = new Client(androidContext, apiKey);
-        configureClientObservers();
+        NativeInterface.configureClientObservers(client);
         return client;
     }
 
@@ -50,7 +50,7 @@ public final class Bugsnag {
      */
     public static Client init(Context androidContext, String apiKey, boolean enableExceptionHandler) {
         client = new Client(androidContext, apiKey, enableExceptionHandler);
-        configureClientObservers();
+        NativeInterface.configureClientObservers(client);
         return client;
     }
 
@@ -62,30 +62,8 @@ public final class Bugsnag {
      */
     public static Client init(Context androidContext, Configuration config) {
         client = new Client(androidContext, config);
-        configureClientObservers();
+        NativeInterface.configureClientObservers(client);
         return client;
-    }
-
-    private static void configureClientObservers() {
-
-        // Ensure that the bugsnag observer is registered
-        // Should only happen if the NDK library is present
-        try {
-            String className = "com.bugsnag.android.ndk.BugsnagObserver";
-            Class c = Class.forName(className);
-            Observer o = (Observer)c.newInstance();
-            client.addObserver(o);
-        } catch (ClassNotFoundException e) {
-            // ignore this one, will happen if the NDK plugin is not present
-            Logger.warn("Failed to find NDK observer");
-        } catch (InstantiationException e) {
-            Logger.warn("Failed to instantiate NDK observer", e);
-        } catch (IllegalAccessException e) {
-            Logger.warn("Could not access NDK observer", e);
-        }
-
-        // Should make NDK components configure
-        client.notifyBugsnagObservers(NotifyType.ALL);
     }
 
     /**

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -11,6 +11,7 @@ import android.text.TextUtils;
 import java.util.Locale;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Observable;
 
 /**
  * A Bugsnag Client instance allows you to use Bugsnag in your Android app.
@@ -23,20 +24,22 @@ import java.util.Map;
  *
  * @see Bugsnag
  */
-public class Client {
+public class Client extends Observable {
+
+
     private static final boolean BLOCKING = true;
     private static final String SHARED_PREF_KEY = "com.bugsnag.android";
     private static final String USER_ID_KEY = "user.id";
     private static final String USER_NAME_KEY = "user.name";
     private static final String USER_EMAIL_KEY = "user.email";
 
-    private final Configuration config;
+    protected final Configuration config;
     private final Context appContext;
-    private final AppData appData;
-    private final DeviceData deviceData;
-    private final Breadcrumbs breadcrumbs;
-    private final User user = new User();
-    private final ErrorStore errorStore;
+    protected final AppData appData;
+    protected final DeviceData deviceData;
+    final Breadcrumbs breadcrumbs;
+    protected final User user = new User();
+    protected final ErrorStore errorStore;
 
     /**
      * Initialize a Bugsnag client
@@ -121,6 +124,11 @@ public class Client {
 
         // Flush any on-disk errors
         errorStore.flush();
+    }
+
+    public void notifyBugsnagObservers(NotifyType type) {
+        setChanged();
+        super.notifyObservers(type.getValue());
     }
 
     /**
@@ -326,6 +334,7 @@ public class Client {
             .remove(USER_EMAIL_KEY)
             .remove(USER_NAME_KEY)
             .commit();
+        notifyBugsnagObservers(NotifyType.USER);
     }
 
     /**
@@ -336,10 +345,24 @@ public class Client {
      * @param id a unique identifier of the current user
      */
     public void setUserId(String id) {
+        setUserId(id, true);
+    }
+
+    /**
+     * Sets the user ID with the option to not notify any NDK components of the change
+     *
+     * @param id a unique identifier of the current user
+     * @param notify whether or not to notify NDK components
+     */
+    void setUserId(String id, boolean notify) {
         user.setId(id);
 
         if (config.getPersistUserBetweenSessions()) {
             storeInSharedPrefs(USER_ID_KEY, id);
+        }
+
+        if (notify) {
+            notifyBugsnagObservers(NotifyType.USER);
         }
     }
 
@@ -350,10 +373,24 @@ public class Client {
      * @param email the email address of the current user
      */
     public void setUserEmail(String email) {
+        setUserEmail(email, true);
+    }
+
+    /**
+     * Sets the user email with the option to not notify any NDK components of the change
+     *
+     * @param email the email address of the current user
+     * @param notify whether or not to notify NDK components
+     */
+    void setUserEmail(String email, boolean notify) {
         user.setEmail(email);
 
         if (config.getPersistUserBetweenSessions()) {
             storeInSharedPrefs(USER_EMAIL_KEY, email);
+        }
+
+        if (notify) {
+            notifyBugsnagObservers(NotifyType.USER);
         }
     }
 
@@ -364,10 +401,24 @@ public class Client {
      * @param name the name of the current user
      */
     public void setUserName(String name) {
+        setUserName(name, true);
+    }
+
+    /**
+     * Sets the user name with the option to not notify any NDK components of the change
+     *
+     * @param name the name of the current user
+     * @param notify whether or not to notify NDK components
+     */
+    void setUserName(String name, boolean notify) {
         user.setName(name);
 
         if (config.getPersistUserBetweenSessions()) {
             storeInSharedPrefs(USER_NAME_KEY, name);
+        }
+
+        if (notify) {
+            notifyBugsnagObservers(NotifyType.USER);
         }
     }
 
@@ -444,7 +495,6 @@ public class Client {
      *
      * @param name       the error name or class
      * @param message    the error message
-     * @param context    the error context
      * @param stacktrace the stackframes associated with the error
      * @param callback   callback invoked on the generated error report for
      *                   additional modification
@@ -459,7 +509,6 @@ public class Client {
      *
      * @param name       the error name or class
      * @param message    the error message
-     * @param context    the error context
      * @param stacktrace the stackframes associated with the error
      * @param callback   callback invoked on the generated error report for
      *                   additional modification
@@ -547,10 +596,22 @@ public class Client {
      */
     public void leaveBreadcrumb(String breadcrumb) {
         breadcrumbs.add(breadcrumb);
+        notifyBugsnagObservers(NotifyType.BREADCRUMB);
     }
 
     public void leaveBreadcrumb(String name, BreadcrumbType type, Map<String, String> metadata) {
+        leaveBreadcrumb(name, type, metadata, true);
+    }
+
+    void leaveBreadcrumb(String name,
+                         BreadcrumbType type,
+                         Map<String, String> metadata,
+                         boolean notify) {
         breadcrumbs.add(name, type, metadata);
+
+        if (notify) {
+            notifyBugsnagObservers(NotifyType.BREADCRUMB);
+        }
     }
 
     /**
@@ -569,6 +630,7 @@ public class Client {
      */
     public void clearBreadcrumbs() {
         breadcrumbs.clear();
+        notifyBugsnagObservers(NotifyType.BREADCRUMB);
     }
 
     /**

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -12,6 +12,7 @@ import java.util.Locale;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Observable;
+import java.util.Observer;
 
 /**
  * A Bugsnag Client instance allows you to use Bugsnag in your Android app.
@@ -24,7 +25,7 @@ import java.util.Observable;
  *
  * @see Bugsnag
  */
-public class Client extends Observable {
+public class Client extends Observable implements Observer {
 
 
     private static final boolean BLOCKING = true;
@@ -122,6 +123,8 @@ public class Client extends Observable {
             enableExceptionHandler();
         }
 
+        config.addObserver(this);
+
         // Flush any on-disk errors
         errorStore.flush();
     }
@@ -129,6 +132,17 @@ public class Client extends Observable {
     public void notifyBugsnagObservers(NotifyType type) {
         setChanged();
         super.notifyObservers(type.getValue());
+    }
+
+    @Override
+    public void update(Observable o, Object arg) {
+        if (arg instanceof Integer) {
+            NotifyType type = NotifyType.fromInt((Integer) arg);
+
+            if (type != null) {
+                notifyBugsnagObservers(type);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/bugsnag/android/Configuration.java
+++ b/src/main/java/com/bugsnag/android/Configuration.java
@@ -27,6 +27,7 @@ public class Configuration {
     private boolean sendThreads = true;
     private boolean enableExceptionHandler = true;
     private boolean persistUserBetweenSessions = false;
+    String defaultExceptionType = "android";
 
     private MetaData metaData = new MetaData();
     private final Collection<BeforeNotify> beforeNotifyTasks = new LinkedList<BeforeNotify>();
@@ -66,6 +67,7 @@ public class Configuration {
      */
     public void setAppVersion(String appVersion) {
         this.appVersion = appVersion;
+        notifyObservers(NotifyType.APP);
     }
 
     /**
@@ -86,6 +88,7 @@ public class Configuration {
      */
     public void setContext(String context) {
         this.context = context;
+        notifyObservers(NotifyType.CONTEXT);
     }
 
     /**
@@ -128,6 +131,7 @@ public class Configuration {
      */
     public void setBuildUUID(String buildUUID) {
         this.buildUUID = buildUUID;
+        notifyObservers(NotifyType.APP);
     }
 
     /**
@@ -154,6 +158,7 @@ public class Configuration {
      */
     public void setFilters(String[] filters) {
         this.filters = filters;
+        this.metaData.setFilters(filters);
     }
 
     /**
@@ -200,6 +205,7 @@ public class Configuration {
      */
     public void setNotifyReleaseStages(String[] notifyReleaseStages) {
         this.notifyReleaseStages = notifyReleaseStages;
+        notifyObservers(NotifyType.RELEASE_STAGES);
     }
 
     /**
@@ -246,6 +252,7 @@ public class Configuration {
      */
     public void setReleaseStage(String releaseStage) {
         this.releaseStage = releaseStage;
+        notifyObservers(NotifyType.APP);
     }
 
     /**
@@ -301,6 +308,7 @@ public class Configuration {
      */
     protected void setMetaData(MetaData metaData) {
         this.metaData = metaData;
+        notifyObservers(NotifyType.META);
     }
 
     /**
@@ -386,4 +394,11 @@ public class Configuration {
 
         return false;
     }
+
+    private void notifyObservers(NotifyType type) {
+        if (Bugsnag.client != null) {
+            Bugsnag.getClient().notifyBugsnagObservers(type);
+        }
+    }
+
 }

--- a/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/src/main/java/com/bugsnag/android/DeviceData.java
@@ -24,14 +24,14 @@ import java.util.Locale;
  */
 class DeviceData implements JsonStream.Streamable {
 
-    private final Float screenDensity;
-    private final Integer dpi;
-    private final String screenResolution;
-    private final Long totalMemory;
-    private final Boolean rooted;
-    private final String locale;
-    private final String id;
-    private final String[] cpuAbi;
+    protected final Float screenDensity;
+    protected final Integer dpi;
+    protected final String screenResolution;
+    protected final Long totalMemory;
+    protected final Boolean rooted;
+    protected final String locale;
+    protected final String id;
+    protected final String[] cpuAbi;
 
     DeviceData(@NonNull Context appContext) {
         screenDensity = getScreenDensity(appContext);

--- a/src/main/java/com/bugsnag/android/Error.java
+++ b/src/main/java/com/bugsnag/android/Error.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 public class Error implements JsonStream.Streamable {
     private static final String PAYLOAD_VERSION = "3";
 
-    private final Configuration config;
+    final Configuration config;
     private AppData appData;
     private DeviceData deviceData;
     private AppState appState;
@@ -45,7 +45,6 @@ public class Error implements JsonStream.Streamable {
     public void toStream(@NonNull JsonStream writer) throws IOException {
         // Merge error metaData into global metadata and apply filters
         MetaData mergedMetaData = MetaData.merge(config.getMetaData(), metaData);
-        mergedMetaData.setFilters(config.getFilters());
 
         // Write error basics
         writer.beginObject();

--- a/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/src/main/java/com/bugsnag/android/Exceptions.java
@@ -49,6 +49,7 @@ class Exceptions implements JsonStream.Streamable {
         writer.beginObject();
             writer.name("errorClass").value(name);
             writer.name("message").value(message);
+            writer.name("type").value(config.defaultExceptionType);
             writer.name("stacktrace").value(stacktrace);
         writer.endObject();
     }

--- a/src/main/java/com/bugsnag/android/MetaData.java
+++ b/src/main/java/com/bugsnag/android/MetaData.java
@@ -83,7 +83,7 @@ public class MetaData implements JsonStream.Streamable {
             tab.remove(key);
         }
 
-        if (notify) {
+        if (notify && Bugsnag.client != null) {
             Bugsnag.getClient().notifyBugsnagObservers(NotifyType.META);
         }
     }
@@ -95,7 +95,10 @@ public class MetaData implements JsonStream.Streamable {
      */
     public void clearTab(String tabName) {
         store.remove(tabName);
-        Bugsnag.getClient().notifyBugsnagObservers(NotifyType.META);
+
+        if (Bugsnag.client != null) {
+            Bugsnag.getClient().notifyBugsnagObservers(NotifyType.META);
+        }
     }
 
     Map<String, Object> getTab(String tabName) {
@@ -111,7 +114,10 @@ public class MetaData implements JsonStream.Streamable {
 
     void setFilters(String... filters) {
         this.filters = filters;
-        Bugsnag.getClient().notifyBugsnagObservers(NotifyType.FILTERS);
+
+        if (Bugsnag.client != null) {
+            Bugsnag.getClient().notifyBugsnagObservers(NotifyType.FILTERS);
+        }
     }
 
     static MetaData merge(MetaData... metaDataList) {

--- a/src/main/java/com/bugsnag/android/MetaData.java
+++ b/src/main/java/com/bugsnag/android/MetaData.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Observable;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -20,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * Diagnostic information is presented on your Bugsnag dashboard in tabs.
  */
-public class MetaData implements JsonStream.Streamable {
+public class MetaData extends Observable implements JsonStream.Streamable {
     private static final String FILTERED_PLACEHOLDER = "[FILTERED]";
     private static final String OBJECT_PLACEHOLDER = "[OBJECT]";
 
@@ -83,9 +84,7 @@ public class MetaData implements JsonStream.Streamable {
             tab.remove(key);
         }
 
-        if (notify && Bugsnag.client != null) {
-            Bugsnag.getClient().notifyBugsnagObservers(NotifyType.META);
-        }
+        notifyBugsnagObservers(NotifyType.META);
     }
 
     /**
@@ -96,9 +95,7 @@ public class MetaData implements JsonStream.Streamable {
     public void clearTab(String tabName) {
         store.remove(tabName);
 
-        if (Bugsnag.client != null) {
-            Bugsnag.getClient().notifyBugsnagObservers(NotifyType.META);
-        }
+        notifyBugsnagObservers(NotifyType.META);
     }
 
     Map<String, Object> getTab(String tabName) {
@@ -115,9 +112,7 @@ public class MetaData implements JsonStream.Streamable {
     void setFilters(String... filters) {
         this.filters = filters;
 
-        if (Bugsnag.client != null) {
-            Bugsnag.getClient().notifyBugsnagObservers(NotifyType.FILTERS);
-        }
+        notifyBugsnagObservers(NotifyType.FILTERS);
     }
 
     static MetaData merge(MetaData... metaDataList) {
@@ -228,5 +223,10 @@ public class MetaData implements JsonStream.Streamable {
         }
 
         return false;
+    }
+
+    private void notifyBugsnagObservers(NotifyType type) {
+        setChanged();
+        super.notifyObservers(type.getValue());
     }
 }

--- a/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -1,0 +1,184 @@
+package com.bugsnag.android;
+
+import java.sql.BatchUpdateException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Used as the entry point for native code to allow proguard to obfuscate other areas if needed
+ */
+class NativeInterface {
+
+    public static String getContext() {
+        return Bugsnag.getClient().getContext();
+    }
+
+    public static String getErrorStorePath() {
+        return Bugsnag.getClient().errorStore.path;
+    }
+
+    public static String getUserId() {
+        return Bugsnag.getClient().user.getId();
+    }
+
+    public static String getUserEmail() {
+        return Bugsnag.getClient().user.getEmail();
+    }
+
+    public static String getUserName() {
+        return Bugsnag.getClient().user.getName();
+    }
+
+    public static String getPackageName() {
+        return Bugsnag.getClient().appData.packageName;
+    }
+
+    public static String getAppName() {
+        return Bugsnag.getClient().appData.appName;
+    }
+
+    public static String getVersionName() {
+        return Bugsnag.getClient().appData.versionName;
+    }
+
+    public static int getVersionCode() {
+        return Bugsnag.getClient().appData.versionCode;
+    }
+
+    public static String getBuildUUID() {
+        return Bugsnag.getClient().config.getBuildUUID();
+    }
+
+    public static String getAppVersion() {
+        return Bugsnag.getClient().appData.getAppVersion();
+    }
+
+    public static String getReleaseStage() {
+        return Bugsnag.getClient().appData.getReleaseStage();
+    }
+
+    public static String getDeviceId() {
+        return Bugsnag.getClient().deviceData.id;
+    }
+
+    public static String getDeviceLocale() {
+        return Bugsnag.getClient().deviceData.locale;
+    }
+
+    public static double getDeviceTotalMemory() {
+        return Bugsnag.getClient().deviceData.totalMemory;
+    }
+
+    public static Boolean getDeviceRooted() {
+        return Bugsnag.getClient().deviceData.rooted;
+    }
+
+    public static float getDeviceScreenDensity() {
+        return Bugsnag.getClient().deviceData.screenDensity;
+    }
+
+    public static int getDeviceDpi() {
+        return Bugsnag.getClient().deviceData.dpi;
+    }
+
+    public static String getDeviceScreenResolution() {
+        return Bugsnag.getClient().deviceData.screenResolution;
+    }
+
+    public static String getDeviceManufacturer() {
+        return android.os.Build.MANUFACTURER;
+    }
+
+    public static String getDeviceBrand() {
+        return android.os.Build.BRAND;
+    }
+
+    public static String getDeviceModel() {
+        return android.os.Build.MODEL;
+    }
+
+    public static String getDeviceOsVersion() {
+        return android.os.Build.VERSION.RELEASE;
+    }
+
+    public static String getDeviceOsBuild() {
+        return android.os.Build.DISPLAY;
+    }
+
+    public static int getDeviceApiLevel() {
+        return android.os.Build.VERSION.SDK_INT;
+    }
+
+    public static String[] getDeviceCpuAbi() {
+        return Bugsnag.getClient().deviceData.cpuAbi;
+    }
+
+
+    public static Map<String, Object> getMetaData() {
+        return Bugsnag.getClient().getMetaData().store;
+    }
+
+    public static Object[] getBreadcrumbs() {
+        return Bugsnag.getClient().breadcrumbs.store.toArray();
+    }
+
+    public static String[] getFilters() {
+        return Bugsnag.getClient().config.getFilters();
+    }
+
+    public static String[] getReleaseStages() {
+        return Bugsnag.getClient().config.getNotifyReleaseStages();
+    }
+
+    public static void setUser(final String id,
+                               final String email,
+                               final String name) {
+
+        Bugsnag.getClient().setUserId(id, false);
+        Bugsnag.getClient().setUserEmail(email, false);
+        Bugsnag.getClient().setUserName(name, false);
+    }
+
+    public static void leaveBreadcrumb(final String name,
+                                       final BreadcrumbType type) {
+
+        Bugsnag.getClient().leaveBreadcrumb(name, type, new HashMap<String, String>(), false);
+    }
+
+    public static void addToTab(final String tab,
+                                final String key,
+                                final Object value) {
+
+        Bugsnag.getClient().config.getMetaData().addToTab(tab, key, value, false);
+    }
+
+    public static void notify(final String name,
+                              final String message,
+                              final Severity severity,
+                              final StackTraceElement[] stacktrace,
+                              final Map<String, Object> metaData) {
+
+        Bugsnag.getClient().notify(name, message, stacktrace, new Callback() {
+            @Override
+            public void beforeNotify(Report report) {
+                report.getError().setSeverity(severity);
+                report.getError().config.defaultExceptionType = "c";
+
+                for (String tab : metaData.keySet()) {
+
+                    Object value = metaData.get(tab);
+
+                    if (value instanceof Map) {
+                        Map map = (Map)value;
+
+                        for (Object key : map.keySet()) {
+                            report.getError().getMetaData().addToTab(tab, key.toString(), map.get(key));
+                        }
+                    } else {
+                        report.getError().getMetaData().addToTab("custom", tab, value);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/bugsnag/android/NotifyType.java
+++ b/src/main/java/com/bugsnag/android/NotifyType.java
@@ -1,0 +1,37 @@
+package com.bugsnag.android;
+
+/**
+ * Used to inform the NDK library which type of data needs to be updated
+ */
+public enum NotifyType {
+    ALL(1),
+    USER(2),
+    APP(3),
+    DEVICE(4),
+    CONTEXT(5),
+    RELEASE_STAGES(6),
+    FILTERS(7),
+    BREADCRUMB(8),
+    META(9);
+
+    private Integer intValue;
+
+    NotifyType(Integer intValue) {
+        this.intValue = intValue;
+    }
+
+    public Integer getValue() {
+        return intValue;
+    }
+
+    public static NotifyType fromInt(Integer intValue) {
+        if (intValue != null) {
+            for (NotifyType type : NotifyType.values()) {
+                if (intValue.equals(type.getValue())) {
+                    return type;
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
We are working towards allowing notifies from Android NDK. This will be done using a separate library that depends on the bugsnag-android library.

This PR adds ways for the new NDK library to read and write data from this library:
 - Adds a `NativeInterface` class, which is used as the main access point for JNI
 - Makes the client class `Observable`, and raises `notifyObservers()` when data gets changed