### PR TITLE
Refactoring `User´

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -46,7 +46,7 @@ final class BugsnagTestUtils {
     }
 
     static Session generateSession() {
-        return new Session("test", new Date(), new User(), false);
+        return new Session("test", new Date(), User.builder().build(), false);
     }
 
     static Configuration generateConfiguration() {

--- a/sdk/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -46,7 +46,7 @@ final class BugsnagTestUtils {
     }
 
     static Session generateSession() {
-        return new Session("test", new Date(), User.builder().build(), false);
+        return new Session("test", new Date(), new User.Builder().build(), false);
     }
 
     static Configuration generateConfiguration() {

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -207,6 +207,14 @@ public class ClientTest {
     }
 
     @Test
+    public void testSetGetUser() {
+        User user = User.builder().build();
+        Client client = new Client(context, "api-key");
+        client.setUser(user);
+        assertThat(client.getUser(), is(user));
+    }
+
+    @Test
     public void testEmptyManifestConfig() {
         Bundle data = new Bundle();
         Configuration newConfig = Client.populateConfigFromManifest(new Configuration("api-key"), data);

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -120,7 +120,7 @@ public class ClientTest {
 
     @Deprecated
     @Test
-    public void testStoreUserInPrefs_deprecated() {
+    public void testStoreUserInPrefsDeprecated() {
         config.setPersistUserBetweenSessions(true);
         Client client = new Client(context, config);
         //noinspection deprecation
@@ -137,7 +137,7 @@ public class ClientTest {
     public void testStoreUserInPrefs() {
         config.setPersistUserBetweenSessions(true);
         Client client = new Client(context, config);
-        client.setUser(User.builder().id(USER_ID).email(USER_EMAIL).name(USER_NAME).build());
+        client.setUser(new User.Builder().id(USER_ID).email(USER_EMAIL).name(USER_NAME).build());
 
         // Check that the user was store in prefs
         SharedPreferences sharedPref = getSharedPrefs(context);
@@ -148,7 +148,7 @@ public class ClientTest {
 
     @Deprecated
     @Test
-    public void testStoreUserInPrefsDisabled_deprecated() {
+    public void testStoreUserInPrefsDisabledDeprecated() {
         config.setPersistUserBetweenSessions(false);
         Client client = new Client(context, config);
         client.setUser(USER_ID, USER_EMAIL, USER_NAME);
@@ -164,7 +164,7 @@ public class ClientTest {
     public void testStoreUserInPrefsDisabled() {
         config.setPersistUserBetweenSessions(false);
         Client client = new Client(context, config);
-        client.setUser(User.builder().id(USER_ID).email(USER_EMAIL).name(USER_NAME).build());
+        client.setUser(new User.Builder().id(USER_ID).email(USER_EMAIL).name(USER_NAME).build());
 
         // Check that the user was not stored in prefs
         SharedPreferences sharedPref = getSharedPrefs(context);
@@ -175,7 +175,7 @@ public class ClientTest {
 
     @Deprecated
     @Test
-    public void testClearUser_deprecated() {
+    public void testClearUserDeprecated() {
         // Set a user in prefs
         setUserPrefs();
 
@@ -208,7 +208,7 @@ public class ClientTest {
 
     @Test
     public void testSetGetUser() {
-        User user = User.builder().build();
+        User user = new User.Builder().build();
         Client client = new Client(context, "api-key");
         client.setUser(user);
         assertThat(client.getUser(), is(user));

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -29,7 +29,7 @@ public class SessionTrackerTest {
         sessionTracker = new SessionTracker(configuration, generateClient(), generateSessionStore(),
             generateSessionTrackingApiClient());
         configuration.setAutoCaptureSessions(true);
-        user = User.builder().build();
+        user = new User.Builder().build();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -29,7 +29,7 @@ public class SessionTrackerTest {
         sessionTracker = new SessionTracker(configuration, generateClient(), generateSessionStore(),
             generateSessionTrackingApiClient());
         configuration.setAutoCaptureSessions(true);
-        user = new User();
+        user = User.builder().build();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/UserTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/UserTest.java
@@ -1,0 +1,53 @@
+package com.bugsnag.android;
+
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class UserTest {
+    @Test
+    public void testBuilder_defaults() {
+        User user = User.builder().build();
+
+        assertThat(user.getId(), is(nullValue()));
+        assertThat(user.getEmail(), is(nullValue()));
+        assertThat(user.getName(), is(nullValue()));
+    }
+
+    @Test
+    public void testBuilder_values() {
+        final String id = UUID.randomUUID().toString();
+        final String email = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+
+        User user = User.builder().name(name).id(id).email(email).build();
+
+        assertThat(user.getId(), is(id));
+        assertThat(user.getEmail(), is(email));
+        assertThat(user.getName(), is(name));
+    }
+
+    @Test
+    public void testBuilder_fromPrevious() {
+        final String id = UUID.randomUUID().toString();
+        final String email = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+
+        User previous = User.builder().name(name).id(id).email(email).build();
+        User successor = User.builder(previous).build();
+
+        assertThat(successor.getId(), is(id));
+        assertThat(successor.getEmail(), is(email));
+        assertThat(successor.getName(), is(name));
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/UserTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/UserTest.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import android.content.SharedPreferences;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -8,7 +10,9 @@ import org.junit.runner.RunWith;
 
 import java.util.UUID;
 
+import static com.bugsnag.android.BugsnagTestUtils.getSharedPrefs;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
@@ -49,5 +53,29 @@ public class UserTest {
         assertThat(successor.getId(), is(id));
         assertThat(successor.getEmail(), is(email));
         assertThat(successor.getName(), is(name));
+    }
+
+    @Test
+    public void testRepo() {
+        SharedPreferences sharedPref = getSharedPrefs(InstrumentationRegistry.getContext());
+
+        User pre = User.builder()
+            .name(UUID.randomUUID().toString())
+            .id(UUID.randomUUID().toString())
+            .email(UUID.randomUUID().toString())
+            .build();
+
+        User.Repo repo = new User.Repo(sharedPref);
+        repo.set(pre);
+
+        User post = repo.get();
+        assertThat(post, is(not(nullValue())));
+
+        assertThat(post.getId(), is(pre.getId()));
+        assertThat(post.getEmail(), is(pre.getEmail()));
+        assertThat(post.getName(), is(pre.getName()));
+
+        repo.set(null);
+        assertThat(repo.get(), is(nullValue()));
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/UserTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/UserTest.java
@@ -19,22 +19,14 @@ import static org.hamcrest.core.Is.is;
 @RunWith(AndroidJUnit4.class)
 @SmallTest
 public class UserTest {
-    @Test
-    public void testBuilder_defaults() {
-        User user = User.builder().build();
-
-        assertThat(user.getId(), is(nullValue()));
-        assertThat(user.getEmail(), is(nullValue()));
-        assertThat(user.getName(), is(nullValue()));
-    }
 
     @Test
-    public void testBuilder_values() {
+    public void testToBuilder() {
         final String id = UUID.randomUUID().toString();
         final String email = UUID.randomUUID().toString();
         final String name = UUID.randomUUID().toString();
 
-        User user = User.builder().name(name).id(id).email(email).build();
+        User user = new User.Builder().name(name).id(id).email(email).build().toBuilder().build();
 
         assertThat(user.getId(), is(id));
         assertThat(user.getEmail(), is(email));
@@ -42,13 +34,35 @@ public class UserTest {
     }
 
     @Test
-    public void testBuilder_fromPrevious() {
+    public void testBuilderDefaults() {
+        User user = new User.Builder().build();
+
+        assertThat(user.getId(), is(nullValue()));
+        assertThat(user.getEmail(), is(nullValue()));
+        assertThat(user.getName(), is(nullValue()));
+    }
+
+    @Test
+    public void testBuilderDefaultConstructor() {
         final String id = UUID.randomUUID().toString();
         final String email = UUID.randomUUID().toString();
         final String name = UUID.randomUUID().toString();
 
-        User previous = User.builder().name(name).id(id).email(email).build();
-        User successor = User.builder(previous).build();
+        User user = new User.Builder().name(name).id(id).email(email).build();
+
+        assertThat(user.getId(), is(id));
+        assertThat(user.getEmail(), is(email));
+        assertThat(user.getName(), is(name));
+    }
+
+    @Test
+    public void testBuilderUserArgument() {
+        final String id = UUID.randomUUID().toString();
+        final String email = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+
+        User previous = new User.Builder().name(name).id(id).email(email).build();
+        User successor = new User.Builder(previous).build();
 
         assertThat(successor.getId(), is(id));
         assertThat(successor.getEmail(), is(email));
@@ -56,16 +70,32 @@ public class UserTest {
     }
 
     @Test
+    public void testBuilderNullArgument() {
+        final String id = UUID.randomUUID().toString();
+        final String email = UUID.randomUUID().toString();
+        final String name = UUID.randomUUID().toString();
+
+        User user = new User.Builder(null).name(name).id(id).email(email).build();
+
+        assertThat(user.getId(), is(id));
+        assertThat(user.getEmail(), is(email));
+        assertThat(user.getName(), is(name));
+    }
+
+    @Test
     public void testRepo() {
         SharedPreferences sharedPref = getSharedPrefs(InstrumentationRegistry.getContext());
+        sharedPref.edit().clear().apply();
 
-        User pre = User.builder()
+        User pre = new User.Builder()
             .name(UUID.randomUUID().toString())
             .id(UUID.randomUUID().toString())
             .email(UUID.randomUUID().toString())
             .build();
 
         User.Repo repo = new User.Repo(sharedPref);
+        assertThat(repo.get(),is(nullValue()));
+
         repo.set(pre);
 
         User post = repo.get();

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -239,7 +239,7 @@ public final class Bugsnag {
      */
     @Deprecated
     public static void setUser(final String id, final String email, final String name) {
-        getClient().setUser(User.builder().id(id).email(email).name(name).build());
+        getClient().setUser(id, email, name);
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -235,55 +235,55 @@ public final class Bugsnag {
     }
 
     /**
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
+     */
+    @Deprecated
+    public static void setUser(final String id, final String email, final String name) {
+        getClient().setUser(User.builder().id(id).email(email).name(name).build());
+    }
+
+    /**
      * Set details of the user currently using your application.
      * You can search for this information in your Bugsnag dashboard.
      * <p>
      * For example:
      * <p>
-     * Bugsnag.setUser("12345", "james@example.com", "James Smith");
+     * Bugsnag.setUser(User.builder().id("12345").email("james@example.com").name("James Smith"));
      *
-     * @param id    a unique identifier of the current user (defaults to a unique id)
-     * @param email the email address of the current user
-     * @param name  the name of the current user
+     * @param user The user information to set or NULL to reset to defaults.
      */
-    public static void setUser(final String id, final String email, final String name) {
-        getClient().setUser(id, email, name);
+    public static void setUser(@Nullable User user) {
+        getClient().setUser(user);
     }
 
     /**
-     * Removes the current user data and sets it back to defaults
+     * @deprecated Use {@link #setUser(User)} and pass NULL<p>
      */
+    @Deprecated
     public static void clearUser() {
-        getClient().clearUser();
+        getClient().setUser(null);
     }
 
     /**
-     * Set a unique identifier for the user currently using your application.
-     * By default, this will be an automatically generated unique id
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param id a unique identifier of the current user
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
      */
+    @Deprecated
     public static void setUserId(final String id) {
         getClient().setUserId(id);
     }
 
     /**
-     * Set the email address of the current user.
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param email the email address of the current user
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
      */
+    @Deprecated
     public static void setUserEmail(final String email) {
         getClient().setUserEmail(email);
     }
 
     /**
-     * Set the name of the current user.
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param name the name of the current user
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
      */
+    @Deprecated
     public static void setUserName(final String name) {
         getClient().setUserName(name);
     }
@@ -549,7 +549,8 @@ public final class Bugsnag {
      *
      * @see MetaData
      */
-    @NonNull public static MetaData getMetaData() {
+    @NonNull
+    public static MetaData getMetaData() {
         return getClient().getMetaData();
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -65,7 +65,7 @@ public class Client extends Observable implements Observer {
     @NonNull
     protected final DeviceData deviceData;
     @NonNull final Breadcrumbs breadcrumbs;
-    protected User user = User.builder().build();
+    protected User user = new User.Builder().build();
     @NonNull
     protected final ErrorStore errorStore;
 
@@ -149,7 +149,7 @@ public class Client extends Observable implements Observer {
             user = new User.Repo(sharedPref).get();
         }
         if (user == null) {
-            user = User.builder().id(deviceData.getUserId()).build();
+            user = new User.Builder().id(deviceData.getUserId()).build();
         }
 
         if (appContext instanceof Application) {
@@ -516,7 +516,7 @@ public class Client extends Observable implements Observer {
      * Set the user information that the Bugsnag {@link Client} supplies with every error.<p>
      * Pass NULL to clear the current user data, i.e. reset it to defaults.
      *
-     * @param user a {@link User} object made by {@link User#builder()} or NULL
+     * @param user a {@link User} object made by {@link com.bugsnag.android.User.Builder} or NULL
      */
     public void setUser(@Nullable User user) {
         setUser(user, true);
@@ -530,7 +530,7 @@ public class Client extends Observable implements Observer {
             new User.Repo(sharedPref).set(user);
         }
 
-        this.user = user != null ? user : User.builder().id(deviceData.getUserId()).build();
+        this.user = user != null ? user : new User.Builder().id(deviceData.getUserId()).build();
 
         if (notify) {
             notifyBugsnagObservers(NotifyType.USER);
@@ -542,7 +542,7 @@ public class Client extends Observable implements Observer {
      */
     @Deprecated
     public void setUser(String id, String email, String name) {
-        setUser(User.builder().id(id).email(email).name(name).build());
+        setUser(user.toBuilder().id(id).email(email).name(name).build());
     }
 
     /**
@@ -558,7 +558,7 @@ public class Client extends Observable implements Observer {
      */
     @Deprecated
     public void setUserId(String id) {
-        setUser(User.builder(user).id(id).build(), true);
+        setUser(user.toBuilder().id(id).build(), true);
     }
 
     /**
@@ -566,7 +566,7 @@ public class Client extends Observable implements Observer {
      */
     @Deprecated
     public void setUserEmail(String email) {
-        setUser(User.builder(user).email(email).build(), true);
+        setUser(user.toBuilder().email(email).build(), true);
     }
 
     /**
@@ -574,7 +574,7 @@ public class Client extends Observable implements Observer {
      */
     @Deprecated
     public void setUserName(String name) {
-        setUser(User.builder(user).name(name).build(), true);
+        setUser(user.toBuilder().name(name).build(), true);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -573,15 +573,7 @@ public class Client extends Observable implements Observer {
      */
     @Deprecated
     public void setUserId(String id) {
-        setUserId(id, true);
-    }
-
-    /**
-     * @deprecated Use {@link #setUser(User, boolean)} and {@link com.bugsnag.android.User.Builder}<p>
-     */
-    @Deprecated
-    void setUserId(String id, boolean notify) {
-        setUser(User.builder(user).id(id).build(), notify);
+        setUser(User.builder(user).id(id).build(), true);
     }
 
     /**
@@ -589,15 +581,7 @@ public class Client extends Observable implements Observer {
      */
     @Deprecated
     public void setUserEmail(String email) {
-        setUserEmail(email, true);
-    }
-
-    /**
-     * @deprecated Use {@link #setUser(User, boolean)} and {@link com.bugsnag.android.User.Builder}<p>
-     */
-    @Deprecated
-    void setUserEmail(String email, boolean notify) {
-        setUser(User.builder(user).email(email).build(), notify);
+        setUser(User.builder(user).email(email).build(), true);
     }
 
     /**
@@ -605,15 +589,7 @@ public class Client extends Observable implements Observer {
      */
     @Deprecated
     public void setUserName(String name) {
-        setUserName(name, true);
-    }
-
-    /**
-     * @deprecated Use {@link #setUser(User, boolean)} and {@link com.bugsnag.android.User.Builder}<p>
-     */
-    @Deprecated
-    void setUserName(String name, boolean notify) {
-        setUser(User.builder(user).name(name).build(), notify);
+        setUser(User.builder(user).name(name).build(), true);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -148,7 +148,9 @@ public class Client extends Observable implements Observer {
             // Check to see if a user was stored in the SharedPreferences
             user = new User.Repo(sharedPref).get();
         }
-        if (user == null) user = User.builder().id(deviceData.getUserId()).build();
+        if (user == null) {
+            user = User.builder().id(deviceData.getUserId()).build();
+        }
 
         if (appContext instanceof Application) {
             Application application = (Application) appContext;
@@ -504,6 +506,13 @@ public class Client extends Observable implements Observer {
     }
 
     /**
+     * @return the current user information associated with the Bugsnag {@link Client}
+     */
+    public User getUser() {
+        return user;
+    }
+
+    /**
      * Set the user information that the Bugsnag {@link Client} supplies with every error.<p>
      * Pass NULL to clear the current user data, i.e. reset it to defaults.
      *
@@ -523,14 +532,9 @@ public class Client extends Observable implements Observer {
 
         this.user = user != null ? user : User.builder().id(deviceData.getUserId()).build();
 
-        if (notify) notifyBugsnagObservers(NotifyType.USER);
-    }
-
-    /**
-     * @return the current user information associated with the Bugsnag {@link Client}
-     */
-    public User getUser() {
-        return user;
+        if (notify) {
+            notifyBugsnagObservers(NotifyType.USER);
+        }
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -507,6 +507,7 @@ public class Client extends Observable implements Observer {
 
     /**
      * @return the current user information associated with the Bugsnag {@link Client}
+     * @see #setUser(User)
      */
     public User getUser() {
         return user;

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Observable;
@@ -418,7 +417,7 @@ public class Configuration extends Observable implements Observer {
      * if set then any user information set will be re-used until
      *
      * @param persistUserBetweenSessions whether or not Bugsnag should persist user information
-     * @see Client#clearUser() is called
+     * @see Client#setUser(User) is called with null
      */
     public void setPersistUserBetweenSessions(boolean persistUserBetweenSessions) {
         this.persistUserBetweenSessions = persistUserBetweenSessions;

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -165,7 +165,7 @@ public class Error implements JsonStream.Streamable {
      */
     @Deprecated
     public void setUser(String id, String email, String name) {
-        this.user = User.builder().id(id).email(email).name(name).build();
+        this.user = new User.Builder(user).id(id).email(email).name(name).build();
     }
 
     /**
@@ -189,7 +189,7 @@ public class Error implements JsonStream.Streamable {
      */
     @Deprecated
     public void setUserId(String id) {
-        setUser(User.builder(user).id(id).build());
+        setUser(new User.Builder(user).id(id).build());
     }
 
     /**
@@ -197,7 +197,7 @@ public class Error implements JsonStream.Streamable {
      */
     @Deprecated
     public void setUserEmail(String email) {
-        this.user = User.builder(user).email(email).build();
+        this.user = new User.Builder(user).email(email).build();
     }
 
     /**
@@ -205,7 +205,7 @@ public class Error implements JsonStream.Streamable {
      */
     @Deprecated
     public void setUserName(String name) {
-        this.user = User.builder(user).name(name).build();
+        this.user = new User.Builder(user).name(name).build();
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -17,8 +17,7 @@ import java.io.IOException;
  */
 public class Error implements JsonStream.Streamable {
 
-    @NonNull
-    final Configuration config;
+    @NonNull final Configuration config;
     private AppData appData;
     private DeviceData deviceData;
     private Breadcrumbs breadcrumbs;
@@ -162,17 +161,19 @@ public class Error implements JsonStream.Streamable {
     }
 
     /**
-     * Set user information associated with this Error
-     *
-     * @param id    the id of the user
-     * @param email the email address of the user
-     * @param name  the name of the user
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
      */
+    @Deprecated
     public void setUser(String id, String email, String name) {
-        this.user = new User(id, email, name);
+        this.user = User.builder().id(id).email(email).name(name).build();
     }
 
-    void setUser(User user) {
+    /**
+     * Set user information associated with just this Error
+     *
+     * @param user the user information you want to supply
+     */
+    void setUser(@Nullable User user) {
         this.user = user;
     }
 
@@ -184,33 +185,27 @@ public class Error implements JsonStream.Streamable {
     }
 
     /**
-     * Set user id associated with this Error
-     *
-     * @param id the id of the user
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
      */
+    @Deprecated
     public void setUserId(String id) {
-        this.user = new User(this.user);
-        this.user.setId(id);
+        setUser(User.builder(user).id(id).build());
     }
 
     /**
-     * Set user email address associated with this Error
-     *
-     * @param email the email address of the user
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
      */
+    @Deprecated
     public void setUserEmail(String email) {
-        this.user = new User(this.user);
-        this.user.setEmail(email);
+        this.user = User.builder(user).email(email).build();
     }
 
     /**
-     * Set user name associated with this Error
-     *
-     * @param name the name of the user
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
      */
+    @Deprecated
     public void setUserName(String name) {
-        this.user = new User(this.user);
-        this.user.setName(name);
+        this.user = User.builder(user).name(name).build();
     }
 
     /**
@@ -286,7 +281,8 @@ public class Error implements JsonStream.Streamable {
     /**
      * Get the message from the exception contained in this Error report.
      */
-    @NonNull public String getExceptionMessage() {
+    @NonNull
+    public String getExceptionMessage() {
         String localizedMessage = exception.getLocalizedMessage();
         return localizedMessage != null ? localizedMessage : "";
     }
@@ -354,7 +350,7 @@ public class Error implements JsonStream.Streamable {
         }
 
         Builder(@NonNull Configuration config, @NonNull String name,
-               @NonNull String message, @NonNull StackTraceElement[] frames, Session session) {
+                @NonNull String message, @NonNull StackTraceElement[] frames, Session session) {
             this(config, new BugsnagException(name, message, frames), session);
         }
 

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -198,19 +198,20 @@ public class NativeInterface {
     }
 
     /**
+     * @deprecated Use {@link #setUser(User)} and {@link com.bugsnag.android.User.Builder}<p>
+     */
+    @Deprecated
+    public static void setUser(String id, String email, String name) {
+        setUser(User.builder().id(id).email(email).name(name).build());
+    }
+
+    /**
      * Sets the user
      *
-     * @param id id
-     * @param email email
-     * @param name name
+     * @param user the user object to set
      */
-    public static void setUser(final String id,
-                               final String email,
-                               final String name) {
-
-        getClient().setUserId(id, false);
-        getClient().setUserEmail(email, false);
-        getClient().setUserName(name, false);
+    public static void setUser(User user) {
+        getClient().setUser(user, false);
     }
 
     public static void leaveBreadcrumb(@NonNull final String name,

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -202,7 +202,7 @@ public class NativeInterface {
      */
     @Deprecated
     public static void setUser(String id, String email, String name) {
-        setUser(User.builder().id(id).email(email).name(name).build());
+        getClient().setUser(id, email, name);
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/User.java
+++ b/sdk/src/main/java/com/bugsnag/android/User.java
@@ -47,21 +47,10 @@ public class User implements JsonStream.Streamable {
     }
 
     /**
-     * Use this to create a new object holding user related details
-     *
-     * @return a builder for {@link User}
+     * Convenience method. The same as calling {@link Builder#Builder(User)}
      */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * Create a new user object based on a previous user object.
-     *
-     * @param user the previous user object.
-     */
-    public static Builder builder(User user) {
-        return new Builder(user);
+    public Builder toBuilder() {
+        return new Builder(this);
     }
 
     public static class Builder {
@@ -69,13 +58,23 @@ public class User implements JsonStream.Streamable {
         @Nullable String email;
         @Nullable String name;
 
+        /**
+         * A builder to create a {@link User} object
+         */
         public Builder() {
         }
 
-        public Builder(User user) {
-            id(user.getId());
-            email(user.getEmail());
-            name(user.getName());
+        /**
+         * A builder to create a {@link User} object
+         *
+         * @param user use an existing user object or pass NULL for an empty builder.
+         */
+        public Builder(@Nullable User user) {
+            if (user != null) {
+                id(user.getId());
+                email(user.getEmail());
+                name(user.getName());
+            }
         }
 
         /**
@@ -145,7 +144,7 @@ public class User implements JsonStream.Streamable {
 
         @Nullable
         User get() {
-            User user = User.builder()
+            User user = new User.Builder()
                 .id(preferences.getString(USER_ID_KEY, null))
                 .name(preferences.getString(USER_NAME_KEY, null))
                 .email(preferences.getString(USER_EMAIL_KEY, null))

--- a/sdk/src/main/java/com/bugsnag/android/User.java
+++ b/sdk/src/main/java/com/bugsnag/android/User.java
@@ -135,7 +135,11 @@ class User implements JsonStream.Streamable {
                     .putString(USER_NAME_KEY, user.getName())
                     .apply();
             } else {
-                preferences.edit().remove(USER_ID_KEY).remove(USER_NAME_KEY).remove(USER_EMAIL_KEY).apply();
+                preferences.edit()
+                    .remove(USER_ID_KEY)
+                    .remove(USER_NAME_KEY)
+                    .remove(USER_EMAIL_KEY)
+                    .apply();
             }
         }
 
@@ -147,8 +151,11 @@ class User implements JsonStream.Streamable {
                 .email(preferences.getString(USER_EMAIL_KEY, null))
                 .build();
 
-            if (user.getId() != null || user.getEmail() != null || user.getName() != null) return user;
-            else return null;
+            if (user.getId() != null || user.getEmail() != null || user.getName() != null) {
+                return user;
+            } else {
+                return null;
+            }
         }
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/User.java
+++ b/sdk/src/main/java/com/bugsnag/android/User.java
@@ -10,9 +10,9 @@ import java.io.IOException;
  * Information about the current user of your application.
  */
 public class User implements JsonStream.Streamable {
-    @Nullable private String id;
-    @Nullable private String email;
-    @Nullable private String name;
+    @Nullable private final String id;
+    @Nullable private final String email;
+    @Nullable private final String name;
 
     User(Builder builder) {
         this.id = builder.id;

--- a/sdk/src/main/java/com/bugsnag/android/User.java
+++ b/sdk/src/main/java/com/bugsnag/android/User.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.io.IOException;
 
@@ -8,21 +9,14 @@ import java.io.IOException;
  * Information about the current user of your application.
  */
 class User implements JsonStream.Streamable {
-    private String id;
-    private String email;
-    private String name;
+    @Nullable private String id;
+    @Nullable private String email;
+    @Nullable private String name;
 
-    User() {
-    }
-
-    User(String id, String email, String name) {
-        this.id = id;
-        this.email = email;
-        this.name = name;
-    }
-
-    User(@NonNull User user) {
-        this(user.id, user.email, user.name);
+    User(Builder builder) {
+        this.id = builder.id;
+        this.email = builder.email;
+        this.name = builder.name;
     }
 
     @Override
@@ -36,27 +30,84 @@ class User implements JsonStream.Streamable {
         writer.endObject();
     }
 
+    @Nullable
     public String getId() {
         return id;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
+    @Nullable
     public String getEmail() {
         return email;
     }
 
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
+    @Nullable
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Create a new user object based on a previous user object.
+     *
+     * @param user the previous user object.
+     */
+    public static Builder builder(User user) {
+        return new Builder(user);
+    }
+
+    public static class Builder {
+        @Nullable String id;
+        @Nullable String email;
+        @Nullable String name;
+
+        public Builder() {
+        }
+
+        public Builder(User user) {
+            id(user.getId());
+            email(user.getEmail());
+            name(user.getName());
+        }
+
+        /**
+         * Set a unique identifier for the user currently using your application.
+         * By default, this will be an automatically generated unique id
+         * You can search for this information in your Bugsnag dashboard.
+         *
+         * @param id a unique identifier of the current user
+         */
+        public Builder id(@Nullable String id) {
+            this.id = id;
+            return this;
+        }
+
+        /**
+         * Set the email address of the current user.
+         * You can search for this information in your Bugsnag dashboard.
+         *
+         * @param email the email address of the current user
+         */
+        public Builder email(@Nullable String email) {
+            this.email = email;
+            return this;
+        }
+
+        /**
+         * Set the name of the current user.
+         * You can search for this information in your Bugsnag dashboard.
+         *
+         * @param name the name of the current user
+         */
+        public Builder name(@Nullable String name) {
+            this.name = name;
+            return this;
+        }
+
+        public User build() {
+            return new User(this);
+        }
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/User.java
+++ b/sdk/src/main/java/com/bugsnag/android/User.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 /**
  * Information about the current user of your application.
  */
-class User implements JsonStream.Streamable {
+public class User implements JsonStream.Streamable {
     @Nullable private String id;
     @Nullable private String email;
     @Nullable private String name;

--- a/sdk/src/main/java/com/bugsnag/android/User.java
+++ b/sdk/src/main/java/com/bugsnag/android/User.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -45,6 +46,11 @@ class User implements JsonStream.Streamable {
         return name;
     }
 
+    /**
+     * Use this to create a new object holding user related details
+     *
+     * @return a builder for {@link User}
+     */
     public static Builder builder() {
         return new Builder();
     }
@@ -108,6 +114,41 @@ class User implements JsonStream.Streamable {
 
         public User build() {
             return new User(this);
+        }
+    }
+
+    static class Repo {
+        private static final String USER_ID_KEY = "user.id";
+        private static final String USER_NAME_KEY = "user.name";
+        private static final String USER_EMAIL_KEY = "user.email";
+        private final SharedPreferences preferences;
+
+        Repo(SharedPreferences preferences) {
+            this.preferences = preferences;
+        }
+
+        void set(@Nullable User user) {
+            if (user != null) {
+                preferences.edit()
+                    .putString(USER_ID_KEY, user.getId())
+                    .putString(USER_EMAIL_KEY, user.getEmail())
+                    .putString(USER_NAME_KEY, user.getName())
+                    .apply();
+            } else {
+                preferences.edit().remove(USER_ID_KEY).remove(USER_NAME_KEY).remove(USER_EMAIL_KEY).apply();
+            }
+        }
+
+        @Nullable
+        User get() {
+            User user = User.builder()
+                .id(preferences.getString(USER_ID_KEY, null))
+                .name(preferences.getString(USER_NAME_KEY, null))
+                .email(preferences.getString(USER_EMAIL_KEY, null))
+                .build();
+
+            if (user.getId() != null || user.getEmail() != null || user.getName() != null) return user;
+            else return null;
         }
     }
 }


### PR DESCRIPTION
* Introduced builder pattern for `User`, `User` is now immutable.
* Reduced duplicate/simplified code related to `User` and moved `User` related implementation details from `Client` to `User´
* Removed methods that were just used internally and migrated them to `Client.setUser(user)`
* Tagged/deprecated all public APIs that set specific `User` fields. In the next semvar major release these  could be removed.
* Added unit tests for the new code and adapted the existing tests such that both the new and the now deprecated methods are covered.

1. Cleaner API after the next major release removes the deprecated methods
2. Easier future SDK updates. Want to add new `User` information? Just update `User`.
3. `User` is now exposed via `Client.getUser()` which solves my issue in #265

@fractalwrench

