### PR TITLE
Filestore thread safety fixes

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -1,7 +1,6 @@
 package com.bugsnag.android;
 
 import static com.bugsnag.android.ErrorStore.ERROR_REPORT_COMPARATOR;
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -16,7 +15,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,11 +22,8 @@ import org.junit.runner.RunWith;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest
@@ -157,6 +152,7 @@ public class ErrorStoreTest {
         assertEquals(0, errorStore.queuedFiles.size());
 
         List<File> storedFiles = errorStore.findStoredFiles();
+        assertEquals(1, storedFiles.size());
         errorStore.cancelQueuedFiles(null);
         assertEquals(1, errorStore.queuedFiles.size());
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -40,9 +40,8 @@ public class ErrorStoreTest {
      */
     @Before
     public void setUp() throws Exception {
-        Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
-        config = client.config;
-        errorStore = client.errorStore;
+        config = new Configuration("api-key");
+        errorStore = new ErrorStore(config, InstrumentationRegistry.getContext());
         assertNotNull(errorStore.storeDirectory);
         errorStorageDir = new File(errorStore.storeDirectory);
         FileUtils.clearFilesInDir(errorStorageDir);

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -169,6 +169,13 @@ public class ErrorStoreTest {
         writeErrorToStore();
         assertEquals(1, errorStore.findStoredFiles().size());
 
+        errorStore.deleteStoredFiles(null);
+        assertEquals(1, errorStore.queuedFiles.size());
+
+        errorStore.deleteStoredFiles(Collections.<File>emptyList());
+        assertEquals(1, errorStore.queuedFiles.size());
+
+
         errorStore.deleteStoredFiles(errorStore.findStoredFiles());
         assertEquals(0, errorStore.findStoredFiles().size());
         assertEquals(0, errorStore.queuedFiles.size());

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -139,9 +139,10 @@ public class ErrorStoreTest {
         assertEquals(1, errorStore.queuedFiles.size());
 
         writeErrorToStore();
+        writeErrorToStore();
         storedFiles = errorStore.findStoredFiles();
         assertEquals(2, storedFiles.size());
-        assertEquals(2, errorStore.queuedFiles.size());
+        assertEquals(3, errorStore.queuedFiles.size());
     }
 
     @Test
@@ -167,7 +168,8 @@ public class ErrorStoreTest {
         assertEquals(0, errorStore.findStoredFiles().size());
 
         writeErrorToStore();
-        assertEquals(1, errorStore.findStoredFiles().size());
+        List<File> storedFiles = errorStore.findStoredFiles();
+        assertEquals(1, storedFiles.size());
 
         errorStore.deleteStoredFiles(null);
         assertEquals(1, errorStore.queuedFiles.size());
@@ -176,7 +178,7 @@ public class ErrorStoreTest {
         assertEquals(1, errorStore.queuedFiles.size());
 
 
-        errorStore.deleteStoredFiles(errorStore.findStoredFiles());
+        errorStore.deleteStoredFiles(storedFiles);
         assertEquals(0, errorStore.findStoredFiles().size());
         assertEquals(0, errorStore.queuedFiles.size());
         assertEquals(0, new File(errorStore.storeDirectory).listFiles().length);
@@ -185,8 +187,14 @@ public class ErrorStoreTest {
     @Test
     public void testFileQueueDuplication() {
         writeErrorToStore();
-        errorStore.findStoredFiles();
+        List<File> ogFiles = errorStore.findStoredFiles();
+        assertEquals(1, ogFiles.size());
+
         List<File> storedFiles = errorStore.findStoredFiles();
+        assertEquals(0, storedFiles.size());
+
+        errorStore.cancelQueuedFiles(ogFiles);
+        storedFiles = errorStore.findStoredFiles();
         assertEquals(1, storedFiles.size());
     }
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
@@ -29,8 +30,9 @@ public class SessionStoreTest {
      */
     @Before
     public void setUp() throws Exception {
-        Client client = new Client(InstrumentationRegistry.getContext(), "api-key");
-        SessionStore sessionStore = client.sessionStore;
+        Configuration config = new Configuration("api-key");
+        Context context = InstrumentationRegistry.getContext();
+        SessionStore sessionStore = new SessionStore(config, context);
         assertNotNull(sessionStore.storeDirectory);
         storageDir = new File(sessionStore.storeDirectory);
         FileUtils.clearFilesInDir(storageDir);

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
@@ -36,8 +36,9 @@ public class SessionTrackingPayloadTest {
     @Before
     public void setUp() throws Exception {
         Context context = InstrumentationRegistry.getContext();
-        Client client = new Client(context, "api-key");
-        sessionStore = client.sessionStore;
+        Configuration config = new Configuration("api-key");
+        sessionStore = new SessionStore(config, context);
+
         Assert.assertNotNull(sessionStore.storeDirectory);
         storageDir = new File(sessionStore.storeDirectory);
         FileUtils.clearFilesInDir(storageDir);

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -127,17 +128,13 @@ class ErrorStore extends FileStore<Error> {
                 config.getErrorApiHeaders());
 
             Logger.info("Deleting sent error file " + errorFile.getName());
-            if (!errorFile.delete()) {
-                errorFile.deleteOnExit();
-            }
+            deleteStoredFiles(Collections.singleton(errorFile));
         } catch (NetworkException exception) {
             Logger.warn("Could not send previously saved error(s)"
                 + " to Bugsnag, will try again later", exception);
         } catch (Exception exception) {
             Logger.warn("Problem sending unsent error from disk", exception);
-            if (!errorFile.delete()) {
-                errorFile.deleteOnExit();
-            }
+            deleteStoredFiles(Collections.singleton(errorFile));
         }
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -127,14 +127,15 @@ class ErrorStore extends FileStore<Error> {
             errorReportApiClient.postReport(config.getEndpoint(), report,
                 config.getErrorApiHeaders());
 
-            Logger.info("Deleting sent error file " + errorFile.getName());
             deleteStoredFiles(Collections.singleton(errorFile));
+            Logger.info("Deleting sent error file " + errorFile.getName());
         } catch (NetworkException exception) {
+            cancelQueuedFiles(Collections.singleton(errorFile));
             Logger.warn("Could not send previously saved error(s)"
                 + " to Bugsnag, will try again later", exception);
         } catch (Exception exception) {
-            Logger.warn("Problem sending unsent error from disk", exception);
             deleteStoredFiles(Collections.singleton(errorFile));
+            Logger.warn("Problem sending unsent error from disk", exception);
         }
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -9,6 +9,8 @@ import java.io.FileWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -59,9 +61,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
                 Arrays.sort(files, comparator);
                 Logger.warn(String.format("Discarding oldest error as stored "
                     + "error limit reached (%s)", files[0].getPath()));
-                if (!files[0].delete()) {
-                    files[0].deleteOnExit();
-                }
+                deleteStoredFiles(Collections.singleton(files[0]));
             }
         }
 
@@ -104,4 +104,13 @@ abstract class FileStore<T extends JsonStream.Streamable> {
         }
         return files;
     }
+
+    void deleteStoredFiles(Collection<File> storedFiles) {
+        for (File storedFile : storedFiles) {
+            if (!storedFile.delete()) {
+                storedFile.deleteOnExit();
+            }
+        }
+    }
+
 }

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -12,8 +12,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -27,7 +29,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
     private final Comparator<File> comparator;
 
     final Lock lock = new ReentrantLock();
-    final Collection<File> queuedFiles = new ConcurrentLinkedQueue<>();
+    final Collection<File> queuedFiles = new HashSet<>();
 
     FileStore(@NonNull Configuration config, @NonNull Context appContext, String folder,
               int maxStoreCount, Comparator<File> comparator) {
@@ -119,6 +121,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
                     }
                 }
             }
+            queuedFiles.addAll(files);
             return files;
         } finally {
             lock.unlock();
@@ -128,7 +131,9 @@ abstract class FileStore<T extends JsonStream.Streamable> {
     void cancelQueuedFiles(Collection<File> files) {
         lock.lock();
         try {
-            queuedFiles.removeAll(files);
+            if (files != null) {
+                queuedFiles.removeAll(files);
+            }
         } finally {
             lock.unlock();
         }

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -120,7 +120,11 @@ abstract class FileStore<T extends JsonStream.Streamable> {
                     File[] values = dir.listFiles();
 
                     if (values != null) {
-                        files.addAll(Arrays.asList(values));
+                        for (File value : values) {
+                            if (value.isFile() && !queuedFiles.contains(value)) {
+                                files.add(value);
+                            }
+                        }
                     }
                 }
             }

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -29,7 +29,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
     private final Comparator<File> comparator;
 
     final Lock lock = new ReentrantLock();
-    final Collection<File> queuedFiles = new HashSet<>();
+    final Collection<File> queuedFiles = new ConcurrentSkipListSet<>();
 
     FileStore(@NonNull Configuration config, @NonNull Context appContext, String folder,
               int maxStoreCount, Comparator<File> comparator) {

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -145,11 +145,13 @@ abstract class FileStore<T extends JsonStream.Streamable> {
     void deleteStoredFiles(Collection<File> storedFiles) {
         lock.lock();
         try {
-            queuedFiles.removeAll(storedFiles);
+            if (storedFiles != null) {
+                queuedFiles.removeAll(storedFiles);
 
-            for (File storedFile : storedFiles) {
-                if (!storedFile.delete()) {
-                    storedFile.deleteOnExit();
+                for (File storedFile : storedFiles) {
+                    if (!storedFile.delete()) {
+                        storedFile.deleteOnExit();
+                    }
                 }
             }
         } finally {

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -68,12 +68,15 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             if (files != null && files.length >= maxStoreCount) {
                 // Sort files then delete the first one (oldest timestamp)
                 Arrays.sort(files, comparator);
-                File oldestFile = files[0];
 
-                if (!queuedFiles.contains(oldestFile)) {
-                    Logger.warn(String.format("Discarding oldest error as stored "
-                        + "error limit reached (%s)", oldestFile.getPath()));
-                    deleteStoredFiles(Collections.singleton(oldestFile));
+                for (int k = 0; k < files.length && files.length >= maxStoreCount; k++) {
+                    File oldestFile = files[k];
+
+                    if (!queuedFiles.contains(oldestFile)) {
+                        Logger.warn(String.format("Discarding oldest error as stored "
+                            + "error limit reached (%s)", oldestFile.getPath()));
+                        deleteStoredFiles(Collections.singleton(oldestFile));
+                    }
                 }
             }
         }

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -171,23 +171,17 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
                         final String endpoint = configuration.getSessionEndpoint();
                         apiClient.postSessionTrackingPayload(endpoint, payload,
                             configuration.getSessionApiHeaders());
-                        deleteStoredFiles(storedFiles);
+                        sessionStore.deleteStoredFiles(storedFiles);
                     } catch (NetworkException exception) { // store for later sending
                         Logger.info("Failed to post stored session payload");
                     } catch (BadResponseException exception) { // drop bad data
                         Logger.warn("Invalid session tracking payload", exception);
-                        deleteStoredFiles(storedFiles);
+                        sessionStore.deleteStoredFiles(storedFiles);
                     }
                 }
             } finally {
                 flushingRequest.release(1);
             }
-        }
-    }
-
-    private void deleteStoredFiles(Collection<File> storedFiles) {
-        for (File storedFile : storedFiles) {
-            storedFile.delete();
         }
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -173,6 +173,7 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
                             configuration.getSessionApiHeaders());
                         sessionStore.deleteStoredFiles(storedFiles);
                     } catch (NetworkException exception) { // store for later sending
+                        sessionStore.cancelQueuedFiles(storedFiles);
                         Logger.info("Failed to post stored session payload");
                     } catch (BadResponseException exception) { // drop bad data
                         Logger.warn("Invalid session tracking payload", exception);


### PR DESCRIPTION
We sometimes receive invalid payloads with an empty/malformed array where an error/session should be - e.g. `[]` or `[,]`. My hypothesis is that this occurs when the max limit of Error/Sessions are cached on disk. When the app is relaunched, if `write` is called just before the payload is serialised, then this can lead to the oldest File being deleted, which means there is no data to serialise.

This attempts to address this scenario by retaining a reference to any Files which are currently being flushed, and not deleting them.

A potential downside to this implementation is that it currently requires manually calling `cancelQueuedFiles` and `deleteStoredFiles`, which could be forgotten.