### PR TITLE
Additional multi client scenarios

### DIFF
--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -4,6 +4,16 @@ Feature: Multi-client support
     configuration options. A report which is captured by a given client should
     use the correct API key and configuration options.
 
+Scenario: A handled error captured while offline is only sent by the original client
+    When I run "MultiClientNotifyScenario" with the defaults
+    When I force stop the "com.bugsnag.android.mazerunner" Android app
+    And I set environment variable "EVENT_TYPE" to "MultiClientNotifyScenario"
+    And I set environment variable "EVENT_METADATA" to "DeliverReport"
+    And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
+    Then I should receive 1 request
+    And the "Bugsnag-API-Key" header equals "abc123" for request 0
+    And the payload field "apiKey" equals "abc123" for request 0
+
 Scenario: An unhandled error captured while offline is detected by two clients with different API keys
     When I run "MultiClientApiKeyScenario" with the defaults
     When I force stop the "com.bugsnag.android.mazerunner" Android app

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -17,3 +17,33 @@ Scenario: An unhandled error captured while offline is detected by two clients w
     And the "Bugsnag-API-Key" header equals "abc123" for request 1
     And the payload field "apiKey" equals "abc123" for request 1
 
+Scenario: An unhandled error captured while offline is detected by two clients with different endpoints
+    When I run "MultiClientEndpointScenario" with the defaults
+    When I force stop the "com.bugsnag.android.mazerunner" Android app
+    And I set environment variable "EVENT_METADATA" to "DeliverReport"
+    And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
+    Then I should receive 1 request
+
+Scenario: An unhandled error captured while online is detected by two clients with different API keys
+    When I run "MultiClientOnlineScenario" with the defaults
+    Then I should receive 2 requests
+    And the "Bugsnag-API-Key" header equals "abc123" for request 0
+    And the payload field "apiKey" equals "abc123" for request 0
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
+    And the payload field "apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 1
+
+Scenario: Sessions while captured offline is detected by two clients with different API keys
+    When I run "MultiClientSessionScenario" with the defaults
+    When I force stop the "com.bugsnag.android.mazerunner" Android app
+    And I set environment variable "EVENT_TYPE" to "MultiClientSessionScenario"
+    And I set environment variable "EVENT_METADATA" to "DeliverSessions"
+    And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
+    Then I should receive 2 requests
+
+    And the "Bugsnag-API-Key" header equals "abc123" for request 1
+    And the payload field "sessions.0.user.name" equals "Alice" for request 1
+    And the payload field "sessions" is an array with 1 element for request 1
+
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
+    And the payload field "sessions.0.user.name" equals "Bob" for request 0
+    And the payload field "sessions" is an array with 1 element for request 10

--- a/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
@@ -2,13 +2,12 @@ package com.bugsnag.android
 
 import android.content.Context
 import android.net.ConnectivityManager
-import com.bugsnag.android.Bugsnag.client
 
 /**
  * Accesses the session tracker and flushes all stored sessions
  */
-internal fun flushAllSessions() {
-    Bugsnag.getClient().sessionTracker.flushStoredSessions()
+internal fun flushAllSessions(client: Client) {
+    Async.run(client.sessionTracker::flushStoredSessions)
 }
 
 internal fun flushErrorStoreAsync(client: Client, apiClient: ErrorReportApiClient) {

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionScenario.kt
@@ -18,7 +18,7 @@ internal class AutoSessionScenario(config: Configuration,
         super.run()
         Bugsnag.setUser("123", "user@example.com", "Joe Bloggs")
         context.startActivity(Intent(context, SecondActivity::class.java))
-        flushAllSessions()
+        flushAllSessions(Bugsnag.getClient())
     }
 
 }

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionScenario.kt
@@ -15,7 +15,7 @@ internal class ManualSessionScenario(config: Configuration,
         super.run()
         Bugsnag.setUser("123", "user@example.com", "Joe Bloggs")
         Bugsnag.startSession()
-        flushAllSessions()
+        flushAllSessions(Bugsnag.getClient())
     }
 
 }

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientApiKeyScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientApiKeyScenario.kt
@@ -27,10 +27,10 @@ internal class MultiClientApiKeyScenario(config: Configuration,
 
     override fun run() {
         configureClients()
-        disableAllDelivery(firstClient!!)
-        disableAllDelivery(secondClient!!)
 
         if ("DeliverReport" != eventMetaData) {
+            disableAllDelivery(firstClient!!)
+            disableAllDelivery(secondClient!!)
             throw IllegalArgumentException("MultiClientApiKeyScenario")
         }
     }

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientEndpointScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientEndpointScenario.kt
@@ -1,0 +1,38 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Client
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.disableAllDelivery
+
+/**
+ * Configures two Bugsnag clients with different endpoints. Only the first error should be
+ * reported.
+ */
+internal class MultiClientEndpointScenario(config: Configuration,
+                                           context: Context) : Scenario(config, context) {
+    var firstClient: Client? = null
+    var secondClient: Client? = null
+
+    fun configureClients() {
+        firstClient = Client(context, config)
+
+        Thread.sleep(10) // enforce request order
+        val secondConfig = Configuration("abc123")
+        secondConfig.endpoint = "http://localhost:1234"
+        secondConfig.sessionEndpoint = "http://localhost:1234"
+        secondClient = Client(context, secondConfig)
+    }
+
+    override fun run() {
+        configureClients()
+        disableAllDelivery(firstClient!!)
+        disableAllDelivery(secondClient!!)
+
+        if ("DeliverReport" != eventMetaData) {
+            throw IllegalArgumentException("MultiClientApiKeyScenario")
+        }
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientNotifyScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientNotifyScenario.kt
@@ -7,11 +7,10 @@ import com.bugsnag.android.Configuration
 import com.bugsnag.android.disableAllDelivery
 
 /**
- * Configures two Bugsnag clients with different endpoints. Only the first error should be
- * reported.
+ * Configures two Bugsnag clients with different API keys, and sends a handled error from one.
  */
-internal class MultiClientEndpointScenario(config: Configuration,
-                                           context: Context) : Scenario(config, context) {
+internal class MultiClientNotifyScenario(config: Configuration,
+                                         context: Context) : Scenario(config, context) {
     var firstClient: Client? = null
     var secondClient: Client? = null
 
@@ -20,8 +19,8 @@ internal class MultiClientEndpointScenario(config: Configuration,
 
         Thread.sleep(10) // enforce request order
         val secondConfig = Configuration("abc123")
-        secondConfig.endpoint = "http://localhost:1234"
-        secondConfig.sessionEndpoint = "http://localhost:1234"
+        secondConfig.endpoint = config.endpoint
+        secondConfig.sessionEndpoint = config.sessionEndpoint
         secondClient = Client(context, secondConfig)
     }
 
@@ -31,7 +30,7 @@ internal class MultiClientEndpointScenario(config: Configuration,
         if ("DeliverReport" != eventMetaData) {
             disableAllDelivery(firstClient!!)
             disableAllDelivery(secondClient!!)
-            throw IllegalArgumentException("MultiClientApiKeyScenario")
+            secondClient!!.notify(RuntimeException("Whoops"))
         }
     }
 

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientOnlineScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientOnlineScenario.kt
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Client
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.disableAllDelivery
+
+/**
+ * Configures two Bugsnag clients with different API keys. The error should be captured by each
+ * and reported immediately. The correct API key should be used for both.
+ */
+internal class MultiClientOnlineScenario(config: Configuration,
+                                         context: Context) : Scenario(config, context) {
+    var firstClient: Client? = null
+    var secondClient: Client? = null
+
+    fun configureClients() {
+        firstClient = Client(context, config)
+
+        Thread.sleep(10) // enforce request order
+        val secondConfig = Configuration("abc123")
+        secondConfig.endpoint = config.endpoint
+        secondConfig.sessionEndpoint = config.sessionEndpoint
+        secondClient = Client(context, secondConfig)
+    }
+
+    override fun run() {
+        configureClients()
+        throw IllegalArgumentException("MultiClientApiKeyScenario")
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientSessionScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientSessionScenario.kt
@@ -28,15 +28,15 @@ internal class MultiClientSessionScenario(config: Configuration,
     override fun run() {
         configureClients()
 
-        if ("DeliverSessions" == eventMetaData) {
-            flushAllSessions(firstClient!!)
-            Thread.sleep(10) // enforce request order
-            flushAllSessions(secondClient!!)
-        } else {
+        if ("DeliverSessions" != eventMetaData) {
             disableAllDelivery(firstClient!!)
             disableAllDelivery(secondClient!!)
             firstClient!!.startSession()
             secondClient!!.startSession()
+        } else {
+            flushAllSessions(firstClient!!)
+            Thread.sleep(10) // enforce request order
+            flushAllSessions(secondClient!!)
         }
     }
 

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientSessionScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientSessionScenario.kt
@@ -1,0 +1,43 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.*
+
+/**
+ * Configures two Bugsnag clients with different API keys. Two sessions are manually started
+ * for each client - the correct API key and user name should be used for both.
+ */
+internal class MultiClientSessionScenario(config: Configuration,
+                                          context: Context) : Scenario(config, context) {
+    var firstClient: Client? = null
+    var secondClient: Client? = null
+
+    fun configureClients() {
+        firstClient = Client(context, config)
+
+        Thread.sleep(10) // enforce request order
+        val secondConfig = Configuration("abc123")
+        secondConfig.endpoint = config.endpoint
+        secondConfig.sessionEndpoint = config.sessionEndpoint
+        secondClient = Client(context, secondConfig)
+
+        firstClient!!.setUserName("Bob")
+        secondClient!!.setUserName("Alice")
+    }
+
+    override fun run() {
+        configureClients()
+
+        if ("DeliverSessions" == eventMetaData) {
+            flushAllSessions(firstClient!!)
+            Thread.sleep(10) // enforce request order
+            flushAllSessions(secondClient!!)
+        } else {
+            disableAllDelivery(firstClient!!)
+            disableAllDelivery(secondClient!!)
+            firstClient!!.startSession()
+            secondClient!!.startSession()
+        }
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Wait.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Wait.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import android.os.Handler
 import android.os.HandlerThread
+import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.flushAllSessions
 
@@ -13,7 +14,7 @@ internal class Wait(config: Configuration, context: Context) : Scenario(config, 
         val thread = HandlerThread("HandlerThread")
         thread.start()
         Handler(thread.looper).post {
-            flushAllSessions()
+            flushAllSessions(Bugsnag.getClient())
         }
     }
 }


### PR DESCRIPTION
Adds the following scenarios when multiple clients are initialised:

- Calling notify while offline is only sent to original client
- Unhandled error while offline is sent twice with different API key for each
- Unhandled error while online is sent twice with different API key for each
- Unhandled error while offline is sent twice with different endpoint for each
- Cached sessions with different API keys are only sent to original client

This also includes a minor change to the TestHarnessHooks which is required to flush the sessions on a per-client basis

Relies on #286 