### PR TITLE
Fix bintray gradle plugin failure, update release steps gradle task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ If you are a project maintainer, you can build and release a new version of
 - Merge any remaining PRs to master, ensuring the commit message matches the release tag (e.g. v4.0.0)
 - [ ] Update the version number and dex count badge by running `make VERSION=[number] bump`
 - [ ] Inspected the updated CHANGELOG, README, and version files to ensure they are correct
-- [ ] Release to GitHub, Maven Central, and Bintray by running `git tag vX.X.X && git push origin --tags && ./gradlew uploadArchives bintrayUpload`
+- [ ] Release to GitHub, Maven Central, and Bintray by running `git tag vX.X.X && git push origin --tags && ./gradlew assembleRelease publishSDKPublicationToMavenRepository publishNDKPublicationToMavenRepository`
   - [ ] "Promote" the release build on Maven Central
     - Go to the [sonatype open source dashboard](https://oss.sonatype.org/index.html#stagingRepositories)
     - Click the search box at the top right, and type “com.bugsnag”

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,7 @@ If you are a project maintainer, you can build and release a new version of
 - Merge any remaining PRs to master, ensuring the commit message matches the release tag (e.g. v4.0.0)
 - [ ] Update the version number and dex count badge by running `make VERSION=[number] bump`
 - [ ] Inspected the updated CHANGELOG, README, and version files to ensure they are correct
-- [ ] Release to GitHub, Maven Central, and Bintray by running `git tag vX.X.X && git push origin --tags && ./gradlew assembleRelease publishSDKPublicationToMavenRepository publishNDKPublicationToMavenRepository`
+- [ ] Release to GitHub, Maven Central, and Bintray by running `git tag vX.X.X && git push origin --tags && ./gradlew assembleRelease publish`
   - [ ] "Promote" the release build on Maven Central
     - Go to the [sonatype open source dashboard](https://oss.sonatype.org/index.html#stagingRepositories)
     - Click the search box at the top right, and type “com.bugsnag”

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.8.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
The bintray gradle plugin was updated for [compatibility with gradle 4.8](https://github.com/bintray/gradle-bintray-plugin/pull/243), but we did not update when we last updated the gradle wrapper. This broke the upload of artefacts to bintray when running `./gradlew bintrayUpload` - updating the plugin resolves this issue.

Additionally, the task for uploading artefacts to sonatype specified in the release steps has been wrong since the [NDK integration was altered](https://github.com/bugsnag/bugsnag-android/commits/master/sdk/build.gradle) - the correct task is now specified in the release steps.
