### PR TITLE
add tests for setting metadata filters by default

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/MetaDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/MetaDataTest.java
@@ -6,6 +6,7 @@ import android.support.test.runner.AndroidJUnit4;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -17,12 +18,20 @@ import java.util.LinkedList;
 import java.util.Map;
 
 import static com.bugsnag.android.BugsnagTestUtils.streamableToJson;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest
 public class MetaDataTest {
+
+    private Client client;
+
+    @Before
+    public void setUp() throws Exception {
+        client = BugsnagTestUtils.generateClient();
+    }
 
     @Test
     public void testBasicSerialization() throws JSONException, IOException {
@@ -187,5 +196,37 @@ public class MetaDataTest {
         assertEquals("[FILTERED]", sensitiveMapJson.getString("password"));
         assertEquals("[FILTERED]", sensitiveMapJson.getString("confirm_password"));
         assertEquals("safe", sensitiveMapJson.getString("normal"));
+    }
+
+    @Test
+    public void testFilterConstructor() throws Exception {
+        MetaData metaData = client.getMetaData();
+        metaData.addToTab("foo", "password", "abc123");
+        JSONObject jsonObject = streamableToJson(metaData);
+
+        assertArrayEquals(new String[]{"password"}, metaData.getFilters());
+        assertEquals("[FILTERED]", jsonObject.getJSONObject("foo").get("password"));
+    }
+
+    @Test
+    public void testFilterSetter() throws Exception {
+        MetaData metaData = new MetaData();
+        client.setMetaData(metaData);
+        assertArrayEquals(new String[]{"password"}, metaData.getFilters());
+    }
+
+    @Test
+    public void testFilterOverride() throws Exception {
+        MetaData metaData = client.getMetaData();
+        client.setFilters("test", "another");
+        assertArrayEquals(new String[]{"test", "another"}, metaData.getFilters());
+    }
+
+    @Test
+    public void testFilterMetadataOverride() throws Exception {
+        MetaData data = new MetaData();
+        data.setFilters("CUSTOM");
+        client.setMetaData(data);
+        assertArrayEquals(new String[]{"CUSTOM"}, data.getFilters());
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -63,7 +63,6 @@ public class Configuration extends Observable implements Observer {
     public Configuration(@NonNull String apiKey) {
         this.apiKey = apiKey;
         this.metaData = new MetaData();
-        setDefaultMetaDataFilters();
         this.metaData.addObserver(this);
     }
 
@@ -388,10 +387,6 @@ public class Configuration extends Observable implements Observer {
             this.metaData = metaData;
         }
 
-        if (this.metaData.getFilters() == null) {
-            setDefaultMetaDataFilters();
-        }
-
         this.metaData.addObserver(this);
         notifyBugsnagObservers(NotifyType.META);
     }
@@ -578,10 +573,6 @@ public class Configuration extends Observable implements Observer {
         }
 
         return false;
-    }
-
-    private void setDefaultMetaDataFilters() {
-        metaData.setFilters("password");
     }
 
     private void notifyBugsnagObservers(@NonNull NotifyType type) {

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -32,7 +32,6 @@ public class Configuration extends Observable implements Observer {
     private String endpoint = "https://notify.bugsnag.com";
     private String sessionEndpoint = "https://sessions.bugsnag.com";
 
-    private String[] filters = new String[]{"password"};
     private String[] ignoreClasses;
     @Nullable
     private String[] notifyReleaseStages = null;
@@ -64,6 +63,7 @@ public class Configuration extends Observable implements Observer {
     public Configuration(@NonNull String apiKey) {
         this.apiKey = apiKey;
         this.metaData = new MetaData();
+        setDefaultMetaDataFilters();
         this.metaData.addObserver(this);
     }
 
@@ -190,7 +190,7 @@ public class Configuration extends Observable implements Observer {
      * @return Filters
      */
     public String[] getFilters() {
-        return filters;
+        return metaData.getFilters();
     }
 
     /**
@@ -207,7 +207,6 @@ public class Configuration extends Observable implements Observer {
      * @param filters a list of keys to filter from metaData
      */
     public void setFilters(String[] filters) {
-        this.filters = filters;
         this.metaData.setFilters(filters);
     }
 
@@ -387,6 +386,10 @@ public class Configuration extends Observable implements Observer {
             this.metaData = new MetaData();
         } else {
             this.metaData = metaData;
+        }
+
+        if (this.metaData.getFilters() == null) {
+            setDefaultMetaDataFilters();
         }
 
         this.metaData.addObserver(this);
@@ -575,6 +578,10 @@ public class Configuration extends Observable implements Observer {
         }
 
         return false;
+    }
+
+    private void setDefaultMetaDataFilters() {
+        metaData.setFilters("password");
     }
 
     private void notifyBugsnagObservers(@NonNull NotifyType type) {

--- a/sdk/src/main/java/com/bugsnag/android/MetaData.java
+++ b/sdk/src/main/java/com/bugsnag/android/MetaData.java
@@ -118,6 +118,10 @@ public class MetaData extends Observable implements JsonStream.Streamable {
         notifyBugsnagObservers(NotifyType.FILTERS);
     }
 
+    String[] getFilters() {
+        return filters;
+    }
+
     @NonNull
     static MetaData merge(@NonNull MetaData... metaDataList) {
         List<Map<String, Object>> stores = new ArrayList<>();

--- a/sdk/src/main/java/com/bugsnag/android/MetaData.java
+++ b/sdk/src/main/java/com/bugsnag/android/MetaData.java
@@ -25,7 +25,8 @@ public class MetaData extends Observable implements JsonStream.Streamable {
     private static final String FILTERED_PLACEHOLDER = "[FILTERED]";
     private static final String OBJECT_PLACEHOLDER = "[OBJECT]";
 
-    private String[] filters;
+    private String[] filters = {"password"};
+
     @NonNull
     final Map<String, Object> store;
 


### PR DESCRIPTION
MetaData filters are currently left as null unless they are explicitly set. This adds a fix and test coverage to prevent this scenario.

Additionally I've added coverage in 2 Maze Runner scenarios: https://github.com/bugsnag/bugsnag-android/pull/262/files