### PR TITLE
refactor: Add accessors for notifier class

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/NotifierTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NotifierTest.java
@@ -1,0 +1,61 @@
+package com.bugsnag.android;
+
+import static com.bugsnag.android.BugsnagTestUtils.streamableToJson;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class NotifierTest {
+
+    private Notifier notifier;
+
+    @Before
+    public void setUp() throws Exception {
+        notifier = new Notifier();
+    }
+
+    @Test
+    public void testName() {
+        assertEquals("Android Bugsnag Notifier", notifier.getName());
+        String expected = "CrossPlatformFramework";
+        notifier.setName(expected);
+        assertEquals(expected, notifier.getName());
+    }
+
+    @Test
+    public void testVersion() {
+        assertNotNull(notifier.getVersion());
+        String expected = "1.2.3";
+        notifier.setVersion(expected);
+        assertEquals(expected, notifier.getVersion());
+    }
+
+    @Test
+    public void testUrl() {
+        assertEquals("https://bugsnag.com", notifier.getURL());
+        String expected = "http://example.com";
+        notifier.setURL(expected);
+        assertEquals(expected, notifier.getURL());
+    }
+
+    @Test
+    public void testJsonSerialisation() throws JSONException, IOException {
+        JSONObject notifierJson = streamableToJson(notifier);
+        assertEquals(3, notifierJson.length());
+        assertEquals("Android Bugsnag Notifier", notifierJson.getString("name"));
+        assertNotNull(notifierJson.getString("version"));
+        assertEquals("https://bugsnag.com", notifierJson.getString("url"));
+    }
+}

--- a/sdk/src/main/java/com/bugsnag/android/Notifier.java
+++ b/sdk/src/main/java/com/bugsnag/android/Notifier.java
@@ -8,24 +8,25 @@ import java.io.IOException;
  * Information about this library, including name and version.
  */
 public class Notifier implements JsonStream.Streamable {
-    static final String NOTIFIER_NAME = "Android Bugsnag Notifier";
-    static final String NOTIFIER_VERSION = "4.5.0";
-    static final String NOTIFIER_URL = "https://bugsnag.com";
-    private String name;
-    private String version;
-    private String url;
+
+    private static final String NOTIFIER_NAME = "Android Bugsnag Notifier";
+    private static final String NOTIFIER_VERSION = "4.5.0";
+    private static final String NOTIFIER_URL = "https://bugsnag.com";
+
+    @NonNull
+    private String name = NOTIFIER_NAME;
+
+    @NonNull
+    private String version = NOTIFIER_VERSION;
+
+    @NonNull
+    private String url = NOTIFIER_URL;
 
     private static final Notifier instance = new Notifier();
 
     @NonNull
     public static Notifier getInstance() {
         return instance;
-    }
-
-    Notifier() {
-        this.name = NOTIFIER_NAME;
-        this.version = NOTIFIER_VERSION;
-        this.url = NOTIFIER_URL;
     }
 
     @Override
@@ -37,16 +38,38 @@ public class Notifier implements JsonStream.Streamable {
         writer.endObject();
     }
 
+    @InternalApi
     public void setVersion(@NonNull String version) {
         this.version = version;
     }
 
+    @InternalApi
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     public void setURL(@NonNull String url) {
         this.url = url;
     }
 
+    @InternalApi
     public void setName(@NonNull String name) {
         this.name = name;
+    }
+
+    @NonNull
+    @InternalApi
+    public String getName() {
+        return name;
+    }
+
+    @NonNull
+    @InternalApi
+    public String getVersion() {
+        return version;
+    }
+
+    @NonNull
+    @InternalApi
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    public String getURL() {
+        return url;
     }
 }


### PR DESCRIPTION
## Goal

Adds public accessors to Notifer, for use as internal API (denoted with marker annotation).
## Changeset

### Changed

Converted fields/methods to properties (getter/setter backed with a field) in Notifier.

## Tests

Added a unit test for JSON serialisation, and a test for the default value + override value of each accessor.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
