### PR TITLE
Allow setting custom session tracking api client

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -12,9 +12,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
+
 import static com.bugsnag.android.BugsnagTestUtils.getSharedPrefs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest
@@ -201,6 +204,25 @@ public class ClientTest {
         assertEquals(false, newConfig.getEnableExceptionHandler());
         assertEquals(true, newConfig.getPersistUserBetweenSessions());
         assertEquals(true, newConfig.shouldAutoCaptureSessions());
+    }
+
+    @Test
+    public void testSessionTrackerApiClient() throws Exception {
+        Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
+        assertTrue(client.sessionTracker.getApiClient() instanceof DefaultHttpClient);
+
+        SessionTrackingApiClient customClient = new SessionTrackingApiClient() {
+            @Override
+            public void postSessionTrackingPayload(String urlString,
+                                                   SessionTrackingPayload payload,
+                                                   Map<String, String> headers)
+                throws NetworkException, BadResponseException {
+
+            }
+        };
+        client.setSessionTrackingApiClient(customClient);
+        assertFalse(client.sessionTracker.getApiClient() instanceof DefaultHttpClient);
+        assertEquals(customClient, client.sessionTracker.getApiClient());
     }
 
 }

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -645,6 +645,7 @@ public class Client extends Observable implements Observer {
             throw new IllegalArgumentException("SessionTrackingApiClient cannot be null.");
         }
         this.sessionTrackingApiClient = apiClient;
+        sessionTracker.setApiClient(apiClient);
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -10,12 +10,9 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
@@ -33,7 +30,7 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
     private final long timeoutMs;
     private final Client client;
     private final SessionStore sessionStore;
-    private final SessionTrackingApiClient apiClient;
+    private SessionTrackingApiClient apiClient;
 
     // This most recent time an Activity was stopped.
     private AtomicLong activityLastStoppedAtMs = new AtomicLong(0);
@@ -70,6 +67,14 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
         Session session = new Session(UUID.randomUUID().toString(), date, user, autoCaptured);
         currentSession.set(session);
         trackSessionIfNeeded(session);
+    }
+
+    void setApiClient(SessionTrackingApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    SessionTrackingApiClient getApiClient() {
+        return apiClient;
     }
 
     /**


### PR DESCRIPTION
Ensures that when a custom session tracking api client is set on the client, the sessionTracker field is also updated.