### PR TITLE
Disable BuildConfig generation

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -29,6 +29,11 @@ android {
         warningsAsErrors true
         checkAllWarnings true
     }
+
+    // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
+    libraryVariants.all {
+        it.generateBuildConfig.enabled = false
+    }
 }
 
 coveralls {


### PR DESCRIPTION
This contains a few fields and a class which is useless to consumers and unused by the library. It's removed by ProGuard and R8, but by not even generating it those bytes are saved for all consumers.