### PR TITLE
Update context tracking to use lifecycle callbacks

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
 
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.GET_TASKS" />
 
   <application
     android:name=".ExampleApplication"

--- a/sdk/src/androidTest/AndroidManifest.xml
+++ b/sdk/src/androidTest/AndroidManifest.xml
@@ -5,7 +5,6 @@
   android:versionName="1.0">
 
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.GET_TASKS" />
 
   <application android:label="Bugsnag Android Tests"></application>
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -1,14 +1,13 @@
 package com.bugsnag.android;
 
-import android.support.test.InstrumentationRegistry;
-import android.util.Pair;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
 
-import static com.bugsnag.android.BugsnagTestUtils.*;
+import static com.bugsnag.android.BugsnagTestUtils.generateClient;
+import static com.bugsnag.android.BugsnagTestUtils.generateSessionStore;
+import static com.bugsnag.android.BugsnagTestUtils.generateSessionTrackingApiClient;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
@@ -95,6 +94,7 @@ public class SessionTrackerTest {
     public void testBasicInForeground() throws Exception {
         assertFalse(sessionTracker.isInForeground());
         assertNull(sessionTracker.getCurrentSession());
+        assertNull(sessionTracker.getContextActivity());
 
         sessionTracker.updateForegroundTracker(ACTIVITY_NAME, true, System.currentTimeMillis());
         assertTrue(sessionTracker.isInForeground());
@@ -104,13 +104,16 @@ public class SessionTrackerTest {
         sessionTracker.updateForegroundTracker("other", true, System.currentTimeMillis());
         assertTrue(sessionTracker.isInForeground());
         assertEquals(firstSession, sessionTracker.getCurrentSession());
+        assertEquals("other", sessionTracker.getContextActivity());
 
         sessionTracker.updateForegroundTracker("other", false, System.currentTimeMillis());
         assertTrue(sessionTracker.isInForeground());
+        assertNull(sessionTracker.getContextActivity());
 
         sessionTracker.updateForegroundTracker(ACTIVITY_NAME, false, System.currentTimeMillis());
         assertFalse(sessionTracker.isInForeground());
         assertEquals(firstSession, sessionTracker.getCurrentSession());
+        assertNull(sessionTracker.getContextActivity());
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -132,7 +132,10 @@ public class SessionTrackerTest {
         assertEquals(100, sessionTracker.getDurationInForegroundMs(now + 100));
 
         sessionTracker.updateForegroundTracker(ACTIVITY_NAME, false, now);
-        assertEquals(0, sessionTracker.getDurationInForegroundMs(now + 200));
+        assertEquals(200, sessionTracker.getDurationInForegroundMs(now + 200));
+
+        sessionTracker.updateForegroundTracker(ACTIVITY_NAME, false, now);
+        assertEquals(0, sessionTracker.getDurationInForegroundMs(now + 300));
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -108,7 +108,7 @@ public class SessionTrackerTest {
 
         sessionTracker.updateForegroundTracker("other", false, System.currentTimeMillis());
         assertTrue(sessionTracker.isInForeground());
-        assertNull(sessionTracker.getContextActivity());
+        assertEquals(ACTIVITY_NAME, sessionTracker.getContextActivity());
 
         sessionTracker.updateForegroundTracker(ACTIVITY_NAME, false, System.currentTimeMillis());
         assertFalse(sessionTracker.isInForeground());

--- a/sdk/src/main/java/com/bugsnag/android/AppData.java
+++ b/sdk/src/main/java/com/bugsnag/android/AppData.java
@@ -9,7 +9,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Information about the running Android app, including app name, version and release stage.
@@ -76,15 +75,7 @@ class AppData extends AppDataSummary {
 
     @Nullable
     String getActiveScreenClass() {
-        try {
-            ActivityManager activityManager = (ActivityManager) appContext.getSystemService(Context.ACTIVITY_SERVICE);
-            List<ActivityManager.RunningTaskInfo> tasks = activityManager.getRunningTasks(1);
-            ActivityManager.RunningTaskInfo runningTask = tasks.get(0);
-            return runningTask.topActivity.getClassName();
-        } catch (Exception e) {
-            Logger.warn("Could not get active screen information, we recommend granting the 'android.permission.GET_TASKS' permission");
-        }
-        return null;
+        return sessionTracker.getContextActivity();
     }
 
     /**
@@ -103,10 +94,12 @@ class AppData extends AppDataSummary {
     private static Boolean isLowMemory(@NonNull Context appContext) {
         try {
             ActivityManager activityManager = (ActivityManager) appContext.getSystemService(Context.ACTIVITY_SERVICE);
-            ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
-            activityManager.getMemoryInfo(memInfo);
 
-            return memInfo.lowMemory;
+            if (activityManager != null) {
+                ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
+                activityManager.getMemoryInfo(memInfo);
+                return memInfo.lowMemory;
+            }
         } catch (Exception e) {
             Logger.warn("Could not check lowMemory status");
         }

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -28,7 +28,7 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
     private static final int DEFAULT_TIMEOUT_MS = 30000;
 
     private final Collection<String>
-        foregroundActivities = new ConcurrentLinkedDeque<>();
+        foregroundActivities = new ConcurrentLinkedQueue<>();
     private final Configuration configuration;
     private final long timeoutMs;
     private final Client client;

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -38,6 +38,7 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
     private AtomicLong activityFirstStartedAtMs = new AtomicLong(0);
     private AtomicReference<Session> currentSession = new AtomicReference<>();
     private Semaphore flushingRequest = new Semaphore(1);
+    private final AtomicReference<String> contextActivity = new AtomicReference<>();
 
     SessionTracker(Configuration configuration, Client client, SessionStore sessionStore,
                    SessionTrackingApiClient apiClient) {
@@ -275,8 +276,10 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
                 startNewSession(new Date(nowMs), client.user, true);
             }
             foregroundActivities.put(activityName, true);
+            contextActivity.set(activityName);
         } else {
             foregroundActivities.remove(activityName);
+            contextActivity.set(null);
             activityLastStoppedAtMs.set(nowMs);
         }
     }
@@ -294,6 +297,10 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
             durationMs = nowMs - sessionStartTimeMs;
         }
         return durationMs > 0 ? durationMs : 0;
+    }
+
+    @Nullable String getContextActivity() {
+        return contextActivity.get();
     }
 
 }

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
@@ -25,8 +27,8 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
     private static final String KEY_LIFECYCLE_CALLBACK = "ActivityLifecycle";
     private static final int DEFAULT_TIMEOUT_MS = 30000;
 
-    private final Set<String>
-        foregroundActivities = new LinkedHashSet<>();
+    private final Collection<String>
+        foregroundActivities = new ConcurrentLinkedDeque<>();
     private final Configuration configuration;
     private final long timeoutMs;
     private final Client client;


### PR DESCRIPTION
`ActivityManager#getRunningTasks` was deprecated on Lollipop and above. This PR changes the automatic Report context so that it is set as the name of the most recently launched `Activity` which is in the started state, or null if this condition cannot be met.