### PR TITLE
Android P FileStore flush fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.4.1 (TBD)
+
+### Bug fixes
+
+* Ensure that unhandled error reports are always sent immediately on launch for Android P and in situations with no connectivity.
+[#319](https://github.com/bugsnag/bugsnag-android/pull/319)
+
 ## 4.4.0 (2018-05-17)
 
 ### Features

--- a/features/startup_crash.feature
+++ b/features/startup_crash.feature
@@ -1,0 +1,14 @@
+Feature: All errors are flushed if a startup crash is persisted
+
+Scenario: 1 startup crash and 1 regular crash persisted
+    When I configure the app to run in the "CrashOfflineWithDelay" state
+    And I run "StartupCrashFlushScenario" with the defaults
+    And I wait for 10 seconds
+
+    And I configure the app to run in the "CrashOfflineAtStartup" state
+    And I relaunch the app
+
+    And I configure the app to run in the "No crash" state
+    And I relaunch the app
+    And I wait for 5 seconds
+    Then I should receive 2 requests

--- a/features/steps/build_steps.rb
+++ b/features/steps/build_steps.rb
@@ -8,3 +8,12 @@ When("I run {string} with the defaults") do |eventType|
     And I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity
   }
 end
+
+When("I relaunch the app") do
+  step('I force stop the "com.bugsnag.android.mazerunner" Android app')
+  step('I start the "com.bugsnag.android.mazerunner" Android app using the "com.bugsnag.android.mazerunner.MainActivity" activity')
+end
+
+When("I configure the app to run in the {string} state") do |event_metadata|
+  step("I set environment variable \"EVENT_METADATA\" to \"#{event_metadata}\"")
+end

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -50,9 +50,22 @@ abstract internal class Scenario(protected val config: Configuration,
      * Sets a NOP implementation for the Error Tracking API and the Session Tracking API,
      * preventing delivery
      */
+    @Deprecated("Disable via config instead, using the new delivery API")
     protected fun disableAllDelivery() {
         disableSessionDelivery()
         disableReportDelivery()
+    }
+
+    protected fun disableAllDelivery(config: Configuration) {
+        config.delivery = object: Delivery {
+            override fun deliver(payload: SessionTrackingPayload?, config: Configuration?) {
+                throw DeliveryFailureException("Error Delivery NOP", RuntimeException("NOP"))
+            }
+
+            override fun deliver(report: Report?, config: Configuration?) {
+                throw DeliveryFailureException("Session Delivery NOP", RuntimeException("NOP"))
+            }
+        }
     }
 
     /**

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StartupCrashFlushScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StartupCrashFlushScenario.kt
@@ -1,0 +1,42 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import android.os.Handler
+import com.bugsnag.android.*
+
+/**
+ * Generates an uncaught exception, catches it, and persists it to disc, preventing any delivery.
+ *
+ * To generate a startup crash, set "eventMetaData" to "StartupCrash", otherwise the default
+ * behaviour is to report a normal crash.
+ *
+ * The mazerunner scenario that tests this works in 3 parts:
+ *
+ * 1. Generate and persist a normal crash on disk, by waiting longer than the threshold for
+ *    a startup crash
+ * 2. Generate and persist a startup crash on disk, by crashing as soon as the scenario starts
+ * 3. Send the stored reports. The startup crash should be delivered synchronously on the main thread,
+ * and the normal crash asynchronously.
+ */
+internal class StartupCrashFlushScenario(config: Configuration,
+                                         context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        if ("CrashOfflineWithDelay" == eventMetaData) {
+            // Part 1 - Persist a regular crash to disk
+            disableAllDelivery(config)
+            super.run()
+            Handler().postDelayed({
+            	throw RuntimeException("Regular crash")
+			}, 6000)
+        } else if ("CrashOfflineAtStartup" == eventMetaData) {
+            // Part 2 - Persist a startup crash to disk
+            disableAllDelivery(config)
+            super.run()
+            throw RuntimeException("Startup crash")
+        } else {
+            // Part 3 - Online, no crashes: send any cached reports
+            super.run()
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Some unhandled error reports aren't being sent immediately on Android P and in situations with no connectivity.

Internally `FileStore` retains a `Collection` of files which have previously been found for a request, to prevent duplicate reports being sent. This puts the onus on the calling code to cancel or delete the files once the request has been completed. 

This changeset ensures that these files are only requested once when calling `flushOnLaunch`, then cancels all files after delivery has taken place (successfully or not), which resets the `FileStore` state.

After this, `flushAsync` is then called, which will flush any remaining reports that have not yet been delivered.

## Changeset

### Changed

`FileStore` (see above description)

## Tests

Manual test on Android P simulator of unhandled crashes. Mazerunner scenario that fails prior to the applied fix.

## Discussion

### Alternative Approaches

The delivery/flushing code is fairly complex, it may be worth rethinking our implementation at some future point.

### Linked issues

#318 

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
