### PR TITLE
test: cancel any background tasks in test runs

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/AppDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AppDataTest.java
@@ -13,6 +13,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +29,11 @@ public class AppDataTest {
     @Before
     public void setUp() throws Exception {
         config = new Configuration("some-api-key");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeNotifyTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,11 @@ public class BeforeNotifyTest {
     @Before
     public void setUp() throws Exception {
         config = new Configuration("api-key");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbLifecycleCrashTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbLifecycleCrashTest.java
@@ -5,6 +5,7 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +27,11 @@ public class BreadcrumbLifecycleCrashTest {
         Context context = InstrumentationRegistry.getContext();
         SessionStore sessionStore = new SessionStore(configuration, context);
         sessionTracker = new SessionTracker(configuration, null, sessionStore);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +26,11 @@ public class ConfigurationTest {
     @Before
     public void setUp() throws Exception {
         config = new Configuration("api-key");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -18,6 +18,7 @@ import android.util.DisplayMetrics;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +35,11 @@ public class DeviceDataTest {
     public void setUp() throws Exception {
         SharedPreferences sharedPref = getSharedPrefs(InstrumentationRegistry.getContext());
         deviceData = new DeviceData(InstrumentationRegistry.getContext(), sharedPref);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -18,6 +18,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +43,11 @@ public class ErrorTest {
         config = new Configuration("api-key");
         RuntimeException exception = new RuntimeException("Example message");
         error = new Error.Builder(config, exception, null).build();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
@@ -11,6 +11,7 @@ import android.support.test.runner.AndroidJUnit4;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +27,11 @@ public class ExceptionsTest {
     @Before
     public void setUp() throws Exception {
         config = new Configuration("api-key");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
@@ -11,6 +11,7 @@ import android.support.test.runner.AndroidJUnit4;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +41,11 @@ public class JsonStreamTest {
         File cacheDir = InstrumentationRegistry.getContext().getCacheDir();
         file = new File(cacheDir, "whoops");
         file.delete();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ReportTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ReportTest.java
@@ -9,6 +9,7 @@ import android.support.test.runner.AndroidJUnit4;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,11 @@ public class ReportTest {
         RuntimeException exception = new RuntimeException("Something broke");
         Error error = new Error.Builder(config, exception, null).build();
         report = new Report("api-key", error);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -45,6 +45,7 @@ public class SessionStoreTest {
      */
     @After
     public void tearDown() throws Exception {
+        Async.cancelTasks();
         FileUtils.clearFilesInDir(storageDir);
     }
 


### PR DESCRIPTION
## Goal

[This](https://travis-ci.org/bugsnag/bugsnag-android/jobs/392772873) test run failed. While our CI problems are far better since merging #326, it seems as though a few tests still generate a client without cancelling Async tasks as part of their teardown. 

This PR addresses that by cancelling tasks in any test where it is not immediately obvious that Async tasks aren't invoked.

## Discussion

### Alternative Approaches

Longer term we should fix this by separating out the initialisation of background tasks to a separate method in the `Client`, rather than the constructor.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
