### PR TITLE
Prevent null metadata

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientRejectedExecutionTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientRejectedExecutionTest.java
@@ -5,6 +5,7 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.LargeTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,6 +57,8 @@ public class ClientRejectedExecutionTest {
         File[] files = errorStorageDir.listFiles();
         assertTrue(files.length > 0);
         File errorFile = files[0];
-        ErrorStoreTest.checkFirstErrorReportFile(errorFile);
+
+        JSONObject payload = ErrorStoreTest.getJsonObjectFromReport(new Report("api", errorFile));
+        ErrorStoreTest.validateReportPayload(payload);
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
@@ -1,0 +1,106 @@
+package com.bugsnag.android;
+
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+/**
+ * Ensures that setting metadata to null doesn't result in NPEs
+ * <p>
+ * See https://github.com/bugsnag/bugsnag-android/issues/194
+ */
+public class NullMetadataTest {
+
+    private static final String TAB_KEY = "tab";
+
+    private Configuration config;
+    private Throwable throwable;
+
+    @Before
+    public void setUp() throws Exception {
+        config = new Configuration("api-key");
+        Bugsnag.init(InstrumentationRegistry.getContext(), config);
+        Bugsnag.setErrorReportApiClient(new ErrorReportApiClient() {
+            @Override
+            public void postReport(String urlString, Report report) throws NetworkException, BadResponseException {
+
+            }
+        });
+
+        throwable = new RuntimeException("Test");
+    }
+
+    @Test
+    public void testErrorDefaultMetaData() throws Exception {
+        Error error = new Error(config, throwable);
+        validateDefaultMetadata(error.getMetaData());
+    }
+
+    @Test
+    public void testSecondErrorDefaultMetaData() throws Exception {
+        Error error = new Error(config, "RuntimeException", "Something broke", new StackTraceElement[]{});
+        validateDefaultMetadata(error.getMetaData());
+    }
+
+    @Test
+    public void testErrorSetMetadataRef() throws Exception {
+        Error error = new Error(config, throwable);
+        MetaData metaData = new MetaData();
+        metaData.addToTab(TAB_KEY, "test", "data");
+        error.setMetaData(metaData);
+        assertNotNull(metaData.getTab(TAB_KEY));
+    }
+
+    @Test
+    public void testErrorSetNullMetadata() throws Exception {
+        Error error = new Error(config, throwable);
+        error.setMetaData(null);
+        validateDefaultMetadata(error.getMetaData());
+    }
+
+    @Test
+    public void testConfigDefaultMetadata() throws Exception {
+        validateDefaultMetadata(config.getMetaData());
+    }
+
+    @Test
+    public void testConfigSetMetadataRef() throws Exception {
+        Configuration configuration = new Configuration("test");
+        configuration.setMetaData(new MetaData());
+        validateDefaultMetadata(configuration.getMetaData());
+    }
+
+    @Test
+    public void testConfigSetNullMetadata() throws Exception {
+        Configuration configuration = new Configuration("test");
+        configuration.setMetaData(null);
+        validateDefaultMetadata(configuration.getMetaData());
+    }
+
+    @Test
+    public void testNotify() throws Exception {
+        Bugsnag.beforeNotify(new BeforeNotify() {
+            @Override
+            public boolean run(Error error) {
+                validateDefaultMetadata(error.getMetaData());
+                return false;
+            }
+        });
+        Error error = new Error(config, new Throwable());
+        Client client = Bugsnag.getClient();
+        client.notify(error, DeliveryStyle.SAME_THREAD, null);
+    }
+
+    private void validateDefaultMetadata(MetaData metaData) {
+        assertNotNull(metaData);
+        assertEquals(0, metaData.getTab(TAB_KEY).size());
+
+        metaData.addToTab(TAB_KEY, "test", "data");
+        assertEquals(1, metaData.getTab(TAB_KEY).size());
+    }
+
+}

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -363,7 +363,8 @@ public final class Bugsnag {
      * @deprecated Use {@link #notify(Throwable, Callback)}
      * to send and modify error reports
      */
-    public static void notify(@NonNull final Throwable exception, final MetaData metaData) {
+    public static void notify(@NonNull final Throwable exception,
+                              @NonNull final MetaData metaData) {
         getClient().notify(exception, new Callback() {
             @Override
             public void beforeNotify(@NonNull Report report) {
@@ -383,7 +384,8 @@ public final class Bugsnag {
      * to send and modify error reports
      */
     @Deprecated
-    public static void notify(@NonNull final Throwable exception, final Severity severity, final MetaData metaData) {
+    public static void notify(@NonNull final Throwable exception, final Severity severity,
+                              @NonNull final MetaData metaData) {
         getClient().notify(exception, new Callback() {
             @Override
             public void beforeNotify(@NonNull Report report) {
@@ -406,7 +408,9 @@ public final class Bugsnag {
      * to send and modify error reports
      */
     @Deprecated
-    public static void notify(@NonNull String name, @NonNull String message, @NonNull StackTraceElement[] stacktrace, Severity severity, MetaData metaData) {
+    public static void notify(@NonNull String name, @NonNull String message,
+                              @NonNull StackTraceElement[] stacktrace, Severity severity,
+                              @NonNull MetaData metaData) {
         final Severity finalSeverity = severity;
         final MetaData finalMetaData = metaData;
         getClient().notify(name, message, stacktrace, new Callback() {
@@ -432,7 +436,9 @@ public final class Bugsnag {
      * to send and modify error reports
      */
     @Deprecated
-    public static void notify(@NonNull String name, @NonNull String message, String context, @NonNull StackTraceElement[] stacktrace, Severity severity, MetaData metaData) {
+    public static void notify(@NonNull String name, @NonNull String message, String context,
+                              @NonNull StackTraceElement[] stacktrace, Severity severity,
+                              @NonNull MetaData metaData) {
         final String finalContext = context;
         final Severity finalSeverity = severity;
         final MetaData finalMetaData = metaData;
@@ -477,7 +483,7 @@ public final class Bugsnag {
      *
      * @see MetaData
      */
-    public static MetaData getMetaData() {
+    @NonNull public static MetaData getMetaData() {
         return getClient().getMetaData();
     }
 
@@ -486,7 +492,7 @@ public final class Bugsnag {
      *
      * @see MetaData
      */
-    public static void setMetaData(final MetaData metaData) {
+    public static void setMetaData(@NonNull final MetaData metaData) {
         getClient().setMetaData(metaData);
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -787,7 +787,7 @@ public class Client extends Observable implements Observer {
         notify(error, style, null);
     }
 
-    private void notify(@NonNull Error error, @NonNull DeliveryStyle style, @Nullable Callback callback) {
+    void notify(@NonNull Error error, @NonNull DeliveryStyle style, @Nullable Callback callback) {
         // Don't notify if this error class should be ignored
         if (error.shouldIgnoreClass()) {
             return;

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -709,7 +709,7 @@ public class Client extends Observable implements Observer {
      *
      * @see MetaData
      */
-    public MetaData getMetaData() {
+    @NonNull public MetaData getMetaData() {
         return config.getMetaData();
     }
 
@@ -718,7 +718,7 @@ public class Client extends Observable implements Observer {
      *
      * @see MetaData
      */
-    public void setMetaData(MetaData metaData) {
+    public void setMetaData(@NonNull MetaData metaData) {
         config.setMetaData(metaData);
     }
 
@@ -869,7 +869,8 @@ public class Client extends Observable implements Observer {
         }
     }
 
-    void cacheAndNotify(@NonNull Throwable exception, Severity severity, MetaData metaData) {
+    void cacheAndNotify(@NonNull Throwable exception, Severity severity,
+                        @NonNull MetaData metaData) {
         Error error = new Error(config, exception);
         error.setSeverity(severity);
         error.setMetaData(metaData);
@@ -911,7 +912,8 @@ public class Client extends Observable implements Observer {
      * @deprecated Use {@link #notify(Throwable, Callback)}
      * to send and modify error reports
      */
-    public void notify(@NonNull Throwable exception, MetaData metaData) {
+    public void notify(@NonNull Throwable exception,
+                       @NonNull MetaData metaData) {
         Error error = new Error(config, exception);
         error.setMetaData(metaData);
         notify(error, !BLOCKING);
@@ -925,7 +927,8 @@ public class Client extends Observable implements Observer {
      * @deprecated Use {@link #notify(Throwable, Callback)}
      * to send and modify error reports
      */
-    public void notifyBlocking(@NonNull Throwable exception, MetaData metaData) {
+    public void notifyBlocking(@NonNull Throwable exception,
+                               @NonNull MetaData metaData) {
         Error error = new Error(config, exception);
         error.setMetaData(metaData);
         notify(error, BLOCKING);
@@ -951,7 +954,8 @@ public class Client extends Observable implements Observer {
      * modify error reports
      */
     @Deprecated
-    public void notify(@NonNull Throwable exception, Severity severity, MetaData metaData) {
+    public void notify(@NonNull Throwable exception, Severity severity,
+                       @NonNull MetaData metaData) {
         Error error = new Error(config, exception);
         error.setSeverity(severity);
         error.setMetaData(metaData);
@@ -969,7 +973,8 @@ public class Client extends Observable implements Observer {
      * and modify error reports
      */
     @Deprecated
-    public void notifyBlocking(@NonNull Throwable exception, Severity severity, MetaData metaData) {
+    public void notifyBlocking(@NonNull Throwable exception, Severity severity,
+                               @NonNull MetaData metaData) {
         Error error = new Error(config, exception);
         error.setSeverity(severity);
         error.setMetaData(metaData);
@@ -989,7 +994,9 @@ public class Client extends Observable implements Observer {
      * to send and modify error reports
      */
     @Deprecated
-    public void notify(@NonNull String name, @NonNull String message, @NonNull StackTraceElement[] stacktrace, Severity severity, MetaData metaData) {
+    public void notify(@NonNull String name, @NonNull String message,
+                       @NonNull StackTraceElement[] stacktrace, Severity severity,
+                       @NonNull MetaData metaData) {
         Error error = new Error(config, name, message, stacktrace);
         error.setSeverity(severity);
         error.setMetaData(metaData);
@@ -1009,7 +1016,9 @@ public class Client extends Observable implements Observer {
      * to send and modify error reports
      */
     @Deprecated
-    public void notifyBlocking(@NonNull String name, @NonNull String message, @NonNull StackTraceElement[] stacktrace, Severity severity, MetaData metaData) {
+    public void notifyBlocking(@NonNull String name, @NonNull String message,
+                               @NonNull StackTraceElement[] stacktrace, Severity severity,
+                               @NonNull MetaData metaData) {
         Error error = new Error(config, name, message, stacktrace);
         error.setSeverity(severity);
         error.setMetaData(metaData);
@@ -1030,7 +1039,9 @@ public class Client extends Observable implements Observer {
      * to send and modify error reports
      */
     @Deprecated
-    public void notify(@NonNull String name, @NonNull String message, String context, @NonNull StackTraceElement[] stacktrace, Severity severity, MetaData metaData) {
+    public void notify(@NonNull String name, @NonNull String message, String context,
+                       @NonNull StackTraceElement[] stacktrace, Severity severity,
+                       @NonNull MetaData metaData) {
         Error error = new Error(config, name, message, stacktrace);
         error.setSeverity(severity);
         error.setMetaData(metaData);
@@ -1052,7 +1063,9 @@ public class Client extends Observable implements Observer {
      * to send and modify error reports
      */
     @Deprecated
-    public void notifyBlocking(@NonNull String name, @NonNull String message, String context, @NonNull StackTraceElement[] stacktrace, Severity severity, MetaData metaData) {
+    public void notifyBlocking(@NonNull String name, @NonNull String message, String context,
+                               @NonNull StackTraceElement[] stacktrace, Severity severity,
+                               @NonNull MetaData metaData) {
         Error error = new Error(config, name, message, stacktrace);
         error.setSeverity(severity);
         error.setMetaData(metaData);

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -38,7 +38,7 @@ public class Configuration extends Observable implements Observer {
     @NonNull
     String defaultExceptionType = "android";
 
-    private MetaData metaData;
+    @NonNull private MetaData metaData;
     private final Collection<BeforeNotify> beforeNotifyTasks = new LinkedHashSet<>();
 
     /**
@@ -216,7 +216,7 @@ public class Configuration extends Observable implements Observer {
      * @param notifyReleaseStages a list of releaseStages to notify for
      * @see #setReleaseStage
      */
-    public void setNotifyReleaseStages(String[] notifyReleaseStages) {
+    public void setNotifyReleaseStages(@Nullable String[] notifyReleaseStages) {
         this.notifyReleaseStages = notifyReleaseStages;
         notifyBugsnagObservers(NotifyType.RELEASE_STAGES);
     }
@@ -310,6 +310,7 @@ public class Configuration extends Observable implements Observer {
      *
      * @return meta data
      */
+    @NonNull
     protected MetaData getMetaData() {
         return metaData;
     }
@@ -319,7 +320,7 @@ public class Configuration extends Observable implements Observer {
      *
      * @param metaData meta data
      */
-    protected void setMetaData(MetaData metaData) {
+    protected void setMetaData(@NonNull MetaData metaData) {
         this.metaData.deleteObserver(this);
         this.metaData = metaData;
         this.metaData.addObserver(this);

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -322,7 +322,14 @@ public class Configuration extends Observable implements Observer {
      */
     protected void setMetaData(@NonNull MetaData metaData) {
         this.metaData.deleteObserver(this);
-        this.metaData = metaData;
+
+        //noinspection ConstantConditions
+        if (metaData == null) {
+            this.metaData = new MetaData();
+        } else {
+            this.metaData = metaData;
+        }
+
         this.metaData.addObserver(this);
         notifyBugsnagObservers(NotifyType.META);
     }

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -40,8 +40,7 @@ public class Error implements JsonStream.Streamable {
 
     Error(@NonNull Configuration config, @NonNull String name,
           @NonNull String message, @NonNull StackTraceElement[] frames) {
-        this.config = config;
-        this.exception = new BugsnagException(name, message, frames);
+        this(config, new BugsnagException(name, message, frames));
     }
 
     public void toStream(@NonNull JsonStream writer) throws IOException {

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -29,7 +29,7 @@ public class Error implements JsonStream.Streamable {
     private Throwable exception;
     @Nullable
     private Severity severity = Severity.WARNING;
-    private MetaData metaData = new MetaData();
+    @NonNull private MetaData metaData = new MetaData();
     private String groupingHash;
     private String context;
 
@@ -41,7 +41,6 @@ public class Error implements JsonStream.Streamable {
     Error(@NonNull Configuration config, @NonNull String name,
           @NonNull String message, @NonNull StackTraceElement[] frames) {
         this.config = config;
-
         this.exception = new BugsnagException(name, message, frames);
     }
 
@@ -231,6 +230,7 @@ public class Error implements JsonStream.Streamable {
      * @see Error#setMetaData
      * @see Error#addToTab
      */
+    @NonNull
     public MetaData getMetaData() {
         return metaData;
     }
@@ -246,7 +246,7 @@ public class Error implements JsonStream.Streamable {
      * @see Error#addToTab
      * @see Error#getMetaData
      */
-    public void setMetaData(MetaData metaData) {
+    public void setMetaData(@NonNull MetaData metaData) {
         this.metaData = metaData;
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -246,7 +246,12 @@ public class Error implements JsonStream.Streamable {
      * @see Error#getMetaData
      */
     public void setMetaData(@NonNull MetaData metaData) {
-        this.metaData = metaData;
+        //noinspection ConstantConditions
+        if (metaData == null) {
+            this.metaData = new MetaData();
+        } else {
+            this.metaData = metaData;
+        }
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/MetaData.java
+++ b/sdk/src/main/java/com/bugsnag/android/MetaData.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Observable;
@@ -44,6 +43,7 @@ public class MetaData extends Observable implements JsonStream.Streamable {
         store = new ConcurrentHashMap<>(m);
     }
 
+    @Override
     public void toStream(@NonNull JsonStream writer) throws IOException {
         objectToStream(store, writer);
     }
@@ -183,8 +183,8 @@ public class MetaData extends Observable implements JsonStream.Streamable {
         } else if (obj instanceof Map) {
             // Map objects
             writer.beginObject();
-            for (Iterator entries = ((Map) obj).entrySet().iterator(); entries.hasNext(); ) {
-                Map.Entry entry = (Map.Entry) entries.next();
+            for (Object o : ((Map) obj).entrySet()) {
+                Map.Entry entry = (Map.Entry) o;
                 Object keyObj = entry.getKey();
                 if (keyObj instanceof String) {
                     String key = (String) keyObj;

--- a/sdk/src/main/java/com/bugsnag/android/MetaData.java
+++ b/sdk/src/main/java/com/bugsnag/android/MetaData.java
@@ -140,7 +140,7 @@ public class MetaData extends Observable implements JsonStream.Streamable {
 
     @NonNull
     private static Map<String, Object> mergeMaps(@NonNull Map<String, Object>... maps) {
-        Map<String, Object> result = new ConcurrentHashMap<String, Object>();
+        Map<String, Object> result = new ConcurrentHashMap<>();
 
         for (Map<String, Object> map : maps) {
             if (map == null) continue;


### PR DESCRIPTION
If null is passed in as a metadata parameter, constructs an empty object instead.

I believe this is the most likely cause for #194, where `addToTab` resulted in a NPE. 