### PR TITLE
Avoid adding extra comma separator if File input is empty or null

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
@@ -1,8 +1,10 @@
 package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -12,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 
@@ -61,4 +64,19 @@ public class JsonStreamTest {
         assertEquals(123, json.getInt("int"));
         assertEquals(123L, json.getLong("long"));
     }
+
+    @Test
+    public void testEmptyFileValue() throws Throwable {
+        File cacheDir = InstrumentationRegistry.getContext().getCacheDir();
+        File file = new File(cacheDir, "whoops");
+        file.createNewFile();
+        stream.beginArray();
+        stream.value(file);
+        stream.value(file);
+        stream.endArray();
+
+        JSONObject json = new JSONObject(writer.toString());
+        assertNotNull(json);
+    }
+
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
@@ -92,17 +92,6 @@ public class JsonStreamTest {
     }
 
     @Test
-    public void testNonReadableFile() throws Throwable {
-        file.createNewFile();
-        file.setReadable(false);
-        stream.beginArray();
-        stream.value(file);
-        stream.value(file);
-        stream.endArray();
-        assertEquals("[]", writer.toString());
-    }
-
-    @Test
     public void testDeletedFile() throws Throwable {
         file.createNewFile();
         file.delete();

--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
@@ -113,16 +113,4 @@ public class JsonStreamTest {
         assertEquals("[]", writer.toString());
     }
 
-    @Test
-    public void testMalformedFile() throws Throwable {
-        FileWriter writer = new FileWriter(file);
-        writer.write("{\"foo\": \"bar");
-        writer.flush();
-        stream.beginArray();
-        stream.value(file);
-        stream.value(file);
-        stream.endArray();
-        assertEquals("[]", this.writer.toString());
-    }
-
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
@@ -28,6 +28,11 @@ public class JsonStreamTest {
     private JsonStream stream;
     private File file;
 
+    /**
+     * Deletes a file in the cache directory if it already exists from previous test cases
+     *
+     * @throws Exception if setup failed
+     */
     @Before
     public void setUp() throws Exception {
         writer = new StringWriter();

--- a/sdk/src/main/java/com/bugsnag/android/JsonStream.java
+++ b/sdk/src/main/java/com/bugsnag/android/JsonStream.java
@@ -49,6 +49,10 @@ public class JsonStream extends JsonWriter {
      * Writes a File (its content) into the stream
      */
     public void value(@NonNull File file) throws IOException {
+        if (file == null || file.length() <= 0) {
+            return;
+        }
+
         super.flush();
         beforeValue(false); // add comma if in array
 


### PR DESCRIPTION
Previously, if the file input was null or empty, an additional comma was added by the JSON serialiser as a separator, leading to invalid JSON, e.g. `[{}, , {}]`. This can lead to session/error payloads being dropped as invalid.

This fixes JSON serialisation so that a comma is not included in this case, e.g. `[{}, {}]`

This doesn't fix the case where a file is non-empty but isn't valid JSON, which will be addressed separately.