### PR TITLE
Address remaining test warnings

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
@@ -20,6 +20,11 @@ public class BeforeRecordBreadcrumbsTest {
 
     private Client client;
 
+    /**
+     * Configures a client which does not automatically record breadcrumbs
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         Configuration configuration = new Configuration("api-key");

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -30,6 +30,10 @@ public class ClientTest {
     private Context context;
     private Configuration config;
 
+    /**
+     * Generates a configuration and clears sharedPrefs values to begin the test with a clean slate
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         context = InstrumentationRegistry.getContext();
@@ -37,6 +41,10 @@ public class ClientTest {
         config = new Configuration("api-key");
     }
 
+    /**
+     * Clears sharedPreferences to remove any values persisted
+     * @throws Exception if IO to sharedPrefs failed
+     */
     @After
     public void tearDown() throws Exception {
         clearSharedPrefs();

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -32,6 +32,11 @@ public class ErrorStoreTest {
     private Configuration config;
     private File errorStorageDir;
 
+    /**
+     * Generates a client and ensures that its errorStore has 0 files persisted
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
@@ -42,6 +47,11 @@ public class ErrorStoreTest {
         FileUtils.clearFilesInDir(errorStorageDir);
     }
 
+    /**
+     * Removes any files from the errorStore generated during testing
+     *
+     * @throws Exception if removing files failed
+     */
     @After
     public void tearDown() throws Exception {
         FileUtils.clearFilesInDir(errorStorageDir);

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -87,9 +87,10 @@ public class ErrorStoreTest {
 
     @Test
     public void testComparator() throws Exception {
-        String first = "1504255147933_683c6b92-b325-4987-80ad-77086509ca1e.json";
-        String second = "1505000000000_683c6b92-b325-4987-80ad-77086509ca1e.json";
-        String startup = "1504500000000_683c6b92-b325-4987-80ad-77086509ca1e_startupcrash.json";
+        final String first = "1504255147933_683c6b92-b325-4987-80ad-77086509ca1e.json";
+        final String second = "1505000000000_683c6b92-b325-4987-80ad-77086509ca1e.json";
+        final String startup = "1504500000000_683c6b92-b325-"
+            + "4987-80ad-77086509ca1e_startupcrash.json";
 
         // handle defaults
         assertEquals(0, ERROR_REPORT_COMPARATOR.compare(null, null));

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -13,6 +13,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -268,6 +269,7 @@ public class ErrorTest {
             severityReason.getJSONObject("attributes");
             fail();
         } catch (JSONException ignored) {
+            Assert.assertNotNull(ignored);
         }
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -26,6 +26,11 @@ public class ErrorTest {
     private Configuration config;
     private Error error;
 
+    /**
+     * Generates a new default error for use by tests
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         config = new Configuration("api-key");

--- a/sdk/src/androidTest/java/com/bugsnag/android/ExceptionHandlerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ExceptionHandlerTest.java
@@ -19,6 +19,12 @@ public class ExceptionHandlerTest {
 
     private Context context;
 
+    /**
+     * Sets the default exception handler to null to avoid any Bugsnag handlers created
+     * in previous test
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         context = InstrumentationRegistry.getContext();

--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
@@ -30,12 +30,12 @@ public class JsonStreamTest {
 
     @Test
     public void testSaneValues() throws JSONException, IOException {
-        Long nullLong = null;
-        Boolean nullBoolean = null;
-        String nullString = null;
-        Integer nullInteger = null;
-        Float nullFloat = null;
-        Double nullDouble = null;
+        final Long nullLong = null;
+        final Boolean nullBoolean = null;
+        final String nullString = null;
+        final Integer nullInteger = null;
+        final Float nullFloat = null;
+        final Double nullDouble = null;
 
         stream.beginObject();
         stream.name("nullLong").value(nullLong);

--- a/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
@@ -22,6 +22,11 @@ public class NullMetadataTest {
     private Configuration config;
     private Throwable throwable;
 
+    /**
+     * Generates a bugsnag client with a NOP error api client
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         config = new Configuration("api-key");

--- a/sdk/src/androidTest/java/com/bugsnag/android/ReportTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ReportTest.java
@@ -21,6 +21,11 @@ public class ReportTest {
 
     private Report report;
 
+    /**
+     * Generates a report
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         Configuration config = new Configuration("example-api-key");

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -39,7 +39,7 @@ public class SessionStoreTest {
     /**
      * Removes any sessions in the store created during testing
      *
-     * @throws Exception
+     * @throws Exception if the operation failed
      */
     @After
     public void tearDown() throws Exception {

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -48,9 +48,9 @@ public class SessionStoreTest {
 
     @Test
     public void testComparator() throws Exception {
-        String first = "1504255147933d06e6168-1c10-4727-80d8-627a5111775b.json";
-        String second = "1505000000000ef070b5b-fc0f-411e-8630-429acc477982.json";
-        String startup = "150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json";
+        final String first = "1504255147933d06e6168-1c10-4727-80d8-627a5111775b.json";
+        final String second = "1505000000000ef070b5b-fc0f-411e-8630-429acc477982.json";
+        final String startup = "150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json";
 
         // handle defaults
         assertEquals(0, SESSION_COMPARATOR.compare(null, null));

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -22,6 +22,11 @@ public class SessionStoreTest {
 
     private File storageDir;
 
+    /**
+     * Generates a session store with 0 files
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
@@ -31,6 +36,11 @@ public class SessionStoreTest {
         FileUtils.clearFilesInDir(storageDir);
     }
 
+    /**
+     * Removes any sessions in the store created during testing
+     *
+     * @throws Exception
+     */
     @After
     public void tearDown() throws Exception {
         FileUtils.clearFilesInDir(storageDir);

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -23,6 +23,11 @@ public class SessionTrackerTest {
     private User user;
     private Configuration configuration;
 
+    /**
+     * Configures a session tracker that automatically captures sessions
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         configuration = new Configuration("test");

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
@@ -28,6 +28,11 @@ public class SessionTrackingPayloadTest {
     private SessionStore sessionStore;
     private File storageDir;
 
+    /**
+     * Configures a session tracking payload and session store, ensuring that 0 files are present
+     *
+     * @throws Exception if initialisation failed
+     */
     @Before
     public void setUp() throws Exception {
         Context context = InstrumentationRegistry.getContext();
@@ -43,6 +48,11 @@ public class SessionTrackingPayloadTest {
         rootNode = streamableToJson(payload);
     }
 
+    /**
+     * Deletes any files in the session store created during the test
+     *
+     * @throws Exception if the operation fails
+     */
     @After
     public void tearDown() throws Exception {
         FileUtils.clearFilesInDir(storageDir);

--- a/sdk/src/androidTest/java/com/bugsnag/android/StrictModeTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/StrictModeTest.java
@@ -10,6 +10,8 @@ import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 
+import junit.framework.Assert;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,6 +67,7 @@ public class StrictModeTest {
                 strictModeHandler.getViolationDescription(invalidArg);
                 fail("Null/empty values not rejected");
             } catch (IllegalArgumentException ignored) {
+                Assert.assertNotNull(ignored);
             }
         }
     }
@@ -101,8 +104,7 @@ public class StrictModeTest {
     /**
      * Generates a StrictMode Exception (as it has private visibility in StrictMode)
      *
-     * @return the StrictModeException. This is nullable as the errors StrictMode detect
-     * depend on the API level.
+     * @return a nullable StrictModeException
      */
     private Exception generateStrictModeException() {
         try {

--- a/sdk/src/androidTest/java/com/bugsnag/android/StrictModeTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/StrictModeTest.java
@@ -107,8 +107,8 @@ public class StrictModeTest {
     private Exception generateStrictModeException() {
         try {
             violateStrictModePolicy();
-        } catch (Exception e) {
-            return e;
+        } catch (Exception exception) {
+            return exception;
         }
         return null;
     }
@@ -120,8 +120,8 @@ public class StrictModeTest {
         try {
             Context context = InstrumentationRegistry.getContext();
             new FileWriter(new File(context.getCacheDir(), "test")).write("test");
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (IOException exception) {
+            exception.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Addresses the following checkstyle warnings in test code:

- Identifiers with <3 alphanumeric chars
- Missing JavaDoc from setup/teardown methods
- Declaration distance from actual usage (addressed by moving closer to usage or adding final modifier)