### PR TITLE
Update context logic to use activity screen name

### DIFF
--- a/src/main/java/com/bugsnag/android/AppState.java
+++ b/src/main/java/com/bugsnag/android/AppState.java
@@ -49,7 +49,7 @@ class AppState implements JsonStream.Streamable {
     }
 
     @Nullable
-    public static String getActiveScreenClass(@Nullable String activeScreen) {
+    public String getActiveScreenClass() {
         if (activeScreen != null) {
             return activeScreen.substring(activeScreen.lastIndexOf('.') + 1);
         } else {

--- a/src/main/java/com/bugsnag/android/Error.java
+++ b/src/main/java/com/bugsnag/android/Error.java
@@ -98,12 +98,12 @@ public class Error implements JsonStream.Streamable {
      */
     @Nullable
     public String getContext() {
-        if(context != null && !TextUtils.isEmpty(context)) {
+        if (!TextUtils.isEmpty(context)) {
             return context;
         } else if (config.getContext() != null) {
             return config.getContext();
-        } else if (appState != null){
-            return AppState.getActiveScreenClass(context);
+        } else if (appState != null) {
+            return appState.getActiveScreenClass();
         } else {
             return null;
         }


### PR DESCRIPTION
Use the activity's class name if no other context has been supplied