### PR TITLE
Always check for network connection prior to starting http requests

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -6,5 +6,6 @@
 
   <!-- Required: Used to deliver Bugsnag crash reports -->
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
 </manifest>

--- a/src/main/java/com/bugsnag/android/Client.java
+++ b/src/main/java/com/bugsnag/android/Client.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -12,7 +13,6 @@ import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
@@ -66,8 +66,9 @@ public class Client extends Observable implements Observer {
     protected final User user = new User();
     @NonNull
     protected final ErrorStore errorStore;
+
     private final EventReceiver eventReceiver = new EventReceiver();
-    private ErrorReportApiClient errorReportApiClient = new DefaultHttpClient();
+    private ErrorReportApiClient errorReportApiClient;
 
     /**
      * Initialize a Bugsnag client
@@ -108,6 +109,8 @@ public class Client extends Observable implements Observer {
     public Client(@NonNull Context androidContext, @NonNull Configuration configuration) {
         warnIfNotAppContext(androidContext);
         appContext = androidContext.getApplicationContext();
+        ConnectivityManager cm = (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        errorReportApiClient = new DefaultHttpClient(cm);
 
         if (appContext instanceof Application && Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
             SdkCompatWrapper sdkCompatWrapper = new SdkCompatWrapper();
@@ -825,7 +828,7 @@ public class Client extends Observable implements Observer {
     void deliver(@NonNull Report report, @NonNull Error error) {
         try {
             errorReportApiClient.postReport(config.getEndpoint(), report);
-            Logger.info(String.format(Locale.US, "Sent 1 new error to Bugsnag"));
+            Logger.info("Sent 1 new error to Bugsnag");
         } catch (DefaultHttpClient.NetworkException e) {
             Logger.info("Could not send error(s) to Bugsnag, saving to disk to send later");
 

--- a/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -54,26 +54,28 @@ class ErrorStore {
                 public void run() {
                     // Look up all saved error files
                     File exceptionDir = new File(path);
-                    if(!exceptionDir.exists() || !exceptionDir.isDirectory()) return;
+                    if (!exceptionDir.exists() || !exceptionDir.isDirectory()) return;
 
                     File[] errorFiles = exceptionDir.listFiles();
-                    if(errorFiles != null && errorFiles.length > 0) {
+                    if (errorFiles != null && errorFiles.length > 0) {
                         Logger.info(String.format(Locale.US, "Sending %d saved error(s) to Bugsnag", errorFiles.length));
 
-                        for(File errorFile : errorFiles) {
+                        for (File errorFile : errorFiles) {
                             try {
                                 Report report = new Report(config.getApiKey(), errorFile);
                                 errorReportApiClient.postReport(config.getEndpoint(), report);
 
                                 Logger.info("Deleting sent error file " + errorFile.getName());
-                                if (!errorFile.delete())
+                                if (!errorFile.delete()) {
                                     errorFile.deleteOnExit();
+                                }
                             } catch (DefaultHttpClient.NetworkException e) {
                                 Logger.warn("Could not send previously saved error(s) to Bugsnag, will try again later", e);
                             } catch (Exception e) {
                                 Logger.warn("Problem sending unsent error from disk", e);
-                                if (!errorFile.delete())
+                                if (!errorFile.delete()) {
                                     errorFile.deleteOnExit();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This prevents the device radio from powering on when no connection isn't available, which would waste battery.