### PR TITLE
feat: add public accessors to error class

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -216,6 +216,7 @@ public class ErrorTest {
     public void testSetGroupingHash() throws JSONException, IOException {
         String groupingHash = "herpderp";
         error.setGroupingHash(groupingHash);
+        assertEquals(groupingHash, error.getGroupingHash());
 
         JSONObject errorJson = streamableToJson(error);
         assertEquals(groupingHash, errorJson.get("groupingHash"));
@@ -313,7 +314,9 @@ public class ErrorTest {
         String expectedContext = "FooActivity";
         sessionTracker.updateForegroundTracker(expectedContext,
             true, System.currentTimeMillis());
-        error.setAppData(new AppData(context, config, sessionTracker));
+        AppData appData = new AppData(context, config, sessionTracker);
+        error.setAppData(appData);
+        assertEquals(appData, error.getAppData());
         assertEquals(expectedContext, error.getContext());
     }
 
@@ -375,6 +378,7 @@ public class ErrorTest {
         Context context = InstrumentationRegistry.getContext();
         DeviceData deviceData = new DeviceData(context, BugsnagTestUtils.getSharedPrefs(context));
         error.setDeviceData(deviceData);
+        assertEquals(deviceData, error.getDeviceData());
 
         JSONObject errorJson = streamableToJson(error);
         JSONObject device = errorJson.getJSONObject("device");

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -68,7 +68,10 @@ public class Client extends Observable implements Observer {
     protected final DeviceData deviceData;
     @NonNull
     final Breadcrumbs breadcrumbs;
+
+    @NonNull
     protected final User user = new User();
+
     @NonNull
     protected final ErrorStore errorStore;
 

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -2,7 +2,6 @@ package com.bugsnag.android;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
 
 import java.io.IOException;
 
@@ -17,29 +16,52 @@ import java.io.IOException;
  */
 public class Error implements JsonStream.Streamable {
 
+    @SuppressWarnings("NullableProblems") // set after construction
+    @NonNull
+    private AppData appData;
+
+    @SuppressWarnings("NullableProblems") // set after construction
+    @NonNull
+    private DeviceData deviceData;
+
+    @SuppressWarnings("NullableProblems") // set after construction
+    @NonNull
+    private User user;
+
+    @Nullable
+    private Severity severity;
+
+    @NonNull
+    private MetaData metaData = new MetaData();
+
+    @Nullable
+    private String groupingHash;
+
+    @Nullable
+    private String context;
+
     @NonNull
     final Configuration config;
-    private AppData appData;
-    private DeviceData deviceData;
+    private final String[] projectPackages;
+    private final Exceptions exceptions;
     private Breadcrumbs breadcrumbs;
-    private User user;
     private final Throwable exception;
-    private Severity severity = Severity.WARNING;
-    @NonNull private MetaData metaData = new MetaData();
-    private String groupingHash;
-    private String context;
     private final HandledState handledState;
     private final Session session;
     private final ThreadState threadState;
 
     Error(@NonNull Configuration config, @NonNull Throwable exception,
-          HandledState handledState, Severity severity, Session session, ThreadState threadState) {
+          HandledState handledState, @NonNull Severity severity,
+          Session session, ThreadState threadState) {
         this.threadState = threadState;
         this.config = config;
         this.exception = exception;
         this.handledState = handledState;
         this.severity = severity;
         this.session = session;
+
+        projectPackages = config.getProjectPackages();
+        exceptions = new Exceptions(config, exception);
     }
 
     @Override
@@ -56,16 +78,16 @@ public class Error implements JsonStream.Streamable {
         writer.name("severityReason").value(handledState);
         writer.name("unhandled").value(handledState.isUnhandled());
 
-        if (config.getProjectPackages() != null) {
+        if (projectPackages != null) {
             writer.name("projectPackages").beginArray();
-            for (String projectPackage : config.getProjectPackages()) {
+            for (String projectPackage : projectPackages) {
                 writer.value(projectPackage);
             }
             writer.endArray();
         }
 
         // Write exception info
-        writer.name("exceptions").value(new Exceptions(config, exception));
+        writer.name("exceptions").value(exceptions);
 
         // Write user info
         writer.name("user").value(user);
@@ -103,7 +125,7 @@ public class Error implements JsonStream.Streamable {
      *
      * @param context what was happening at the time of a crash
      */
-    public void setContext(String context) {
+    public void setContext(@Nullable String context) {
         this.context = context;
     }
 
@@ -112,7 +134,7 @@ public class Error implements JsonStream.Streamable {
      */
     @Nullable
     public String getContext() {
-        if (!TextUtils.isEmpty(context)) {
+        if (context != null) {
             return context;
         } else if (config.getContext() != null) {
             return config.getContext();
@@ -131,8 +153,18 @@ public class Error implements JsonStream.Streamable {
      *
      * @param groupingHash a string to use when grouping errors
      */
-    public void setGroupingHash(String groupingHash) {
+    public void setGroupingHash(@Nullable String groupingHash) {
         this.groupingHash = groupingHash;
+    }
+
+    /**
+     * Get the grouping hash associated with this Error.
+     *
+     * @return the grouping hash, if set
+     */
+    @Nullable
+    public String getGroupingHash() {
+        return groupingHash;
     }
 
     /**
@@ -172,13 +204,14 @@ public class Error implements JsonStream.Streamable {
         this.user = new User(id, email, name);
     }
 
-    void setUser(User user) {
+    void setUser(@NonNull User user) {
         this.user = user;
     }
 
     /**
      * @return user information associated with this Error
      */
+    @NonNull
     public User getUser() {
         return user;
     }
@@ -286,7 +319,8 @@ public class Error implements JsonStream.Streamable {
     /**
      * Get the message from the exception contained in this Error report.
      */
-    @NonNull public String getExceptionMessage() {
+    @NonNull
+    public String getExceptionMessage() {
         String localizedMessage = exception.getLocalizedMessage();
         return localizedMessage != null ? localizedMessage : "";
     }
@@ -307,11 +341,31 @@ public class Error implements JsonStream.Streamable {
         deviceData.id = id;
     }
 
-    void setAppData(AppData appData) {
+    /**
+     * Retrieves the {@link AppData} associated with this error
+     *
+     * @return the app metadata
+     */
+    @NonNull
+    public AppData getAppData() {
+        return appData;
+    }
+    /**
+     * Retrieves the {@link DeviceData} associated with this error
+     *
+     * @return the device metadata
+     */
+
+    @NonNull
+    public DeviceData getDeviceData() {
+        return deviceData;
+    }
+
+    void setAppData(@NonNull AppData appData) {
         this.appData = appData;
     }
 
-    void setDeviceData(DeviceData deviceData) {
+    void setDeviceData(@NonNull DeviceData deviceData) {
         this.deviceData = deviceData;
     }
 
@@ -354,7 +408,7 @@ public class Error implements JsonStream.Streamable {
         }
 
         Builder(@NonNull Configuration config, @NonNull String name,
-               @NonNull String message, @NonNull StackTraceElement[] frames, Session session) {
+                @NonNull String message, @NonNull StackTraceElement[] frames, Session session) {
             this(config, new BugsnagException(name, message, frames), session);
         }
 

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import java.io.IOException;
 
@@ -134,7 +135,7 @@ public class Error implements JsonStream.Streamable {
      */
     @Nullable
     public String getContext() {
-        if (context != null) {
+        if (!TextUtils.isEmpty(context)) {
             return context;
         } else if (config.getContext() != null) {
             return config.getContext();


### PR DESCRIPTION
## Goal

Adds public accessors to Error, for use by 3rd party developers and internal API, and nullability annotations.

Note: the intention is for further work to be carried out in a separate PR (extracting the data capture to a separate class, etc)

## Changeset

### Changed

Converted fields/methods to properties (getter/setter backed with a field) in Error.

## Tests

Adapted unit tests for the default value + override value of each accessor.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
