### PR TITLE
Fixes jcenter breaking our build by specifying the google repo first

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
         mavenLocal()
     }
     dependencies {
@@ -14,8 +14,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 repositories {
-    jcenter()
     google()
+    jcenter()
 }
 
 android {

--- a/examplelib/build.gradle
+++ b/examplelib/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
-        jcenter()
         mavenLocal()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.bugsnag:bugsnag-android-gradle-plugin:3.1.0'

--- a/mazerunner/build.gradle
+++ b/mazerunner/build.gradle
@@ -1,6 +1,6 @@
 repositories {
-    jcenter()
     google()
+    jcenter()
 }
 
 buildscript {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -5,8 +5,8 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.kt3k.coveralls'
 
 repositories {
-    jcenter()
     google()
+    jcenter()
 }
 
 android {


### PR DESCRIPTION
JCenter started silently proxying the google maven repo, whose artefacts have incorrect checksums. This results in a 409 status code, meaning gradle is unable to resolve required google dependencies and the entire build breaks

## Changeset

### Changed
`google()` is specified before `jcenter()`, which alters the order of resolution of dependencies.

## Discussion

### Alternative Approaches

Move away from jcenter in favour of maven central.



## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
