### PR TITLE
Add scenarios for asynchronously flushing error store

### DIFF
--- a/features/async_error_flush.feature
+++ b/features/async_error_flush.feature
@@ -1,0 +1,16 @@
+Feature: Flushing errors does not send duplicates
+
+Scenario: Only 1 request sent if connectivity change occurs before launch
+    When I run "AsyncErrorConnectivityScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+
+Scenario: Only 1 request sent if multiple connectivity changes occur
+    When I run "AsyncErrorDoubleFlushScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+
+Scenario: Only 1 request sent if connectivity change occurs after launch
+    When I run "AsyncErrorLaunchScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API

--- a/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
@@ -1,8 +1,41 @@
 package com.bugsnag.android
 
+import android.content.Context
+import android.net.ConnectivityManager
+import com.bugsnag.android.Bugsnag.client
+
 /**
  * Accesses the session tracker and flushes all stored sessions
  */
 internal fun flushAllSessions() {
     Bugsnag.getClient().sessionTracker.flushStoredSessions()
 }
+
+internal fun flushErrorStoreAsync(client: Client, apiClient: ErrorReportApiClient) {
+    client.errorStore.flushAsync(apiClient)
+}
+
+internal fun flushErrorStoreOnLaunch(client: Client, apiClient: ErrorReportApiClient) {
+    client.errorStore.flushOnLaunch(apiClient)
+}
+
+/**
+ * Creates an error API client with a 500ms delay, emulating poor network connectivity
+ */
+internal fun createSlowErrorApiClient(context: Context): ErrorReportApiClient {
+    val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
+    val defaultHttpClient = DefaultHttpClient(cm)
+
+    return ErrorReportApiClient({ url: String?,
+                                  report: Report?,
+                                  headers: MutableMap<String, String>? ->
+        Thread.sleep(500)
+        defaultHttpClient.postReport(url, report, headers)
+    })
+}
+
+internal fun writeErrorToStore(client: Client) {
+    val error = Error.Builder(Configuration("api-key"), RuntimeException(), null).build()
+    client.errorStore.write(error)
+}
+

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorConnectivityScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorConnectivityScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.*
+
+/**
+ * Tests that only 1 request is sent in the case where stored reports are concurrently flushed,
+ * in the case that a connectivity change occurs before launch.
+ */
+internal class AsyncErrorConnectivityScenario(config: Configuration,
+                                              context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+        val apiClient = createSlowErrorApiClient(context)
+        Bugsnag.setErrorReportApiClient(apiClient)
+
+        writeErrorToStore(Bugsnag.getClient())
+        flushErrorStoreAsync(Bugsnag.getClient(), apiClient)
+        flushErrorStoreOnLaunch(Bugsnag.getClient(), apiClient)
+        Thread.sleep(50)
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorDoubleFlushScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorDoubleFlushScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.*
+
+/**
+ * Tests that only 1 request is sent in the case where stored reports are concurrently flushed,
+ * in the case that two connectivity changes occur in quick succession.
+ */
+internal class AsyncErrorDoubleFlushScenario(config: Configuration,
+                                             context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+        val apiClient = createSlowErrorApiClient(context)
+        Bugsnag.setErrorReportApiClient(apiClient)
+
+        writeErrorToStore(Bugsnag.getClient())
+        flushErrorStoreAsync(Bugsnag.getClient(), apiClient)
+        flushErrorStoreAsync(Bugsnag.getClient(), apiClient)
+        Thread.sleep(50)
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorLaunchScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorLaunchScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.*
+
+/**
+ * Tests that only 1 request is sent in the case where stored reports are concurrently flushed,
+ * in the case that a connectivity change occurs after launch.
+ */
+internal class AsyncErrorLaunchScenario(config: Configuration,
+                                        context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+        val apiClient = createSlowErrorApiClient(context)
+        Bugsnag.setErrorReportApiClient(apiClient)
+
+        writeErrorToStore(Bugsnag.getClient())
+        flushErrorStoreOnLaunch(Bugsnag.getClient(), apiClient)
+        flushErrorStoreAsync(Bugsnag.getClient(), apiClient)
+        Thread.sleep(50)
+    }
+
+}


### PR DESCRIPTION
Adds scenarios which ensure that only 1 request is sent for the following scenarios:

- Connectivity changes immediately before onLaunch flush
- Connectivity changes immediately after onLaunch flush
- Connectivity changes in quick succession