### PR TITLE
Add test coverage for client.notifyBlocking

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
@@ -1,0 +1,87 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class ClientNotifyTest {
+
+    private Client client;
+    private FakeClient apiClient;
+
+    /**
+     * Generates a configuration and clears sharedPrefs values to begin the test with a clean slate
+     * @throws Exception if initialisation failed
+     */
+    @Before
+    public void setUp() throws Exception {
+        client = BugsnagTestUtils.generateClient();
+        apiClient = new FakeClient();
+        client.setErrorReportApiClient(apiClient);
+    }
+
+    @Test
+    public void testNotifyBlocking() {
+        client.notifyBlocking(new RuntimeException("Testing"));
+        assertEquals(Severity.WARNING, apiClient.report.getError().getSeverity());
+    }
+
+    @Test
+    public void testNotifyBlocking2() {
+        client.notifyBlocking(new RuntimeException("Testing"), new Callback() {
+            @Override
+            public void beforeNotify(Report report) {
+                report.getError().setUserName("Foo");
+            }
+        });
+        Error error = apiClient.report.getError();
+        assertEquals(Severity.WARNING, error.getSeverity());
+        assertEquals("Foo", error.getUser().getName());
+    }
+
+    @Test
+    public void testNotifyBlocking3() {
+        client.notifyBlocking(new RuntimeException("Testing"), Severity.INFO);
+        assertEquals(Severity.INFO, apiClient.report.getError().getSeverity());
+    }
+
+    @Test
+    public void testNotifyBlocking4() {
+        StackTraceElement[] stacktrace = {
+            new StackTraceElement("MyClass", "MyMethod", "MyFile", 5)
+        };
+
+        client.notifyBlocking("Name", "Message", stacktrace, new Callback() {
+            @Override
+            public void beforeNotify(Report report) {
+                report.getError().setSeverity(Severity.ERROR);
+            }
+        });
+        Error error = apiClient.report.getError();
+        assertEquals(Severity.ERROR, error.getSeverity());
+        assertEquals("Name", error.getExceptionName());
+        assertEquals("Message", error.getExceptionMessage());
+    }
+
+    static class FakeClient implements ErrorReportApiClient {
+        Report report;
+
+        @Override
+        public void postReport(String urlString,
+                               Report report,
+                               Map<String, String> headers)
+            throws NetworkException, BadResponseException {
+            this.report = report;
+        }
+    }
+
+}


### PR DESCRIPTION
Adds missing test coverage for non-deprecated overloads of notifyBlocking in the client class