### PR TITLE
Prevent ConcurrentModificationException in Before notify/breadcrumb callbacks

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentBeforeNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentBeforeNotifyTest.java
@@ -1,0 +1,46 @@
+package com.bugsnag.android;
+
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+
+/**
+ * Ensures that if a {@link BeforeNotify} is added or removed during iteration, a
+ * {@link java.util.ConcurrentModificationException} is not thrown
+ */
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class ConcurrentBeforeNotifyTest {
+
+    private Client client;
+
+    @Before
+    public void setUp() throws Exception {
+        client = BugsnagTestUtils.generateClient();
+    }
+
+    @Test
+    public void testClientNotifyModification() throws Exception {
+        final Collection<BeforeNotify> beforeNotifyTasks = client.config.getBeforeNotifyTasks();
+        client.beforeNotify(new BeforeNotify() {
+            @Override
+            public boolean run(Error error) {
+                beforeNotifyTasks.clear();
+                return true;
+            }
+        });
+        client.beforeNotify(new BeforeNotify() {
+            @Override
+            public boolean run(Error error) {
+                return true;
+            }
+        });
+        client.notify(new RuntimeException());
+    }
+
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import android.support.annotation.NonNull;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -10,12 +11,12 @@ import org.junit.runner.RunWith;
 import java.util.Collection;
 
 /**
- * Ensures that if a {@link BeforeNotify} is added or removed during iteration, a
+ * Ensures that if a callback is added or removed during iteration, a
  * {@link java.util.ConcurrentModificationException} is not thrown
  */
 @RunWith(AndroidJUnit4.class)
 @SmallTest
-public class ConcurrentBeforeNotifyTest {
+public class ConcurrentCallbackTest {
 
     private Client client;
 
@@ -42,5 +43,27 @@ public class ConcurrentBeforeNotifyTest {
         });
         client.notify(new RuntimeException());
     }
+
+    @Test
+    public void testClientBreadcrumbModification() throws Exception {
+        final Collection<BeforeRecordBreadcrumb> breadcrumbTasks = client.config.getBeforeRecordBreadcrumbTasks();
+
+        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+            @Override
+            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+                breadcrumbTasks.clear();
+                return true;
+            }
+        });
+        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+            @Override
+            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+                return true;
+            }
+        });
+        client.leaveBreadcrumb("Whoops");
+        client.notify(new RuntimeException());
+    }
+
 
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -31,16 +31,12 @@ public class ConcurrentCallbackTest {
         client.beforeNotify(new BeforeNotify() {
             @Override
             public boolean run(Error error) {
-                beforeNotifyTasks.clear();
+                beforeNotifyTasks.add(new BeforeNotifySkeleton());
+                // modify the Set, when iterating to the next callback this should not crash
                 return true;
             }
         });
-        client.beforeNotify(new BeforeNotify() {
-            @Override
-            public boolean run(Error error) {
-                return true;
-            }
-        });
+        client.beforeNotify(new BeforeNotifySkeleton());
         client.notify(new RuntimeException());
     }
 
@@ -51,19 +47,28 @@ public class ConcurrentCallbackTest {
         client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
             @Override
             public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
-                breadcrumbTasks.clear();
+                breadcrumbTasks.add(new BeforeRecordBreadcrumbSkeleton());
+                // modify the Set, when iterating to the next callback this should not crash
                 return true;
             }
         });
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
-            @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
-                return true;
-            }
-        });
+        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumbSkeleton());
         client.leaveBreadcrumb("Whoops");
         client.notify(new RuntimeException());
     }
 
+    static class BeforeNotifySkeleton implements BeforeNotify {
+        @Override
+        public boolean run(Error error) {
+            return true;
+        }
+    }
+
+    static class BeforeRecordBreadcrumbSkeleton implements BeforeRecordBreadcrumb {
+        @Override
+        public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            return true;
+        }
+    }
 
 }

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * User-specified configuration storage object, contains information
@@ -50,9 +51,9 @@ public class Configuration extends Observable implements Observer {
 
     @NonNull
     private MetaData metaData;
-    private final Collection<BeforeNotify> beforeNotifyTasks = new LinkedHashSet<>();
+    private final Collection<BeforeNotify> beforeNotifyTasks = new ConcurrentLinkedQueue<>();
     private final Collection<BeforeRecordBreadcrumb> beforeRecordBreadcrumbTasks
-        = new LinkedHashSet<>();
+        = new ConcurrentLinkedQueue<>();
     private String codeBundleId;
     private String notifierType;
 
@@ -547,7 +548,9 @@ public class Configuration extends Observable implements Observer {
      * @param beforeNotify the new before notify task
      */
     protected void beforeNotify(BeforeNotify beforeNotify) {
-        this.beforeNotifyTasks.add(beforeNotify);
+        if (!beforeNotifyTasks.contains(beforeNotify)) {
+            beforeNotifyTasks.add(beforeNotify);
+        }
     }
 
     /**
@@ -556,7 +559,9 @@ public class Configuration extends Observable implements Observer {
      * @param beforeRecordBreadcrumb the new before breadcrumb task
      */
     protected void beforeRecordBreadcrumb(BeforeRecordBreadcrumb beforeRecordBreadcrumb) {
-        this.beforeRecordBreadcrumbTasks.add(beforeRecordBreadcrumb);
+        if (!beforeRecordBreadcrumbTasks.contains(beforeRecordBreadcrumb)) {
+            beforeRecordBreadcrumbTasks.add(beforeRecordBreadcrumb);
+        }
     }
 
     /**


### PR DESCRIPTION
Prevents a `ConcurrentModificationException` from occurring in the `BeforeNotify` and `BeforeRecordBreadcrumb` callbacks, if an element is added to the collection during or at the same time as `notify` is called.

A `ConcurrentLinkedQueue` is used in place of a `LinkedHashSet` as this retains the order of the callbacks. There's a bit of a tradeoff here with [#127](https://github.com/bugsnag/bugsnag-android/issues/127) - I've added a check to the client method to avoid adding duplicate callbacks, and assumed that anyone adding to the Collection directly knows what they're doing.