### PR TITLE
feat: update proguard rules to keep line number/source info

### DIFF
--- a/sdk/proguard-rules.pro
+++ b/sdk/proguard-rules.pro
@@ -1,3 +1,4 @@
+-keepattributes LineNumberTable,SourceFile
 -keep class com.bugsnag.android.NativeInterface { *; }
 -keep class com.bugsnag.android.Breadcrumb { *; }
 -keep class com.bugsnag.android.Breadcrumbs { *; }


### PR DESCRIPTION
## Goal

Automatically keep source file and line number information with ProGuard, as otherwise grouping is likely to differ for existing projects.

### Linked issues

Related to #345 

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
