### PR TITLE
Enqueue activity lifecycle events when client not initialised

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -28,7 +28,7 @@ android {
         targetSdkVersion Integer.parseInt(project.ANDROID_TARGET_SDK_VERSION)
 
         manifestPlaceholders = [
-            bugsnagApiKey                    : "066f5ad3590596f9aa8d601ea89af845",
+            bugsnagApiKey                    : "572dd1154e6c5b291e5d1b42e506ae34",
             bugsnagBuildUUID                 : "abc123",
             bugsnagAppVersion                : "1.0.0",
             bugsnagEndpoint                  : "https://notify.bugsnag.com",

--- a/example/src/androidTest/java/com/bugsnag/android/CrashReportTest.java
+++ b/example/src/androidTest/java/com/bugsnag/android/CrashReportTest.java
@@ -53,7 +53,7 @@ public class CrashReportTest {
         assertNotNull(report);
         JSONObject json = getJson(report);
 
-        assertEquals("066f5ad3590596f9aa8d601ea89af845", json.getString("apiKey"));
+        assertNotNull(json.getString("apiKey"));
         assertEquals(3, json.length());
 
         JSONObject event = json.getJSONArray("events").getJSONObject(0);

--- a/sdk/src/androidTest/java/com/bugsnag/android/LifecycleBreadcrumbLoggerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/LifecycleBreadcrumbLoggerTest.java
@@ -1,0 +1,42 @@
+package com.bugsnag.android;
+
+import android.util.Pair;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+public class LifecycleBreadcrumbLoggerTest {
+
+    private static final String FIRST_ACTIVITY = "MyActivity";
+    private static final String SECOND_ACTIVITY = "SecondActivity";
+    private static final String FIRST_CB = "onCreate";
+    private static final String SECOND_CB = "onStart";
+
+    @Test
+    public void testLifecycleQueueing() throws Exception {
+        LifecycleBreadcrumbLogger logger = new LifecycleBreadcrumbLogger(null);
+        logger.leaveLifecycleBreadcrumb(FIRST_ACTIVITY, FIRST_CB);
+        logger.leaveLifecycleBreadcrumb(SECOND_ACTIVITY, SECOND_CB);
+
+        assertEquals(2, logger.queue.size());
+
+        Pair<String, String> poll = logger.queue.poll();
+        assertEquals(FIRST_ACTIVITY, poll.first);
+        assertEquals(FIRST_CB, poll.second);
+
+        poll = logger.queue.poll();
+        assertEquals(SECOND_ACTIVITY, poll.first);
+        assertEquals(SECOND_CB, poll.second);
+    }
+
+    @Test
+    public void testLifecycleLogging() throws Exception {
+        LifecycleBreadcrumbLogger logger = new LifecycleBreadcrumbLogger(BugsnagTestUtils.generateClient());
+        logger.leaveLifecycleBreadcrumb(FIRST_ACTIVITY, FIRST_CB);
+        logger.leaveLifecycleBreadcrumb(SECOND_ACTIVITY, SECOND_CB);
+        assertTrue(logger.queue.isEmpty());
+    }
+
+}

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -120,17 +120,17 @@ public class Client extends Observable implements Observer {
         launchTimeMs = time.getTime();
         warnIfNotAppContext(androidContext);
         appContext = androidContext.getApplicationContext();
-        ConnectivityManager cm = (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
-        errorReportApiClient = new DefaultHttpClient(cm);
 
         if (appContext instanceof Application) {
             Application application = (Application) appContext;
-            application.registerActivityLifecycleCallbacks(new LifecycleBreadcrumbLogger());
+            application.registerActivityLifecycleCallbacks(new LifecycleBreadcrumbLogger(this));
         } else {
             Logger.warn("Bugsnag is unable to setup automatic activity lifecycle breadcrumbs on API " +
                 "Levels below 14.");
         }
 
+        ConnectivityManager cm = (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        errorReportApiClient = new DefaultHttpClient(cm);
         config = configuration;
 
         // populate from manifest (in the case where the constructor was called directly by the

--- a/sdk/src/main/java/com/bugsnag/android/LifecycleBreadcrumbLogger.java
+++ b/sdk/src/main/java/com/bugsnag/android/LifecycleBreadcrumbLogger.java
@@ -15,7 +15,7 @@ class LifecycleBreadcrumbLogger implements Application.ActivityLifecycleCallback
 
     private static final String KEY_LIFECYCLE_CALLBACK = "ActivityLifecycle";
 
-    private final Queue<Pair<String, String>> queue = new ConcurrentLinkedQueue<>();
+    final Queue<Pair<String, String>> queue = new ConcurrentLinkedQueue<>();
     private final Client client;
 
     LifecycleBreadcrumbLogger(Client client) {
@@ -24,42 +24,44 @@ class LifecycleBreadcrumbLogger implements Application.ActivityLifecycleCallback
 
     @Override
     public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
-        leaveLifecycleBreadcrumb(activity, "onCreate()");
+        leaveLifecycleBreadcrumb(getActivityName(activity), "onCreate()");
     }
 
     @Override
     public void onActivityStarted(@NonNull Activity activity) {
-        leaveLifecycleBreadcrumb(activity, "onStart()");
+        leaveLifecycleBreadcrumb(getActivityName(activity), "onStart()");
     }
 
     @Override
     public void onActivityResumed(@NonNull Activity activity) {
-        leaveLifecycleBreadcrumb(activity, "onResume()");
+        leaveLifecycleBreadcrumb(getActivityName(activity), "onResume()");
     }
 
     @Override
     public void onActivityPaused(@NonNull Activity activity) {
-        leaveLifecycleBreadcrumb(activity, "onPause()");
+        leaveLifecycleBreadcrumb(getActivityName(activity), "onPause()");
     }
 
     @Override
     public void onActivityStopped(@NonNull Activity activity) {
-        leaveLifecycleBreadcrumb(activity, "onStop()");
+        leaveLifecycleBreadcrumb(getActivityName(activity), "onStop()");
     }
 
     @Override
     public void onActivitySaveInstanceState(@NonNull Activity activity, Bundle outState) {
-        leaveLifecycleBreadcrumb(activity, "onSaveInstanceState()");
+        leaveLifecycleBreadcrumb(getActivityName(activity), "onSaveInstanceState()");
     }
 
     @Override
     public void onActivityDestroyed(@NonNull Activity activity) {
-        leaveLifecycleBreadcrumb(activity, "onDestroy()");
+        leaveLifecycleBreadcrumb(getActivityName(activity), "onDestroy()");
     }
 
-    private void leaveLifecycleBreadcrumb(@NonNull Activity activity, String lifecycleCallback) {
-        String activityName = activity.getClass().getSimpleName();
+    private String getActivityName(@NonNull Activity activity) {
+        return activity.getClass().getSimpleName();
+    }
 
+    void leaveLifecycleBreadcrumb(String activityName, String lifecycleCallback) {
         if (client == null) { // not initialised yet, enqueue breadcrumbs for later
             queue.add(new Pair<>(activityName, lifecycleCallback));
         } else {

--- a/sdk/src/main/java/com/bugsnag/android/LifecycleBreadcrumbLogger.java
+++ b/sdk/src/main/java/com/bugsnag/android/LifecycleBreadcrumbLogger.java
@@ -4,13 +4,23 @@ import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.util.Pair;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 class LifecycleBreadcrumbLogger implements Application.ActivityLifecycleCallbacks {
 
     private static final String KEY_LIFECYCLE_CALLBACK = "ActivityLifecycle";
+
+    private final Queue<Pair<String, String>> queue = new ConcurrentLinkedQueue<>();
+    private final Client client;
+
+    LifecycleBreadcrumbLogger(Client client) {
+        this.client = client;
+    }
 
     @Override
     public void onActivityCreated(@NonNull Activity activity, Bundle savedInstanceState) {
@@ -49,9 +59,22 @@ class LifecycleBreadcrumbLogger implements Application.ActivityLifecycleCallback
 
     private void leaveLifecycleBreadcrumb(@NonNull Activity activity, String lifecycleCallback) {
         String activityName = activity.getClass().getSimpleName();
+
+        if (client == null) { // not initialised yet, enqueue breadcrumbs for later
+            queue.add(new Pair<>(activityName, lifecycleCallback));
+        } else {
+            while (!queue.isEmpty()) {
+                Pair<String, String> pair = queue.poll();
+                leaveBreadcrumb(pair.first, pair.second);
+            }
+            leaveBreadcrumb(activityName, lifecycleCallback);
+        }
+    }
+
+    private void leaveBreadcrumb(String activityName, String lifecycleCallback) {
         Map<String, String> metadata = new HashMap<>();
         metadata.put(KEY_LIFECYCLE_CALLBACK, lifecycleCallback);
-        Bugsnag.leaveBreadcrumb(activityName, BreadcrumbType.NAVIGATION, metadata);
+        client.leaveBreadcrumb(activityName, BreadcrumbType.NAVIGATION, metadata);
     }
 
 }


### PR DESCRIPTION
Android Lifecycle events can currently be received before the `Client` has been fully constructed, leading to a crash. This updates the `LifecycleBreadcrumbLogger` so that it uses a `Client` object directly, and queues any breadcrumbs if the client is not yet initialised.