### PR TITLE
Expose Support Annotations dependency transitively

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:support-annotations:$supportLibVersion"
+    api "com.android.support:support-annotations:$supportLibVersion"
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
 


### PR DESCRIPTION
Exposes the support annotations as a transitive dependency, by replacing `implementation` with `api`. This is required for React Native projects, which are much less likely to have the Google Maven Repo specified than Android projects:

https://github.com/bugsnag/bugsnag-react-native/issues/177
Overview: https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#new_configurations