### PR TITLE
Add binary architecture of application to payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Bug fixes
+
+* Add binary architecture of application to payload
+ [#389](https://github.com/bugsnag/bugsnag-android/pull/389)
+
 ## 4.9.3 (2018-11-29)
 
 ### Bug fixes

--- a/features/native_api.feature
+++ b/features/native_api.feature
@@ -12,6 +12,7 @@ Feature: Native API
         And the event "user.id" equals "324523"
         And the event "user.email" is null
         And the event "unhandled" is false
+        And the event "app.binaryArch" is not null
 
     Scenario: Adding user information in Java followed by a C crash
         When I run "CXXJavaUserInfoNativeCrashScenario"

--- a/features/native_crash_handling.feature
+++ b/features/native_crash_handling.feature
@@ -11,6 +11,7 @@ Feature: Native crash reporting
         And the exception "type" equals "c"
         And the event "severity" equals "error"
         And the event "unhandled" is true
+        And the event "app.binaryArch" is not null
 
     # This scenario will not pass on API levels < 18, as stack corruption
     # is handled without calling atexit handlers, etc.

--- a/ndk/src/main/jni/bugsnag.c
+++ b/ndk/src/main/jni/bugsnag.c
@@ -13,10 +13,7 @@ static JNIEnv *bsg_global_jni_env = NULL;
 
 void bugsnag_set_binary_arch(JNIEnv *env);
 
-void bugsnag_init(JNIEnv *env) {
-    bsg_global_jni_env = env;
-    bugsnag_set_binary_arch(env);
-}
+void bugsnag_init(JNIEnv *env) { bsg_global_jni_env = env; }
 
 void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
                         bsg_severity_t severity);
@@ -114,6 +111,9 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
 
   jstring jname = (*env)->NewStringUTF(env, name);
   jstring jmessage = (*env)->NewStringUTF(env, message);
+
+  // set application's binary arch
+  bugsnag_set_binary_arch(env);
 
   (*env)->CallStaticVoidMethod(env, interface_class, notify_method, jname,
                                jmessage, jseverity, trace);

--- a/ndk/src/main/jni/metadata.c
+++ b/ndk/src/main/jni/metadata.c
@@ -199,6 +199,20 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
   (*env)->DeleteLocalRef(env, keylist);
 }
 
+char *bsg_binary_arch() {
+#if defined(__i386__)
+    return "x86";
+#elif defined(__x86_64__)
+    return "x86_64";
+#elif defined(__arm__)
+    return "arm32";
+#elif defined(__aarch64__)
+    return "arm64";
+#else
+    return "unknown";
+#endif
+}
+
 void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                            bugsnag_report *report) {
   jobject data = (*env)->CallStaticObjectMethod(
@@ -232,6 +246,9 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   report->app.in_foreground =
       bsg_get_map_value_bool(env, jni_cache, data, "inForeground");
 
+  bsg_strncpy_safe(report->app.binaryArch,
+                     bsg_binary_arch(),
+                     sizeof(report->app.binaryArch));
   (*env)->DeleteLocalRef(env, data);
 }
 

--- a/ndk/src/main/jni/metadata.h
+++ b/ndk/src/main/jni/metadata.h
@@ -19,4 +19,7 @@ void bsg_populate_metadata(JNIEnv *env, bugsnag_report *report, jobject metadata
  */
 void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
                                  jobject metadata);
+
+char *bsg_binary_arch();
+
 #endif

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -80,6 +80,7 @@ typedef struct {
   bool in_foreground;
   bool low_memory;
   size_t memory_usage;
+  char binaryArch[32];
 } bsg_app_info;
 
 typedef struct {

--- a/ndk/src/main/jni/utils/serializer.c
+++ b/ndk/src/main/jni/utils/serializer.c
@@ -158,6 +158,8 @@ char *bsg_serialize_report_to_json_string(bugsnag_report *report) {
     if (strlen(report->app.build_uuid) > 0) {
       json_object_dotset_string(event, "app.buildUUID", report->app.build_uuid);
     }
+    json_object_dotset_string(event, "app.binaryArch",
+                              report->app.binaryArch);
     json_object_dotset_number(event, "app.duration", report->app.duration);
     json_object_dotset_number(event, "app.durationInForeground",
                               report->app.duration_in_foreground);

--- a/sdk/src/main/java/com/bugsnag/android/AppData.java
+++ b/sdk/src/main/java/com/bugsnag/android/AppData.java
@@ -26,6 +26,7 @@ class AppData {
     private final Context appContext;
 
     private final String packageName;
+    private String binaryArch = null;
 
     @Nullable
     final String appName;
@@ -76,6 +77,7 @@ class AppData {
         map.put("durationInForeground", calculateDurationInForeground());
         map.put("inForeground", client.sessionTracker.isInForeground());
         map.put("packageName", packageName);
+        map.put("binaryArch", binaryArch);
         return map;
     }
 
@@ -88,6 +90,10 @@ class AppData {
         map.put("memoryUsage", getMemoryUsage());
         map.put("lowMemory", isLowMemory());
         return map;
+    }
+
+    void setBinaryArch(String binaryArch) {
+        this.binaryArch = binaryArch;
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -1366,4 +1366,8 @@ public class Client extends Observable implements Observer {
         return AppData.getDurationMs();
     }
 
+    void setBinaryArch(String binaryArch) {
+        getAppData().setBinaryArch(binaryArch);
+    }
+
 }

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -345,6 +345,13 @@ public class NativeInterface {
     }
 
     /**
+     * Set the binary arch used in the application
+     */
+    public static void setBinaryArch(final String binaryArch) {
+        getClient().setBinaryArch(binaryArch);
+    }
+
+    /**
      * Return the client report app version
      */
     public static String getAppVersion() {


### PR DESCRIPTION
## Goal

64-bit devices on Android can load 32-bit libraries, as mixing between 32/64 bits is not allowed. This changeset explicitly adds the binary arch used by the app at runtime to handled and unhandled reports, to allow the pipeline to select the correct mapping file for stacktrace deobfuscation.

## Changeset

- Added `bsg_binary_arch` to calculate the current architecture.
- Added field to handled native reports by setting the binary arch on `bugsnag_init`, via the `NativeInterface`.
- Added field to unhandled native reports by setting the binary arch in the serializer.

## Tests

Altered existing mazerunner scenarios to ensure that a handled/unhandled native exception contain the `app.binaryArch` field.
