### PR TITLE
Add Strictmode scenarios

### DIFF
--- a/features/strict_mode_disc.feature
+++ b/features/strict_mode_disc.feature
@@ -6,3 +6,4 @@ Scenario: Test handled Android Exception
     And the request is a valid for the error reporting API
     And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
     And the exception "message" equals "policy=262145 violation=1"
+    And the event "metaData.StrictMode.Violation" equals "DiskWrite"

--- a/features/strict_mode_disc.feature
+++ b/features/strict_mode_disc.feature
@@ -1,0 +1,8 @@
+Feature: Android support
+
+Scenario: Test handled Android Exception
+    When I run "StrictModeDiscScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
+    And the exception "message" equals "policy=262145 violation=1"

--- a/features/strict_mode_network.feature
+++ b/features/strict_mode_network.feature
@@ -6,3 +6,4 @@ Scenario: Test handled Android Exception
     And the request is a valid for the error reporting API
     And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
     And the exception "message" equals "policy=262148 violation=4"
+    And the event "metaData.StrictMode.Violation" equals "NetworkOperation"

--- a/features/strict_mode_network.feature
+++ b/features/strict_mode_network.feature
@@ -1,0 +1,8 @@
+Feature: Android support
+
+Scenario: Test handled Android Exception
+    When I run "StrictModeNetworkScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
+    And the exception "message" equals "policy=262145 violation=1"

--- a/features/strict_mode_network.feature
+++ b/features/strict_mode_network.feature
@@ -5,4 +5,4 @@ Scenario: Test handled Android Exception
     Then I should receive a request
     And the request is a valid for the error reporting API
     And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
-    And the exception "message" equals "policy=262145 violation=1"
+    And the exception "message" equals "policy=262148 violation=4"

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : Activity() {
     private fun executeTestCase() {
         val eventType = intent.getStringExtra("EVENT_TYPE")
         Log.d("Bugsnag", "Received test case, executing " + eventType)
-        val testCase = factory.testCaseForName(eventType)
+        val testCase = factory.testCaseForName(eventType, this)
         testCase.run()
     }
 

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/TestCaseFactory.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/TestCaseFactory.kt
@@ -1,12 +1,15 @@
 package com.bugsnag.android.mazerunner
 
+import android.content.Context
 import com.bugsnag.android.mazerunner.scenarios.Scenario
 
 internal class TestCaseFactory {
 
-    fun testCaseForName(eventType: String?): Scenario {
+    fun testCaseForName(eventType: String?, context: Context?): Scenario {
         val clz = Class.forName("com.bugsnag.android.mazerunner.scenarios.$eventType")
-        return clz.newInstance() as Scenario
+        val scenario = clz.newInstance() as Scenario
+        scenario.context = context
+        return scenario
     }
 
 }

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -1,9 +1,12 @@
 package com.bugsnag.android.mazerunner.scenarios
 
+import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.NetworkException
 
 abstract internal class Scenario {
+
+    var context: Context? = null
 
     abstract fun run()
 

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
@@ -1,0 +1,20 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.os.StrictMode
+import java.io.File
+
+/**
+ * Generates a strictmode exception caused by writing to disc on main thread
+ */
+internal class StrictModeDiscScenario : Scenario() {
+
+    override fun run() {
+        StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder()
+            .detectDiskWrites()
+            .penaltyDeath()
+            .build())
+        val file = File(context?.cacheDir, "fake")
+        file.writeBytes("test".toByteArray())
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
@@ -1,0 +1,20 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.os.StrictMode
+import java.io.File
+
+/**
+ * Generates a strictmode exception caused by writing to disc on main thread
+ */
+internal class StrictModeNetworkScenario : Scenario() {
+
+    override fun run() {
+        StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder()
+            .detectDiskWrites()
+            .penaltyDeath()
+            .build())
+        val file = File(context?.cacheDir, "fake")
+        file.writeBytes("test".toByteArray())
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
@@ -1,20 +1,23 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.os.StrictMode
-import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
 
 /**
- * Generates a strictmode exception caused by writing to disc on main thread
+ * Generates a strictmode exception caused by performing a network request on the main thread
  */
 internal class StrictModeNetworkScenario : Scenario() {
 
     override fun run() {
         StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder()
-            .detectDiskWrites()
+            .detectNetwork()
             .penaltyDeath()
             .build())
-        val file = File(context?.cacheDir, "fake")
-        file.writeBytes("test".toByteArray())
+
+        val urlConnection = URL("http://example.com").openConnection() as HttpURLConnection
+        urlConnection.doOutput = true
+        urlConnection.responseMessage
     }
 
 }

--- a/sdk/src/main/java/com/bugsnag/android/ExceptionHandler.java
+++ b/sdk/src/main/java/com/bugsnag/android/ExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import android.os.StrictMode;
 import android.support.annotation.NonNull;
 
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -70,8 +71,16 @@ class ExceptionHandler implements UncaughtExceptionHandler {
 
             String severityReason = strictModeThrowable
                 ? HandledState.REASON_STRICT_MODE : HandledState.REASON_UNHANDLED_EXCEPTION;
-            client.cacheAndNotify(throwable, Severity.ERROR,
-                metaData, severityReason, violationDesc);
+
+            if (strictModeThrowable) { // writes to disk on main thread
+                StrictMode.ThreadPolicy originalThreadPolicy = StrictMode.getThreadPolicy();
+                StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.LAX);
+
+                client.cacheAndNotify(throwable, Severity.ERROR,
+                    metaData, severityReason, violationDesc);
+
+                StrictMode.setThreadPolicy(originalThreadPolicy);
+            }
         }
 
         // Pass exception on to original exception handler


### PR DESCRIPTION
Adds a scenario to test Strictmode:

- Disk writes on main thread
- Network requests on main thread

Also prevents the crash handler from crashing due to StrictMode policy violations in the disk write scenario.