### PR TITLE
refactor: potential fix for flaky async client notify tests

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyAsyncTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyAsyncTest.java
@@ -1,5 +1,10 @@
 package com.bugsnag.android;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -10,11 +15,6 @@ import org.junit.runner.RunWith;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 @SmallTest
@@ -99,11 +99,13 @@ public class ClientNotifyAsyncTest {
 
         @Override
         public void postReport(String urlString,
-                               Report report, Map<String, String> headers) throws NetworkException, BadResponseException {
+                               Report report,
+                               Map<String, String> headers)
+            throws NetworkException, BadResponseException {
             try {
                 nullCheckLatch.await(20, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+            } catch (InterruptedException exception) {
+                exception.printStackTrace();
             }
             super.postReport(urlString, report, headers);
         }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyAsyncTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyAsyncTest.java
@@ -103,7 +103,7 @@ public class ClientNotifyAsyncTest {
                                Map<String, String> headers)
             throws NetworkException, BadResponseException {
             try {
-                nullCheckLatch.await(20, TimeUnit.MILLISECONDS);
+                nullCheckLatch.await(100, TimeUnit.MILLISECONDS);
             } catch (InterruptedException exception) {
                 exception.printStackTrace();
             }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyAsyncTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyAsyncTest.java
@@ -1,0 +1,112 @@
+package com.bugsnag.android;
+
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class ClientNotifyAsyncTest {
+
+    private Client client;
+    private NullCheckClient apiClient;
+
+    /**
+     * Generates a configuration and clears sharedPrefs values to begin the test with a clean slate
+     *
+     * @throws Exception if initialisation failed
+     */
+    @Before
+    public void setUp() throws Exception {
+        client = BugsnagTestUtils.generateClient();
+        apiClient = new NullCheckClient();
+        client.setErrorReportApiClient(apiClient);
+    }
+
+    @Test
+    public void testNotifyAsyncMetadata() throws Exception {
+        MetaData metaData = new MetaData();
+        metaData.addToTab("animals", "dog", true);
+
+        client.notify(new RuntimeException("Foo"), metaData);
+        assertNull(apiClient.report);
+        apiClient.nullCheckLatch.countDown();
+
+        apiClient.awaitReport();
+        assertNotNull(apiClient.report);
+        MetaData data = apiClient.report.getError().getMetaData();
+        assertTrue((Boolean) data.getTab("animals").get("dog"));
+    }
+
+    @Test
+    public void testNotifyAsyncSeverity() throws Exception {
+        client.notify(new RuntimeException("Foo"), Severity.INFO);
+        assertNull(apiClient.report);
+        apiClient.nullCheckLatch.countDown();
+
+        apiClient.awaitReport();
+        assertNotNull(apiClient.report);
+        assertEquals(Severity.INFO, apiClient.report.getError().getSeverity());
+    }
+
+    @Test
+    public void testNotifyAsyncSeverityMetadata() throws Exception {
+        MetaData metaData = new MetaData();
+        metaData.addToTab("animals", "bird", "chicken");
+
+        client.notify(new RuntimeException("Foo"), Severity.ERROR, metaData);
+        assertNull(apiClient.report);
+        apiClient.nullCheckLatch.countDown();
+
+        apiClient.awaitReport();
+        assertNotNull(apiClient.report);
+        MetaData data = apiClient.report.getError().getMetaData();
+        assertEquals("chicken", data.getTab("animals").get("bird"));
+        assertEquals(Severity.ERROR, apiClient.report.getError().getSeverity());
+    }
+
+    @Test
+    public void testNotifyAsyncCallback() throws Exception {
+        client.notify(new RuntimeException("Foo"), new Callback() {
+            @Override
+            public void beforeNotify(Report report) {
+                report.getError().setContext("Manual");
+            }
+        });
+        assertNull(apiClient.report);
+        apiClient.nullCheckLatch.countDown();
+
+        apiClient.awaitReport();
+        assertNotNull(apiClient.report);
+        assertEquals("Manual", apiClient.report.getError().getContext());
+    }
+
+    static class NullCheckClient extends ClientNotifyTest.FakeClient {
+
+        CountDownLatch nullCheckLatch = new CountDownLatch(1);
+
+        @Override
+        public void postReport(String urlString,
+                               Report report, Map<String, String> headers) throws NetworkException, BadResponseException {
+            try {
+                nullCheckLatch.await(20, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            super.postReport(urlString, report, headers);
+        }
+    }
+
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
@@ -1,9 +1,6 @@
 package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
@@ -78,60 +78,6 @@ public class ClientNotifyTest {
         assertEquals("Message", error.getExceptionMessage());
     }
 
-    @Test
-    public void testNotifyAsyncMetadata() throws Exception {
-        MetaData metaData = new MetaData();
-        metaData.addToTab("animals", "dog", true);
-
-        client.notify(new RuntimeException("Foo"), metaData);
-        assertNull(apiClient.report);
-
-        apiClient.awaitReport();
-        assertNotNull(apiClient.report);
-        MetaData data = apiClient.report.getError().getMetaData();
-        assertTrue((Boolean) data.getTab("animals").get("dog"));
-    }
-
-    @Test
-    public void testNotifyAsyncSeverity() throws Exception {
-        client.notify(new RuntimeException("Foo"), Severity.INFO);
-        assertNull(apiClient.report);
-
-        apiClient.awaitReport();
-        assertNotNull(apiClient.report);
-        assertEquals(Severity.INFO, apiClient.report.getError().getSeverity());
-    }
-
-    @Test
-    public void testNotifyAsyncSeverityMetadata() throws Exception {
-        MetaData metaData = new MetaData();
-        metaData.addToTab("animals", "bird", "chicken");
-
-        client.notify(new RuntimeException("Foo"), Severity.ERROR, metaData);
-        assertNull(apiClient.report);
-
-        apiClient.awaitReport();
-        assertNotNull(apiClient.report);
-        MetaData data = apiClient.report.getError().getMetaData();
-        assertEquals("chicken", data.getTab("animals").get("bird"));
-        assertEquals(Severity.ERROR, apiClient.report.getError().getSeverity());
-    }
-
-    @Test
-    public void testNotifyAsyncCallback() throws Exception {
-        client.notify(new RuntimeException("Foo"), new Callback() {
-            @Override
-            public void beforeNotify(Report report) {
-                report.getError().setContext("Manual");
-            }
-        });
-        assertNull(apiClient.report);
-
-        apiClient.awaitReport();
-        assertNotNull(apiClient.report);
-        assertEquals("Manual", apiClient.report.getError().getContext());
-    }
-
     static class FakeClient implements ErrorReportApiClient {
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -143,7 +89,7 @@ public class ClientNotifyTest {
                                Map<String, String> headers)
             throws NetworkException, BadResponseException {
             try {
-                Thread.sleep(1); // simulate async request
+                Thread.sleep(10); // simulate async request
             } catch (InterruptedException ignored) {
                 ignored.printStackTrace();
             }


### PR DESCRIPTION
Uses a countdown latch rather than sleeping for 1ms to check whether a method is async. This seems to fail rather consistently at the moment on Travis API 21 emulators, which are faster than the 16/19 ones.

This implementation splits the test into two classes - one with blocking calls, and one with async.