### PR TITLE
build: make android lint stricter

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -25,8 +25,9 @@ android {
     }
 
     lintOptions {
-        disable 'DefaultLocale', 'Typos'
         abortOnError true
+        warningsAsErrors true
+        checkAllWarnings true
     }
 }
 

--- a/sdk/src/main/java/com/bugsnag/android/StrictModeHandler.java
+++ b/sdk/src/main/java/com/bugsnag/android/StrictModeHandler.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import android.annotation.SuppressLint;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
@@ -27,6 +28,7 @@ class StrictModeHandler {
 
     private static final String STRICT_MODE_CLZ_NAME = "android.os.StrictMode";
 
+    @SuppressLint("UseSparseArrays")
     private static final Map<Integer, String> POLICY_CODE_MAP = new HashMap<>();
 
     static {


### PR DESCRIPTION
Run all android lint inspections, and fail the build with an error if any warnings are found. Suppresses the one existing warning in the module.