### PR TITLE
feat: Allow setting context to null from beforeSend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Allow setting context to null from callbacks
+  [#381](https://github.com/bugsnag/bugsnag-android/pull/381)
+
 ## 4.9.0 (2018-10-29)
 
 ### Enhancements

--- a/features/before_send.feature
+++ b/features/before_send.feature
@@ -47,3 +47,14 @@ Feature: Run callbacks before reports delivered
         And the exception "type" equals "android"
         And the event "severity" equals "error"
         And the event "unhandled" is false
+
+    Scenario: Unset context
+        When I run "NotifyBeforeSendUnsetContextScenario"
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the exception "errorClass" equals "java.lang.Exception"
+        And the exception "message" equals "Registration failure"
+        And the event "context" is null
+        And the exception "type" equals "android"
+        And the event "severity" equals "error"
+        And the event "unhandled" is false

--- a/features/error_context.feature
+++ b/features/error_context.feature
@@ -16,3 +16,12 @@ Scenario: Context manually set
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the exception "message" equals "ManualContextScenario"
     And the event "context" equals "FooContext"
+
+Scenario: Context passed an an argument to notify
+    When I run "ArgumentContextScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the exception "errorClass" equals "RuntimeException"
+    And the exception "message" equals "deprecated"
+    And the event "context" equals "NewContext"

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ArgumentContextScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ArgumentContextScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.MetaData
+import com.bugsnag.android.Severity
+import com.bugsnag.android.mazerunner.scenarios.Scenario
+
+/**
+ * Sends a handled exception to Bugsnag, which includes manual context.
+ */
+internal class ArgumentContextScenario(config: Configuration,
+                                       context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.getClient().notify("RuntimeException", "deprecated", "NewContext", emptyArray<StackTraceElement>(), Severity.ERROR, MetaData())
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NotifyBeforeSendUnsetContextScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NotifyBeforeSendUnsetContextScenario.java
@@ -1,0 +1,34 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.BeforeSend;
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.Report;
+import com.bugsnag.android.Severity;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+
+public class NotifyBeforeSendUnsetContextScenario extends Scenario {
+
+    public NotifyBeforeSendUnsetContextScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        config.beforeSend(new BeforeSend() {
+            @Override
+            public boolean run(Report report) {
+                report.getError().setContext(null);
+                report.getError().setSeverity(Severity.ERROR);
+
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        Bugsnag.notify(new Exception("Registration failure"));
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -315,25 +315,10 @@ public class ErrorTest {
     }
 
     @Test
-    public void testConfigContext() throws Exception {
-        String expected = "Junit test suite";
-        error.setContext(null);
-        config.setContext(expected);
-        assertEquals(expected, error.getContext());
-    }
-
-    @Test
     public void testNullContext() throws Exception {
         error.setContext(null);
         error.setAppData(null);
         assertNull(error.getContext());
-    }
-
-    @Test
-    public void testActiveScreen() throws Exception {
-        error.setContext(null);
-        error.getMetaData().addToTab("app", "activeScreen", "FooActivity");
-        assertEquals("FooActivity", error.getContext());
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/AppData.java
+++ b/sdk/src/main/java/com/bugsnag/android/AppData.java
@@ -108,7 +108,7 @@ class AppData {
         return client.sessionTracker.getDurationInForegroundMs(nowMs);
     }
 
-    private String getActiveScreenClass() {
+    String getActiveScreenClass() {
         return client.sessionTracker.getContextActivity();
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -838,6 +838,12 @@ public class Client extends Observable implements Observer {
         // Attach user info to the error
         error.setUser(user);
 
+        // Attach default context from active activity
+        if (TextUtils.isEmpty(error.getContext())) {
+            String context = config.getContext();
+            error.setContext(context != null ? context : appData.getActiveScreenClass());
+        }
+
         // Run beforeNotify tasks, don't notify if any return true
         if (!runBeforeNotifyTasks(error)) {
             Logger.info("Skipping notification - beforeNotify task returned false");

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -2,7 +2,6 @@ package com.bugsnag.android;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.text.TextUtils;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -71,7 +70,7 @@ public class Error implements JsonStream.Streamable {
 
         // Write error basics
         writer.beginObject();
-        writer.name("context").value(getContext());
+        writer.name("context").value(context);
         writer.name("metaData").value(mergedMetaData);
 
         writer.name("severity").value(severity);
@@ -134,19 +133,7 @@ public class Error implements JsonStream.Streamable {
      */
     @Nullable
     public String getContext() {
-        if (!TextUtils.isEmpty(context)) {
-            return context;
-        } else if (config.getContext() != null) {
-            return config.getContext();
-        } else if (metaData != null) {
-            Map<String, Object> app = metaData.getTab("app");
-            Object activeScreen = app.get("activeScreen");
-
-            if (activeScreen instanceof String) {
-                return (String) activeScreen;
-            }
-        }
-        return null;
+        return context;
     }
 
     /**


### PR DESCRIPTION
## Changeset

* Moved automatic context detection from during serialization to capture-time, which is in `Client`
* Deleted a test for the context logic in Error

## Tests

* [x] Add new test scenario for overriding context
* (Other scenarios cover automatic context assignment and setting context to a new value)

## Review

- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
