### PR TITLE
Session tracking amends

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -81,7 +81,7 @@ public class Client extends Observable implements Observer {
     private final long launchTimeMs;
 
     private final EventReceiver eventReceiver = new EventReceiver();
-    private final SessionTracker sessionTracker;
+    final SessionTracker sessionTracker;
     private ErrorReportApiClient errorReportApiClient;
     private SessionTrackingApiClient sessionTrackingApiClient;
     private final Handler handler;
@@ -141,9 +141,29 @@ public class Client extends Observable implements Observer {
 
         sessionTracker = new SessionTracker(configuration, this, sessionStore, sessionTrackingApiClient, appContext);
 
-        if (configuration.shouldAutoCaptureSessions()) { // create initial session
-            sessionTracker.startNewSession(new Date(), null, true);
+        // Set up and collect constant app and device diagnostics
+        SharedPreferences sharedPref = appContext.getSharedPreferences(SHARED_PREF_KEY, Context.MODE_PRIVATE);
+
+        appData = new AppData(appContext, config, sessionTracker);
+        deviceData = new DeviceData(appContext, sharedPref);
+
+        // Set up breadcrumbs
+        breadcrumbs = new Breadcrumbs();
+
+        // Set sensible defaults
+        setProjectPackages(appContext.getPackageName());
+
+        if (config.getPersistUserBetweenSessions()) {
+            // Check to see if a user was stored in the SharedPreferences
+            user.setId(sharedPref.getString(USER_ID_KEY, deviceData.getUserId()));
+            user.setName(sharedPref.getString(USER_NAME_KEY, null));
+            user.setEmail(sharedPref.getString(USER_EMAIL_KEY, null));
+        } else {
+            user.setId(deviceData.getUserId());
         }
+
+        // create initial session
+        sessionTracker.startNewSession(new Date(), user, true);
 
         if (appContext instanceof Application) {
             Application application = (Application) appContext;
@@ -167,27 +187,6 @@ public class Client extends Observable implements Observer {
             if (buildUUID != null) {
                 config.setBuildUUID(buildUUID);
             }
-        }
-
-        // Set up and collect constant app and device diagnostics
-        SharedPreferences sharedPref = appContext.getSharedPreferences(SHARED_PREF_KEY, Context.MODE_PRIVATE);
-
-        appData = new AppData(appContext, config, sessionTracker);
-        deviceData = new DeviceData(appContext, sharedPref);
-
-        // Set up breadcrumbs
-        breadcrumbs = new Breadcrumbs();
-
-        // Set sensible defaults
-        setProjectPackages(appContext.getPackageName());
-
-        if (config.getPersistUserBetweenSessions()) {
-            // Check to see if a user was stored in the SharedPreferences
-            user.setId(sharedPref.getString(USER_ID_KEY, deviceData.getUserId()));
-            user.setName(sharedPref.getString(USER_NAME_KEY, null));
-            user.setEmail(sharedPref.getString(USER_EMAIL_KEY, null));
-        } else {
-            user.setId(deviceData.getUserId());
         }
 
         // Create the error store that is used in the exception handler

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -357,6 +357,15 @@ public class Configuration extends Observable implements Observer {
      */
     public void setAutoCaptureSessions(boolean autoCapture) {
         this.autoCaptureSessions = autoCapture;
+
+        if (autoCapture) { // track any existing sessions
+            Client client = Bugsnag.getClient();
+
+            //noinspection ConstantConditions
+            if (client != null && client.sessionTracker != null) {
+                client.sessionTracker.onAutoCaptureEnabled();
+            }
+        }
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -91,7 +91,7 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
      */
     private void trackSessionIfNeeded(boolean autoCaptured, Session session) {
         String releaseStage = getReleaseStage();
-        boolean notifyForRelease = client != null && configuration.shouldNotifyForReleaseStage(releaseStage);
+        boolean notifyForRelease = configuration.shouldNotifyForReleaseStage(releaseStage);
 
         if ((configuration.shouldAutoCaptureSessions() || !autoCaptured) && notifyForRelease) {
             sessionQueue.add(session);

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -73,13 +73,24 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
             Session session = new Session(UUID.randomUUID().toString(), date, user);
             session.setAutoCaptured(autoCaptured);
 
-            if (configuration.shouldAutoCaptureSessions() || !autoCaptured) {
+            String releaseStage = getReleaseStage();
+            boolean notifyForRelease = client != null && configuration.shouldNotifyForReleaseStage(releaseStage);
+
+            if ((configuration.shouldAutoCaptureSessions() || !autoCaptured) && notifyForRelease) {
                 sessionQueue.add(session);
                 sessionStore.write(session); // store session for sending
             }
             currentSession = session;
         }
 
+    }
+
+    private String getReleaseStage() {
+        if (configuration.getReleaseStage() != null) {
+            return configuration.getReleaseStage();
+        } else {
+            return AppDataSummary.guessReleaseStage(context);
+        }
     }
 
     @Nullable

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -82,6 +82,13 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
         return session;
     }
 
+    /**
+     * Determines whether or not a session should be tracked. If this is true, the session will be
+     * stored and sent to the Bugsnag API, otherwise no action will occur in this method.
+     *
+     * @param autoCaptured whether the session was automatically captured by the SDK or not
+     * @param session      the session
+     */
     private void trackSessionIfNeeded(boolean autoCaptured, Session session) {
         String releaseStage = getReleaseStage();
         boolean notifyForRelease = client != null && configuration.shouldNotifyForReleaseStage(releaseStage);


### PR DESCRIPTION
- Respect notifyReleaseStages by not tracking sessions if this config is set
- When autoCaptureSessions is set via config after initialisation, track an existing session if present (required for downstream notifiers)