### PR TITLE
Enable automatic session tracking by default

### DIFF
--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -42,8 +42,7 @@ class MainActivity : Activity() {
     private fun prepareConfig(): Configuration {
         val config = Configuration(intent.getStringExtra("BUGSNAG_API_KEY"))
         val port = intent.getStringExtra("BUGSNAG_PORT")
-        config.endpoint = "${findHostname()}:$port"
-        config.sessionEndpoint = "${findHostname()}:$port"
+        config.setEndpoints("${findHostname()}:$port", "${findHostname()}:$port")
         return config
     }
 

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoContextScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoContextScenario.kt
@@ -14,6 +14,7 @@ internal class AutoContextScenario(config: Configuration,
                                    context: Context) : Scenario(config, context) {
 
     override fun run() {
+        config.setAutoCaptureSessions(false)
         super.run()
         context.startActivity(Intent(context, SecondActivity::class.java))
 

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionScenario.kt
@@ -14,7 +14,6 @@ internal class AutoSessionScenario(config: Configuration,
                                    context: Context) : Scenario(config, context) {
 
     override fun run() {
-        config.setAutoCaptureSessions(true)
         super.run()
         Bugsnag.setUser("123", "user@example.com", "Joe Bloggs")
         context.startActivity(Intent(context, SecondActivity::class.java))

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
@@ -109,7 +109,9 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testDefaults() throws Exception {
+    public void testAutoCaptureSessions() throws Exception {
+        assertTrue(config.shouldAutoCaptureSessions());
+        config.setAutoCaptureSessions(false);
         assertFalse(config.shouldAutoCaptureSessions());
     }
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
@@ -28,6 +28,40 @@ public class ConfigurationTest {
 
     @Test
     public void testEndpoints() {
+        String notify = "https://notify.myexample.com";
+        String sessions = "https://sessions.myexample.com";
+        config.setEndpoints(notify, sessions);
+
+        assertEquals(notify, config.getEndpoint());
+        assertEquals(sessions, config.getSessionEndpoint());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNullNotifyEndpoint() {
+        //noinspection ConstantConditions
+        config.setEndpoints(null, "http://example.com");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyNotifyEndpoint() {
+        config.setEndpoints("", "http://example.com");
+    }
+
+    @Test
+    public void testInvalidSessionEndpoint() {
+        //noinspection ConstantConditions
+        config.setEndpoints("http://example.com", null);
+        assertFalse(config.shouldAutoCaptureSessions());
+
+        config.setEndpoints("http://example.com", "");
+        assertFalse(config.shouldAutoCaptureSessions());
+
+        config.setEndpoints("http://example.com", "http://sessions.example.com");
+        assertTrue(config.shouldAutoCaptureSessions());
+    }
+
+    @Test
+    public void testEndpoint() {
         // Default endpoints
         assertEquals("https://notify.bugsnag.com", config.getEndpoint());
 
@@ -38,7 +72,7 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void testSessionEndpoints() {
+    public void testSessionEndpoint() {
         // Default endpoints
         assertEquals("https://sessions.bugsnag.com", config.getSessionEndpoint());
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -181,4 +181,11 @@ public class SessionTrackerTest {
         assertNotEquals(firstSession, sessionTracker.getCurrentSession());
     }
 
+    @Test
+    public void startSessionNoEndpoint() throws Exception {
+        assertNull(sessionTracker.getCurrentSession());
+        configuration.setEndpoints("http://localhost:1234", "");
+        sessionTracker.startNewSession(new Date(), user, false);
+        assertNull(sessionTracker.getCurrentSession());
+    }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -188,4 +188,19 @@ public class SessionTrackerTest {
         sessionTracker.startNewSession(new Date(), user, false);
         assertNull(sessionTracker.getCurrentSession());
     }
+
+    @Test
+    public void startSessionAutoCaptureEnabled() {
+        assertNull(sessionTracker.getCurrentSession());
+        sessionTracker.startNewSession(new Date(), user, false);
+        assertNotNull(sessionTracker.getCurrentSession());
+    }
+
+    @Test
+    public void startSessionAutoCaptureDisabled() {
+        configuration.setAutoCaptureSessions(false);
+        assertNull(sessionTracker.getCurrentSession());
+        sessionTracker.startNewSession(new Date(), user, false);
+        assertNotNull(sessionTracker.getCurrentSession());
+    }
 }

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -117,7 +117,8 @@ public final class Bugsnag {
      * endpoint.
      *
      * @param endpoint the custom endpoint to send report to
-     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoint(String)} instead.
+     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoints(String, String)}
+     * instead.
      */
     @Deprecated
     public static void setEndpoint(final String endpoint) {

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -312,21 +312,21 @@ public class Client extends Observable implements Observer {
         config.setAppVersion(data.getString(MF_APP_VERSION));
         config.setReleaseStage(data.getString(MF_RELEASE_STAGE));
 
-        String endpoint = data.getString(MF_ENDPOINT);
-
-        if (endpoint != null) {
-            config.setEndpoint(endpoint);
-        }
-        String sessionEndpoint = data.getString(MF_SESSIONS_ENDPOINT);
-
-        if (sessionEndpoint != null) {
-            config.setSessionEndpoint(sessionEndpoint);
+        if (data.containsKey(MF_ENDPOINT)) {
+            String endpoint = data.getString(MF_ENDPOINT);
+            String sessionEndpoint = data.getString(MF_SESSIONS_ENDPOINT);
+            //noinspection ConstantConditions (pass in null/empty as this function will warn)
+            config.setEndpoints(endpoint, sessionEndpoint);
         }
 
         config.setSendThreads(data.getBoolean(MF_SEND_THREADS, true));
         config.setPersistUserBetweenSessions(
             data.getBoolean(MF_PERSIST_USER_BETWEEN_SESSIONS, false));
-        config.setAutoCaptureSessions(data.getBoolean(MF_AUTO_CAPTURE_SESSIONS, false));
+
+        if (data.containsKey(MF_AUTO_CAPTURE_SESSIONS)) {
+            config.setAutoCaptureSessions(data.getBoolean(MF_AUTO_CAPTURE_SESSIONS));
+        }
+
         config.setEnableExceptionHandler(
             data.getBoolean(MF_ENABLE_EXCEPTION_HANDLER, true));
         return config;

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -390,7 +390,10 @@ public class Client extends Observable implements Observer {
      * endpoint.
      *
      * @param endpoint the custom endpoint to send report to
+     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoints(String, String)}
+     * instead.
      */
+    @Deprecated
     public void setEndpoint(String endpoint) {
         config.setEndpoint(endpoint);
     }

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -136,7 +136,10 @@ public class Configuration extends Observable implements Observer {
      * endpoint.
      *
      * @param endpoint the custom endpoint to send report to
+     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoints(String, String)}
+     * instead.
      */
+    @Deprecated
     public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
     }
@@ -175,7 +178,10 @@ public class Configuration extends Observable implements Observer {
      * endpoint.
      *
      * @param endpoint the custom endpoint to send session data to
+     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoints(String, String)}
+     * instead.
      */
+    @Deprecated
     public void setSessionEndpoint(String endpoint) {
         this.sessionEndpoint = endpoint;
     }

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -144,8 +144,23 @@ public class Configuration extends Observable implements Observer {
         this.endpoint = endpoint;
     }
 
+    /**
+     * Set the endpoints to send data to. By default we'll send error reports to
+     * https://notify.bugsnag.com, and sessions to https://session.bugsnag.com, but you can
+     * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoint.
+     *
+     * Please note that it is recommended that you set both endpoints. If the notify endpoint is
+     * missing, an exception will be thrown. If the session endpoint is missing, a warning will be
+     * logged and sessions will not be sent automatically.
+     * 
+     * @param notify the notify endpoint
+     * @param sessions the sessions endpoint
+     *
+     * @throws IllegalArgumentException if the notify endpoint is empty or null
+     */
     @SuppressWarnings("ConstantConditions")
-    public void setEndpoints(@NonNull String notify, @NonNull String sessions) {
+    public void setEndpoints(@NonNull String notify, @NonNull String sessions)
+        throws IllegalArgumentException {
         boolean invalidNotify = TextUtils.isEmpty(notify);
         invalidSessionsEndpoint = TextUtils.isEmpty(sessions);
 

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -42,7 +42,7 @@ public class Configuration extends Observable implements Observer {
     private boolean enableExceptionHandler = true;
     private boolean persistUserBetweenSessions = false;
     private long launchCrashThresholdMs = 5 * 1000;
-    private boolean autoCaptureSessions = false;
+    private boolean autoCaptureSessions = true;
     private boolean automaticallyCollectBreadcrumbs = true;
 
     @NonNull

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,6 +56,7 @@ public class Configuration extends Observable implements Observer {
         = new ConcurrentLinkedQueue<>();
     private String codeBundleId;
     private String notifierType;
+    volatile boolean invalidSessionsEndpoint;
 
     /**
      * Construct a new Bugsnag configuration object
@@ -137,6 +139,24 @@ public class Configuration extends Observable implements Observer {
      */
     public void setEndpoint(String endpoint) {
         this.endpoint = endpoint;
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public void setEndpoints(@NonNull String notify, @NonNull String sessions) {
+        boolean invalidNotify = TextUtils.isEmpty(notify);
+        invalidSessionsEndpoint = TextUtils.isEmpty(sessions);
+
+        if (invalidNotify) {
+            throw new IllegalArgumentException("Notify endpoint cannot be empty or null.");
+        }
+        if (invalidSessionsEndpoint) {
+            Logger.warn("The session tracking endpoint has not been set. " +
+                "Session tracking is disabled");
+            autoCaptureSessions = false;
+        }
+        this.endpoint = notify;
+        this.sessionEndpoint = sessions;
+        this.autoCaptureSessions = !invalidNotify && !invalidSessionsEndpoint;
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -64,6 +64,11 @@ class SessionTracker implements Application.ActivityLifecycleCallbacks {
      * @param user the session user (if any)
      */
     void startNewSession(@NonNull Date date, @Nullable User user, boolean autoCaptured) {
+        if (configuration.invalidSessionsEndpoint) {
+            Logger.warn("The session tracking endpoint has not been set. " +
+                "Session tracking is disabled");
+            return;
+        }
         Session session = new Session(UUID.randomUUID().toString(), date, user, autoCaptured);
         currentSession.set(session);
         trackSessionIfNeeded(session);


### PR DESCRIPTION
## Goal

Enables automatic tracking of sessions by default, and adds a new API for setting the notify/session endpoints which deprecates the old method.

## Design

This should prevent the unintentional scenario where a user sets the notify endpoint with a sessions endpoint.

## Changeset

### Added
`config.setEndpoints(String notify, String sessions)`

### Changed
Deprecation notice for:
`config.setEndpoint`
`config.setSessionsEndpoint`
`client.setEndpoint`

Manifest meta-data parsing logic

## Tests

An additional Mazerunner test for ensuring a session is automatically tracked on app launch, and unit tests for ensuring:

- Setting autoCaptureSessions to false prevents a session from being sent at app load
- Manually calling sendSession() sends a session regardless of the state of autoCaptureSessions
- Manually calling sendSession() with endpoint configured but not sessionsEndpoint issues a warning and does not send a session

This doesn't automatically test that configuring endpoint without session endpoint logs a warning, as this is difficult to achieve on Android.

## Discussion

### Outstanding Questions

The deprecated options are not aliased onto the new API - I believe this is ok.

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
