### PR TITLE
Generate correct pom file for bintrayUpload

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -72,9 +72,34 @@ publishing {
             artifactId 'bugsnag-android'
             version "${project.VERSION_NAME}"
 
-
             pom.withXml {
-                def dependenciesNode = asNode().appendNode('dependencies')
+                Node root = asNode()
+
+                // top-level metadata
+                Node packaging = root.get('packaging').first()
+                packaging.value = project.POM_PACKAGING
+                root.appendNode('name', project.POM_NAME)
+                root.appendNode('description', project.POM_DESCRIPTION)
+                root.appendNode('url', project.POM_URL)
+
+                // licenses
+                Node licenseNode = root.appendNode('licenses').appendNode('license')
+                licenseNode.appendNode('name', project.POM_LICENCE_NAME)
+                licenseNode.appendNode('url', project.POM_LICENCE_URL)
+                licenseNode.appendNode('distribution', project.POM_LICENCE_DIST)
+
+                // developers
+                Node devNode = root.appendNode('developers').appendNode('developer')
+                devNode.appendNode('id', project.POM_DEVELOPER_ID)
+                devNode.appendNode('name', project.POM_DEVELOPER_NAME)
+
+                // scm
+                Node scmNode = root.appendNode('scm')
+                scmNode.appendNode('connection', project.POM_SCM_CONNECTION)
+                scmNode.appendNode('developerConnection', project.POM_SCM_DEV_CONNECTION)
+                scmNode.appendNode('url', project.POM_SCM_URL)
+
+                def dependenciesNode = root.appendNode('dependencies')
 
                 // Iterate over the implementation dependencies (we don't want the test ones), adding a <dependency> node for each
                 configurations.implementation.allDependencies.each {
@@ -84,6 +109,7 @@ publishing {
                         dependencyNode.appendNode('groupId', it.group)
                         dependencyNode.appendNode('artifactId', it.name)
                         dependencyNode.appendNode('version', it.version)
+                        dependencyNode.appendNode('scope', 'compile')
                     }
                 }
             }


### PR DESCRIPTION
Updates the POM file generation for JCenter so that it creates the same file structure as for mavenCentral. This can be tested by running the `generatePomFileForProductionApplication` task and inspecting the POM file in the build dir.