### PR TITLE
Fix crash when rotating screen due to EventReceiver

### DIFF
--- a/example/src/main/java/com/bugsnag/android/example/ExampleApplication.java
+++ b/example/src/main/java/com/bugsnag/android/example/ExampleApplication.java
@@ -1,6 +1,8 @@
 package com.bugsnag.android.example;
 
 import android.app.Application;
+import android.os.Build;
+import android.os.StrictMode;
 
 import com.bugsnag.android.Bugsnag;
 
@@ -12,6 +14,19 @@ public class ExampleApplication extends Application {
 
         // Initialize the Bugsnag client
         Bugsnag.init(this);
+
+        if (false && Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+            StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                .detectAll()
+                .penaltyDeath()
+                .build());
+
+            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
+                .detectAll()
+                .penaltyDeath()
+                .build());
+        }
+
     }
 
 }

--- a/example/src/main/java/com/bugsnag/android/example/ExampleApplication.java
+++ b/example/src/main/java/com/bugsnag/android/example/ExampleApplication.java
@@ -1,8 +1,6 @@
 package com.bugsnag.android.example;
 
 import android.app.Application;
-import android.os.Build;
-import android.os.StrictMode;
 
 import com.bugsnag.android.Bugsnag;
 
@@ -14,19 +12,6 @@ public class ExampleApplication extends Application {
 
         // Initialize the Bugsnag client
         Bugsnag.init(this);
-
-        if (false && Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
-            StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
-                .detectAll()
-                .penaltyDeath()
-                .build());
-
-            StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder()
-                .detectAll()
-                .penaltyDeath()
-                .build());
-        }
-
     }
 
 }

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -1015,7 +1015,14 @@ public class Client extends Observable implements Observer {
      * @throws Throwable if something goes wrong
      */
     protected void finalize() throws Throwable {
-        appContext.unregisterReceiver(eventReceiver);
+        if (eventReceiver != null) {
+            try {
+                appContext.unregisterReceiver(eventReceiver);
+            }
+            catch (IllegalArgumentException e) {
+                Logger.warn("Receiver not registered");
+            }
+        }
         super.finalize();
     }
 


### PR DESCRIPTION
I observed a crash when rotating the screen on the emulator, due to the eventReceiver not being registered - I believe this should stop that particular case.