### PR TITLE
Replace android ID with per-install random UUID

### DIFF
--- a/src/androidTest/java/com/bugsnag/android/BugsnagTestCase.java
+++ b/src/androidTest/java/com/bugsnag/android/BugsnagTestCase.java
@@ -7,6 +7,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.test.AndroidTestCase;
 
 public class BugsnagTestCase extends AndroidTestCase {
@@ -24,5 +26,9 @@ public class BugsnagTestCase extends AndroidTestCase {
 
     protected JSONArray streamableToJsonArray(JsonStream.Streamable streamable) throws JSONException, IOException  {
         return new JSONArray(streamableToString(streamable));
+    }
+
+    protected SharedPreferences getSharedPrefs() {
+        return getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
     }
 }

--- a/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -10,7 +10,7 @@ public class ClientTest extends BugsnagTestCase {
         super.setUp();
 
         // Make sure no user is stored
-        SharedPreferences sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        SharedPreferences sharedPref = getSharedPrefs();
         sharedPref.edit()
             .remove("user.id")
             .remove("user.email")
@@ -45,7 +45,7 @@ public class ClientTest extends BugsnagTestCase {
     public void testRestoreUserFromPrefs() {
 
         // Set a user in prefs
-        SharedPreferences sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        SharedPreferences sharedPref = getSharedPrefs();
         sharedPref.edit()
             .putString("user.id", "123456")
             .putString("user.email", "mr.test@email.com")
@@ -83,7 +83,7 @@ public class ClientTest extends BugsnagTestCase {
         client.setUser("123456", "mr.test@email.com", "Mr Test");
 
         // Check that the user was store in prefs
-        SharedPreferences sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        SharedPreferences sharedPref = getSharedPrefs();
         assertEquals("123456", sharedPref.getString("user.id", null));
         assertEquals("mr.test@email.com", sharedPref.getString("user.email", null));
         assertEquals("Mr Test", sharedPref.getString("user.name", null));
@@ -96,7 +96,7 @@ public class ClientTest extends BugsnagTestCase {
         client.setUser("123456", "mr.test@email.com", "Mr Test");
 
         // Check that the user was not stored in prefs
-        SharedPreferences sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        SharedPreferences sharedPref = getSharedPrefs();
         assertFalse(sharedPref.contains("user.id"));
         assertFalse(sharedPref.contains("user.email"));
         assertFalse(sharedPref.contains("user.name"));
@@ -105,7 +105,7 @@ public class ClientTest extends BugsnagTestCase {
     public void testClearUser() {
 
         // Set a user in prefs
-        SharedPreferences sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        SharedPreferences sharedPref = getSharedPrefs();
         sharedPref.edit()
             .putString("user.id", "123456")
             .putString("user.email", "mr.test@email.com")
@@ -117,7 +117,7 @@ public class ClientTest extends BugsnagTestCase {
         client.clearUser();
 
         // Check that there is no user information in the prefs anymore
-        sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        sharedPref = getSharedPrefs();
         assertFalse(sharedPref.contains("user.id"));
         assertFalse(sharedPref.contains("user.email"));
         assertFalse(sharedPref.contains("user.name"));
@@ -128,7 +128,7 @@ public class ClientTest extends BugsnagTestCase {
         super.tearDown();
 
         // Make sure no user is stored
-        SharedPreferences sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        SharedPreferences sharedPref = getSharedPrefs();
         sharedPref.edit()
             .remove("user.id")
             .remove("user.email")

--- a/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -15,7 +15,7 @@ public class DeviceDataTest extends BugsnagTestCase {
 
     public void testSaneValues() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
-        SharedPreferences sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        SharedPreferences sharedPref = getSharedPrefs();
         DeviceData deviceData = new DeviceData(getContext(), sharedPref);
         JSONObject deviceDataJson = streamableToJson(deviceData);
 
@@ -36,6 +36,7 @@ public class DeviceDataTest extends BugsnagTestCase {
             // Emulators returned null for android id before android 2.2
             assertNotNull(deviceDataJson.getString("id"));
 
+            // historically Android ID was used, this should no longer be the case
             ContentResolver cr = getContext().getContentResolver();
             String androidId = Settings.Secure.getString(cr, Settings.Secure.ANDROID_ID);
             assertNotSame(androidId, deviceDataJson.getString("id"));

--- a/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import android.content.ContentResolver;
+import android.provider.Settings;
 import android.util.DisplayMetrics;
 
 import org.json.JSONException;
@@ -8,6 +10,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 
 public class DeviceDataTest extends BugsnagTestCase {
+
     public void testSaneValues() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
         DeviceData deviceData = new DeviceData(getContext());
@@ -29,6 +32,11 @@ public class DeviceDataTest extends BugsnagTestCase {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.FROYO) {
             // Emulators returned null for android id before android 2.2
             assertNotNull(deviceDataJson.getString("id"));
+
+            ContentResolver cr = getContext().getContentResolver();
+            String androidId = Settings.Secure.getString(cr, Settings.Secure.ANDROID_ID);
+            assertNotSame(androidId, deviceDataJson.getString("id"));
         }
+
     }
 }

--- a/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -1,6 +1,8 @@
 package com.bugsnag.android;
 
 import android.content.ContentResolver;
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
 
@@ -13,7 +15,8 @@ public class DeviceDataTest extends BugsnagTestCase {
 
     public void testSaneValues() throws JSONException, IOException {
         Configuration config = new Configuration("some-api-key");
-        DeviceData deviceData = new DeviceData(getContext());
+        SharedPreferences sharedPref = getContext().getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
+        DeviceData deviceData = new DeviceData(getContext(), sharedPref);
         JSONObject deviceDataJson = streamableToJson(deviceData);
 
         assertEquals("android", deviceDataJson.getString("osName"));

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.UUID;
 
 enum DeliveryStyle {
     SAME_THREAD,
@@ -101,8 +102,10 @@ public class Client extends Observable implements Observer {
         }
 
         // Set up and collect constant app and device diagnostics
+        SharedPreferences sharedPref = appContext.getSharedPreferences(SHARED_PREF_KEY, Context.MODE_PRIVATE);
+
         appData = new AppData(appContext, config);
-        deviceData = new DeviceData(appContext);
+        deviceData = new DeviceData(appContext, sharedPref);
         AppState.init();
 
         // Set up breadcrumbs
@@ -113,7 +116,6 @@ public class Client extends Observable implements Observer {
 
         if (config.getPersistUserBetweenSessions()) {
             // Check to see if a user was stored in the SharedPreferences
-            SharedPreferences sharedPref = appContext.getSharedPreferences(SHARED_PREF_KEY, Context.MODE_PRIVATE);
             user.setId(sharedPref.getString(USER_ID_KEY, deviceData.getUserId()));
             user.setName(sharedPref.getString(USER_NAME_KEY, null));
             user.setEmail(sharedPref.getString(USER_EMAIL_KEY, null));

--- a/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/src/main/java/com/bugsnag/android/DeviceData.java
@@ -1,19 +1,17 @@
 package com.bugsnag.android;
 
 import android.annotation.TargetApi;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Resources;
 import android.os.Build;
-import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Locale;
+import java.util.UUID;
 
 /**
  * Information about the current Android device which doesn't change over time,
@@ -40,7 +38,7 @@ class DeviceData implements JsonStream.Streamable {
         totalMemory = getTotalMemory();
         rooted = isRooted();
         locale = getLocale();
-        id = getAndroidId(appContext);
+        id = getUniqueInstallId();
         cpuAbi = getCpuAbi();
     }
 
@@ -167,12 +165,11 @@ class DeviceData implements JsonStream.Streamable {
     }
 
     /**
-     * Get the unique device id for the current Android device
+     * Get the unique id for the current app installation
      */
     @NonNull
-    private static String getAndroidId(Context appContext) {
-        ContentResolver cr = appContext.getContentResolver();
-        return Settings.Secure.getString(cr, Settings.Secure.ANDROID_ID);
+    private static String getUniqueInstallId() {
+        return UUID.randomUUID().toString(); // TODO persist in shared prefs
     }
 
     /**


### PR DESCRIPTION
This replaces the use of Settings.Secure.ANDROID_ID with a random UUID, which is generated on each install of the app.