### PR TITLE
Add mazerunner scenario for thread id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 GIT
   remote: git@github.com:bugsnag/maze-runner
-  revision: f7123450d5a75b719911c6dd3baa0507e6062c2d
+  revision: 19a9f6ef393861bc05b1f70b197a342f0b11260e
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)
       cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)
       rack (~> 2.0.0)
+      rake (~> 12.3.0)
       test-unit (~> 3.2.0)
 
 GEM
@@ -32,17 +33,18 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
-    gherkin (5.0.0)
+    gherkin (5.1.0)
     method_source (0.9.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
-    power_assert (1.1.1)
+    power_assert (1.1.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rack (2.0.5)
-    test-unit (3.2.7)
+    rake (12.3.1)
+    test-unit (3.2.8)
       power_assert
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git@github.com:bugsnag/maze-runner
-  revision: 19a9f6ef393861bc05b1f70b197a342f0b11260e
+  revision: 177f27da9966aed2cb87687fa8384d6141d2fa05
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)

--- a/features/error_reporting_thread.feature
+++ b/features/error_reporting_thread.feature
@@ -1,0 +1,7 @@
+Feature: Error Reporting Thread
+
+Scenario: Only 1 thread is flagged as the error reporting thread
+    When I run "HandledExceptionScenario" with the defaults
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the thread "main" contains the error reporting flag

--- a/features/error_reporting_thread.feature
+++ b/features/error_reporting_thread.feature
@@ -4,4 +4,4 @@ Scenario: Only 1 thread is flagged as the error reporting thread
     When I run "HandledExceptionScenario" with the defaults
     Then I should receive a request
     And the request is a valid for the error reporting API
-    And the thread "main" contains the error reporting flag
+    And the thread with name "main" contains the error reporting flag


### PR DESCRIPTION
Adds a mazerunner scenario which validates that only 1 thread sets the `errorReportingThread` flag in the payload, when a handled exception is delivered on the main thread.