### PR TITLE
Add cached report scenario

### DIFF
--- a/features/report_cache.feature
+++ b/features/report_cache.feature
@@ -1,0 +1,17 @@
+Feature: Android support
+
+Scenario: Test Unhandled Android Exception with Session
+    When I run "ReportCacheScenario" with the defaults
+    Then I should receive no requests
+
+    When I force stop the "com.bugsnag.android.mazerunner" Android app
+    And I set environment variable "EVENT_TYPE" to "Wait"
+    And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
+    Then I should receive a request
+
+    And the request is a valid for the error reporting API
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the payload field "notifier.name" equals "Android Bugsnag Notifier"
+    And the payload field "events" is an array with 1 element
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the exception "message" equals "ReportCacheScenario"

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ReportCacheScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ReportCacheScenario.kt
@@ -1,0 +1,18 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+
+/**
+ * Sends an unhandled exception which is cached on disk to Bugsnag, then sent on a separate launch.
+ */
+internal class ReportCacheScenario(config: Configuration,
+                                   context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+        disableAllDelivery()
+        throw RuntimeException("ReportCacheScenario")
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Wait.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Wait.kt
@@ -1,0 +1,12 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+
+internal class Wait(config: Configuration, context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+    }
+
+}


### PR DESCRIPTION
Adds a scenario that checks a report is delivered after caching on disk and the app process is relaunched