### PR TITLE
Add ThreadSafe annotation to com.bugsnag.android, remove infer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Add ThreadSafe annotation to com.bugsnag.android, remove infer dependency
+  [#370](https://github.com/bugsnag/bugsnag-android/pull/370)
+  [#366](https://github.com/bugsnag/bugsnag-android/issues/366)
+
 ## 4.8.1 (2018-09-27)
 
 * [NDK] Fix a packaging issue on Maven Central in v4.8.0

--- a/examples/sdk-app-example/proguard.pro
+++ b/examples/sdk-app-example/proguard.pro
@@ -23,5 +23,3 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
--dontwarn com.facebook.infer.annotation.ThreadSafe
--dontwarn javax.annotation.concurrent.NotThreadSafe

--- a/scripts/infer.sh
+++ b/scripts/infer.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 ./gradlew clean && infer --disable-issue-type "NULL_DEREFERENCE" \
---disable-issue-type "RESOURCE_LEAK" -- ./gradlew sdk:build
+--disable-issue-type "RESOURCE_LEAK" \
+--threadsafe-aliases "[\"ThreadSafe\"]" \
+ -- ./gradlew sdk:build -Pinfer=true

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -65,7 +65,9 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 
-    compile "com.facebook.infer.annotation:infer-annotation:0.11.2"
+    if (project.hasProperty('infer')) {
+        implementation "com.facebook.infer.annotation:infer-annotation:0.11.2"
+    }
 }
 
 // Disable doclint:

--- a/sdk/src/main/java/com/bugsnag/android/BadResponseException.java
+++ b/sdk/src/main/java/com/bugsnag/android/BadResponseException.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.util.Locale;
 
 /**

--- a/sdk/src/main/java/com/bugsnag/android/BeforeNotify.java
+++ b/sdk/src/main/java/com/bugsnag/android/BeforeNotify.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 /**
  * A callback to be run before every report to Bugsnag.
  * <p>

--- a/sdk/src/main/java/com/bugsnag/android/BeforeRecordBreadcrumb.java
+++ b/sdk/src/main/java/com/bugsnag/android/BeforeRecordBreadcrumb.java
@@ -2,8 +2,6 @@ package com.bugsnag.android;
 
 import android.support.annotation.NonNull;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 /**
  * Add a "before breadcrumb" callback, to execute code before every
  * breadcrumb captured by Bugsnag.

--- a/sdk/src/main/java/com/bugsnag/android/BreadcrumbType.java
+++ b/sdk/src/main/java/com/bugsnag/android/BreadcrumbType.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 /**
  * Recognized types of breadcrumbs
  */

--- a/sdk/src/main/java/com/bugsnag/android/BugsnagException.java
+++ b/sdk/src/main/java/com/bugsnag/android/BugsnagException.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 /**
  * Used to store information about an exception that was not provided with an exception object
  */

--- a/sdk/src/main/java/com/bugsnag/android/DateUtils.java
+++ b/sdk/src/main/java/com/bugsnag/android/DateUtils.java
@@ -2,8 +2,6 @@ package com.bugsnag.android;
 
 import android.support.annotation.NonNull;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/sdk/src/main/java/com/bugsnag/android/DeliveryCompat.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeliveryCompat.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 /**
  * A compatibility implementation of {@link Delivery} which wraps {@link ErrorReportApiClient} and
  * {@link SessionTrackingApiClient}. This class allows for backwards compatibility for users still

--- a/sdk/src/main/java/com/bugsnag/android/DeliveryFailureException.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeliveryFailureException.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 /**
  * This should be thrown if delivery of a request was not successful and you wish to try again
  * later. The notifier will cache the payload and initiate delivery at a future time.

--- a/sdk/src/main/java/com/bugsnag/android/DeliveryStyle.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeliveryStyle.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 @ThreadSafe
 enum DeliveryStyle {
     SAME_THREAD,

--- a/sdk/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeviceData.java
@@ -18,8 +18,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 import android.util.DisplayMetrics;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.io.File;
 import java.util.Date;
 import java.util.HashMap;

--- a/sdk/src/main/java/com/bugsnag/android/ErrorReportApiClient.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorReportApiClient.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.util.Map;
 
 /**

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -3,8 +3,6 @@ package com.bugsnag.android;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/sdk/src/main/java/com/bugsnag/android/FileStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/FileStore.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;

--- a/sdk/src/main/java/com/bugsnag/android/IOUtils.java
+++ b/sdk/src/main/java/com/bugsnag/android/IOUtils.java
@@ -3,8 +3,6 @@ package com.bugsnag.android;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.Reader;

--- a/sdk/src/main/java/com/bugsnag/android/JsonStream.java
+++ b/sdk/src/main/java/com/bugsnag/android/JsonStream.java
@@ -11,9 +11,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
-@NotThreadSafe
 public class JsonStream extends JsonWriter {
 
     private final ObjectJsonStreamer objectJsonStreamer;

--- a/sdk/src/main/java/com/bugsnag/android/JsonWriter.java
+++ b/sdk/src/main/java/com/bugsnag/android/JsonWriter.java
@@ -25,8 +25,6 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 /**
  * Writes a JSON (<a href="http://www.ietf.org/rfc/rfc4627.txt">RFC 4627</a>)
  * encoded value to a stream, one token at a time. The stream includes both
@@ -126,7 +124,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  * @since 1.6
  */
 @SuppressWarnings({"checkstyle:AvoidEscapedUnicodeCharacters", "checkstyle:IllegalTokenText"})
-@NotThreadSafe
 public class JsonWriter implements Closeable {
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Logger.java
+++ b/sdk/src/main/java/com/bugsnag/android/Logger.java
@@ -2,8 +2,6 @@ package com.bugsnag.android;
 
 import android.util.Log;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 @ThreadSafe
 final class Logger {
 

--- a/sdk/src/main/java/com/bugsnag/android/MapUtils.java
+++ b/sdk/src/main/java/com/bugsnag/android/MapUtils.java
@@ -2,8 +2,6 @@ package com.bugsnag.android;
 
 import android.support.annotation.Nullable;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.util.Map;
 
 @ThreadSafe

--- a/sdk/src/main/java/com/bugsnag/android/NetworkException.java
+++ b/sdk/src/main/java/com/bugsnag/android/NetworkException.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.io.IOException;
 
 /**

--- a/sdk/src/main/java/com/bugsnag/android/NotifyType.java
+++ b/sdk/src/main/java/com/bugsnag/android/NotifyType.java
@@ -2,8 +2,6 @@ package com.bugsnag.android;
 
 import android.support.annotation.Nullable;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 /**
  * Used to inform the NDK library which type of data needs to be updated
  */

--- a/sdk/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionStore.java
@@ -3,8 +3,6 @@ package com.bugsnag.android;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.io.File;
 import java.util.Comparator;
 import java.util.Locale;

--- a/sdk/src/main/java/com/bugsnag/android/SessionTrackingApiClient.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTrackingApiClient.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.util.Map;
 
 /**

--- a/sdk/src/main/java/com/bugsnag/android/StrictModeHandler.java
+++ b/sdk/src/main/java/com/bugsnag/android/StrictModeHandler.java
@@ -4,8 +4,6 @@ import android.annotation.SuppressLint;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
-import com.facebook.infer.annotation.ThreadSafe;
-
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;

--- a/sdk/src/main/java/com/bugsnag/android/ThreadSafe.java
+++ b/sdk/src/main/java/com/bugsnag/android/ThreadSafe.java
@@ -1,0 +1,11 @@
+package com.bugsnag.android;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+@interface ThreadSafe {
+}


### PR DESCRIPTION
## Goal
Removes the need for a compile-time dependency on the infer-annotation artefact.

## Changeset
- Added `@ThreadSafe` annotation to bugsnag package
- Removed imports of infer-annotation 
- Altered build process so that the `infer` property must be set to compile infer-annotation artefact

## Tests
- Ran `./infer.sh`
- Ran `./gradlew sdk:assemble` to confirm
- Ran `generatePomFileForProductionPublication` task to confirm that the generated POM excludes the infer-annotation dependency.
- Ran existing unit/mazerunner tests on CI

## Discussion

### Alternative Approaches

We could attempt forking Uber's [infer plugin](https://github.com/uber-common/infer-plugin), which is deprecated.

### Linked issues

Fixes #366 

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
