### PR TITLE
Add client breadcrumbs code coverage

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.getSharedPrefs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -234,6 +235,30 @@ public class ClientTest {
         client.setSessionTrackingApiClient(customClient);
         assertFalse(client.sessionTracker.getApiClient() instanceof DefaultHttpClient);
         assertEquals(customClient, client.sessionTracker.getApiClient());
+    }
+
+    @Test
+    public void testMaxBreadcrumbs() {
+        Client client = generateClient();
+        assertEquals(0, client.breadcrumbs.store.size());
+
+        client.setMaxBreadcrumbs(1);
+
+        client.leaveBreadcrumb("test");
+        client.leaveBreadcrumb("another");
+        assertEquals(1, client.breadcrumbs.store.size());
+    }
+
+    @Test
+    public void testClearBreadcrumbs() {
+        Client client = generateClient();
+        assertEquals(0, client.breadcrumbs.store.size());
+
+        client.leaveBreadcrumb("test");
+        assertEquals(1, client.breadcrumbs.store.size());
+
+        client.clearBreadcrumbs();
+        assertEquals(0, client.breadcrumbs.store.size());
     }
 
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -248,6 +248,11 @@ public class ClientTest {
         client.leaveBreadcrumb("test");
         client.leaveBreadcrumb("another");
         assertEquals(1, client.breadcrumbs.store.size());
+
+        Breadcrumb poll = client.breadcrumbs.store.poll();
+        assertEquals(BreadcrumbType.MANUAL, poll.getType());
+        assertEquals("manual", poll.getName());
+        assertEquals("another", poll.getMetadata().get("message"));
     }
 
     @Test
@@ -261,7 +266,7 @@ public class ClientTest {
         client.clearBreadcrumbs();
         assertEquals(0, client.breadcrumbs.store.size());
     }
-  
+
     @Test
     public void testClientAddToTab() {
         Client client = generateClient();


### PR DESCRIPTION
Adds tests which cover client breadcrumb methods directly - other tests already verify the behaviour of the breadcrumbs class itself.