### PR TITLE
fix: prevent potential lifecycle breadcrumb crash

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbLifecycleCrashTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbLifecycleCrashTest.java
@@ -15,6 +15,11 @@ public class BreadcrumbLifecycleCrashTest {
 
     private SessionTracker sessionTracker;
 
+    /**
+     * Creates a SessionTracker with a null client
+     *
+     * @throws Exception if the SessionTracker couldn't be created
+     */
     @Before
     public void setUp() throws Exception {
         Configuration configuration = new Configuration("api-key");

--- a/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbLifecycleCrashTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbLifecycleCrashTest.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class BreadcrumbLifecycleCrashTest {
+
+    private SessionTracker sessionTracker;
+
+    @Before
+    public void setUp() throws Exception {
+        Configuration configuration = new Configuration("api-key");
+        Context context = InstrumentationRegistry.getContext();
+        SessionStore sessionStore = new SessionStore(configuration, context);
+        SessionTrackingApiClient apiClient = BugsnagTestUtils.generateSessionTrackingApiClient();
+        sessionTracker = new SessionTracker(configuration, null, sessionStore, apiClient);
+    }
+
+    @Test
+    public void testLifecycleBreadcrumbCrash() {
+        // should not crash with a null client
+        sessionTracker.leaveLifecycleBreadcrumb("FooActivity", "onCreate");
+    }
+
+}

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -242,7 +242,12 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
         if (configuration.isAutomaticallyCollectingBreadcrumbs()) {
             Map<String, String> metadata = new HashMap<>();
             metadata.put(KEY_LIFECYCLE_CALLBACK, lifecycleCallback);
-            client.leaveBreadcrumb(activityName, BreadcrumbType.NAVIGATION, metadata);
+
+            try {
+                client.leaveBreadcrumb(activityName, BreadcrumbType.NAVIGATION, metadata);
+            } catch (Exception ex) {
+                Logger.warn("Failed to leave breadcrumb in SessionTracker: " + ex.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Change `SessionTracker` to ignore exceptions when creating lifecycle breadcrumb before a client is fully constructed. This uses the same logic as `EventReceiver`.