### PR TITLE
build: Automatically update dex / size / count badge during release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ test:
 	./gradlew :sdk:connectedCheck
 
 bump: badge
+ifneq ($(shell git diff --staged),)
+	@git diff --staged
+	@$(error You have uncommitted changes. Push or discard them to continue)
+endif
 ifeq ($(VERSION),)
 	@$(error VERSION is not defined. Run with `make VERSION=number bump`)
 endif
@@ -21,6 +25,10 @@ endif
 	 sdk/src/main/java/com/bugsnag/android/Notifier.java
 
 badge: build
+ifneq ($(shell git diff),)
+	@git diff
+	@$(error You have unstaged changes. Commit or discard them to continue)
+endif
 	@echo "Counting ..."
 	@./gradlew countReleaseDexMethods > counter.txt
 	@awk 'BEGIN{ \
@@ -38,6 +46,9 @@ badge: build
 
 # Makes a release
 release: clean bump
+ifneq ($(shell git diff origin/master..master),)
+	@$(error You have unpushed commits on the master branch)
+endif
 ifeq ($(VERSION),)
 	@$(error VERSION is not defined. Run with `make VERSION=number release`)
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: build
 
-.PHONY: build test clean
+.PHONY: build test clean bump badge release
 
 build:
 	./gradlew sdk:build
@@ -11,7 +11,7 @@ clean:
 test:
 	./gradlew :sdk:connectedCheck
 
-bump:
+bump: badge
 ifeq ($(VERSION),)
 	@$(error VERSION is not defined. Run with `make VERSION=number bump`)
 endif
@@ -37,7 +37,7 @@ badge: build
 
 
 # Makes a release
-release:
+release: clean bump
 ifeq ($(VERSION),)
 	@$(error VERSION is not defined. Run with `make VERSION=number release`)
 endif

--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,8 @@ release: clean bump
 ifeq ($(VERSION),)
 	@$(error VERSION is not defined. Run with `make VERSION=number release`)
 endif
-	make VERSION=$(VERSION) bump && git commit -am "v$(VERSION)" && git tag v$(VERSION) \
-	&& git push origin && git push --tags && ./gradlew clean assemble uploadArchives bintrayUpload
+	@git add -p README.md gradle.properties sdk/src/main/java/com/bugsnag/android/Notifier.java
+	@git commit -m "Release v$(VERSION)"
+	@git tag v$(VERSION)
+	@git push origin master v$(VERSION)
+	@./gradlew uploadArchives bintrayUpload

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 .PHONY: build test clean
 
 build:
-	./gradlew build
+	./gradlew sdk:build
 
 clean:
 	./gradlew clean

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,21 @@ endif
 	@sed -i '' "s/NOTIFIER_VERSION = .*;/NOTIFIER_VERSION = \"$(VERSION)\";/"\
 	 sdk/src/main/java/com/bugsnag/android/Notifier.java
 
+badge: build
+	@echo "Counting ..."
+	@./gradlew countReleaseDexMethods > counter.txt
+	@awk 'BEGIN{ \
+		"cat counter.txt | grep \"com.bugsnag.android\$\"" | getline output;\
+		split(output, counts);\
+		"du -k sdk/build/outputs/aar/bugsnag-android-release.aar | cut -f1" | getline size;\
+		printf "![Method count and size](https://img.shields.io/badge/Methods%%20and%%20size-";\
+		printf counts[1] "%%20classes%%20|%%20" counts[2] "%%20methods%%20|%%20" counts[3] "%%20fields%%20|%%20";\
+		printf size "%%20KB-e91e63.svg)";\
+		};' > tmp_url.txt
+	@awk '/!.*Method count and size.*/ { getline < "tmp_url.txt" }1' README.md > README.md.tmp
+	@mv README.md.tmp README.md
+	@rm counter.txt tmp_url.txt
+
 
 # Makes a release
 release:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 
 # Makes a release
 release:
-ifeq ($(VERSION),)g
+ifeq ($(VERSION),)
 	@$(error VERSION is not defined. Run with `make VERSION=number release`)
 endif
 	make VERSION=$(VERSION) bump && git commit -am "v$(VERSION)" && git tag v$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 [![Documentation](https://img.shields.io/badge/documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/android/)
 [![Build status](https://travis-ci.org/bugsnag/bugsnag-android.svg?branch=master)](https://travis-ci.org/bugsnag/bugsnag-android)
 [![Coverage Status](https://coveralls.io/repos/github/bugsnag/bugsnag-android/badge.svg?branch=master)](https://coveralls.io/github/bugsnag/bugsnag-android?branch=master)
-[![Method count and size](https://img.shields.io/badge/Methods%20and%20size-core:%20742%20|%20deps:%2032%20|%2090%20KB-e91e63.svg)](http://www.methodscount.com/?lib=com.bugsnag%3Abugsnag-android%3A4.0.0)
+<!-- Auto-generated line below: -->
+![Method count and size](https://img.shields.io/badge/Methods%20and%20size-79%20classes%20|%20630%20methods%20|%20312%20fields%20|%20116%20KB-e91e63.svg)
 
 Get comprehensive [Android crash reports](https://www.bugsnag.com/platforms/android/) to quickly debug errors.
 
 Bugsnag's [Android crash reporting](https://www.bugsnag.com/platforms/android/)
 library automatically detects crashes in your Android apps, collecting
 diagnostic information and immediately notifying your development team, helping
-you to understand and resolve issues as fast as possible. 
+you to understand and resolve issues as fast as possible.
 
 ## Features
 


### PR DESCRIPTION
Invoke ~arcane magic~ awk to update the badge for library sizes when running the release and bump tasks. Also added more checks to ensure the git status is clean before running.