### PR TITLE
Add coverage for client metadata tab methods

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -1,8 +1,10 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.getSharedPrefs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
@@ -234,6 +236,22 @@ public class ClientTest {
         client.setSessionTrackingApiClient(customClient);
         assertFalse(client.sessionTracker.getApiClient() instanceof DefaultHttpClient);
         assertEquals(customClient, client.sessionTracker.getApiClient());
+    }
+
+    @Test
+    public void testClientAddToTab() {
+        Client client = generateClient();
+        client.addToTab("drink", "cola", "cherry");
+        assertNotNull(client.getMetaData().getTab("drink"));
+    }
+
+    @Test
+    public void testClientClearTab() {
+        Client client = generateClient();
+        client.addToTab("drink", "cola", "cherry");
+
+        client.clearTab("drink");
+        assertTrue(client.getMetaData().getTab("drink").isEmpty());
     }
 
 }


### PR DESCRIPTION
Adds test coverage for addToTab and clearTab client methods. The metadata internals themselves are already covered in existing tests