### PR TITLE
Add scenarios for setting custom API clients

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: git@github.com:bugsnag/maze-runner
-  revision: 65bdcb7a135ef0a5864d03c454f7a1654f850237
+  revision: f7123450d5a75b719911c6dd3baa0507e6062c2d
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)
+      cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)
       rack (~> 2.0.0)
       test-unit (~> 3.2.0)
@@ -11,7 +12,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.11.1)
+    backports (3.11.3)
     builder (3.2.3)
     coderay (1.1.2)
     cucumber (3.1.0)
@@ -27,7 +28,7 @@ GEM
       backports (>= 3.8.0)
       cucumber-tag_expressions (~> 1.1.0)
       gherkin (>= 5.0.0)
-    cucumber-expressions (5.0.13)
+    cucumber-expressions (5.0.15)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
@@ -40,7 +41,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.4)
+    rack (2.0.5)
     test-unit (3.2.7)
       power_assert
 

--- a/features/custom_client.feature
+++ b/features/custom_client.feature
@@ -1,5 +1,17 @@
 Feature: Using custom API clients for reporting errors
 
+Scenario: Set a custom error API client and notify an error
+    When I run "CustomClientErrorScenario" with the defaults
+    Then I should receive 1 request
+    And the "Custom-Client" header equals "Hello World"
+    And the request is a valid for the error reporting API
+
+Scenario: Set a custom session API client and start a session
+    When I run "CustomClientSessionScenario" with the defaults
+    Then I should receive 1 request
+    And the "Custom-Client" header equals "Hello World"
+    And the request is a valid for the session tracking API
+
 Scenario: Set a custom error client and flush a stored error
     When I run "CustomClientErrorFlushScenario" with the defaults
     When I force stop the "com.bugsnag.android.mazerunner" Android app
@@ -8,3 +20,4 @@ Scenario: Set a custom error client and flush a stored error
     And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
     Then I should receive 1 request
     And the "Custom-Client" header equals "Hello World"
+

--- a/features/custom_client.feature
+++ b/features/custom_client.feature
@@ -1,0 +1,10 @@
+Feature: Using custom API clients for reporting errors
+
+Scenario: Set a custom error client and flush a stored error
+    When I run "CustomClientErrorFlushScenario" with the defaults
+    When I force stop the "com.bugsnag.android.mazerunner" Android app
+    And I set environment variable "EVENT_TYPE" to "CustomClientErrorFlushScenario"
+    And I set environment variable "EVENT_METADATA" to "DeliverReports"
+    And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
+    Then I should receive 1 request
+    And the "Custom-Client" header equals "Hello World"

--- a/features/custom_client.feature
+++ b/features/custom_client.feature
@@ -1,14 +1,14 @@
 Feature: Using custom API clients for reporting errors
 
-    Scenario: Set a custom session client and flush a stored session
-        When I run "CustomClientSessionFlushScenario" with the defaults
-        When I force stop the "com.bugsnag.android.mazerunner" Android app
-        And I set environment variable "EVENT_TYPE" to "CustomClientSessionFlushScenario"
-        And I set environment variable "EVENT_METADATA" to "DeliverSessions"
-        And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
-        Then I should receive 2 requests
-        And the "Custom-Client" header equals "Hello World" for request 0
-        And the "Custom-Client" header equals "Hello World" for request 1
+Scenario: Set a custom session client and flush a stored session
+    When I run "CustomClientSessionFlushScenario" with the defaults
+    When I force stop the "com.bugsnag.android.mazerunner" Android app
+    And I set environment variable "EVENT_TYPE" to "CustomClientSessionFlushScenario"
+    And I set environment variable "EVENT_METADATA" to "DeliverSessions"
+    And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
+    Then I should receive 2 requests
+    And the "Custom-Client" header equals "Hello World" for request 0
+    And the "Custom-Client" header equals "Hello World" for request 1
 
 Scenario: Set a custom error API client and notify an error
     When I run "CustomClientErrorScenario" with the defaults

--- a/features/custom_client.feature
+++ b/features/custom_client.feature
@@ -1,5 +1,15 @@
 Feature: Using custom API clients for reporting errors
 
+    Scenario: Set a custom session client and flush a stored session
+        When I run "CustomClientSessionFlushScenario" with the defaults
+        When I force stop the "com.bugsnag.android.mazerunner" Android app
+        And I set environment variable "EVENT_TYPE" to "CustomClientSessionFlushScenario"
+        And I set environment variable "EVENT_METADATA" to "DeliverSessions"
+        And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
+        Then I should receive 2 requests
+        And the "Custom-Client" header equals "Hello World" for request 0
+        And the "Custom-Client" header equals "Hello World" for request 1
+
 Scenario: Set a custom error API client and notify an error
     When I run "CustomClientErrorScenario" with the defaults
     Then I should receive 1 request
@@ -20,4 +30,3 @@ Scenario: Set a custom error client and flush a stored error
     And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
     Then I should receive 1 request
     And the "Custom-Client" header equals "Hello World"
-

--- a/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
@@ -34,6 +34,11 @@ internal fun createSlowErrorApiClient(context: Context): ErrorReportApiClient {
     })
 }
 
+internal fun createDefaultHttpClient(context: Context): ErrorReportApiClient {
+    val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
+    return DefaultHttpClient(cm)
+}
+
 internal fun writeErrorToStore(client: Client) {
     val error = Error.Builder(Configuration("api-key"), RuntimeException(), null).build()
     client.errorStore.write(error)

--- a/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import android.content.Context
 import android.net.ConnectivityManager
 import com.bugsnag.android.Bugsnag.client
+import java.util.*
 
 /**
  * Accesses the session tracker and flushes all stored sessions
@@ -34,7 +35,12 @@ internal fun createSlowErrorApiClient(context: Context): ErrorReportApiClient {
     })
 }
 
-internal fun createDefaultHttpClient(context: Context): ErrorReportApiClient {
+internal fun createDefaultErrorClient(context: Context): ErrorReportApiClient {
+    val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
+    return DefaultHttpClient(cm)
+}
+
+internal fun createDefaultSessionClient(context: Context): SessionTrackingApiClient {
     val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
     return DefaultHttpClient(cm)
 }
@@ -43,4 +49,3 @@ internal fun writeErrorToStore(client: Client) {
     val error = Error.Builder(Configuration("api-key"), RuntimeException(), null).build()
     client.errorStore.write(error)
 }
-

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientErrorFlushScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientErrorFlushScenario.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import android.util.Log
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.createDefaultHttpClient
+
+/**
+ * Sends an unhandled exception which is cached on disk to Bugsnag, then sent on a separate launch,
+ * using a custom API client which modifies the request.
+ */
+internal class CustomClientErrorFlushScenario(config: Configuration,
+                                              context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+
+        if ("DeliverReports" == eventMetaData) {
+            Bugsnag.setErrorReportApiClient { urlString, report, headers ->
+                headers["Custom-Client"] = "Hello World"
+                createDefaultHttpClient(context).postReport(urlString, report, headers)
+            }
+        } else {
+            disableAllDelivery()
+            throw RuntimeException("ReportCacheScenario")
+        }
+
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientErrorFlushScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientErrorFlushScenario.kt
@@ -1,10 +1,9 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
-import android.util.Log
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.createDefaultHttpClient
+import com.bugsnag.android.createDefaultErrorClient
 
 /**
  * Sends an unhandled exception which is cached on disk to Bugsnag, then sent on a separate launch,
@@ -19,7 +18,7 @@ internal class CustomClientErrorFlushScenario(config: Configuration,
         if ("DeliverReports" == eventMetaData) {
             Bugsnag.setErrorReportApiClient { urlString, report, headers ->
                 headers["Custom-Client"] = "Hello World"
-                createDefaultHttpClient(context).postReport(urlString, report, headers)
+                createDefaultErrorClient(context).postReport(urlString, report, headers)
             }
         } else {
             disableAllDelivery()

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientErrorScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientErrorScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.createDefaultErrorClient
+
+/**
+ * Sends a handled exception to Bugsnag using a custom API client which modifies the request.
+ */
+internal class CustomClientErrorScenario(config: Configuration,
+                                         context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+
+        Bugsnag.setErrorReportApiClient { urlString, report, headers ->
+            headers["Custom-Client"] = "Hello World"
+            createDefaultErrorClient(context).postReport(urlString, report, headers)
+        }
+        Bugsnag.notify(RuntimeException("Hello"))
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientSessionFlushScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientSessionFlushScenario.kt
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.createDefaultSessionClient
+
+/**
+ * Sends a session which is cached on disk to Bugsnag, then sent on a separate launch,
+ * using a custom API client which modifies the request.
+ */
+internal class CustomClientSessionFlushScenario(config: Configuration,
+                                                context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+
+        if ("DeliverSessions" == eventMetaData) {
+            // simulate activity lifecycle callback occurring before api client can be set
+            Bugsnag.startSession()
+
+            Bugsnag.setSessionTrackingApiClient { urlString, report, headers ->
+                headers["Custom-Client"] = "Hello World"
+                val sessionClient = createDefaultSessionClient(context)
+                sessionClient.postSessionTrackingPayload(urlString, report, headers)
+            }
+        } else {
+            disableAllDelivery()
+            Bugsnag.startSession()
+        }
+    }
+
+}

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientSessionScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomClientSessionScenario.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.createDefaultSessionClient
+
+/**
+ * Sends a session using a custom API client which modifies the request.
+ */
+internal class CustomClientSessionScenario(config: Configuration,
+                                           context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+
+        Bugsnag.setSessionTrackingApiClient { urlString, report, headers ->
+            headers["Custom-Client"] = "Hello World"
+            val sessionClient = createDefaultSessionClient(context)
+            sessionClient.postSessionTrackingPayload(urlString, report, headers)
+        }
+
+        Bugsnag.startSession()
+    }
+
+}

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -59,7 +59,7 @@ public class Client extends Observable implements Observer {
     static final String MF_AUTO_CAPTURE_SESSIONS =
         BUGSNAG_NAMESPACE + ".AUTO_CAPTURE_SESSIONS";
 
-    private volatile boolean clientInitialised = false;
+    volatile boolean clientInitialised = false;
 
     @NonNull
     protected final Configuration config;
@@ -217,13 +217,13 @@ public class Client extends Observable implements Observer {
             public void run() {
                 try {
                     Thread.sleep(10); // allow users to set custom API clients
-                    clientInitialised = true;
                     errorStore.flushOnLaunch(errorReportApiClient);
                 } catch (InterruptedException exception) {
                     Logger.warn("Failed to flush errors on launch", exception);
                 }
             }
         });
+        clientInitialised = true;
     }
 
     private class ConnectivityChangeReceiver extends BroadcastReceiver {

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -94,6 +94,12 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
                 Async.run(new Runnable() {
                     @Override
                     public void run() {
+
+                        if (!client.clientInitialised) { // store
+                            sessionStore.write(session);
+                            return;
+                        }
+
                         //FUTURE:SM It would be good to optimise this
                         flushStoredSessions();
 


### PR DESCRIPTION
Adds mazerunner scenarios which confirm that custom API clients are always used for sending of errors/sessions, and fixes edge cases where that may not be the case. Scenarios added include:

- Handled error
- Unhandled error cached
- Manual session
- Manual session cached

Scenarios are verified using a custom API client that writes an extra header. If this is not present, the wrong API client was used.

The fixes to the notifier include:

- Delaying flushing of stored error reports until the error API client can be overridden
- Ignoring connectivity changes if they occur before the error API client can be overriden
- Writing sessions to disk if they occur before the session API client can be overriden