### PR TITLE
chore: add git hooks for checkstyle/lint

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+echo "Running lint + checkstyle before push";
+./gradlew lint checkstyle
+


### PR DESCRIPTION
Runs checkstyle and lint before pushing code, enabling us to catch issues earlier than CI.

This file should be symlinked to `.git/hooks/pre-push`