### PR TITLE
Fix Travis CI build

### DIFF
--- a/ndk/build.gradle
+++ b/ndk/build.gradle
@@ -85,8 +85,8 @@ publishing {
                 url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
             }
             credentials {
-                username = NEXUS_USERNAME
-                password = NEXUS_PASSWORD
+                username = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
+                password = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
             }
         }
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -103,8 +103,8 @@ publishing {
                 url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
             }
             credentials {
-                username = NEXUS_USERNAME
-                password = NEXUS_PASSWORD
+                username = project.hasProperty("NEXUS_USERNAME") ? "$NEXUS_USERNAME" : System.getenv("NEXUS_USERNAME")
+                password = project.hasProperty("NEXUS_PASSWORD") ? "$NEXUS_PASSWORD" : System.getenv("NEXUS_PASSWORD")
             }
         }
     }


### PR DESCRIPTION
In the bugsnag-android-ndk repository, the `NEXUS_USERNAME` and `NEXUS_PASSWORD` credentials were supplied as an [envar on Travis](https://github.com/bugsnag/bugsnag-android-ndk/blob/master/build.gradle#L96). This changeset alters the SDK + NDK build script to use the previous method of supplying the username/password, which passes the lint/unit test steps.

The mazerunner scenarios seem to have passed one job, but are having a bit of trouble with timeouts. I will try restarting the jobs, but this would be worth keeping an eye on.