### PR TITLE
Perf: use buffered streams for IO

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonWriterTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonWriterTest.java
@@ -1,0 +1,27 @@
+package com.bugsnag.android;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import static org.junit.Assert.*;
+
+public class JsonWriterTest {
+
+    @Test(expected = IOException.class)
+    public void testClose() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputStreamWriter writer = new OutputStreamWriter(baos);
+        JsonWriter jsonWriter = new JsonWriter(writer);
+
+        jsonWriter.beginObject().endObject();
+        jsonWriter.flush();
+        assertEquals("{}", new String(baos.toByteArray(), "UTF-8"));
+
+        jsonWriter.close();
+        writer.write(5); // can't write to a closed stream, throws IOException
+    }
+
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonWriterTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonWriterTest.java
@@ -1,12 +1,12 @@
 package com.bugsnag.android;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-
-import static org.junit.Assert.*;
 
 public class JsonWriterTest {
 

--- a/sdk/src/main/java/com/bugsnag/android/DefaultHttpClient.java
+++ b/sdk/src/main/java/com/bugsnag/android/DefaultHttpClient.java
@@ -3,11 +3,13 @@ package com.bugsnag.android;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.Map;
 
 class DefaultHttpClient implements ErrorReportApiClient, SessionTrackingApiClient {
@@ -69,7 +71,9 @@ class DefaultHttpClient implements ErrorReportApiClient, SessionTrackingApiClien
 
             try {
                 out = conn.getOutputStream();
-                JsonStream stream = new JsonStream(new OutputStreamWriter(out));
+                Charset charset = Charset.forName("UTF-8");
+                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out, charset));
+                JsonStream stream = new JsonStream(writer);
                 streamable.toStream(stream);
                 stream.close();
             } finally {

--- a/sdk/src/main/java/com/bugsnag/android/DefaultHttpClient.java
+++ b/sdk/src/main/java/com/bugsnag/android/DefaultHttpClient.java
@@ -67,17 +67,16 @@ class DefaultHttpClient implements ErrorReportApiClient, SessionTrackingApiClien
                 conn.addRequestProperty(entry.getKey(), entry.getValue());
             }
 
-            OutputStream out = null;
+            JsonStream stream = null;
 
             try {
-                out = conn.getOutputStream();
+                OutputStream out = conn.getOutputStream();
                 Charset charset = Charset.forName("UTF-8");
                 BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out, charset));
-                JsonStream stream = new JsonStream(writer);
+                stream = new JsonStream(writer);
                 streamable.toStream(stream);
-                stream.close();
             } finally {
-                IOUtils.closeQuietly(out);
+                IOUtils.closeQuietly(stream);
             }
 
 

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -70,22 +70,20 @@ abstract class FileStore<T extends JsonStream.Streamable> {
 
         String filename = getFilename(streamable);
 
-        Writer out = null;
+
+        JsonStream stream = null;
         try {
             FileOutputStream fos = new FileOutputStream(filename);
-            out = new BufferedWriter(new OutputStreamWriter(fos, "UTF-8"));
-
-            JsonStream stream = new JsonStream(out);
+            Writer out = new BufferedWriter(new OutputStreamWriter(fos, "UTF-8"));
+            stream = new JsonStream(out);
             stream.value(streamable);
-            stream.close();
-
             Logger.info(String.format("Saved unsent payload to disk (%s) ", filename));
             return filename;
         } catch (Exception exception) {
             Logger.warn(String.format("Couldn't save unsent payload to disk (%s) ",
                 filename), exception);
         } finally {
-            IOUtils.closeQuietly(out);
+            IOUtils.closeQuietly(stream);
         }
         return null;
     }

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -4,8 +4,11 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,7 +72,8 @@ abstract class FileStore<T extends JsonStream.Streamable> {
 
         Writer out = null;
         try {
-            out = new FileWriter(filename);
+            FileOutputStream fos = new FileOutputStream(filename);
+            out = new BufferedWriter(new OutputStreamWriter(fos, "UTF-8"));
 
             JsonStream stream = new JsonStream(out);
             stream.value(streamable);

--- a/sdk/src/main/java/com/bugsnag/android/JsonStream.java
+++ b/sdk/src/main/java/com/bugsnag/android/JsonStream.java
@@ -3,9 +3,12 @@ package com.bugsnag.android;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.Writer;
 
 public class JsonStream extends JsonWriter {
@@ -53,9 +56,10 @@ public class JsonStream extends JsonWriter {
         beforeValue(false); // add comma if in array
 
         // Copy the file contents onto the stream
-        FileReader input = null;
+        Reader input = null;
         try {
-            input = new FileReader(file);
+            FileInputStream fis = new FileInputStream(file);
+            input = new BufferedReader(new InputStreamReader(fis, "UTF-8"));
             IOUtils.copy(input, out);
         } finally {
             IOUtils.closeQuietly(input);


### PR DESCRIPTION
`FileReader` and `FileWriter` are not buffered, meaning they are slow. This change wraps all IO streams in a buffered reader/writer which in an (unscientific) unit test of the ErrorStore, reduced the write of an error from ~230ms to ~115ms.

This also allows us to specify the charset encoding explicitly, which is a potential (but unproven) cause for File serialisation issues on devices from certain manufacturers.