### PR TITLE
Ensure that exception message is never null

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -244,6 +244,16 @@ public class ErrorTest {
         errorJson.getJSONObject("session"); // session should not be serialised
     }
 
+    @Test
+    public void checkExceptionMessageNullity() throws Exception {
+        String msg = "Foo";
+        Error err = new Error.Builder(config, new RuntimeException(msg), null).build();
+        assertEquals(msg, err.getExceptionMessage());
+
+        err = new Error.Builder(config, new RuntimeException(), null).build();
+        assertEquals("", err.getExceptionMessage());
+    }
+
     private void validateEmptyAttributes(JSONObject severityReason) {
         try {
             severityReason.getJSONObject("attributes");

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -286,8 +286,9 @@ public class Error implements JsonStream.Streamable {
     /**
      * Get the message from the exception contained in this Error report.
      */
-    public String getExceptionMessage() {
-        return exception.getLocalizedMessage();
+    @NonNull public String getExceptionMessage() {
+        String localizedMessage = exception.getLocalizedMessage();
+        return localizedMessage != null ? localizedMessage : "";
     }
 
     /**


### PR DESCRIPTION
The exception message is added to the breadcrumb metadata, which can cause a crash in the NDK when accessing the value via the JNI.