### PR TITLE
Fix: serialise breadcrumb message correctly

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbsTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbsTest.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BreadcrumbType.MANUAL;
+import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.streamableToJsonArray;
 import static org.junit.Assert.assertEquals;
 
@@ -16,6 +18,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Queue;
 
 
 @RunWith(AndroidJUnit4.class)
@@ -172,4 +175,21 @@ public class BreadcrumbsTest {
         assertEquals("left", node.getJSONObject("metaData").get("direction"));
         assertEquals(1, breadcrumbsJson.length());
     }
+
+    @Test
+    public void testClientMethods() {
+        Client client = generateClient();
+        client.leaveBreadcrumb("Hello World");
+        Queue<Breadcrumb> store = client.breadcrumbs.store;
+        int count = 0;
+
+        for (Breadcrumb breadcrumb : store) {
+            if (MANUAL == breadcrumb.getType() && "manual".equals(breadcrumb.getName())) {
+                count++;
+                assertEquals("Hello World", breadcrumb.getMetadata().get("message"));
+            }
+        }
+        assertEquals(1, count);
+    }
+
 }

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -1172,8 +1172,7 @@ public class Client extends Observable implements Observer {
      * @param breadcrumb the log message to leave (max 140 chars)
      */
     public void leaveBreadcrumb(@NonNull String breadcrumb) {
-        Map<String, String> metaData = Collections.emptyMap();
-        Breadcrumb crumb = new Breadcrumb(breadcrumb, BreadcrumbType.MANUAL, metaData);
+        Breadcrumb crumb = new Breadcrumb(breadcrumb);
 
         if (runBeforeBreadcrumbTasks(crumb)) {
             breadcrumbs.add(crumb);


### PR DESCRIPTION
The breadcrumb message should be serialised as part of the metadata, not as the name attribute.