### PR TITLE
Trim very long stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.4.1 (TBD)
+
+### Bug fixes
+
+* Trim long stacktraces to max limit of 200 [#324](https://github.com/bugsnag/bugsnag-android/pull/324)
+
 ## 4.4.1 (2018-05-30)
 
 ### Bug fixes

--- a/features/trimmed_stacktrace.feature
+++ b/features/trimmed_stacktrace.feature
@@ -1,0 +1,7 @@
+Feature: Reporting large stacktrace
+
+Scenario: A large stacktrace should have its frames trimmed to a reasonable number
+    When I run "TrimmedStacktraceScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the payload field "events.0.exceptions.0.stacktrace" is an array with 200 elements

--- a/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/TrimmedStacktraceScenario.kt
+++ b/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/TrimmedStacktraceScenario.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Sends an exception with a long stacktrace to Bugsnag, which should trim the stack frames so that
+ * the request can be sent
+ */
+internal class TrimmedStacktraceScenario(config: Configuration,
+                                         context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+        val stacktrace = mutableListOf<StackTraceElement>()
+
+        for (lineNumber in 1..100000) {
+            stacktrace.add(StackTraceElement("SomeClass",
+                "someRecursiveMethod", "Foo.kt", lineNumber))
+        }
+
+        Bugsnag.notify("CustomException", "foo", stacktrace.toTypedArray(), null)
+    }
+
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
@@ -17,6 +17,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @FlakyTest(detail = "Checks a stacktrace's line number, so fails when lines are added/deleted.")
 @RunWith(AndroidJUnit4.class)
@@ -38,7 +40,7 @@ public class StacktraceTest {
         JSONArray stacktraceJson = streamableToJsonArray(stacktrace);
 
         JSONObject firstFrame = (JSONObject) stacktraceJson.get(0);
-        assertEquals(32, firstFrame.get("lineNumber"));
+        assertEquals(34, firstFrame.get("lineNumber"));
         assertEquals("com.bugsnag.android.StacktraceTest.setUp", firstFrame.get("method"));
         assertEquals("StacktraceTest.java", firstFrame.get("file"));
         assertFalse(firstFrame.has("inProject"));
@@ -53,6 +55,20 @@ public class StacktraceTest {
 
         JSONObject firstFrame = (JSONObject) stacktraceJson.get(0);
         assertTrue(firstFrame.getBoolean("inProject"));
+    }
+
+    @Test
+    public void testStacktraceTrimming() throws Throwable {
+        List<StackTraceElement> elements = new ArrayList<>();
+
+        for (int k = 0; k < 1000; k++) {
+            elements.add(new StackTraceElement("SomeClass", "someMethod", "someFile", k));
+        }
+
+        StackTraceElement[] ary = new StackTraceElement[elements.size()];
+        Stacktrace stacktrace = new Stacktrace(config, elements.toArray(ary));
+        JSONArray jsonArray = streamableToJsonArray(stacktrace);
+        assertEquals(200, jsonArray.length());
     }
 
 }

--- a/sdk/src/main/java/com/bugsnag/android/ExceptionHandler.java
+++ b/sdk/src/main/java/com/bugsnag/android/ExceptionHandler.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import android.os.StrictMode;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Map;
@@ -91,7 +92,7 @@ class ExceptionHandler implements UncaughtExceptionHandler {
             originalHandler.uncaughtException(thread, throwable);
         } else {
             System.err.printf("Exception in thread \"%s\" ", thread.getName());
-            throwable.printStackTrace(System.err);
+            Logger.warn("Exception", throwable);
         }
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/Stacktrace.java
+++ b/sdk/src/main/java/com/bugsnag/android/Stacktrace.java
@@ -38,7 +38,7 @@ class Stacktrace implements JsonStream.Streamable {
 
                 writer.endObject();
             } catch (Exception lineEx) {
-                Logger.warn("Failed to serialise stacktrace", lineEx);
+                Logger.warn("Failed to serialize stacktrace", lineEx);
             }
         }
 

--- a/sdk/src/main/java/com/bugsnag/android/Stacktrace.java
+++ b/sdk/src/main/java/com/bugsnag/android/Stacktrace.java
@@ -9,6 +9,9 @@ import java.io.IOException;
  * where appropriate.
  */
 class Stacktrace implements JsonStream.Streamable {
+
+    private static final int STACKTRACE_TRIM_LENGTH = 200;
+
     final Configuration config;
     final StackTraceElement[] stacktrace;
 
@@ -21,7 +24,8 @@ class Stacktrace implements JsonStream.Streamable {
     public void toStream(@NonNull JsonStream writer) throws IOException {
         writer.beginArray();
 
-        for (StackTraceElement el : stacktrace) {
+        for (int k = 0; k < stacktrace.length && k < STACKTRACE_TRIM_LENGTH; k++) {
+            StackTraceElement el = stacktrace[k];
             try {
                 writer.beginObject();
                 writer.name("method").value(el.getClassName() + "." + el.getMethodName());

--- a/sdk/src/main/java/com/bugsnag/android/Stacktrace.java
+++ b/sdk/src/main/java/com/bugsnag/android/Stacktrace.java
@@ -38,7 +38,7 @@ class Stacktrace implements JsonStream.Streamable {
 
                 writer.endObject();
             } catch (Exception lineEx) {
-                lineEx.printStackTrace(System.err);
+                Logger.warn("Failed to serialise stacktrace", lineEx);
             }
         }
 


### PR DESCRIPTION
## Goal

Trims very long stacktraces by ensuring that only the first 200 stack frames are serialised. This should ensure that for a stacktrace with 10^6 stackframes, the notifier will still deliver unhandled errors, and the pipeline won't drop the request.

Additionally, `Logger` is used rather than `printStacktrace`. The former is redirected by Android to logcat, but a message limit can result in
an SSLException being thrown for large messages. `Logger` uses logcat internally and is disabled in production by default, which should prevent these issues affecting users.

## Changeset

### Changed

- Stacktrace serialisation now ends after 200 frames have been processed.
- Throwables are put through the `Logger` rather than `printStacktrace`.

## Tests

Added a mazerunner scenario and JUnit test.

## Discussion

### Outstanding Questions

I've picked 200 frames as it seemed like a reasonable number. We may want to determine whether this sounds sensible for all our notifiers, if we want the same trimming behaviour across platforms.

### Linked issues
Fixes #322 

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
