### PR TITLE
Track dex count

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.2'
     }
 }
 repositories {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -158,5 +158,4 @@ dexcount {
     includeTotalMethodCount = true
     orderByMethodCount = true
     verbose true
-    maxMethodCount = 64000
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.getkeepsafe.dexcount'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.kt3k.coveralls'
@@ -149,3 +150,13 @@ bintray {
 }
 
 apply from: "../checkstyle.gradle"
+
+dexcount {
+    includeClasses = true
+    includeClassCount = true
+    includeFieldCount = true
+    includeTotalMethodCount = true
+    orderByMethodCount = true
+    verbose true
+    maxMethodCount = 64000
+}


### PR DESCRIPTION
Adds a gradle plugin to the sdk which outputs method count on each build.

It may be worth adding a limit that fails the build using `maxMethodCount`, e.g. 1,200. This would prevent the case where a large library inadvertently gets added as a dependency, or where the number of methods creeps up over time without adding new functionality.

It may be worth investigating similar tooling for other platforms.