### PR TITLE
refactor: Document Report accessors

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/Report.java
+++ b/sdk/src/main/java/com/bugsnag/android/Report.java
@@ -13,11 +13,17 @@ import java.io.IOException;
  * using your API key.
  */
 public class Report implements JsonStream.Streamable {
+
     @Nullable
     private final File errorFile;
+
     @Nullable
-    private Error error;
-    private Notifier notifier;
+    private final Error error;
+
+    @NonNull
+    private final Notifier notifier;
+
+    @NonNull
     private String apiKey;
 
     Report(@NonNull String apiKey, @Nullable File errorFile) {
@@ -51,11 +57,10 @@ public class Report implements JsonStream.Streamable {
         // Write in-memory event
         if (error != null) {
             writer.value(error);
-        }
-
-        // Write on-disk event
-        if (errorFile != null) {
+        } else if (errorFile != null) { // Write on-disk event
             writer.value(errorFile);
+        } else {
+            Logger.warn("Expected error or errorFile, found empty payload instead");
         }
 
         // End events array
@@ -70,20 +75,45 @@ public class Report implements JsonStream.Streamable {
         return error;
     }
 
+    /**
+     * Alters the API key used for this error report.
+     *
+     * @param apiKey the new API key
+     */
     public void setApiKey(@NonNull String apiKey) {
         this.apiKey = apiKey;
     }
 
+    /**
+     * @return the API key sent as part of this report.
+     */
+    @NonNull
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    @InternalApi
+    @Deprecated
     public void setNotifierVersion(@NonNull String version) {
         notifier.setVersion(version);
     }
 
+    @InternalApi
+    @Deprecated
     public void setNotifierName(@NonNull String name) {
         notifier.setName(name);
     }
 
+    @InternalApi
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    @Deprecated
     public void setNotifierURL(@NonNull String url) {
         notifier.setURL(url);
+    }
+
+    @InternalApi
+    @NonNull
+    public Notifier getNotifier() {
+        return notifier;
     }
 }


### PR DESCRIPTION
## Goal

Document existing public accessors on the Report object, and add nullability annotations.

## Changeset

- Nullability annotations
- Accessors/JavaDoc
- Deprecated notifier proxy methods in favour of accessing the `notifier` object directly


## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
