### PR TITLE
test: add event metadata flag to mazerunner

### DIFF
--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -32,8 +32,10 @@ class MainActivity : Activity() {
 
     private fun executeTestCase() {
         val eventType = intent.getStringExtra("EVENT_TYPE")
+        val eventMetaData = intent.getStringExtra("EVENT_METADATA")
         Log.d("Bugsnag", "Received test case, executing " + eventType)
         val testCase = factory.testCaseForName(eventType, prepareConfig(), this)
+        testCase.eventMetaData = eventMetaData
         testCase.run()
     }
 

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -8,6 +8,8 @@ import com.bugsnag.android.NetworkException
 abstract internal class Scenario(protected val config: Configuration,
                                  protected val context: Context) {
 
+    var eventMetaData: String? = null
+
     open fun run() {
         Bugsnag.init(context, config)
         Bugsnag.setLoggingEnabled(true)


### PR DESCRIPTION
Reads the metadata flag set by mazerunner, and parses it into the scenario. This can be useful if a scenario requires two or more distinct types of behaviour, as `eventMetaData` can be set to different values e.g. `"foo"` and `"bar"`

Originates from #286 