### PR TITLE
Update Android Gradle Plugin to v3.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,11 @@ buildscript {
         mavenCentral()
         jcenter()
     }
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.3.10'
+    ext.agpVersion = "3.2.1"
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath "com.android.tools.build:gradle:$agpVersion"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -4,9 +4,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath "com.android.tools.build:gradle:$agpVersion"
         classpath 'com.bugsnag:bugsnag-android-gradle-plugin:3.4.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.30"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -78,7 +78,7 @@ dependencies {
     // api project(path: ':ndk', configuration: 'default')
     implementation 'com.android.support:appcompat-v7:27.0.0'
     implementation 'com.android.support:support-v4:27.0.0'
-    kotlinExampleImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.30"
+    kotlinExampleImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     androidTestImplementation "com.android.support.test:runner:0.5", {
         exclude group: 'com.android.support', module: 'support-annotations'
     }

--- a/features/fixtures/mazerunner/build.gradle
+++ b/features/fixtures/mazerunner/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         google()
         jcenter()
     }
-    ext.kotlin_version = '1.2.30'
+    ext.kotlin_version = '1.3.10'
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -66,7 +66,7 @@ android {
 dependencies {
     implementation(name:'bugsnag-android', ext:'aar')
     implementation(name:'bugsnag-android-ndk', ext:'aar')
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.21"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "com.facebook.infer.annotation:infer-annotation:0.11.2"
     api "com.android.support:support-annotations:27.0.0"
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -30,6 +30,7 @@ android {
         abortOnError true
         warningsAsErrors true
         checkAllWarnings true
+        baseline file("lint-baseline.xml")
     }
 
     // TODO replace with https://issuetracker.google.com/issues/72050365 once released.

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -50,7 +50,7 @@ coveralls {
 dependencies {
     api "com.android.support:support-annotations:$supportLibVersion"
 
-    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/sdk/lint-baseline.xml
+++ b/sdk/lint-baseline.xml
@@ -1,0 +1,1973 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="4" by="lint 3.2.1" client="gradle" variant="all" version="3.2.1">
+
+    <issue
+        id="KotlinPropertyAccess"
+        message="This method should be called `getAutoCaptureSessions` such that `autoCaptureSessions` can be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+        errorLine1="    public boolean shouldAutoCaptureSessions() {"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="409"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="KotlinPropertyAccess"
+        message="This getter should be public such that `codeBundleId` can be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+        errorLine1="    String getCodeBundleId() {"
+        errorLine2="           ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="558"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="KotlinPropertyAccess"
+        message="This getter should be public such that `notifierType` can be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
+        errorLine1="    String getNotifierType() {"
+        errorLine2="           ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="562"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public BadResponseException(String msg, int responseCode) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/BadResponseException.java"
+            line="13"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    boolean run(Error error);"
+        errorLine2="                ~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/BeforeNotify.java"
+            line="21"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    boolean run(Report report);"
+        errorLine2="                ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/BeforeSend.java"
+            line="19"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String toString() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/BreadcrumbType.java"
+            line="48"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setAppVersion(final String appVersion) {"
+        errorLine2="                                           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="89"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static String getContext() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="98"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setContext(final String context) {"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="109"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setEndpoint(final String endpoint) {"
+        errorLine2="                                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="124"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setBuildUUID(final String buildUuid) {"
+        errorLine2="                                          ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="137"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setFilters(final String... filters) {"
+        errorLine2="                                        ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="154"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setIgnoreClasses(final String... ignoreClasses) {"
+        errorLine2="                                              ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="167"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setNotifyReleaseStages(final String... notifyReleaseStages) {"
+        errorLine2="                                                    ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="182"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setProjectPackages(final String... projectPackages) {"
+        errorLine2="                                                ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="198"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setReleaseStage(final String releaseStage) {"
+        errorLine2="                                             ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="212"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setUser(final String id, final String email, final String name) {"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="250"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setUser(final String id, final String email, final String name) {"
+        errorLine2="                                                      ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="250"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setUser(final String id, final String email, final String name) {"
+        errorLine2="                                                                          ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="250"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setUserId(final String id) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="268"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setUserEmail(final String email) {"
+        errorLine2="                                          ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="278"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setUserName(final String name) {"
+        errorLine2="                                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="288"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void beforeNotify(final BeforeNotify beforeNotify) {"
+        errorLine2="                                          ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="350"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void beforeRecordBreadcrumb(final BeforeRecordBreadcrumb beforeRecordBreadcrumb) {"
+        errorLine2="                                                    ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="372"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void notify(@NonNull final Throwable exception, final Callback callback) {"
+        errorLine2="                                                                        ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="392"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                              Callback callback) {"
+        errorLine2="                              ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="408"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void notify(@NonNull final Throwable exception, final Severity severity) {"
+        errorLine2="                                                                        ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="419"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void notify(@NonNull final Throwable exception, final Severity severity,"
+        errorLine2="                                                                        ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="451"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                              @NonNull StackTraceElement[] stacktrace, Severity severity,"
+        errorLine2="                                                                       ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="476"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void notify(@NonNull String name, @NonNull String message, String context,"
+        errorLine2="                                                                             ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="505"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                              @NonNull StackTraceElement[] stacktrace, Severity severity,"
+        errorLine2="                                                                       ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="506"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                                            Map&lt;String, Object> clientData,"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="526"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                                            Callback callback) {"
+        errorLine2="                                            ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="528"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void addToTab(final String tab, final String key, final Object value) {"
+        errorLine2="                                      ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="545"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void addToTab(final String tab, final String key, final Object value) {"
+        errorLine2="                                                        ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="545"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void addToTab(final String tab, final String key, final Object value) {"
+        errorLine2="                                                                          ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="545"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void clearTab(String tabName) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Bugsnag.java"
+            line="554"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public BugsnagException(String name, String message, StackTraceElement[] frames) {"
+        errorLine2="                            ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/BugsnagException.java"
+            line="22"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public BugsnagException(String name, String message, StackTraceElement[] frames) {"
+        errorLine2="                                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/BugsnagException.java"
+            line="22"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public BugsnagException(String name, String message, StackTraceElement[] frames) {"
+        errorLine2="                                                         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/BugsnagException.java"
+            line="22"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getName() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/BugsnagException.java"
+            line="32"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    void beforeNotify(Report report);"
+        errorLine2="                      ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Callback.java"
+            line="14"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void update(Observable observable, Object arg) {"
+        errorLine2="                       ~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="273"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void update(Observable observable, Object arg) {"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="273"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void startFirstSession(Activity activity) {"
+        errorLine2="                                  ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="297"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setAppVersion(String appVersion) {"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="307"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getContext() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="316"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setContext(String context) {"
+        errorLine2="                           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="327"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setEndpoint(String endpoint) {"
+        errorLine2="                            ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="342"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setBuildUUID(final String buildUuid) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="355"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setFilters(String... filters) {"
+        errorLine2="                           ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="373"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setIgnoreClasses(String... ignoreClasses) {"
+        errorLine2="                                 ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="386"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setNotifyReleaseStages(String... notifyReleaseStages) {"
+        errorLine2="                                       ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="401"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setProjectPackages(String... projectPackages) {"
+        errorLine2="                                   ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="417"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setReleaseStage(String releaseStage) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="429"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUser(String id, String email, String name) {"
+        errorLine2="                        ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="473"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUser(String id, String email, String name) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="473"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUser(String id, String email, String name) {"
+        errorLine2="                                                 ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="473"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUserId(String id) {"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="532"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUserEmail(String email) {"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="546"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUserName(String name) {"
+        errorLine2="                            ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="560"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void beforeNotify(BeforeNotify beforeNotify) {"
+        errorLine2="                             ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="622"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void beforeRecordBreadcrumb(BeforeRecordBreadcrumb beforeRecordBreadcrumb) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="644"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void notify(@NonNull Throwable exception, Callback callback) {"
+        errorLine2="                                                     ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="668"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                       Callback callback) {"
+        errorLine2="                       ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="688"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void notify(@NonNull Throwable exception, Severity severity) {"
+        errorLine2="                                                     ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="703"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void notify(@NonNull Throwable exception, Severity severity,"
+        errorLine2="                                                     ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="739"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                       @NonNull StackTraceElement[] stacktrace, Severity severity,"
+        errorLine2="                                                                ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="763"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                       String context,"
+        errorLine2="                       ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="789"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                       Severity severity,"
+        errorLine2="                       ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="791"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void notifyBlocking(@NonNull Throwable exception, Callback callback) {"
+        errorLine2="                                                             ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="928"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                               Callback callback) {"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="948"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void notifyBlocking(@NonNull Throwable exception, Severity severity,"
+        errorLine2="                                                             ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="984"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                               Severity severity,"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1010"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                               String context,"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1036"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                               Severity severity,"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1038"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void notifyBlocking(@NonNull Throwable exception, Severity severity) {"
+        errorLine2="                                                             ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1056"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                              Map&lt;String, Object> clientData,"
+        errorLine2="                              ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1073"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                              Callback callback) {"
+        errorLine2="                              ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1075"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tab, String key, Object value) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1123"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tab, String key, Object value) {"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1123"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tab, String key, Object value) {"
+        errorLine2="                                                 ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1123"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void clearTab(String tabName) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Client.java"
+            line="1132"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void update(Observable observable, Object arg) {"
+        errorLine2="                       ~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="76"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void update(Observable observable, Object arg) {"
+        errorLine2="                                              ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="76"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getAppVersion() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="98"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setAppVersion(String appVersion) {"
+        errorLine2="                              ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="108"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getContext() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="120"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setContext(String context) {"
+        errorLine2="                           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="131"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getEndpoint() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="143"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setEndpoint(String endpoint) {"
+        errorLine2="                            ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="157"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getSessionEndpoint() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="201"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setSessionEndpoint(String endpoint) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="215"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getBuildUUID() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="225"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setBuildUUID(String buildUuid) {"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="238"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String[] getFilters() {"
+        errorLine2="           ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="250"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setFilters(String[] filters) {"
+        errorLine2="                           ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="267"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String[] getIgnoreClasses() {"
+        errorLine2="           ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="276"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setIgnoreClasses(String[] ignoreClasses) {"
+        errorLine2="                                 ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="289"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String[] getProjectPackages() {"
+        errorLine2="           ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="323"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setProjectPackages(String[] projectPackages) {"
+        errorLine2="                                   ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="339"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getReleaseStage() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="348"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setReleaseStage(String releaseStage) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="360"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setNotifierType(String notifierType) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="546"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setCodeBundleId(String codeBundleId) {"
+        errorLine2="                                ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="554"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public Map&lt;String, String> getErrorApiHeaders() {"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="627"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public Map&lt;String, String> getSessionApiHeaders() {"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="640"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void beforeSend(BeforeSend beforeSend) {"
+        errorLine2="                           ~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="669"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    protected boolean shouldNotifyForReleaseStage(String releaseStage) {"
+        errorLine2="                                                  ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="681"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    protected boolean shouldIgnoreClass(String className) {"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="696"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    protected void beforeNotify(BeforeNotify beforeNotify) {"
+        errorLine2="                                ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="710"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    protected void beforeRecordBreadcrumb(BeforeRecordBreadcrumb beforeRecordBreadcrumb) {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="721"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    protected Collection&lt;BeforeRecordBreadcrumb> getBeforeRecordBreadcrumbTasks() {"
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="750"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    void deliver(SessionTrackingPayload payload,"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Delivery.java"
+            line="39"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                 Configuration config) throws DeliveryFailureException;"
+        errorLine2="                 ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Delivery.java"
+            line="40"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    void deliver(Report report,"
+        errorLine2="                 ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Delivery.java"
+            line="61"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                 Configuration config) throws DeliveryFailureException;"
+        errorLine2="                 ~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Delivery.java"
+            line="62"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public DeliveryFailureException(String message) {"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/DeliveryFailureException.java"
+            line="13"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public DeliveryFailureException(String message, Throwable cause) {"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/DeliveryFailureException.java"
+            line="17"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public DeliveryFailureException(String message, Throwable cause) {"
+        errorLine2="                                                    ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/DeliveryFailureException.java"
+            line="17"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUser(String id, String email, String name) {"
+        errorLine2="                        ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="194"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUser(String id, String email, String name) {"
+        errorLine2="                                   ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="194"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUser(String id, String email, String name) {"
+        errorLine2="                                                 ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="194"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUserId(String id) {"
+        errorLine2="                          ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="215"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUserEmail(String email) {"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="225"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void setUserName(String name) {"
+        errorLine2="                            ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="235"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tabName, String key, Object value) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="253"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tabName, String key, Object value) {"
+        errorLine2="                                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="253"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tabName, String key, Object value) {"
+        errorLine2="                                                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="253"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void clearTab(String tabName) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="262"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getExceptionName() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="302"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public Throwable getException() {"
+        errorLine2="           ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Error.java"
+            line="322"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    void postReport(String urlString, Report report, Map&lt;String, String> headers)"
+        errorLine2="                    ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/ErrorReportApiClient.java"
+            line="29"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    void postReport(String urlString, Report report, Map&lt;String, String> headers)"
+        errorLine2="                                      ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/ErrorReportApiClient.java"
+            line="29"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    void postReport(String urlString, Report report, Map&lt;String, String> headers)"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/ErrorReportApiClient.java"
+            line="29"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public EventReceiver(Client client) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/EventReceiver.java"
+            line="28"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void onReceive(Context context, @NonNull Intent intent) {"
+        errorLine2="                          ~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/EventReceiver.java"
+            line="33"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public JsonStream(Writer out) {"
+        errorLine2="                      ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/JsonStream.java"
+            line="29"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tabName, String key, Object value) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/MetaData.java"
+            line="60"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tabName, String key, Object value) {"
+        errorLine2="                                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/MetaData.java"
+            line="60"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void addToTab(String tabName, String key, Object value) {"
+        errorLine2="                                                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/MetaData.java"
+            line="60"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void clearTab(String tabName) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/MetaData.java"
+            line="81"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="        public final MessageType type;"
+        errorLine2="                     ~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="118"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="        public final Object value;"
+        errorLine2="                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="119"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="        public Message(MessageType type, Object value) {"
+        errorLine2="                       ~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="121"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="        public Message(MessageType type, Object value) {"
+        errorLine2="                                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="121"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static String getContext() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="176"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static String getNativeReportPath() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="184"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setUser(final String id,"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="254"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                               final String email,"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="255"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                               final String name) {"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="256"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void leaveBreadcrumb(String name, String type, Map&lt;String, String> metadata) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="274"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void leaveBreadcrumb(String name, String type, Map&lt;String, String> metadata) {"
+        errorLine2="                                                    ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="274"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void leaveBreadcrumb(String name, String type, Map&lt;String, String> metadata) {"
+        errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="274"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void addToTab(final String tab,"
+        errorLine2="                                      ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="283"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                                final String key,"
+        errorLine2="                                      ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="284"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                                final Object value) {"
+        errorLine2="                                      ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="285"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setReleaseStage(final String stage) {"
+        errorLine2="                                             ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="292"
+            column="46"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static String getReleaseStage() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="299"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static String getSessionEndpoint() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="306"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static String getEndpoint() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="313"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setSessionEndpoint(final String endpoint) {"
+        errorLine2="                                                ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="321"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setEndpoint(final String endpoint) {"
+        errorLine2="                                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="329"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setContext(final String context) {"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="336"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setAppVersion(final String version) {"
+        errorLine2="                                           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="343"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static String getAppVersion() {"
+        errorLine2="                  ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="350"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static String[] getNotifyReleaseStages() {"
+        errorLine2="                  ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="357"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setNotifyReleaseStages(String[] notifyReleaseStages) {"
+        errorLine2="                                              ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="364"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void deliverReport(String releaseStage, String payload) {"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="376"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void deliverReport(String releaseStage, String payload) {"
+        errorLine2="                                                          ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="376"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                              final Severity severity,"
+        errorLine2="                                    ~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="396"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public NetworkException(String msg, Throwable cause) {"
+        errorLine2="                            ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NetworkException.java"
+            line="13"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public NetworkException(String msg, Throwable cause) {"
+        errorLine2="                                        ~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NetworkException.java"
+            line="13"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public Integer getValue() {"
+        errorLine2="           ~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NotifyType.java"
+            line="26"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    void postSessionTrackingPayload(String urlString,"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/SessionTrackingApiClient.java"
+            line="25"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                                    SessionTrackingPayload payload,"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/SessionTrackingApiClient.java"
+            line="26"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="                                    Map&lt;String, String> headers)"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/SessionTrackingApiClient.java"
+            line="27"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getName() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Severity.java"
+            line="42"
+            column="12"/>
+    </issue>
+
+</issues>

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -71,7 +71,7 @@ public class Client extends Observable implements Observer {
 
     final SessionStore sessionStore;
 
-    private final EventReceiver eventReceiver;
+    final EventReceiver eventReceiver;
     final SessionTracker sessionTracker;
     SharedPreferences sharedPrefs;
 
@@ -230,7 +230,7 @@ public class Client extends Observable implements Observer {
         errorStore.flushOnLaunch();
     }
 
-    private class ConnectivityChangeReceiver extends BroadcastReceiver {
+    class ConnectivityChangeReceiver extends BroadcastReceiver {
         @Override
         public void onReceive(Context context, Intent intent) {
             ConnectivityManager cm =
@@ -263,7 +263,7 @@ public class Client extends Observable implements Observer {
         }
     }
 
-    private void enqueuePendingNativeReports() {
+    void enqueuePendingNativeReports() {
         setChanged();
         notifyObservers(new Message(
             NativeInterface.MessageType.DELIVER_PENDING, null));

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -26,7 +26,7 @@ class ErrorStore extends FileStore<Error> {
     private static final long LAUNCH_CRASH_TIMEOUT_MS = 2000;
     private static final int LAUNCH_CRASH_POLL_MS = 50;
 
-    private volatile boolean flushOnLaunchCompleted = false;
+    volatile boolean flushOnLaunchCompleted = false;
     private final Semaphore semaphore = new Semaphore(1);
 
     static final Comparator<File> ERROR_REPORT_COMPARATOR = new Comparator<File>() {
@@ -116,7 +116,7 @@ class ErrorStore extends FileStore<Error> {
         }
     }
 
-    private void flushReports(Collection<File> storedReports) {
+    void flushReports(Collection<File> storedReports) {
         if (!storedReports.isEmpty() && semaphore.tryAcquire(1)) {
             try {
                 Logger.info(String.format(Locale.US,

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -30,10 +30,11 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
 
     private final Collection<String>
         foregroundActivities = new ConcurrentLinkedQueue<>();
-    private final Configuration configuration;
     private final long timeoutMs;
-    private final Client client;
-    private final SessionStore sessionStore;
+
+    final Configuration configuration;
+    final Client client;
+    final SessionStore sessionStore;
 
     // This most recent time an Activity was stopped.
     private AtomicLong activityLastStoppedAtMs = new AtomicLong(0);


### PR DESCRIPTION
## Goal

Update the AGP to v3.2+, to enable the `SyntheticAccessor` lint check. Synthetic accessors are generated when an inner class accesses a private method or field in its enclosing class, for example:

```
class Foo {
    private Bar bar;
    
    class Baz {
        Baz() {
            bar.toString(); // creates a synthetic accessor method to access bar
        }
    }
}
```

## Changeset

- Update AGP to v3.2.1 (latest stable)
- Update Kotlin version to v1.3.10 (latest stable), as AGP v3.2.1 only supports Kotlin 1.2.71+
- Migrate to `kotlin-stdlib` dependency, as the deprecated `kotlin-stdlib-jre` artefact is not available in 1.3.10
- Adds baseline lint file to suppress existing issues for `UnknownNullness` and `KotlinPropertyAccess`.
- Relax visibility of methods/fields identified in `SyntheticAccessor` lint check to package-private, which removes 8 unnecessary methods 🎉 

## Tests

Ran existing test suites on CI

## Discussion

Internal tickets have been created for addressing the pre-existing `KotlinPropertyAccess` and `UnknownNullness` checks in a separate PR.