### PR TITLE
Cache unhandled exceptions prior to delivery

### DIFF
--- a/src/main/java/com/bugsnag/android/ExceptionHandler.java
+++ b/src/main/java/com/bugsnag/android/ExceptionHandler.java
@@ -48,7 +48,7 @@ class ExceptionHandler implements UncaughtExceptionHandler {
     public void uncaughtException(Thread t, Throwable e) {
         // Notify any subscribed clients of the uncaught exception
         for(Client client : clientMap.keySet()) {
-            client.notifyBlocking(e, Severity.ERROR);
+            client.cacheAndNotify(e, Severity.ERROR);
         }
 
         // Pass exception on to original exception handler


### PR DESCRIPTION
Previously, unhandled exceptions were sent immediately to the server,
blocking the current thread. In the case that the blocked thread was the
main thread, this caused an exception and prevented the report from
being sent or cached after the fact because the app would then terminate.

This change introduces a third delivery style (in addition to blocking
and non-blocking) which writes the report to the error cache and then
delivers asynchronously (`ASYNC_WITH_CACHE`).

Fixes #138