### PR TITLE
Automatically leave breadcrumbs for Activity Lifecycle callbacks

### DIFF
--- a/example/src/main/java/com/bugsnag/android/example/ExampleApplication.java
+++ b/example/src/main/java/com/bugsnag/android/example/ExampleApplication.java
@@ -1,6 +1,8 @@
 package com.bugsnag.android.example;
 
+import android.app.Activity;
 import android.app.Application;
+import android.os.Bundle;
 
 import com.bugsnag.android.Bugsnag;
 
@@ -12,6 +14,44 @@ public class ExampleApplication extends Application {
 
         // Initialize the Bugsnag client
         Bugsnag.init(this);
+
+        registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
+            @Override
+            public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+
+            }
+
+            @Override
+            public void onActivityStarted(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityResumed(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityPaused(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityStopped(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+
+            }
+
+            @Override
+            public void onActivityDestroyed(Activity activity) {
+
+            }
+        });
+
     }
 
 }

--- a/example/src/main/java/com/bugsnag/android/example/ExampleApplication.java
+++ b/example/src/main/java/com/bugsnag/android/example/ExampleApplication.java
@@ -1,8 +1,6 @@
 package com.bugsnag.android.example;
 
-import android.app.Activity;
 import android.app.Application;
-import android.os.Bundle;
 
 import com.bugsnag.android.Bugsnag;
 
@@ -14,44 +12,6 @@ public class ExampleApplication extends Application {
 
         // Initialize the Bugsnag client
         Bugsnag.init(this);
-
-        registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
-            @Override
-            public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-
-            }
-
-            @Override
-            public void onActivityStarted(Activity activity) {
-
-            }
-
-            @Override
-            public void onActivityResumed(Activity activity) {
-
-            }
-
-            @Override
-            public void onActivityPaused(Activity activity) {
-
-            }
-
-            @Override
-            public void onActivityStopped(Activity activity) {
-
-            }
-
-            @Override
-            public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-
-            }
-
-            @Override
-            public void onActivityDestroyed(Activity activity) {
-
-            }
-        });
-
     }
 
 }

--- a/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -1,8 +1,5 @@
 package com.bugsnag.android;
 
-import android.app.Application;
-import java.util.Map;
-import java.util.Observer;
 import android.content.Context;
 
 import java.util.Map;
@@ -26,7 +23,6 @@ public final class Bugsnag {
      * @param  androidContext  an Android context, usually <code>this</code>
      */
     public static Client init(Context androidContext) {
-        warnIfNotAppContext(androidContext);
         client = new Client(androidContext);
         NativeInterface.configureClientObservers(client);
         return client;
@@ -39,7 +35,6 @@ public final class Bugsnag {
      * @param  apiKey          your Bugsnag API key from your Bugsnag dashboard
      */
     public static Client init(Context androidContext, String apiKey) {
-        warnIfNotAppContext(androidContext);
         client = new Client(androidContext, apiKey);
         NativeInterface.configureClientObservers(client);
         return client;
@@ -53,7 +48,6 @@ public final class Bugsnag {
      * @param  enableExceptionHandler  should we automatically handle uncaught exceptions?
      */
     public static Client init(Context androidContext, String apiKey, boolean enableExceptionHandler) {
-        warnIfNotAppContext(androidContext);
         client = new Client(androidContext, apiKey, enableExceptionHandler);
         NativeInterface.configureClientObservers(client);
         return client;
@@ -66,7 +60,6 @@ public final class Bugsnag {
      * @param config         a configuration for the Client
      */
     public static Client init(Context androidContext, Configuration config) {
-        warnIfNotAppContext(androidContext);
         client = new Client(androidContext, config);
         NativeInterface.configureClientObservers(client);
         return client;
@@ -535,12 +528,5 @@ public final class Bugsnag {
         }
 
         return client;
-    }
-
-    private static void warnIfNotAppContext(Context androidContext) {
-        if (!(androidContext instanceof Application)) {
-            Logger.warn("Warning - Non-Application context detected! Please ensure that you are " +
-                "initializing Bugsnag from a custom Application class.");
-        }
     }
 }

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -104,8 +104,9 @@ public class Client extends Observable implements Observer {
         appContext = androidContext.getApplicationContext();
 
         if (appContext instanceof Application && Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            SdkCompatWrapper sdkCompatWrapper = new SdkCompatWrapper();
             Application application = (Application) appContext;
-            application.registerActivityLifecycleCallbacks(new LifecycleBreadcrumbLogger());
+            sdkCompatWrapper.setupLifecycleLogger(application);
         }
         else {
             Logger.warn("Bugsnag is unable to setup automatic activity lifecycle breadcrumbs on API " +

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -1,9 +1,11 @@
 package com.bugsnag.android;
 
+import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -15,7 +17,6 @@ import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.UUID;
 
 enum DeliveryStyle {
     SAME_THREAD,
@@ -99,8 +100,17 @@ public class Client extends Observable implements Observer {
      * @param configuration  a configuration for the Client
      */
     public Client(@NonNull Context androidContext, @NonNull Configuration configuration) {
-
+        warnIfNotAppContext(androidContext);
         appContext = androidContext.getApplicationContext();
+
+        if (appContext instanceof Application && Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            Application application = (Application) appContext;
+            application.registerActivityLifecycleCallbacks(new LifecycleBreadcrumbLogger());
+        }
+        else {
+            Logger.warn("Bugsnag is unable to setup automatic activity lifecycle breadcrumbs on API " +
+                "Levels below 14.");
+        }
 
         config = configuration;
 
@@ -1006,5 +1016,12 @@ public class Client extends Observable implements Observer {
     protected void finalize() throws Throwable {
         appContext.unregisterReceiver(eventReceiver);
         super.finalize();
+    }
+
+    private static void warnIfNotAppContext(Context androidContext) {
+        if (!(androidContext instanceof Application)) {
+            Logger.warn("Warning - Non-Application context detected! Please ensure that you are " +
+                "initializing Bugsnag from a custom Application class.");
+        }
     }
 }

--- a/src/main/java/com/bugsnag/android/LifecycleBreadcrumbCompat.java
+++ b/src/main/java/com/bugsnag/android/LifecycleBreadcrumbCompat.java
@@ -1,0 +1,22 @@
+package com.bugsnag.android;
+
+import android.app.Application;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+
+/**
+ * This class wraps the {@link LifecycleBreadcrumbLogger}. This is necessary because otherwise
+ * {@link VerifyError} would be thrown when the implementation class was loaded, as older APIs don't
+ * have a method definition for {@link android.app.Application.ActivityLifecycleCallbacks}.
+ */
+@RequiresApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+final class SdkCompatWrapper {
+
+    private final LifecycleBreadcrumbLogger logger = new LifecycleBreadcrumbLogger();
+
+    @RequiresApi(api = Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+    void setupLifecycleLogger(Application application) {
+        application.registerActivityLifecycleCallbacks(logger);
+    }
+
+}

--- a/src/main/java/com/bugsnag/android/LifecycleBreadcrumbLogger.java
+++ b/src/main/java/com/bugsnag/android/LifecycleBreadcrumbLogger.java
@@ -1,0 +1,59 @@
+package com.bugsnag.android;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.RequiresApi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiresApi(api = Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+class LifecycleBreadcrumbLogger implements Application.ActivityLifecycleCallbacks {
+
+    private static final String KEY_LIFECYCLE_CALLBACK = "ActivityLifecycleCallback";
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        leaveLifecycleBreadcrumb(activity, "onCreate()");
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+        leaveLifecycleBreadcrumb(activity, "onStart()");
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        leaveLifecycleBreadcrumb(activity, "onResume()");
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+        leaveLifecycleBreadcrumb(activity, "onPause()");
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+        leaveLifecycleBreadcrumb(activity, "onStop()");
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        leaveLifecycleBreadcrumb(activity, "onSaveInstanceState()");
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+        leaveLifecycleBreadcrumb(activity, "onDestroy()");
+    }
+
+    private void leaveLifecycleBreadcrumb(Activity activity, String lifecycleCallback) {
+        String activityName = activity.getClass().getSimpleName();
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(KEY_LIFECYCLE_CALLBACK, lifecycleCallback);
+        Bugsnag.leaveBreadcrumb(activityName, BreadcrumbType.NAVIGATION, metadata);
+    }
+
+}


### PR DESCRIPTION
Automatically leaves breadcrumbs for any change in the Activity Lifecycle for the Application. The breadcrumb includes the name of the Activity, and the name of the lifecycle callback. If the device is below API 14 (<1% of market share), a warning message is logged out.