### PR TITLE
Support multi client storage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:bugsnag/maze-runner
-  revision: 9f5b7f220441d047888ffdd91bd6b32be6367078
+  revision: f7123450d5a75b719911c6dd3baa0507e6062c2d
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)
@@ -12,7 +12,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.11.2)
+    backports (3.11.3)
     builder (3.2.3)
     coderay (1.1.2)
     cucumber (3.1.0)

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -56,4 +56,4 @@ Scenario: Sessions while captured offline is detected by two clients with differ
 
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa" for request 0
     And the payload field "sessions.0.user.name" equals "Bob" for request 0
-    And the payload field "sessions" is an array with 1 element for request 10
+    And the payload field "sessions" is an array with 1 element for request 0

--- a/features/multi_client.feature
+++ b/features/multi_client.feature
@@ -4,6 +4,14 @@ Feature: Multi-client support
     configuration options. A report which is captured by a given client should
     use the correct API key and configuration options.
 
+Scenario: Multiple clients send errors stored in the old directory
+    When I run "MultiClientOldDirScenario" with the defaults
+    When I force stop the "com.bugsnag.android.mazerunner" Android app
+    And I set environment variable "EVENT_TYPE" to "MultiClientOldDirScenario"
+    And I set environment variable "EVENT_METADATA" to "DeliverReport"
+    And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
+    Then I should receive 2 requests
+
 Scenario: A handled error captured while offline is only sent by the original client
     When I run "MultiClientNotifyScenario" with the defaults
     When I force stop the "com.bugsnag.android.mazerunner" Android app

--- a/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
@@ -2,6 +2,8 @@ package com.bugsnag.android
 
 import android.content.Context
 import android.net.ConnectivityManager
+import java.io.File
+import java.io.FileWriter
 
 /**
  * Accesses the session tracker and flushes all stored sessions
@@ -31,6 +33,19 @@ internal fun createSlowErrorApiClient(context: Context): ErrorReportApiClient {
         Thread.sleep(500)
         defaultHttpClient.postReport(url, report, headers)
     })
+}
+
+/**
+ * Writes an error to the old directory format (i.e. bugsnag-errors)
+ */
+internal fun writeErrorToOldDir(client: Client) {
+    val configuration = Configuration("api-key")
+    val error = Error.Builder(configuration, RuntimeException(), null).build()
+    val filename = client.errorStore.getFilename(error)
+
+    val file = File(client.errorStore.oldDirectory, filename)
+    val writer = JsonStream(FileWriter(file))
+    error.toStream(writer)
 }
 
 internal fun writeErrorToStore(client: Client) {

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientOldDirScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientOldDirScenario.kt
@@ -1,0 +1,39 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Client
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.disableAllDelivery
+import com.bugsnag.android.writeErrorToOldDir
+
+/**
+ * Configures two Bugsnag clients with different API keys. A single error report is written to the
+ * old directory format, which should then be reported by both clients.
+ *
+ */
+internal class MultiClientOldDirScenario(config: Configuration,
+                                         context: Context) : Scenario(config, context) {
+    var firstClient: Client? = null
+    var secondClient: Client? = null
+
+    fun configureClients() {
+        firstClient = Client(context, config)
+
+        Thread.sleep(10) // enforce request order
+        val secondConfig = Configuration("abc123")
+        secondConfig.endpoint = config.endpoint
+        secondConfig.sessionEndpoint = config.sessionEndpoint
+        secondClient = Client(context, secondConfig)
+    }
+
+    override fun run() {
+        configureClients()
+
+        if ("DeliverReport" != eventMetaData) {
+            disableAllDelivery(firstClient!!)
+            disableAllDelivery(secondClient!!)
+            writeErrorToOldDir(firstClient!!)
+        }
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientSessionScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiClientSessionScenario.kt
@@ -35,7 +35,7 @@ internal class MultiClientSessionScenario(config: Configuration,
             secondClient!!.startSession()
         } else {
             flushAllSessions(firstClient!!)
-            Thread.sleep(10) // enforce request order
+            Thread.sleep(50) // enforce request order
             flushAllSessions(secondClient!!)
         }
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -23,6 +23,8 @@ import org.junit.runner.RunWith;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.file.Paths;
+import java.util.List;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest
@@ -121,6 +123,21 @@ public class ErrorStoreTest {
         assertTrue(errorStore.isStartupCrash(5345));
         assertTrue(errorStore.isStartupCrash(9999));
         assertFalse(errorStore.isStartupCrash(10000));
+    }
+
+    @Test
+    public void testFindOldFiles() throws Throwable {
+        new File(errorStorageDir, "foo.json").createNewFile();
+
+        File dir = new File(errorStorageDir, "1059309/52903");
+        dir.mkdirs(); // api/endpoint dirs
+        new File(dir, "foo.json").createNewFile();
+
+        List<File> files = errorStore.findStoredFiles();
+        for (File file : files) {
+            assertTrue(file.getAbsolutePath().endsWith("foo.json"));
+        }
+        assertEquals(2, files.size());
     }
 
     /**

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -44,7 +44,7 @@ public class ErrorStoreTest {
         config = client.config;
         errorStore = client.errorStore;
         errorStorageDir = errorStore.storageDir;
-        FileUtils.clearFilesInDir(errorStorageDir);
+        FileUtils.clearFiles(errorStore);
     }
 
     /**
@@ -54,7 +54,7 @@ public class ErrorStoreTest {
      */
     @After
     public void tearDown() throws Exception {
-        FileUtils.clearFilesInDir(errorStorageDir);
+        FileUtils.clearFiles(errorStore);
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -23,7 +23,6 @@ import org.junit.runner.RunWith;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.nio.file.Paths;
 import java.util.List;
 
 @RunWith(AndroidJUnit4.class)
@@ -44,8 +43,7 @@ public class ErrorStoreTest {
         Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
         config = client.config;
         errorStore = client.errorStore;
-        Assert.assertNotNull(errorStore.storeDirectory);
-        errorStorageDir = new File(errorStore.storeDirectory);
+        errorStorageDir = errorStore.storageDir;
         FileUtils.clearFilesInDir(errorStorageDir);
     }
 
@@ -127,10 +125,8 @@ public class ErrorStoreTest {
 
     @Test
     public void testFindOldFiles() throws Throwable {
-        new File(errorStorageDir, "foo.json").createNewFile();
-
-        File dir = new File(errorStorageDir, "1059309/52903");
-        dir.mkdirs(); // api/endpoint dirs
+        new File(errorStore.oldDirectory, "foo.json").createNewFile();
+        File dir = errorStore.storageDir;
         new File(dir, "foo.json").createNewFile();
 
         List<File> files = errorStore.findStoredFiles();

--- a/sdk/src/androidTest/java/com/bugsnag/android/FileUtils.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/FileUtils.java
@@ -7,7 +7,13 @@ final class FileUtils {
     private FileUtils() {
     }
 
-    static void clearFilesInDir(File storageDir) {
+    static void clearFiles(FileStore fileStore) {
+        File storageDir = fileStore.storageDir;
+        clearFilesInDir(storageDir);
+        clearFilesInDir(new File(fileStore.oldDirectory));
+    }
+
+    private static void clearFilesInDir(File storageDir) {
         if (!storageDir.isDirectory()) {
             throw new IllegalArgumentException();
         }

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -15,12 +15,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.util.List;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest
 public class SessionStoreTest {
 
     private File storageDir;
+    private SessionStore sessionStore;
 
     /**
      * Generates a session store with 0 files
@@ -30,7 +32,7 @@ public class SessionStoreTest {
     @Before
     public void setUp() throws Exception {
         Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
-        SessionStore sessionStore = client.sessionStore;
+        sessionStore = client.sessionStore;
         assertNotNull(sessionStore.storeDirectory);
         storageDir = new File(sessionStore.storeDirectory);
         FileUtils.clearFilesInDir(storageDir);
@@ -68,6 +70,21 @@ public class SessionStoreTest {
         // startup is handled correctly
         assertTrue(SESSION_COMPARATOR.compare(new File(first), new File(startup)) < 0);
         assertTrue(SESSION_COMPARATOR.compare(new File(second), new File(startup)) > 0);
+    }
+
+    @Test
+    public void testFindOldFiles() throws Throwable {
+        new File(storageDir, "foo.json").createNewFile();
+
+        File dir = new File(storageDir, "1059309/52903");
+        dir.mkdirs(); // api/endpoint dirs
+        new File(dir, "foo.json").createNewFile();
+
+        List<File> files = sessionStore.findStoredFiles();
+        for (File file : files) {
+            assertTrue(file.getAbsolutePath().endsWith("foo.json"));
+        }
+        assertEquals(2, files.size());
     }
 
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -33,8 +33,7 @@ public class SessionStoreTest {
     public void setUp() throws Exception {
         Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
         sessionStore = client.sessionStore;
-        assertNotNull(sessionStore.storeDirectory);
-        storageDir = new File(sessionStore.storeDirectory);
+        storageDir = sessionStore.storageDir;
         FileUtils.clearFilesInDir(storageDir);
     }
 
@@ -74,10 +73,8 @@ public class SessionStoreTest {
 
     @Test
     public void testFindOldFiles() throws Throwable {
-        new File(storageDir, "foo.json").createNewFile();
-
-        File dir = new File(storageDir, "1059309/52903");
-        dir.mkdirs(); // api/endpoint dirs
+        new File(sessionStore.oldDirectory, "foo.json").createNewFile();
+        File dir = sessionStore.storageDir;
         new File(dir, "foo.json").createNewFile();
 
         List<File> files = sessionStore.findStoredFiles();

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -34,7 +34,7 @@ public class SessionStoreTest {
         Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
         sessionStore = client.sessionStore;
         storageDir = sessionStore.storageDir;
-        FileUtils.clearFilesInDir(storageDir);
+        FileUtils.clearFiles(sessionStore);
     }
 
     /**
@@ -44,7 +44,7 @@ public class SessionStoreTest {
      */
     @After
     public void tearDown() throws Exception {
-        FileUtils.clearFilesInDir(storageDir);
+        FileUtils.clearFiles(sessionStore);
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
@@ -38,8 +38,7 @@ public class SessionTrackingPayloadTest {
         Context context = InstrumentationRegistry.getContext();
         Client client = new Client(context, "api-key");
         sessionStore = client.sessionStore;
-        Assert.assertNotNull(sessionStore.storeDirectory);
-        storageDir = new File(sessionStore.storeDirectory);
+        storageDir = sessionStore.storageDir;
         FileUtils.clearFilesInDir(storageDir);
 
         session = generateSession();

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
@@ -26,7 +26,6 @@ public class SessionTrackingPayloadTest {
     private AppData appData;
 
     private SessionStore sessionStore;
-    private File storageDir;
 
     /**
      * Configures a session tracking payload and session store, ensuring that 0 files are present
@@ -38,8 +37,7 @@ public class SessionTrackingPayloadTest {
         Context context = InstrumentationRegistry.getContext();
         Client client = new Client(context, "api-key");
         sessionStore = client.sessionStore;
-        storageDir = sessionStore.storageDir;
-        FileUtils.clearFilesInDir(storageDir);
+        FileUtils.clearFiles(sessionStore);
 
         session = generateSession();
         appData = new AppData(context, new Configuration("a"), generateSessionTracker());
@@ -54,7 +52,7 @@ public class SessionTrackingPayloadTest {
      */
     @After
     public void tearDown() throws Exception {
-        FileUtils.clearFilesInDir(storageDir);
+        FileUtils.clearFiles(sessionStore);
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -88,6 +88,9 @@ class ErrorStore extends FileStore<Error> {
      * Flush any on-disk errors to Bugsnag
      */
     void flushAsync(final ErrorReportApiClient errorReportApiClient) {
+        if (storageDir == null) {
+            return;
+        }
         try {
             Async.run(new Runnable() {
                 @Override

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -162,7 +162,8 @@ class ErrorStore extends FileStore<Error> {
         boolean isStartupCrash = isStartupCrash(AppData.getDurationMs());
         String suffix = isStartupCrash ? STARTUP_CRASH : "";
         return String.format(Locale.US, "%s/%d_%s%s.json",
-            storageDir.getAbsolutePath(), System.currentTimeMillis(), UUID.randomUUID().toString(), suffix);
+            storageDir.getAbsolutePath(), System.currentTimeMillis(),
+            UUID.randomUUID().toString(), suffix);
     }
 
     boolean isStartupCrash(long durationMs) {

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -46,7 +46,7 @@ class ErrorStore extends FileStore<Error> {
 
     ErrorStore(@NonNull Configuration config, @NonNull Context appContext) {
         super(config, appContext,
-            "/bugsnag-errors/", 128, ERROR_REPORT_COMPARATOR);
+            "bugsnag-errors", 128, ERROR_REPORT_COMPARATOR);
     }
 
     void flushOnLaunch(final ErrorReportApiClient errorReportApiClient) {
@@ -88,10 +88,6 @@ class ErrorStore extends FileStore<Error> {
      * Flush any on-disk errors to Bugsnag
      */
     void flushAsync(final ErrorReportApiClient errorReportApiClient) {
-        if (storeDirectory == null) {
-            return;
-        }
-
         try {
             Async.run(new Runnable() {
                 @Override
@@ -162,8 +158,8 @@ class ErrorStore extends FileStore<Error> {
     String getFilename(Error error) {
         boolean isStartupCrash = isStartupCrash(AppData.getDurationMs());
         String suffix = isStartupCrash ? STARTUP_CRASH : "";
-        return String.format(Locale.US, "%s%d_%s%s.json",
-            storeDirectory, System.currentTimeMillis(), UUID.randomUUID().toString(), suffix);
+        return String.format(Locale.US, "%s/%d_%s%s.json",
+            storageDir.getAbsolutePath(), System.currentTimeMillis(), UUID.randomUUID().toString(), suffix);
     }
 
     boolean isStartupCrash(long durationMs) {

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -25,7 +25,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
     private final int maxStoreCount;
     private final Comparator<File> comparator;
 
-    FileStore(@NonNull Configuration config, @NonNull Context appContext, String folderName,
+    FileStore(@NonNull Configuration config, @NonNull Context appContext, String folder,
               int maxStoreCount, Comparator<File> comparator) {
         this.config = config;
         this.maxStoreCount = maxStoreCount;
@@ -33,11 +33,9 @@ abstract class FileStore<T extends JsonStream.Streamable> {
 
         String path;
         try {
-            File baseDir = new File(appContext.getCacheDir().getAbsolutePath(), folderName);
+            File baseDir = new File(appContext.getCacheDir().getAbsolutePath(), folder);
             path = baseDir.getAbsolutePath();
-
             storageDir = getStorageDir(path, config);
-            storageDir.mkdirs();
 
             if (!storageDir.exists()) {
                 Logger.warn("Could not prepare file storage directory");
@@ -122,10 +120,14 @@ abstract class FileStore<T extends JsonStream.Streamable> {
         }
     }
 
-    File getStorageDir(String path, @NonNull Configuration config) {
+    // support multiple clients in the same app by using a unique directory path
+
+    private File getStorageDir(String path, @NonNull Configuration config) {
         String apiKey = "" + config.getApiKey().hashCode();
         String endpoint = "" + config.getEndpoint().hashCode();
-        return Paths.get(path, apiKey, endpoint).toFile();
+        File dir = Paths.get(path, apiKey, endpoint).toFile();
+        dir.mkdirs();
+        return dir;
     }
 
 }

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -16,12 +17,15 @@ abstract class FileStore<T extends JsonStream.Streamable> {
 
     @NonNull
     protected final Configuration config;
+
     @Nullable
-    final String storeDirectory;
+    final String oldDirectory;
+
+    File storageDir;
     private final int maxStoreCount;
     private final Comparator<File> comparator;
 
-    FileStore(@NonNull Configuration config, @NonNull Context appContext, String folder,
+    FileStore(@NonNull Configuration config, @NonNull Context appContext, String folderName,
               int maxStoreCount, Comparator<File> comparator) {
         this.config = config;
         this.maxStoreCount = maxStoreCount;
@@ -29,11 +33,13 @@ abstract class FileStore<T extends JsonStream.Streamable> {
 
         String path;
         try {
-            path = appContext.getCacheDir().getAbsolutePath() + folder;
+            File baseDir = new File(appContext.getCacheDir().getAbsolutePath(), folderName);
+            path = baseDir.getAbsolutePath();
 
-            File outFile = new File(path);
-            outFile.mkdirs();
-            if (!outFile.exists()) {
+            storageDir = getStorageDir(path, config);
+            storageDir.mkdirs();
+
+            if (!storageDir.exists()) {
                 Logger.warn("Could not prepare file storage directory");
                 path = null;
             }
@@ -41,19 +47,18 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             Logger.warn("Could not prepare file storage directory", exception);
             path = null;
         }
-        this.storeDirectory = path;
+        this.oldDirectory = path;
     }
 
     @Nullable
     String write(@NonNull T streamable) {
-        if (storeDirectory == null) {
+        if (storageDir == null) {
             return null;
         }
 
         // Limit number of saved errors to prevent disk space issues
-        File exceptionDir = new File(storeDirectory);
-        if (exceptionDir.isDirectory()) {
-            File[] files = exceptionDir.listFiles();
+        if (storageDir.isDirectory()) {
+            File[] files = storageDir.listFiles();
             if (files != null && files.length >= maxStoreCount) {
                 // Sort files then delete the first one (oldest timestamp)
                 Arrays.sort(files, comparator);
@@ -86,22 +91,41 @@ abstract class FileStore<T extends JsonStream.Streamable> {
         return null;
     }
 
-    @NonNull abstract String getFilename(T streamable);
+    @NonNull
+    abstract String getFilename(T streamable);
 
     List<File> findStoredFiles() {
         List<File> files = new ArrayList<>();
 
-        if (storeDirectory != null) {
-            File dir = new File(storeDirectory);
-
-            if (dir.exists() && dir.isDirectory()) {
-                File[] values = dir.listFiles();
-
-                if (values != null) {
-                    files.addAll(Arrays.asList(values));
-                }
-            }
+        if (oldDirectory != null) {
+            File dir = new File(oldDirectory);
+            addStoredFiles(dir, files);
+        }
+        if (storageDir != null) {
+            addStoredFiles(storageDir, files);
         }
         return files;
     }
+
+    void addStoredFiles(File dir, List<File> files) {
+        if (!dir.exists() || !dir.isDirectory()) {
+            return;
+        }
+        File[] values = dir.listFiles();
+
+        if (values != null) {
+            for (File value : values) {
+                if (value.isFile()) {
+                    files.add(value);
+                }
+            }
+        }
+    }
+
+    File getStorageDir(String path, @NonNull Configuration config) {
+        String apiKey = "" + config.getApiKey().hashCode();
+        String endpoint = "" + config.getEndpoint().hashCode();
+        return Paths.get(path, apiKey, endpoint).toFile();
+    }
+
 }

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -10,6 +10,7 @@ import java.io.Writer;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -56,14 +57,16 @@ abstract class FileStore<T extends JsonStream.Streamable> {
 
         // Limit number of saved errors to prevent disk space issues
         if (storageDir.isDirectory()) {
-            File[] files = storageDir.listFiles();
-            if (files != null && files.length >= maxStoreCount) {
+            List<File> storedFiles = findStoredFiles();
+
+            if (storedFiles.size() >= maxStoreCount) {
                 // Sort files then delete the first one (oldest timestamp)
-                Arrays.sort(files, comparator);
+                Collections.sort(storedFiles, comparator);
+                File oldestFile = storedFiles.get(0);
                 Logger.warn(String.format("Discarding oldest error as stored "
-                    + "error limit reached (%s)", files[0].getPath()));
-                if (!files[0].delete()) {
-                    files[0].deleteOnExit();
+                    + "error limit reached (%s)", oldestFile.getPath()));
+                if (!oldestFile.delete()) {
+                    oldestFile.deleteOnExit();
                 }
             }
         }

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -125,8 +125,13 @@ abstract class FileStore<T extends JsonStream.Streamable> {
     private File getStorageDir(String path, @NonNull Configuration config) {
         String apiKey = "" + config.getApiKey().hashCode();
         String endpoint = "" + config.getEndpoint().hashCode();
-        File dir = Paths.get(path, apiKey, endpoint).toFile();
+
+        File apiDir = new File(path, apiKey);
+        apiDir.mkdirs();
+
+        File dir = new File(apiDir, endpoint);
         dir.mkdirs();
+
         return dir;
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -65,7 +65,7 @@ public class NativeInterface {
 
     @Nullable
     public static String getErrorStorePath() {
-        return getClient().errorStore.oldDirectory;
+        return getClient().errorStore.storageDir.getAbsolutePath();
     }
 
     public static String getUserId() {

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -65,7 +65,7 @@ public class NativeInterface {
 
     @Nullable
     public static String getErrorStorePath() {
-        return getClient().errorStore.storeDirectory;
+        return getClient().errorStore.oldDirectory;
     }
 
     public static String getUserId() {

--- a/sdk/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionStore.java
@@ -33,15 +33,15 @@ class SessionStore extends FileStore<Session> {
     };
 
     SessionStore(@NonNull Configuration config, @NonNull Context appContext) {
-        super(config, appContext, "/bugsnag-sessions/",
+        super(config, appContext, "bugsnag-sessions",
             128, SESSION_COMPARATOR);
     }
 
     @NonNull
     @Override
     String getFilename(Session session) {
-        return String.format(Locale.US, "%s%s%d.json",
-            storeDirectory, UUID.randomUUID().toString(), System.currentTimeMillis());
+        return String.format(Locale.US, "%s/%s%d.json",
+            storageDir.getAbsolutePath(), UUID.randomUUID().toString(), System.currentTimeMillis());
     }
 
 }


### PR DESCRIPTION
Adds support for storage of files on a per-client basis, by using a different directory for each client based on a hash of their configured API key and endpoint.

This PR alters the `FileStore` class and its descendants so that new errors/sessions are stored in the appropriate location. Previously cached errors/sessions will still be flushed from disk from the old location - JUnit test coverage is added for this.

Also see #286 and #285 