### PR TITLE
Enable test coverage with jacoco

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - while [[ `adb shell pm path android` == 'Error'* ]]; do sleep 2; done
   - adb shell input keyevent 82 &
 
-script: ./gradlew lint connectedCheck
+script: ./gradlew lint createDebugCoverageReport coveralls
 
 sudo: false
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
     }
 }
 repositories {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -16,6 +16,12 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
+    buildTypes {
+        debug {
+            testCoverageEnabled = true
+        }
+    }
+
     lintOptions {
         disable 'DefaultLocale', 'Typos'
         abortOnError true

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'com.github.kt3k.coveralls'
 
 repositories {
     jcenter()
@@ -28,6 +29,9 @@ android {
     }
 }
 
+coveralls {
+    jacocoReportPath = "$buildDir/reports/coverage/debug/report.xml"
+}
 dependencies {
     api "com.android.support:support-annotations:$supportLibVersion"
     testImplementation "junit:junit:$junitVersion"


### PR DESCRIPTION
Adds the `createDebugCoverageReport` task, which generates a Jacoco report under the build folder when run.