### PR TITLE
Add timestamp accessor to breadcrumb

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/sdk/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -61,6 +61,11 @@ public final class Breadcrumb implements JsonStream.Streamable {
         return metadata;
     }
 
+    @NonNull
+    public String getTimestamp() {
+        return timestamp;
+    }
+
     @Override
     public void toStream(@NonNull JsonStream writer) throws IOException {
         writer.beginObject();


### PR DESCRIPTION
We need to be able to read all of the breadcrumb properties from the unity notifier and this is the only one that is missing