### PR TITLE
Handle null values in MetaData.mergeMaps, preventing potential NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.X.X (TBD)
+## 4.9.3 (2018-11-29)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Bug fixes
+
+* Handle null values in MetaData.mergeMaps, preventing potential NPE
+ [#386](https://github.com/bugsnag/bugsnag-android/pull/386)
+
+
 ## 4.9.2 (2018-11-07)
 
 ### Bug fixes

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MetaDataNestedNullScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MetaDataNestedNullScenario.kt
@@ -1,0 +1,35 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import java.util.HashMap
+
+/**
+ * Sends a handled exception to Bugsnag, which includes a nested null value in a metadata map
+ */
+internal class MetaDataNestedNullScenario(
+    config: Configuration,
+    context: Context
+) : Scenario(config, context) {
+
+    init {
+        config.setAutoCaptureSessions(false)
+
+    }
+
+    override fun run() {
+        super.run()
+
+        val configMap = HashMap<String, Any?>()
+        configMap["test"] = null
+        Bugsnag.addToTab("Custom", "foo", configMap)
+
+        Bugsnag.notify(RuntimeException("MetaDataScenario")) {
+            val map = HashMap<String, Any?>()
+            map["test"] = null
+            it.error?.addToTab("Custom", "foo", map)
+        }
+    }
+
+}

--- a/features/meta_data_scenario.feature
+++ b/features/meta_data_scenario.feature
@@ -5,3 +5,8 @@ Scenario: Sends a handled exception which includes custom metadata added in a no
     Then I should receive a request
     And the request is a valid for the error reporting API
     And the event "metaData.Custom.foo" equals "Hello World!"
+
+Scenario: Add nested null value to metadata tab
+    When I run "MetaDataNestedNullScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=4.9.2
+VERSION_NAME=4.9.3
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git

--- a/sdk/src/androidTest/java/com/bugsnag/android/MetaDataMergeTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/MetaDataMergeTest.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import static org.junit.Assert.assertFalse;
-
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -11,13 +9,17 @@ public class MetaDataMergeTest {
 
     @Test
     public void testConcurrentMapMerge() {
-        MetaData metaData = new MetaData();
+        MetaData.merge(generateMetaData(), generateMetaData());
+    }
 
+    /**
+     * Generates a metadata object with a tab value containing a map with a null entry
+     */
+    private MetaData generateMetaData() {
+        MetaData metaData = new MetaData();
         Map<Object, Object> nestedMap = new HashMap<>();
         metaData.addToTab("foo", "bar", nestedMap);
         nestedMap.put("whoops", null);
-
-        Map<String, Object> mergedMap = MetaData.merge(metaData, metaData).store;
-        assertFalse(mergedMap.containsKey("whoops"));
+        return metaData;
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/MetaDataMergeTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/MetaDataMergeTest.java
@@ -1,0 +1,23 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MetaDataMergeTest {
+
+    @Test
+    public void testConcurrentMapMerge() {
+        MetaData metaData = new MetaData();
+
+        Map<Object, Object> nestedMap = new HashMap<>();
+        metaData.addToTab("foo", "bar", nestedMap);
+        nestedMap.put("whoops", null);
+
+        Map<String, Object> mergedMap = MetaData.merge(metaData, metaData).store;
+        assertFalse(mergedMap.containsKey("whoops"));
+    }
+}

--- a/sdk/src/main/java/com/bugsnag/android/MetaData.java
+++ b/sdk/src/main/java/com/bugsnag/android/MetaData.java
@@ -146,9 +146,7 @@ public class MetaData extends Observable implements JsonStream.Streamable {
                 Object overridesValue = map.get(key);
 
                 if (overridesValue != null) {
-                    if (baseValue != null
-                        && baseValue instanceof Map
-                        && overridesValue instanceof Map) {
+                    if (baseValue instanceof Map && overridesValue instanceof Map) {
                         // Both original and overrides are Maps, go deeper
                         @SuppressWarnings("unchecked")
                         Map<String, Object> first = (Map<String, Object>) baseValue;
@@ -159,8 +157,9 @@ public class MetaData extends Observable implements JsonStream.Streamable {
                         result.put(key, overridesValue);
                     }
                 } else {
-                    // No collision, just use base value
-                    result.put(key, baseValue);
+                    if (baseValue != null) { // No collision, just use base value
+                        result.put(key, baseValue);
+                    }
                 }
             }
         }

--- a/sdk/src/main/java/com/bugsnag/android/Notifier.java
+++ b/sdk/src/main/java/com/bugsnag/android/Notifier.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 public class Notifier implements JsonStream.Streamable {
 
     private static final String NOTIFIER_NAME = "Android Bugsnag Notifier";
-    private static final String NOTIFIER_VERSION = "4.9.2";
+    private static final String NOTIFIER_VERSION = "4.9.3";
     private static final String NOTIFIER_URL = "https://bugsnag.com";
 
     @NonNull


### PR DESCRIPTION


## Goal
Prevent NPE crash when attempting to deliver error reports.

## Design

`MetaData` tab values can be `HashMaps`, whose entries can be null. `MetaData.mergeMaps` seemed to assume that the `Map` was always a `ConcurrentHashMap`, whose entries cannot be null. 

On React Native this manifested as a NPE when merging `config.metaData` and `report.metaData` due to `app.activeScreen` being intermittently recorded as null. This can occur on any platform which uses bugsnag-android, however.

## Changeset

Added a null check when adding the base value to the merged map.

## Tests

Wrote unit test + mazerunner scenario, and manually verified that valid reports are sent from a React Native example app using a local bugsnag-android artefact.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
