### PR TITLE
Add metadata filter scenarios

### DIFF
--- a/features/auto_filter.feature
+++ b/features/auto_filter.feature
@@ -1,0 +1,11 @@
+Feature: Android support
+
+Scenario: Automatic Filter Tracking
+    When I run "AutoFilterScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the exception "message" equals "AutoFilterScenario"
+    And the event "metaData.custom.foo" equals "hunter2"
+    And the event "metaData.custom.password" equals "[FILTERED]"
+    And the event "metaData.user.password" equals "[FILTERED]"

--- a/features/manual_filter.feature
+++ b/features/manual_filter.feature
@@ -1,0 +1,11 @@
+Feature: Android support
+
+Scenario: Manual Filter Tracking
+    When I run "ManualFilterScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the exception "message" equals "ManualFilterScenario"
+    And the event "metaData.custom.foo" equals "[FILTERED]"
+    And the event "metaData.user.foo" equals "[FILTERED]"
+    And the event "metaData.custom.bar" equals "hunter2"

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoFilterScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoFilterScenario.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Sends a handled exception to Bugsnag, which contains metadata that should be filtered
+ */
+internal class AutoFilterScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+        Bugsnag.addToTab("user", "password", "hunter2")
+        Bugsnag.addToTab("custom", "password", "hunter2")
+        Bugsnag.addToTab("custom", "foo", "hunter2")
+        Bugsnag.notify(generateException())
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualFilterScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualFilterScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Sends a handled exception to Bugsnag, which contains metadata that should be filtered
+ */
+internal class ManualFilterScenario(config: Configuration,
+                                    context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+        Bugsnag.setFilters("foo")
+        Bugsnag.addToTab("user", "foo", "hunter2")
+        Bugsnag.addToTab("custom", "foo", "hunter2")
+        Bugsnag.addToTab("custom", "bar", "hunter2")
+        Bugsnag.notify(generateException())
+    }
+
+}


### PR DESCRIPTION
Adds a scenario for manually specified and automatic filters to remove sensitive metadata.

Note: the automatic scenario fails due to a bug in the Notifier (separate PR inbound)