### PR TITLE
Try to avoid using Settings.Secure.Android_ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,11 @@ android {
 }
 
 dependencies {
+    repositories {
+        jcenter()
+    }
     compile "com.android.support:support-annotations:25.1.1"
+    androidTestCompile "junit:junit:4.12"
 }
 
 // Disable doclint:

--- a/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -9,7 +9,9 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
 
 public class DeviceDataTest extends BugsnagTestCase {
     public void testSaneValues() throws JSONException, IOException {
@@ -44,6 +46,6 @@ public class DeviceDataTest extends BugsnagTestCase {
         assertEquals(id1, deviceIdSource.getId());
 
         // Instrumentation test should never enter legacy mode
-        assertNotEquals(Settings.Secure.getString(getContext().getContentResolver(), Settings.Secure.ANDROID_ID), deviceIdSource);
+        assertThat(Settings.Secure.getString(getContext().getContentResolver(), Settings.Secure.ANDROID_ID), not(equalTo(deviceIdSource.getId())));
     }
 }

--- a/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -1,11 +1,15 @@
 package com.bugsnag.android;
 
+import android.annotation.SuppressLint;
+import android.provider.Settings;
 import android.util.DisplayMetrics;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+
+import static org.junit.Assert.assertNotEquals;
 
 public class DeviceDataTest extends BugsnagTestCase {
     public void testSaneValues() throws JSONException, IOException {
@@ -30,5 +34,16 @@ public class DeviceDataTest extends BugsnagTestCase {
             // Emulators returned null for android id before android 2.2
             assertNotNull(deviceDataJson.getString("id"));
         }
+    }
+
+    @SuppressLint("HardwareIds")
+    public void testDeviceIdSource() {
+        DeviceIdSource deviceIdSource = new DeviceIdSource(getContext());
+        final String id1 = deviceIdSource.getId();
+        assertNotNull(id1);
+        assertEquals(id1, deviceIdSource.getId());
+
+        // Instrumentation test should never enter legacy mode
+        assertNotEquals(Settings.Secure.getString(getContext().getContentResolver(), Settings.Secure.ANDROID_ID), deviceIdSource);
     }
 }

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -8,8 +8,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
-import java.util.Locale;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
@@ -35,10 +35,11 @@ public class Client extends Observable implements Observer {
 
 
     private static final boolean BLOCKING = true;
-    private static final String SHARED_PREF_KEY = "com.bugsnag.android";
+    static final String SHARED_PREF_KEY = "com.bugsnag.android";
     private static final String USER_ID_KEY = "user.id";
     private static final String USER_NAME_KEY = "user.name";
     private static final String USER_EMAIL_KEY = "user.email";
+    static final String DEVICE_TOKEN_KEY = "device.token";
 
     protected final Configuration config;
     private final Context appContext;

--- a/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/src/main/java/com/bugsnag/android/DeviceData.java
@@ -1,18 +1,15 @@
 package com.bugsnag.android;
 
 import android.annotation.TargetApi;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Resources;
 import android.os.Build;
-import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Locale;
 
 /**
@@ -40,7 +37,7 @@ class DeviceData implements JsonStream.Streamable {
         totalMemory = getTotalMemory();
         rooted = isRooted();
         locale = getLocale();
-        id = getAndroidId(appContext);
+        id = new DeviceIdSource(appContext).getId();
         cpuAbi = getCpuAbi();
     }
 
@@ -164,15 +161,6 @@ class DeviceData implements JsonStream.Streamable {
     @NonNull
     private static String getLocale() {
         return Locale.getDefault().toString();
-    }
-
-    /**
-     * Get the unique device id for the current Android device
-     */
-    @NonNull
-    private static String getAndroidId(Context appContext) {
-        ContentResolver cr = appContext.getContentResolver();
-        return Settings.Secure.getString(cr, Settings.Secure.ANDROID_ID);
     }
 
     /**

--- a/src/main/java/com/bugsnag/android/DeviceIdSource.java
+++ b/src/main/java/com/bugsnag/android/DeviceIdSource.java
@@ -1,0 +1,58 @@
+package com.bugsnag.android;
+
+
+import android.annotation.SuppressLint;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.provider.Settings;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.UUID;
+
+class DeviceIdSource {
+    private final Context context;
+    private final SharedPreferences preferences;
+
+    DeviceIdSource(@NonNull Context context) {
+        this.context = context;
+        preferences = context.getSharedPreferences(Client.SHARED_PREF_KEY, Context.MODE_PRIVATE);
+    }
+
+    @NonNull
+    public String getId() {
+        String currentId = preferences.getString(Client.DEVICE_TOKEN_KEY, null);
+        if (currentId == null) {
+            if (isLegacyInstall()) currentId = getLegacyId();
+            if (currentId == null) currentId = UUID.randomUUID().toString();
+
+            final SharedPreferences.Editor editor = preferences.edit().putString(Client.DEVICE_TOKEN_KEY, currentId);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) editor.apply();
+            else editor.commit();
+        }
+        return currentId;
+    }
+
+    private boolean isLegacyInstall() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) return false;
+        try {
+            final PackageInfo info = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+            return info.firstInstallTime != info.lastUpdateTime;
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    @SuppressLint("HardwareIds")
+    @Nullable
+    private String getLegacyId() {
+        ContentResolver cr = context.getContentResolver();
+        return Settings.Secure.getString(cr, Settings.Secure.ANDROID_ID);
+    }
+}
+


### PR DESCRIPTION
Closes #83.

In some time one could think removing the legacy mode as I doubt there is merit tieing bug reports toegether that are month apart and at that point the Android_ID is stored in preferences and wouldn't need to be accessed directly anymore (making "security" review tools happy that `Settings.Secure.Android_ID` is not accessed).

Testing lacks a bit, maybe at some point the library could be refactored and moved away from instrumentation tests...