### PR TITLE
Close closeables even more quietly

### DIFF
--- a/src/main/java/com/bugsnag/android/IOUtils.java
+++ b/src/main/java/com/bugsnag/android/IOUtils.java
@@ -18,7 +18,7 @@ class IOUtils {
             if (closeable != null) {
                 closeable.close();
             }
-        } catch (final IOException ioe) {
+        } catch (final Exception ioe) {
             // ignore
         }
     }


### PR DESCRIPTION
In the case that the Closeable throws some other exception (which can
happen on certain devices), this handling gets quite noisy.

Fixes #149