### PR TITLE
Fix crash when enabling auto session capture

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -219,6 +219,18 @@ public final class Bugsnag {
     }
 
     /**
+     * Sets whether or not Bugsnag should automatically capture and report User sessions whenever
+     * the app enters the foreground.
+     * <p>
+     * By default this behavior is disabled.
+     *
+     * @param autoCapture whether sessions should be captured automatically
+     */
+    public static void setAutoCaptureSessions(boolean autoCapture) {
+        getClient().setAutoCaptureSessions(autoCapture);
+    }
+
+    /**
      * Set details of the user currently using your application.
      * You can search for this information in your Bugsnag dashboard.
      * <p>

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -484,6 +484,26 @@ public class Client extends Observable implements Observer {
         config.setSendThreads(sendThreads);
     }
 
+
+    /**
+     * Sets whether or not Bugsnag should automatically capture and report User sessions whenever
+     * the app enters the foreground.
+     * <p>
+     * By default this behavior is disabled.
+     *
+     * @param autoCapture whether sessions should be captured automatically
+     */
+    public void setAutoCaptureSessions(boolean autoCapture) {
+        config.setAutoCaptureSessions(autoCapture);
+
+        if (autoCapture) { // track any existing sessions
+            //noinspection ConstantConditions
+            if (sessionTracker != null) {
+                sessionTracker.onAutoCaptureEnabled();
+            }
+        }
+    }
+
     /**
      * Set details of the user currently using your application.
      * You can search for this information in your Bugsnag dashboard.

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -357,15 +357,6 @@ public class Configuration extends Observable implements Observer {
      */
     public void setAutoCaptureSessions(boolean autoCapture) {
         this.autoCaptureSessions = autoCapture;
-
-        if (autoCapture) { // track any existing sessions
-            Client client = Bugsnag.getClient();
-
-            //noinspection ConstantConditions
-            if (client != null && client.sessionTracker != null) {
-                client.sessionTracker.onAutoCaptureEnabled();
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
- Fixes `java.lang.IllegalStateException: You must call Bugsnag.init` crash when enabling auto session capture.
- Remove encapsulation breaking usage of `Bugsnag` client singleton from `Configuration`
- Adds `setAutoCaptureSessions` method to `Client` and `Bugsnag` client singleton