### PR TITLE
feat: Run report modification callbacks before native crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## TBD
 
+### Enhancements
+
+* Add a callback to allow modifying reports immediately prior to delivery,
+  including fatal crashes from native C/C++ code. For more information, see the
+  [callback reference](https://docs.bugsnag.com/platforms/android/sdk/customizing-error-reports).
+  [#379](https://github.com/bugsnag/bugsnag-android/pull/379)
+
 ### Bug fixes
 
 * [NDK] Improve stack trace quality for signals raised on ARM32 devices

--- a/features/before_send.feature
+++ b/features/before_send.feature
@@ -1,0 +1,49 @@
+Feature: Run callbacks before reports delivered
+
+    Scenario: Change report before native crash report delivered
+        When I run "NativeBeforeSendScenario"
+        And I configure the app to run in the "non-crashy" state
+        And I relaunch the app
+        Then I should receive a request
+        And the request payload contains a completed native report
+        And the exception "errorClass" equals "SIGSEGV"
+        And the exception "message" equals "Segmentation violation (invalid memory reference)"
+        And the event "context" equals "!important"
+        And the exception "type" equals "c"
+        And the event "severity" equals "error"
+        And the event "unhandled" is true
+
+    Scenario: Change report before JVM crash report delivered
+        When I run "BeforeSendScenario"
+        And I configure the app to run in the "non-crashy" state
+        And I relaunch the app
+        Then I should receive a request
+        And the request payload contains a completed native report
+        And the exception "errorClass" equals "java.lang.RuntimeException"
+        And the exception "message" equals "Ruh-roh"
+        And the event "context" equals "UNSET"
+        And the exception "type" equals "android"
+        And the event "severity" equals "error"
+        And the event "unhandled" is true
+
+    Scenario: Change report before native notify() report delivered
+        When I run "NativeNotifyBeforeSendScenario"
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the exception "errorClass" equals "Ad-hoc"
+        And the exception "message" equals "Auto-generated issue"
+        And the event "context" equals "hello"
+        And the exception "type" equals "c"
+        And the event "severity" equals "info"
+        And the event "unhandled" is false
+
+    Scenario: Change report before notify() report delivered
+        When I run "NotifyBeforeSendScenario"
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the exception "errorClass" equals "java.lang.Exception"
+        And the exception "message" equals "Registration failure"
+        And the event "context" equals "RESET"
+        And the exception "type" equals "android"
+        And the event "severity" equals "error"
+        And the event "unhandled" is false

--- a/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
+++ b/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
@@ -45,6 +45,13 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXExtraordinaryLongStringScenario
 }
 
 JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_NativeNotifyBeforeSendScenario_activate(JNIEnv *env,
+                                                                         jobject instance) {
+  bugsnag_notify_env(env, (char *)"Ad-hoc",
+                     (char *)"Auto-generated issue", BSG_SEVERITY_INFO);
+}
+
+JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXNotifyScenario_activate(JNIEnv *env,
                                                                          jobject instance) {
   bugsnag_notify_env(env, (char *)"Vitamin C deficiency",

--- a/features/fixtures/mazerunner/src/main/cpp/entrypoint.cpp
+++ b/features/fixtures/mazerunner/src/main/cpp/entrypoint.cpp
@@ -189,6 +189,12 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXWriteReadOnlyMemoryScenario_cra
 }
 
 JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_NativeBeforeSendScenario_crash(JNIEnv *env,
+                                                                             jobject instance) {
+    printf("This one here: %s\n", crash_improper_cast(39));
+}
+
+JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXImproperTypecastScenario_crash(JNIEnv *env,
                                                                                 jobject instance) {
     printf("This one here: %s\n", crash_improper_cast(39));

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/BeforeSendScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/BeforeSendScenario.java
@@ -1,0 +1,36 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.BeforeSend;
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.Report;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+
+public class BeforeSendScenario extends Scenario {
+
+    public BeforeSendScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                report.getError().setContext("UNSET");
+
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        throw new RuntimeException("Ruh-roh");
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NativeBeforeSendScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NativeBeforeSendScenario.java
@@ -1,0 +1,43 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.BeforeSend;
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.Report;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+
+public class NativeBeforeSendScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public NativeBeforeSendScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                report.getError().setContext("!important");
+
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NativeNotifyBeforeSendScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NativeNotifyBeforeSendScenario.java
@@ -1,0 +1,39 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.BeforeSend;
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.Report;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+
+public class NativeNotifyBeforeSendScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void activate();
+
+    public NativeNotifyBeforeSendScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                report.getError().setContext("hello");
+
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        activate();
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NotifyBeforeSendScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NotifyBeforeSendScenario.java
@@ -1,0 +1,34 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.BeforeSend;
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.Report;
+import com.bugsnag.android.Severity;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+
+public class NotifyBeforeSendScenario extends Scenario {
+
+    public NotifyBeforeSendScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                report.getError().setContext("RESET");
+                report.getError().setSeverity(Severity.ERROR);
+
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        Bugsnag.notify(new Exception("Registration failure"));
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendTest.java
@@ -1,0 +1,114 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class BeforeSendTest {
+
+    private Client client;
+    private Configuration config;
+    private Report lastReport;
+    private String result = "";
+
+    /**
+     * Configures a client
+     */
+    @Before
+    public void setUp() throws Exception {
+        result = "";
+        config = new Configuration("key");
+        config.setDelivery(new Delivery() {
+            @Override
+            public void deliver(SessionTrackingPayload payload,
+                                Configuration config)
+                throws DeliveryFailureException {}
+
+            @Override
+            public void deliver(Report report,
+                                Configuration config)
+                throws DeliveryFailureException {
+                lastReport = report;
+            }
+        });
+        client = new Client(InstrumentationRegistry.getContext(), config);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        lastReport = null;
+        Async.cancelTasks();
+    }
+
+    @Test
+    public void testCallbackOrderPreserved() {
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                result = result + "a";
+                return true;
+            }
+        });
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                result = result + "b";
+                return true;
+            }
+        });
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                result = result + "c";
+                return true;
+            }
+        });
+        client.notifyBlocking(new Exception("womp womp"));
+        assertEquals("abc", result);
+        assertNotNull(lastReport);
+    }
+
+    @Test
+    public void testCancelReport() {
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                result = result + "a";
+                return true;
+            }
+        });
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                result = result + "b";
+                return false;
+            }
+        });
+        client.notifyBlocking(new Exception("womp womp"));
+        assertEquals("ab", result);
+        assertNull(lastReport);
+    }
+
+    @Test
+    public void testAlterReport() {
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                report.getError().setGroupingHash("123");
+                return true;
+            }
+        });
+        client.notifyBlocking(new Exception("womp womp"));
+        assertEquals("123", lastReport.getError().getGroupingHash());
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/CachedThreadTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/CachedThreadTest.java
@@ -1,0 +1,80 @@
+package com.bugsnag.android;
+
+import static com.bugsnag.android.BugsnagTestUtils.streamableToJson;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class CachedThreadTest {
+
+    @Test
+    public void testToStreamErrorHandlingThread() throws JSONException, IOException {
+        StackTraceElement[] stacktrace = {
+            new StackTraceElement("", "run_func", "librunner.so", 5038),
+            new StackTraceElement("Runner", "runFunc", "Runner.java", 14),
+            new StackTraceElement("App", "launch", "App.java", 70),
+        };
+
+        CachedThread thread = new CachedThread(new Configuration("key"), 24, "main-one", "ando",
+                                                true, stacktrace);
+        JSONObject result = streamableToJson(thread);
+        assertEquals(24, result.getLong("id"));
+        assertEquals("main-one", result.getString("name"));
+        assertEquals("ando", result.getString("type"));
+        assertEquals(true, result.getBoolean("errorReportingThread"));
+
+        JSONArray frames = result.getJSONArray("stacktrace");
+        assertEquals(3, frames.length());
+        assertEquals("run_func", frames.getJSONObject(0).getString("method"));
+        assertEquals("librunner.so", frames.getJSONObject(0).getString("file"));
+        assertEquals(5038, frames.getJSONObject(0).getInt("lineNumber"));
+        assertEquals("Runner.runFunc", frames.getJSONObject(1).getString("method"));
+        assertEquals("Runner.java", frames.getJSONObject(1).getString("file"));
+        assertEquals(14, frames.getJSONObject(1).getInt("lineNumber"));
+        assertEquals("App.launch", frames.getJSONObject(2).getString("method"));
+        assertEquals("App.java", frames.getJSONObject(2).getString("file"));
+        assertEquals(70, frames.getJSONObject(2).getInt("lineNumber"));
+    }
+
+    @Test
+    public void testToStreamNonErrorHandlingThread() throws JSONException, IOException {
+        StackTraceElement[] stacktrace = {
+            new StackTraceElement("", "run_func", "librunner.so", 5038),
+            new StackTraceElement("Runner", "runFunc", "Runner.java", 14),
+            new StackTraceElement("App", "launch", "App.java", 70),
+        };
+
+        CachedThread thread = new CachedThread(new Configuration("key"), 24, "main-one", "ando",
+                                                false, stacktrace);
+        JSONObject result = streamableToJson(thread);
+        assertEquals(24, result.getLong("id"));
+        assertEquals("main-one", result.getString("name"));
+        assertEquals("ando", result.getString("type"));
+        assertFalse("Error reporting thread should not be set when false",
+                    result.has("errorReportingThread"));
+
+        JSONArray frames = result.getJSONArray("stacktrace");
+        assertEquals(3, frames.length());
+        assertEquals("run_func", frames.getJSONObject(0).getString("method"));
+        assertEquals("librunner.so", frames.getJSONObject(0).getString("file"));
+        assertEquals(5038, frames.getJSONObject(0).getInt("lineNumber"));
+        assertEquals("Runner.runFunc", frames.getJSONObject(1).getString("method"));
+        assertEquals("Runner.java", frames.getJSONObject(1).getString("file"));
+        assertEquals(14, frames.getJSONObject(1).getInt("lineNumber"));
+        assertEquals("App.launch", frames.getJSONObject(2).getString("method"));
+        assertEquals("App.java", frames.getJSONObject(2).getString("file"));
+        assertEquals(70, frames.getJSONObject(2).getInt("lineNumber"));
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorReaderTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorReaderTest.java
@@ -1,0 +1,298 @@
+package com.bugsnag.android;
+
+import static com.bugsnag.android.BugsnagTestUtils.streamableToJson;
+import static com.bugsnag.android.BugsnagTestUtils.streamableToJsonArray;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class ErrorReaderTest {
+
+    private static Error error = null;
+
+    /** Constructs an Error from a JSON file */
+    @BeforeClass
+    public static void setUp() throws IOException {
+        InputStream input = InstrumentationRegistry.getContext().getResources()
+            .openRawResource(com.bugsnag.android.test.R.raw.error);
+        File fixtureFile = File.createTempFile("error", ".json");
+        OutputStream output = new FileOutputStream(fixtureFile);
+        try {
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+            output.flush();
+        } finally {
+            output.close();
+        }
+        error = ErrorReader.readError(new Configuration("key"), fixtureFile);
+    }
+
+    @Test
+    public void testReadError() throws IOException {
+        assertNotNull(error);
+    }
+
+    @Test(expected = IOException.class)
+    public void testReadPartialFileThrows() throws IOException {
+        File fixtureFile = null;
+        try {
+            fixtureFile = File.createTempFile("error", ".json");
+            FileOutputStream output = new FileOutputStream(fixtureFile);
+            output.write("{".getBytes());
+        } catch (Exception ex) {
+            assertTrue("Failed to configure test", false);
+        }
+        ErrorReader.readError(new Configuration("api-key"), fixtureFile);
+    }
+
+    @Test(expected = IOException.class)
+    public void testReadEmptyErrorFileThrows() throws IOException {
+        File fixtureFile = null;
+        try {
+            fixtureFile = File.createTempFile("error", ".json");
+            FileOutputStream output = new FileOutputStream(fixtureFile);
+            output.write("{}".getBytes());
+        } catch (Exception ex) {
+            assertTrue("Failed to configure test", false);
+        }
+        ErrorReader.readError(new Configuration("api-key"), fixtureFile);
+    }
+
+    @Test
+    public void testReadErrorSeverity() throws JSONException {
+        assertEquals(Severity.WARNING, error.getSeverity());
+    }
+
+    @Test
+    public void testReadErrorSession() throws Exception {
+        Session session = error.getSession();
+        assertNotNull(session);
+        assertEquals("225bcada-e0c8-15a0-0bba-0e3c7f43c13f", session.getId());
+        assertEquals(2, session.getHandledCount());
+        assertEquals(1, session.getUnhandledCount());
+
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        format.setTimeZone(tz);
+        assertEquals("2018-10-19T18:56:13Z", format.format(session.getStartedAt()));
+
+        User user = session.getUser();
+        assertEquals("Rasputin", user.getName());
+        assertEquals("ras@example.com", user.getEmail());
+        assertEquals("9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d", user.getId());
+    }
+
+    @Test
+    public void testReadErrorAppData() throws JSONException {
+        Map<String, Object> appData = error.getAppData();
+        assertNotNull(appData);
+        assertEquals(appData.get("version"), "1.1.14");
+        assertEquals(appData.get("id"), "com.bugsnag.android.mazerunner");
+        assertEquals(appData.get("type"), "android");
+        assertEquals(appData.get("releaseStage"), "beta4");
+        assertEquals(appData.get("versionCode"), 34);
+        assertEquals(appData.get("buildUUID"), "2338403b-4ca1-40f5-bdee-3b82c2cb305a");
+        assertEquals(appData.get("duration"), 169);
+        assertEquals(appData.get("durationInForeground"), 0);
+        assertEquals(true, appData.get("inForeground"));
+    }
+
+    @Test
+    public void testReadErrorDeviceData() throws JSONException {
+        Map<String, Object> data = error.getDeviceData();
+        assertNotNull(data);
+        assertEquals("android", data.get("osName"));
+        assertEquals("9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d", data.get("id"));
+        assertEquals("5.0.2", data.get("osVersion"));
+        assertEquals("Hudan", data.get("manufacturer"));
+        assertEquals("sdk_phone_armv7", data.get("model"));
+        assertEquals("portrait", data.get("orientation"));
+        assertEquals(134217728, data.get("totalMemory"));
+    }
+
+    @Test
+    public void testReadErrorHandledState() throws JSONException {
+        HandledState state = error.getHandledState();
+        assertNotNull(state);
+        assertTrue(state.isUnhandled());
+        assertEquals("signal", state.calculateSeverityReasonType());
+    }
+
+    @Test
+    public void testReadErrorMetaData() throws JSONException {
+        MetaData metadata = error.getMetaData();
+        assertNotNull(metadata);
+        assertEquals("com.bugsnag.android.mazerunner", metadata.getTab("app").get("packageName"));
+        assertEquals("1.1.14", metadata.getTab("app").get("versionName"));
+        assertEquals("MainActivity", metadata.getTab("app").get("activeScreen"));
+        assertEquals("MazeRunner", metadata.getTab("app").get("name"));
+        assertEquals(false, metadata.getTab("app").get("lowMemory"));
+        assertEquals(false, metadata.getTab("customer").get("accountee"));
+        assertEquals("Acme Co", metadata.getTab("customer").get("name"));
+        assertEquals(23423, metadata.getTab("customer").get("id"));
+        assertEquals("sdk_phone_armv7-eng 5.0.2 LSY66K 3079185 test-keys",
+                     metadata.getTab("device").get("osBuild"));
+        assertEquals(21, metadata.getTab("device").get("apiLevel"));
+        assertEquals("O-Matic", metadata.getTab("device").get("brand"));
+        assertEquals(false, metadata.getTab("device").get("emulator"));
+        assertEquals(true, metadata.getTab("device").get("jailbroken"));
+        assertEquals("en_US", metadata.getTab("device").get("locale"));
+        assertEquals("allowed", metadata.getTab("device").get("locationStatus"));
+        assertEquals("cellular", metadata.getTab("device").get("networkAccess"));
+        assertEquals(160, metadata.getTab("device").get("dpi"));
+        assertEquals(1, metadata.getTab("device").get("screenDensity"));
+        assertEquals("480x320", metadata.getTab("device").get("screenResolution"));
+        assertEquals("2018-10-19T18:56:13Z", metadata.getTab("device").get("time"));
+        @SuppressWarnings("unchecked")
+        List<String> cpuAbi = (List<String>)metadata.getTab("device").get("cpuAbi");
+        assertEquals("armeabi-v7a", cpuAbi.get(0));
+        assertEquals("armeabi", cpuAbi.get(1));
+    }
+
+    @Test
+    public void testReadErrorUser() throws JSONException {
+        User user = error.getUser();
+        assertNotNull(user);
+        assertEquals("Rasputin", user.getName());
+        assertEquals("ras@example.com", user.getEmail());
+        assertEquals("9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d", user.getId());
+    }
+
+    @Test
+    public void testReadErrorExceptionClass() throws JSONException, IOException {
+        assertEquals("SIGSEGV",
+                     streamableToJsonArray(error.getExceptions())
+                                                .getJSONObject(0).getString("errorClass"));
+    }
+
+    @Test
+    public void testReadErrorExceptionMessage() throws JSONException, IOException {
+        assertEquals("Segmentation violation (invalid memory reference)",
+                     streamableToJsonArray(error.getExceptions())
+                                                .getJSONObject(0).getString("message"));
+    }
+
+    @Test
+    public void testReadErrorExceptionType() throws JSONException, IOException {
+        assertEquals("c", streamableToJsonArray(error.getExceptions())
+                            .getJSONObject(0).getString("type"));
+    }
+
+    @Test
+    public void testReadErrorExceptionStacktrace() throws JSONException, IOException {
+        JSONArray stacktrace = streamableToJsonArray(error.getExceptions())
+                                    .getJSONObject(0)
+                                    .getJSONArray("stacktrace");
+        assertEquals(3, stacktrace.length());
+
+        JSONObject frame0 = stacktrace.getJSONObject(0);
+        assertEquals("_ZNK3art6Thread13DecodeJObjectEP8_jobject", frame0.getString("method"));
+        assertEquals("libmuraccis.so", frame0.getString("file"));
+        assertEquals(2241790, frame0.getInt("lineNumber"));
+
+        JSONObject frame1 = stacktrace.getJSONObject(1);
+        assertEquals("java.lang.Daemons$ReferenceQueueDaemon.run", frame1.getString("method"));
+        assertEquals("Daemons.java", frame1.getString("file"));
+        assertEquals(150, frame1.getInt("lineNumber"));
+
+        JSONObject frame2 = stacktrace.getJSONObject(2);
+        assertEquals("java.lang.Thread.run", frame2.getString("method"));
+        assertEquals("Thread.java", frame2.getString("file"));
+        assertEquals(761, frame2.getInt("lineNumber"));
+    }
+
+    @Test
+    public void testReadErrorGroupingHash() throws JSONException {
+        assertEquals("400-b", error.getGroupingHash());
+    }
+
+    @Test
+    public void testReadErrorContext() throws JSONException {
+        assertEquals("MainActivity", error.getContext());
+    }
+
+    @Test
+    public void testReadErrorBreadcrumbs() throws JSONException, IOException {
+        JSONArray breadcrumbs = streamableToJson(error).getJSONArray("breadcrumbs");
+        assertNotNull(breadcrumbs);
+        assertEquals(3, breadcrumbs.length());
+
+        JSONObject crumb0 = breadcrumbs.getJSONObject(0);
+        assertEquals("MainActivity", crumb0.getString("name"));
+        assertEquals("navigation", crumb0.getString("type"));
+        assertEquals("2018-10-19T18:56:13Z", crumb0.getString("timestamp"));
+        JSONObject crumb0metadata = crumb0.getJSONObject("metaData");
+        assertEquals(1, crumb0metadata.length());
+        assertEquals("onStart()", crumb0metadata.getString("ActivityLifecycle"));
+
+        JSONObject crumb1 = breadcrumbs.getJSONObject(1);
+        assertEquals("MainActivity", crumb1.getString("name"));
+        assertEquals("navigation", crumb1.getString("type"));
+        assertEquals("2018-10-19T18:56:13Z", crumb1.getString("timestamp"));
+        JSONObject crumb1metadata = crumb1.getJSONObject("metaData");
+        assertEquals(1, crumb1metadata.length());
+        assertEquals("onResume()", crumb1metadata.getString("ActivityLifecycle"));
+
+        JSONObject crumb2 = breadcrumbs.getJSONObject(2);
+        assertEquals("RINGER_MODE_CHANGED", crumb2.getString("name"));
+        assertEquals("state", crumb2.getString("type"));
+        assertEquals("2018-10-19T18:56:13Z", crumb2.getString("timestamp"));
+        JSONObject crumb2metadata = crumb2.getJSONObject("metaData");
+        assertEquals(2, crumb2metadata.length());
+        assertEquals("RINGER_MODE_CHANGED: 2", crumb2metadata.getString("Extra"));
+        assertEquals("android.media.RINGER_MODE_CHANGED",
+                     crumb2metadata.getString("Intent Action"));
+    }
+
+    @Test
+    public void testReadErrorThreadState() throws JSONException, IOException {
+        JSONArray threads = streamableToJson(error).getJSONArray("threads");
+        assertNotNull(threads);
+        assertEquals(7, threads.length());
+        for (int i = 0; i < threads.length(); i++) {
+            JSONObject thread = threads.getJSONObject(i);
+            assertNotNull(thread.getString("name"));
+            assertEquals("android", thread.getString("type"));
+            assertNotNull(thread.getInt("id"));
+            JSONArray stacktrace = thread.getJSONArray("stacktrace");
+            assertFalse(stacktrace.length() == 0);
+            for (int j = 0; j < stacktrace.length(); j++) {
+                JSONObject frame = stacktrace.getJSONObject(j);
+                assertNotNull(frame.getString("method"));
+                assertNotNull(frame.getString("file"));
+                assertNotEquals(0, frame.getInt("lineNumber"));
+            }
+        }
+    }
+}

--- a/sdk/src/androidTest/res/raw/error.json
+++ b/sdk/src/androidTest/res/raw/error.json
@@ -1,0 +1,442 @@
+{
+  "exceptions": [
+    {
+      "stacktrace": [
+        {
+          "method": "_ZNK3art6Thread13DecodeJObjectEP8_jobject",
+          "file": "libmuraccis.so",
+          "lineNumber": 2241790
+        },
+        {
+          "method": "java.lang.Daemons$ReferenceQueueDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 150
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ],
+      "errorClass": "SIGSEGV",
+      "message": "Segmentation violation (invalid memory reference)",
+      "type": "c"
+    }
+  ],
+  "breadcrumbs": [
+    {
+      "name": "MainActivity",
+      "timestamp": "2018-10-19T18:56:13Z",
+      "type": "navigation",
+      "metaData": {
+        "ActivityLifecycle": "onStart()"
+      }
+    },
+    {
+      "name": "MainActivity",
+      "timestamp": "2018-10-19T18:56:13Z",
+      "type": "navigation",
+      "metaData": {
+        "ActivityLifecycle": "onResume()"
+      }
+    },
+    {
+      "name": "RINGER_MODE_CHANGED",
+      "timestamp": "2018-10-19T18:56:13Z",
+      "type": "state",
+      "metaData": {
+        "Extra": "RINGER_MODE_CHANGED: 2",
+        "Intent Action": "android.media.RINGER_MODE_CHANGED"
+      }
+    }
+  ],
+  "context": "MainActivity",
+  "severity": "warning",
+  "unhandled": true,
+  "severityReason": {
+    "type": "signal",
+    "attributes": {
+      "signalType": "SIGSEGV"
+    }
+  },
+  "app": {
+    "version": "1.1.14",
+    "id": "com.bugsnag.android.mazerunner",
+    "type": "android",
+    "releaseStage": "beta4",
+    "versionCode": 34,
+    "buildUUID": "2338403b-4ca1-40f5-bdee-3b82c2cb305a",
+    "duration": 169,
+    "durationInForeground": 0,
+    "inForeground": true
+  },
+  "metaData": {
+    "app": {
+      "packageName": "com.bugsnag.android.mazerunner",
+      "versionName": "1.1.14",
+      "activeScreen": "MainActivity",
+      "name": "MazeRunner",
+      "lowMemory": false
+    },
+    "device": {
+      "osBuild": "sdk_phone_armv7-eng 5.0.2 LSY66K 3079185 test-keys",
+      "apiLevel": 21,
+      "brand": "O-Matic",
+      "emulator": false,
+      "jailbroken": true,
+      "locale": "en_US",
+      "locationStatus": "allowed",
+      "networkAccess": "cellular",
+      "dpi": 160,
+      "screenDensity": 1,
+      "screenResolution": "480x320",
+      "time": "2018-10-19T18:56:13Z",
+      "cpuAbi": [
+        "armeabi-v7a",
+        "armeabi"
+      ]
+    },
+    "customer": {
+      "name": "Acme Co",
+      "id": 23423,
+      "accountee": false
+    }
+  },
+  "device": {
+    "osName": "android",
+    "id": "9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d",
+    "osVersion": "5.0.2",
+    "manufacturer": "Hudan",
+    "model": "sdk_phone_armv7",
+    "orientation": "portrait",
+    "totalMemory": 134217728
+  },
+  "session": {
+    "id": "225bcada-e0c8-15a0-0bba-0e3c7f43c13f",
+    "startedAt": "2018-10-19T18:56:13Z",
+    "events": {
+        "handled": 2,
+        "unhandled": 1
+    },
+    "user": {
+      "id": "9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d",
+      "name": "Rasputin",
+      "email": "ras@example.com"
+    }
+  },
+  "user": {
+    "id": "9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d",
+    "name": "Rasputin",
+    "email": "ras@example.com"
+  },
+  "groupingHash": "400-b",
+  "threads": [
+    {
+      "id": 1,
+      "name": "main",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "dalvik.system.VMStack.getThreadStackTrace",
+          "file": "VMStack.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Thread.getStackTrace",
+          "file": "Thread.java",
+          "lineNumber": 1566
+        },
+        {
+          "method": "com.bugsnag.android.ThreadState.<init>",
+          "file": "ThreadState.java",
+          "lineNumber": 40
+        },
+        {
+          "method": "com.bugsnag.android.Error$Builder.<init>",
+          "file": "Error.java",
+          "lineNumber": 414
+        },
+        {
+          "method": "com.bugsnag.android.Client.notify",
+          "file": "Client.java",
+          "lineNumber": 678
+        },
+        {
+          "method": "com.bugsnag.android.Bugsnag.notify",
+          "file": "Bugsnag.java",
+          "lineNumber": 407
+        },
+        {
+          "method": "com.bugsnag.android.mazerunner.scenarios.AppVersionScenario.run",
+          "file": "AppVersionScenario.kt",
+          "lineNumber": 19,
+          "inProject": true
+        },
+        {
+          "method": "com.bugsnag.android.mazerunner.MainActivity$onCreate$1.run",
+          "file": "MainActivity.kt",
+          "lineNumber": 29,
+          "inProject": true
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 751
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 95
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 154
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 6119
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run",
+          "file": "ZygoteInit.java",
+          "lineNumber": 886
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 776
+        }
+      ],
+      "errorReportingThread": true
+    },
+    {
+      "id": 590,
+      "name": "ReferenceQueueDaemon",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Daemons$ReferenceQueueDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 150
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 591,
+      "name": "FinalizerDaemon",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 407
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 188
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 209
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 204
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 592,
+      "name": "FinalizerWatchdogDaemon",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded",
+          "file": "Daemons.java",
+          "lineNumber": 269
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 249
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 593,
+      "name": "HeapTaskDaemon",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "dalvik.system.VMRuntime.runHeapTasks",
+          "file": "VMRuntime.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Daemons$HeapTaskDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 433
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 598,
+      "name": "pool-1-thread-1",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Thread.parkFor$",
+          "file": "Thread.java",
+          "lineNumber": 2127
+        },
+        {
+          "method": "sun.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": 325
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 161
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 2035
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 413
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1058
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1118
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 607
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 599,
+      "name": "Bugsnag Thread #1",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Thread.parkFor$",
+          "file": "Thread.java",
+          "lineNumber": 2127
+        },
+        {
+          "method": "sun.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": 325
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 161
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 2035
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 413
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1058
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1118
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 607
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    }
+  ]
+}

--- a/sdk/src/main/java/com/bugsnag/android/BeforeNotify.java
+++ b/sdk/src/main/java/com/bugsnag/android/BeforeNotify.java
@@ -1,11 +1,12 @@
 package com.bugsnag.android;
 
 /**
- * A callback to be run before every report to Bugsnag.
+ * A callback to be run before reports are sent to Bugsnag.
  * <p>
  * <p>You can use this to add or modify information attached to an error
  * before it is sent to your dashboard. You can also return
  * <code>false</code> from any callback to halt execution.
+ * <p>"Before notify" callbacks do not run when a fatal C/C++ crash occurs.
  */
 @ThreadSafe
 public interface BeforeNotify {

--- a/sdk/src/main/java/com/bugsnag/android/BeforeSend.java
+++ b/sdk/src/main/java/com/bugsnag/android/BeforeSend.java
@@ -1,0 +1,20 @@
+package com.bugsnag.android;
+
+/**
+ * A callback to be run before every report sent to Bugsnag.
+ * <p>
+ * <p>You can use this to add or modify information attached to an error
+ * before it is delivered to your dashboard. You can also return
+ * <code>false</code> from any callback to halt execution.
+ */
+@ThreadSafe
+public interface BeforeSend {
+    /**
+     * Runs the callback. If the callback returns
+     * <code>false</code> any further BeforeSend callbacks will not be called
+     * and the report will not be sent to Bugsnag.
+     *
+     * @param report the {@link Report} to be sent to Bugsnag
+     */
+    boolean run(Report report);
+}

--- a/sdk/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/sdk/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -46,6 +46,16 @@ public final class Breadcrumb implements JsonStream.Streamable {
         this.name = name;
     }
 
+    Breadcrumb(@NonNull String name,
+               @NonNull BreadcrumbType type,
+               @NonNull Date captureDate,
+               @NonNull Map<String, String> metadata) {
+        this.timestamp = DateUtils.toIso8601(captureDate);
+        this.type = type;
+        this.metadata = metadata;
+        this.name = name;
+    }
+
     @NonNull
     public String getName() {
         return name;

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -326,12 +326,14 @@ public final class Bugsnag {
 
 
     /**
-     * Add a "before notify" callback, to execute code before every
-     * report to Bugsnag.
+     * Add a "before notify" callback, to execute code before sending
+     * reports to Bugsnag.
      * <p>
      * You can use this to add or modify information attached to an error
      * before it is sent to your dashboard. You can also return
-     * <code>false</code> from any callback to halt execution.
+     * <code>false</code> from any callback to prevent delivery. "Before
+     * notify" callbacks do not run before reports generated in the event
+     * of immediate app termination from crashes in C/C++ code.
      * <p>
      * For example:
      * <p>

--- a/sdk/src/main/java/com/bugsnag/android/CachedThread.java
+++ b/sdk/src/main/java/com/bugsnag/android/CachedThread.java
@@ -1,0 +1,40 @@
+package com.bugsnag.android;
+
+import android.support.annotation.NonNull;
+
+import java.io.IOException;
+
+/**
+ * A representation of a thread recorded in a {@link Report}
+ */
+class CachedThread implements JsonStream.Streamable {
+    private long id;
+    private String name;
+    private String type;
+    private boolean isErrorReportingThread;
+    private StackTraceElement[] frames;
+    private Configuration config;
+
+    CachedThread(Configuration config, long id, String name, String type,
+                 boolean isErrorReportingThread, StackTraceElement[] frames) {
+        this.id = id;
+        this.config = config;
+        this.name = name;
+        this.type = type;
+        this.isErrorReportingThread = isErrorReportingThread;
+        this.frames = frames;
+    }
+
+    @Override
+    public void toStream(@NonNull JsonStream writer) throws IOException {
+        writer.beginObject();
+        writer.name("id").value(id);
+        writer.name("name").value(name);
+        writer.name("type").value(type);
+        writer.name("stacktrace").value(new Stacktrace(config, frames));
+        if (isErrorReportingThread) {
+            writer.name("errorReportingThread").value(true);
+        }
+        writer.endObject();
+    }
+}

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -598,12 +598,14 @@ public class Client extends Observable implements Observer {
     }
 
     /**
-     * Add a "before notify" callback, to execute code before every
-     * report to Bugsnag.
+     * Add a "before notify" callback, to execute code before sending
+     * reports to Bugsnag.
      * <p/>
      * You can use this to add or modify information attached to an error
      * before it is sent to your dashboard. You can also return
-     * <code>false</code> from any callback to halt execution.
+     * <code>false</code> from any callback to prevent delivery. "Before
+     * notify" callbacks do not run before reports generated in the event
+     * of immediate app termination from crashes in C/C++ code.
      * <p/>
      * For example:
      * <p/>

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -50,6 +50,7 @@ public class Configuration extends Observable implements Observer {
     @NonNull
     private MetaData metaData;
     private final Collection<BeforeNotify> beforeNotifyTasks = new ConcurrentLinkedQueue<>();
+    private final Collection<BeforeSend> beforeSendTasks = new ConcurrentLinkedQueue<>();
     private final Collection<BeforeRecordBreadcrumb> beforeRecordBreadcrumbTasks
         = new ConcurrentLinkedQueue<>();
     private String codeBundleId;
@@ -461,6 +462,16 @@ public class Configuration extends Observable implements Observer {
     }
 
     /**
+     * Gets any before send tasks to run
+     *
+     * @return the before send tasks
+     */
+    @NonNull
+    protected Collection<BeforeSend> getBeforeSendTasks() {
+        return beforeSendTasks;
+    }
+
+    /**
      * Get whether or not Bugsnag should persist user information between application settings
      *
      * @return whether or not Bugsnag should persist user information
@@ -632,6 +643,33 @@ public class Configuration extends Observable implements Observer {
         map.put(HEADER_API_KEY, apiKey);
         map.put(HEADER_BUGSNAG_SENT_AT, DateUtils.toIso8601(new Date()));
         return map;
+    }
+
+    /**
+     * Add a callback to modify or cancel a report immediately before
+     * it is delivered to Bugsnag.
+     *
+     * Unlike {@link BeforeNotify} callbacks, "before send" callbacks are not
+     * necessarily run in the same app session as when the report was generated,
+     * as the application may have terminated before delivery or networking
+     * conditions prevented delivering the report until a later date.
+     * <p>
+     * Example usage:
+     * <pre>
+     * config.beforeSend((Report report) -&gt; {
+     *   Error error = report.getError();
+     *   error.setContext(getImportantField(error));
+     *   return true;
+     * });
+     * </pre>
+     * @param beforeSend a callback to run before delivering errors to Bugsnag
+     * @see BeforeSend
+     * @see Report
+     */
+    public void beforeSend(BeforeSend beforeSend) {
+        if (!beforeSendTasks.contains(beforeSend)) {
+            beforeSendTasks.add(beforeSend);
+        }
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/DateUtils.java
+++ b/sdk/src/main/java/com/bugsnag/android/DateUtils.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import android.support.annotation.NonNull;
 
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -24,5 +25,9 @@ class DateUtils {
 
     static String toIso8601(@NonNull Date date) {
         return iso8601Holder.get().format(date);
+    }
+
+    static Date fromIso8601(@NonNull String date) throws ParseException {
+        return iso8601Holder.get().parse(date);
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -389,6 +389,10 @@ public class Error implements JsonStream.Streamable {
         return exceptions;
     }
 
+    Session getSession() {
+        return session;
+    }
+
     static class Builder {
         private final Configuration config;
         private final Throwable exception;

--- a/sdk/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -1,0 +1,439 @@
+package com.bugsnag.android;
+
+import android.support.annotation.NonNull;
+import android.util.JsonReader;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+class ErrorReader {
+
+    /**
+     * Parses an {@link Error} cached as JSON into an Error object.
+     *
+     * @throws IOException if the file cannot be parsed into a valid JSON object,
+     *                     such as if the JSON syntax is invalid or a required
+     *                     field is missing.
+     */
+    static Error readError(@NonNull Configuration config, @NonNull File errorFile)
+            throws IOException {
+        JsonReader reader = null;
+
+        try {
+            User user = null;
+            Exceptions exceptions = null;
+            Severity severity = Severity.ERROR;
+            Session session = null;
+            String context = null;
+            String groupingHash = null;
+            Map<String, Object> appData = null;
+            Map<String, Object> deviceData = null;
+            MetaData metaData = null;
+            ThreadState threadState = null;
+            Breadcrumbs crumbs = null;
+            ArrayList<String> severityReasonValues = null;
+            boolean unhandled = false;
+
+            reader = new JsonReader(new FileReader(errorFile));
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "app":
+                        appData = jsonObjectToMap(reader);
+                        break;
+                    case "breadcrumbs":
+                        crumbs = readBreadcrumbs(config, reader);
+                        break;
+                    case "context":
+                        context = reader.nextString();
+                        break;
+                    case "device":
+                        deviceData = jsonObjectToMap(reader);
+                        break;
+                    case "exceptions":
+                        exceptions = readExceptions(config, reader);
+                        break;
+                    case "groupingHash":
+                        groupingHash = reader.nextString();
+                        break;
+                    case "metaData":
+                        metaData = new MetaData(jsonObjectToMap(reader));
+                        break;
+                    case "session":
+                        session = readSession(reader);
+                        break;
+                    case "severity":
+                        severity = Severity.fromString(reader.nextString());
+                        break;
+                    case "severityReason":
+                        severityReasonValues = readSeverityReason(reader);
+                        break;
+                    case "threads":
+                        threadState = readThreadState(config, reader);
+                        break;
+                    case "unhandled":
+                        unhandled = reader.nextBoolean();
+                        break;
+                    case "user":
+                        user = readUser(reader);
+                        break;
+                    default:
+                        reader.skipValue();
+                }
+            }
+            reader.endObject();
+            if (severityReasonValues == null || exceptions == null) {
+                throw new IOException("File did not contain a valid error");
+            }
+            String severityReasonAttribute = severityReasonValues.size() > 1
+                ? severityReasonValues.get(1)
+                : null;
+            HandledState handledState = new HandledState(severityReasonValues.get(0), severity,
+                                                         unhandled, severityReasonAttribute);
+            Error error = new Error(config, exceptions.getException(), handledState, severity,
+                                    session, threadState);
+            error.getExceptions().setExceptionType(exceptions.getExceptionType());
+            error.setUser(user);
+            error.setContext(context);
+            error.setGroupingHash(groupingHash);
+            error.setAppData(appData);
+            error.setMetaData(metaData);
+            error.setDeviceData(deviceData);
+            error.setBreadcrumbs(crumbs);
+
+            return error;
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (Exception ex) { /* nothing to do here if this fails */ }
+            }
+        }
+    }
+
+    private static Breadcrumbs readBreadcrumbs(Configuration config, JsonReader reader)
+        throws IOException {
+        Breadcrumbs crumbs = new Breadcrumbs(config);
+        reader.beginArray();
+        while (reader.hasNext()) {
+            String name = null;
+            String type = null;
+            Map<String, String> metadata = new HashMap<>();
+            Date captureDate = null;
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "name":
+                        name = reader.nextString();
+                        break;
+                    case "timestamp":
+                        try {
+                            captureDate = DateUtils.fromIso8601(reader.nextString());
+                        } catch (Exception ex) {
+                            throw new IOException("Failed to parse breadcrumb timestamp: ", ex);
+                        }
+                        break;
+                    case "type":
+                        type = reader.nextString().toUpperCase(Locale.US);
+                        break;
+                    case "metaData":
+                        reader.beginObject();
+                        while (reader.hasNext()) {
+                            metadata.put(reader.nextName(), reader.nextString());
+                        }
+                        reader.endObject();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+
+            reader.endObject();
+            if (name != null && captureDate != null && type != null) {
+                crumbs.add(new Breadcrumb(name, BreadcrumbType.valueOf(type),
+                                          captureDate, metadata));
+            }
+        }
+        reader.endArray();
+        return crumbs;
+    }
+
+    private static Exceptions readExceptions(Configuration config, JsonReader reader)
+        throws IOException {
+        reader.beginArray();
+        reader.beginObject();
+        String errorClass = null;
+        String message = null;
+        String type = Configuration.DEFAULT_EXCEPTION_TYPE;
+        StackTraceElement[] frames = new StackTraceElement[]{};
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "errorClass":
+                    errorClass = reader.nextString();
+                    break;
+                case "message":
+                    message = reader.nextString();
+                    break;
+                case "stacktrace":
+                    frames = readStackFrames(reader);
+                    break;
+                case "type":
+                    type = reader.nextString();
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endObject();
+        reader.endArray();
+        Exceptions ex = new Exceptions(config, new BugsnagException(errorClass, message, frames));
+        ex.setExceptionType(type);
+        return ex;
+    }
+
+    private static StackTraceElement[] readStackFrames(JsonReader reader) throws IOException {
+        ArrayList<StackTraceElement> frames = new ArrayList<>();
+        reader.beginArray();
+        while (reader.hasNext()) {
+            String method = null;
+            String file = null;
+            int lineNumber = 0;
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "method":
+                        method = reader.nextString();
+                        break;
+                    case "file":
+                        file = reader.nextString();
+                        break;
+                    case "lineNumber":
+                        lineNumber = reader.nextInt();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+
+                }
+            }
+            reader.endObject();
+            frames.add(new StackTraceElement("", method, file, lineNumber));
+        }
+        reader.endArray();
+        return frames.toArray(new StackTraceElement[frames.size()]);
+    }
+
+    /**
+     * Parses severity reason type and attributes.
+     *
+     * Returns a list containing the severity reason and attribute value. If the
+     * attribute value is null, then the list only contains the severity reason. If
+     * severity reason is null then then an {@link IOException} is thrown as the
+     * report is invalid.
+     *
+     * @return the values for severity reason and attribute value if any
+     * @throws IOException if the report is missing severity reason
+     */
+    private static ArrayList<String> readSeverityReason(JsonReader reader) throws IOException {
+        reader.beginObject();
+        String type = null;
+        String attributeValue = null;
+        while (reader.hasNext()) {
+            String name = reader.nextName();
+            if (name.equals("type")) {
+                type = reader.nextString();
+            } else if (name.equals("attributes")) {
+                reader.beginObject();
+                reader.nextName();
+                attributeValue = reader.nextString();
+                reader.endObject();
+            } else {
+                reader.skipValue();
+            }
+        }
+        reader.endObject();
+        ArrayList<String> values = new ArrayList<>();
+        if (type != null) {
+            values.add(type);
+        } else {
+            throw new IOException("Severity Reason type is required");
+        }
+
+        if (attributeValue != null) {
+            values.add(attributeValue);
+        }
+        return values;
+    }
+
+    private static Session readSession(JsonReader reader) throws IOException {
+        String id = null;
+        Date startedAt = null;
+        int unhandled = 0;
+        int handled = 0;
+        User user = null;
+        reader.beginObject();
+        while (reader.hasNext()) {
+            String name = reader.nextName();
+            if (name.equals("id")) {
+                id = reader.nextString();
+            } else if (name.equals("startedAt")) {
+                try {
+                    startedAt = DateUtils.fromIso8601(reader.nextString());
+                } catch (Exception ex) {
+                    throw new IOException("Unable to parse session startedAt: ", ex);
+                }
+            } else if (name.equals("events")) {
+                reader.beginObject();
+                while (reader.hasNext()) {
+                    String eventName = reader.nextName();
+                    if (eventName.equals("unhandled")) {
+                        unhandled = reader.nextInt();
+                    } else if (eventName.equals("handled")) {
+                        handled = reader.nextInt();
+                    } else {
+                        reader.skipValue();
+                    }
+                }
+                reader.endObject();
+            } else if (name.equals("user")) {
+                user = readUser(reader);
+            } else {
+                reader.skipValue();
+            }
+        }
+        reader.endObject();
+
+        if (id != null && startedAt != null) {
+            return new Session(id, startedAt, user, unhandled, handled);
+        }
+        throw new IOException("Session data missing required fields");
+    }
+
+    private static User readUser(JsonReader reader) throws IOException {
+        User user = new User();
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "name":
+                    user.setName(reader.nextString());
+                    break;
+                case "id":
+                    user.setId(reader.nextString());
+                    break;
+                case "email":
+                    user.setEmail(reader.nextString());
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+            }
+        }
+        reader.endObject();
+
+        return user;
+    }
+
+    private static ThreadState readThreadState(Configuration config, JsonReader reader)
+        throws IOException {
+        List<CachedThread> threads = new ArrayList<>();
+        reader.beginArray();
+        while (reader.hasNext()) {
+            long id = 0;
+            String name = null;
+            String type = null;
+            boolean errorReportingThread = false;
+            StackTraceElement[] frames = null;
+            reader.beginObject();
+            while (reader.hasNext()) {
+                switch (reader.nextName()) {
+                    case "id":
+                        id = reader.nextLong();
+                        break;
+                    case "name":
+                        name = reader.nextString();
+                        break;
+                    case "type":
+                        type = reader.nextString();
+                        break;
+                    case "stacktrace":
+                        frames = readStackFrames(reader);
+                        break;
+                    case "errorReportingThread":
+                        errorReportingThread = reader.nextBoolean();
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
+            }
+            reader.endObject();
+            if (type != null && frames != null) {
+                threads.add(new CachedThread(config, id, name, type, errorReportingThread, frames));
+            }
+        }
+        reader.endArray();
+        return new ThreadState(threads.toArray(new CachedThread[threads.size()]));
+    }
+
+    private static Map<String, Object> jsonObjectToMap(JsonReader reader) throws IOException {
+        Map<String, Object> data = new HashMap<>();
+        reader.beginObject();
+        while (reader.hasNext()) {
+            String key = reader.nextName();
+            Object value = coerceSerializableFromJSON(reader);
+            if (value != null) {
+                data.put(key, value);
+            }
+        }
+        reader.endObject();
+
+        return data;
+    }
+
+    private static List<Object> jsonArrayToList(JsonReader reader) throws IOException {
+        List<Object> objects = new ArrayList<>();
+        reader.beginArray();
+        while (reader.hasNext()) {
+            Object value = coerceSerializableFromJSON(reader);
+            if (value != null) {
+                objects.add(value);
+            }
+        }
+        reader.endArray();
+        return objects;
+    }
+
+    private static Object coerceSerializableFromJSON(JsonReader reader) throws IOException {
+        switch (reader.peek()) {
+            case BEGIN_OBJECT:
+                return jsonObjectToMap(reader);
+            case STRING:
+                return reader.nextString();
+            case BOOLEAN:
+                return reader.nextBoolean();
+            case NUMBER:
+                try {
+                    return reader.nextInt();
+                } catch (NumberFormatException ex) {
+                    try {
+                        return reader.nextLong();
+                    } catch (NumberFormatException ex2) {
+                        return reader.nextDouble();
+                    }
+                }
+            case BEGIN_ARRAY:
+                return jsonArrayToList(reader);
+            default:
+                return null;
+        }
+    }
+}

--- a/sdk/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/sdk/src/main/java/com/bugsnag/android/Exceptions.java
@@ -39,6 +39,14 @@ class Exceptions implements JsonStream.Streamable {
         writer.endArray();
     }
 
+    Throwable getException() {
+        return exception;
+    }
+
+    String getExceptionType() {
+        return exceptionType;
+    }
+
     void setExceptionType(@NonNull String type) {
         exceptionType = type;
     }

--- a/sdk/src/main/java/com/bugsnag/android/HandledState.java
+++ b/sdk/src/main/java/com/bugsnag/android/HandledState.java
@@ -14,7 +14,7 @@ final class HandledState implements JsonStream.Streamable {
 
     @StringDef({REASON_UNHANDLED_EXCEPTION, REASON_STRICT_MODE, REASON_HANDLED_EXCEPTION,
         REASON_USER_SPECIFIED, REASON_CALLBACK_SPECIFIED, REASON_PROMISE_REJECTION,
-        REASON_LOG})
+        REASON_LOG, REASON_SIGNAL})
     @Retention(RetentionPolicy.SOURCE)
     @interface SeverityReason {
     }
@@ -25,6 +25,7 @@ final class HandledState implements JsonStream.Streamable {
     static final String REASON_USER_SPECIFIED = "userSpecifiedSeverity";
     static final String REASON_CALLBACK_SPECIFIED = "userCallbackSetSeverity";
     static final String REASON_PROMISE_REJECTION = "unhandledPromiseRejection";
+    static final String REASON_SIGNAL = "signal";
     static final String REASON_LOG = "log";
 
     @SeverityReason
@@ -75,7 +76,7 @@ final class HandledState implements JsonStream.Streamable {
         }
     }
 
-    private HandledState(String severityReasonType, Severity currentSeverity, boolean unhandled,
+    HandledState(String severityReasonType, Severity currentSeverity, boolean unhandled,
                          @Nullable String attributeValue) {
         this.severityReasonType = severityReasonType;
         this.defaultSeverity = currentSeverity;

--- a/sdk/src/main/java/com/bugsnag/android/Session.java
+++ b/sdk/src/main/java/com/bugsnag/android/Session.java
@@ -21,6 +21,16 @@ class Session implements JsonStream.Streamable {
         this.autoCaptured = new AtomicBoolean(autoCaptured);
     }
 
+    Session(String id, Date startedAt, User user, int unhandledCount, int handledCount) {
+        this.id = id;
+        this.startedAt = new Date(startedAt.getTime());
+        this.user = user;
+        this.autoCaptured = new AtomicBoolean(false);
+        this.unhandledCount = new AtomicInteger(unhandledCount);
+        this.handledCount = new AtomicInteger(handledCount);
+        this.tracked = new AtomicBoolean(true);
+    }
+
     private AtomicInteger unhandledCount = new AtomicInteger();
     private AtomicInteger handledCount = new AtomicInteger();
     private AtomicBoolean tracked = new AtomicBoolean(false);


### PR DESCRIPTION
## Goal

Added support for modifying all reports (including native crash reports) prior to delivery.

## Design

Added new functionality to convert an Error cached on disk back into an Error object, which is then added to reports. The new callbacks are run on the resulting report object just prior to delivery.

## Changeset

|||
|--|--|
|Source| `15 files changed, 645 insertions(+), 33 deletions(-)`|
|Tests| `14 files changed, 1166 insertions(+), 7 deletions(-)` (mostly fixtures)|

### Added

* `ErrorReader` - A collection of static methods to read a report from a file, throwing an exception if the report is in some way invalid (such as broken JSON or missing required fields)
* `Configuration.beforeSend` - New callbacks are added to the configuration directly before calling `Bugsnag.init`

### Removed

* `Report.errorFile` - when constructed with a file, a report then creates an Error object, so every report now has an `Error`

## Tests

* Added new unit tests for deserializing an Error using the Reader class
* Added new integration tests for running `beforeSend` callbacks before native/and non-native crashes and notify() calls

## Discussion

This new configuration option bypasses adding convenience methods to Bugsnag/Client to avoid cases where reports may be delivered prior to the callback being added. Something like:

```java
Bugsnag.init(this); // <-- reports start sending
Bugsnag.beforeSend( ... ); // <-- already too late
```

## Review

This pull request is ready for final review, in particular:

- [ ] Performance concerns during serialization
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise?
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
