### PR TITLE
Allow loading different configurations depending on build variant

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -9,10 +9,31 @@ buildscript {
     }
 }
 apply plugin: 'com.android.application'
+apply plugin: 'com.bugsnag.android.gradle'
 
 android {
     compileSdkVersion 25
     buildToolsVersion '25.0.2'
+
+    defaultConfig {
+        manifestPlaceholders = [
+            bugsnagApiKey: "066f5ad3590596f9aa8d601ea89af845",
+            bugsnagBuildUUID: "123",
+            bugsnagAppVersion: "1.2.3",
+            bugsnagEndpoint: "https://example.com",
+            bugsnagReleaseStage: "debug",
+            bugsnagSendThreads: true,
+            bugsnagEnableExceptionHandler: true,
+            bugsnagPersistUserBetweenSessions: false,
+        ]
+
+        // TODO enter below into manifest placeholder
+
+//            private String[] filters = new String[]{"password"};
+//            private String[] ignoreClasses;
+//            private String[] notifyReleaseStages = null;
+//            private String[] projectPackages;
+    }
 
     buildTypes {
 
@@ -26,17 +47,8 @@ android {
         }
     }
 
-    productFlavors {
-        free {
-            buildConfigField "String", "bugsnagApiKey", "\"066f5ad3590596f9aa8d601ea89af845\""
-            resValue "string", "bugsnagApiKey", "066f5ad3590596f9aa8d601ea89af845"
-            manifestPlaceholders = [bugsnagApiKey: "066f5ad3590596f9aa8d601ea89af845"]
-        }
-    }
-
     defaultConfig {
         minSdkVersion 4
-        manifestPlaceholders = [bugsnagApiKey: "066f5ad3590596f9aa8d601ea89af845"]
     }
 }
 
@@ -44,4 +56,3 @@ dependencies {
     compile rootProject
 }
 
-apply plugin: 'com.bugsnag.android.gradle'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -26,6 +26,14 @@ android {
         }
     }
 
+    productFlavors {
+        free {
+            buildConfigField "String", "bugsnagApiKey", "\"066f5ad3590596f9aa8d601ea89af845\""
+            resValue "string", "bugsnagApiKey", "066f5ad3590596f9aa8d601ea89af845"
+            manifestPlaceholders = [bugsnagApiKey: "066f5ad3590596f9aa8d601ea89af845"]
+        }
+    }
+
     defaultConfig {
         minSdkVersion 4
         manifestPlaceholders = [bugsnagApiKey: "066f5ad3590596f9aa8d601ea89af845"]

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,6 +28,7 @@ android {
 
     defaultConfig {
         minSdkVersion 4
+        manifestPlaceholders = [bugsnagApiKey: "066f5ad3590596f9aa8d601ea89af845"]
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -9,7 +9,6 @@ buildscript {
     }
 }
 apply plugin: 'com.android.application'
-apply plugin: 'com.bugsnag.android.gradle'
 
 android {
     compileSdkVersion 25
@@ -18,21 +17,14 @@ android {
     defaultConfig {
         manifestPlaceholders = [
             bugsnagApiKey: "066f5ad3590596f9aa8d601ea89af845",
-            bugsnagBuildUUID: "123",
-            bugsnagAppVersion: "1.2.3",
-            bugsnagEndpoint: "https://example.com",
+            bugsnagBuildUUID: "abc123",
+            bugsnagAppVersion: "1.0.0",
+            bugsnagEndpoint: "https://notify.bugsnag.com",
             bugsnagReleaseStage: "debug",
             bugsnagSendThreads: true,
             bugsnagEnableExceptionHandler: true,
             bugsnagPersistUserBetweenSessions: false,
         ]
-
-        // TODO enter below into manifest placeholder
-
-//            private String[] filters = new String[]{"password"};
-//            private String[] ignoreClasses;
-//            private String[] notifyReleaseStages = null;
-//            private String[] projectPackages;
     }
 
     buildTypes {
@@ -56,3 +48,4 @@ dependencies {
     compile rootProject
 }
 
+apply plugin: 'com.bugsnag.android.gradle'

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -13,7 +13,10 @@
             </intent-filter>
         </activity>
 
-        <meta-data android:name="com.bugsnag.android.API_KEY" android:value="066f5ad3590596f9aa8d601ea89af845"/>
+      <!-- Uses a manifest placeholder to specify the API key. This means that different keys
+      can be supplied depending on the build variant. See
+       https://developer.android.com/studio/build/manifest-build-variables.html-->
+        <meta-data android:name="com.bugsnag.android.API_KEY" android:value="${bugsnagApiKey}"/>
     </application>
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
       package="com.bugsnag.android.example"
       android:versionCode="1"
       android:versionName="1.0">
+
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.GET_TASKS" />
+
     <application android:label="Bugsnag Example App" android:icon="@drawable/ic_launcher">
         <activity android:name="ExampleActivity"
                   android:label="Bugsnag Example App"
@@ -16,9 +20,15 @@
       <!-- Uses a manifest placeholder to specify the API key. This means that different keys
       can be supplied depending on the build variant. See
        https://developer.android.com/studio/build/manifest-build-variables.html-->
-        <meta-data android:name="com.bugsnag.android.API_KEY" android:value="${bugsnagApiKey}"/>
-    </application>
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.GET_TASKS" />
+        <meta-data android:name="com.bugsnag.android.API_KEY" android:value="${bugsnagApiKey}"/>
+        <meta-data android:name="com.bugsnag.android.BUILD_UUID" android:value="${bugsnagBuildUUID}"/>
+        <meta-data android:name="com.bugsnag.android.APP_VERSION" android:value="${bugsnagAppVersion}"/>
+        <meta-data android:name="com.bugsnag.android.ENDPOINT" android:value="${bugsnagEndpoint}"/>
+        <meta-data android:name="com.bugsnag.android.RELEASE_STAGE" android:value="${bugsnagReleaseStage}"/>
+        <meta-data android:name="com.bugsnag.android.SEND_THREADS" android:value="${bugsnagSendThreads}"/>
+        <meta-data android:name="com.bugsnag.android.ENABLE_EXCEPTION_HANDLER" android:value="${bugsnagEnableExceptionHandler}"/>
+        <meta-data android:name="com.bugsnag.android.PERSIST_USER_BETWEEN_SESSIONS" android:value="${bugsnagPersistUserBetweenSessions}"/>
+
+    </application>
 </manifest>

--- a/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -132,8 +132,21 @@ public class ClientTest extends BugsnagTestCase {
         assertFalse(sharedPref.contains("user.name"));
     }
 
-    public void testFullManifestConfig() {
+    public void testEmptyManifestConfig() {
         Configuration config = new Configuration("api-key");
+        Bundle data = new Bundle();
+        Configuration newConfig = Client.populateConfigFromManifest(new Configuration("api-key"), data);
+
+        assertEquals(config.getBuildUUID(), newConfig.getBuildUUID());
+        assertEquals(config.getAppVersion(), newConfig.getAppVersion());
+        assertEquals(config.getReleaseStage(), newConfig.getReleaseStage());
+        assertEquals(config.getEndpoint(), newConfig.getEndpoint());
+        assertEquals(config.getSendThreads(), newConfig.getSendThreads());
+        assertEquals(config.getEnableExceptionHandler(), newConfig.getEnableExceptionHandler());
+        assertEquals(config.getPersistUserBetweenSessions(), newConfig.getPersistUserBetweenSessions());
+    }
+
+    public void testFullManifestConfig() {
         String buildUuid = "123";
         String appVersion = "v1.0";
         String releaseStage = "debug";
@@ -149,7 +162,6 @@ public class ClientTest extends BugsnagTestCase {
         data.putBoolean(MF_PERSIST_USER_BETWEEN_SESSIONS, true);
 
         Configuration newConfig = Client.populateConfigFromManifest(new Configuration("api-key"), data);
-        assertNotSame(config, newConfig);
         assertEquals(buildUuid, newConfig.getBuildUUID());
         assertEquals(appVersion, newConfig.getAppVersion());
         assertEquals(releaseStage, newConfig.getReleaseStage());

--- a/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -137,6 +137,7 @@ public class ClientTest extends BugsnagTestCase {
         Bundle data = new Bundle();
         Configuration newConfig = Client.populateConfigFromManifest(new Configuration("api-key"), data);
 
+        assertEquals(config.getApiKey(), newConfig.getApiKey());
         assertEquals(config.getBuildUUID(), newConfig.getBuildUUID());
         assertEquals(config.getAppVersion(), newConfig.getAppVersion());
         assertEquals(config.getReleaseStage(), newConfig.getReleaseStage());

--- a/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -2,6 +2,15 @@ package com.bugsnag.android;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import static com.bugsnag.android.Client.MF_APP_VERSION;
+import static com.bugsnag.android.Client.MF_BUILD_UUID;
+import static com.bugsnag.android.Client.MF_ENABLE_EXCEPTION_HANDLER;
+import static com.bugsnag.android.Client.MF_ENDPOINT;
+import static com.bugsnag.android.Client.MF_PERSIST_USER_BETWEEN_SESSIONS;
+import static com.bugsnag.android.Client.MF_RELEASE_STAGE;
+import static com.bugsnag.android.Client.MF_SEND_THREADS;
 
 public class ClientTest extends BugsnagTestCase {
 
@@ -121,6 +130,33 @@ public class ClientTest extends BugsnagTestCase {
         assertFalse(sharedPref.contains("user.id"));
         assertFalse(sharedPref.contains("user.email"));
         assertFalse(sharedPref.contains("user.name"));
+    }
+
+    public void testFullManifestConfig() {
+        Configuration config = new Configuration("api-key");
+        String buildUuid = "123";
+        String appVersion = "v1.0";
+        String releaseStage = "debug";
+        String endpoint = "http://example.com";
+
+        Bundle data = new Bundle();
+        data.putString(MF_BUILD_UUID, buildUuid);
+        data.putString(MF_APP_VERSION, appVersion);
+        data.putString(MF_RELEASE_STAGE, releaseStage);
+        data.putString(MF_ENDPOINT, endpoint);
+        data.putBoolean(MF_SEND_THREADS, false);
+        data.putBoolean(MF_ENABLE_EXCEPTION_HANDLER, false);
+        data.putBoolean(MF_PERSIST_USER_BETWEEN_SESSIONS, true);
+
+        Configuration newConfig = Client.populateConfigFromManifest(new Configuration("api-key"), data);
+        assertNotSame(config, newConfig);
+        assertEquals(buildUuid, newConfig.getBuildUUID());
+        assertEquals(appVersion, newConfig.getAppVersion());
+        assertEquals(releaseStage, newConfig.getReleaseStage());
+        assertEquals(endpoint, newConfig.getEndpoint());
+        assertEquals(false, newConfig.getSendThreads());
+        assertEquals(false, newConfig.getEnableExceptionHandler());
+        assertEquals(true, newConfig.getPersistUserBetweenSessions());
     }
 
     @Override

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -4,10 +4,12 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Collections;
 import java.util.Map;
@@ -34,12 +36,22 @@ enum DeliveryStyle {
  */
 public class Client extends Observable implements Observer {
 
-
     private static final boolean BLOCKING = true;
     private static final String SHARED_PREF_KEY = "com.bugsnag.android";
+    private static final String BUGSNAG_NAMESPACE = "com.bugsnag.android";
     private static final String USER_ID_KEY = "user.id";
     private static final String USER_NAME_KEY = "user.name";
     private static final String USER_EMAIL_KEY = "user.email";
+
+    private static final String MF_API_KEY = BUGSNAG_NAMESPACE + ".API_KEY";
+    private static final String MF_BUILD_UUID = BUGSNAG_NAMESPACE + ".BUILD_UUID";
+    private static final String MF_APP_VERSION = BUGSNAG_NAMESPACE + ".APP_VERSION";
+    private static final String MF_ENDPOINT = BUGSNAG_NAMESPACE + ".ENDPOINT";
+    private static final String MF_RELEASE_STAGE = BUGSNAG_NAMESPACE + ".RELEASE_STAGE";
+    private static final String MF_SEND_THREADS = BUGSNAG_NAMESPACE + ".SEND_THREADS";
+    private static final String MF_ENABLE_EXCEPTION_HANDLER = BUGSNAG_NAMESPACE + ".ENABLE_EXCEPTION_HANDLER";
+    private static final String MF_PERSIST_USER_BETWEEN_SESSIONS = BUGSNAG_NAMESPACE + ".PERSIST_USER_BETWEEN_SESSIONS";
+    private static final String MF_FILTERS = BUGSNAG_NAMESPACE + ".FILTERS";
 
     protected final Configuration config;
     private final Context appContext;
@@ -94,7 +106,7 @@ public class Client extends Observable implements Observer {
         String buildUUID = null;
         try {
             ApplicationInfo ai = appContext.getPackageManager().getApplicationInfo(appContext.getPackageName(), PackageManager.GET_META_DATA);
-            buildUUID = ai.metaData.getString("com.bugsnag.android.BUILD_UUID");
+            buildUUID = ai.metaData.getString(MF_BUILD_UUID);
         } catch (Exception ignore) {
         }
         if (buildUUID != null) {
@@ -169,7 +181,19 @@ public class Client extends Observable implements Observer {
         if (TextUtils.isEmpty(apiKey)) {
             try {
                 ApplicationInfo ai = appContext.getPackageManager().getApplicationInfo(appContext.getPackageName(), PackageManager.GET_META_DATA);
-                apiKey = ai.metaData.getString("com.bugsnag.android.API_KEY");
+                Bundle data = ai.metaData;
+
+                apiKey = data.getString(MF_API_KEY);
+
+                // TODO serialise following, otherwise use the defaults
+                data.getString(MF_BUILD_UUID);
+                data.getString(MF_APP_VERSION);
+                data.getString(MF_ENDPOINT);
+                data.getString(MF_RELEASE_STAGE);
+                data.getBoolean(MF_SEND_THREADS);
+                data.getBoolean(MF_ENABLE_EXCEPTION_HANDLER);
+                data.getBoolean(MF_PERSIST_USER_BETWEEN_SESSIONS);
+
             } catch (Exception ignore) {
             }
         }

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -168,7 +168,7 @@ public class Client extends Observable implements Observer {
 
     /**
      * Creates a new configuration object based on the provided parameters
-     * will read the API key from the manifest file if it is not provided
+     * will read the API key and other configuration values from the manifest if it is not provided
      *
      * @param androidContext         The context of the application
      * @param apiKey                 The API key to use
@@ -209,6 +209,13 @@ public class Client extends Observable implements Observer {
         return newConfig;
     }
 
+    /**
+     * Populates the config with meta-data values supplied from the manifest as a Bundle.
+     *
+     * @param config the config to mutate
+     * @param data the manifest bundle
+     * @return the updated config
+     */
     static Configuration populateConfigFromManifest(Configuration config, Bundle data) {
         config.setBuildUUID(data.getString(MF_BUILD_UUID));
         config.setAppVersion(data.getString(MF_APP_VERSION));

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -100,7 +100,8 @@ public class Client extends Observable implements Observer {
 
         config = configuration;
 
-        // populate from manifest (if the constructor was called directly by the User)
+        // populate from manifest (in the case where the constructor was called directly by the
+        // User or no UUID was supplied)
         if (config.getBuildUUID() == null) {
             String buildUUID = null;
             try {


### PR DESCRIPTION
Configuration values can now be supplied as meta-data elements in the manifest, which allows for the use of manifest placeholders. 