### PR TITLE
Prevent errors from leaving a self-referencing breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Bug fixes
+
+* Prevent errors from leaving a self-referencing breadcrumb
+ [#391](https://github.com/bugsnag/bugsnag-android/pull/391)
+
 ## 4.9.3 (2018-11-29)
 
 ### Bug fixes
 
 * Handle null values in MetaData.mergeMaps, preventing potential NPE
  [#386](https://github.com/bugsnag/bugsnag-android/pull/386)
-
 
 ## 4.9.2 (2018-11-07)
 

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -1229,6 +1229,7 @@ public class Client extends Observable implements Observer {
             Logger.warn("Could not send error(s) to Bugsnag,"
                 + " saving to disk to send later", exception);
             errorStore.write(error);
+            leaveErrorBreadcrumb(error);
         } catch (Exception exception) {
             Logger.warn("Problem sending error to Bugsnag", exception);
         }

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -898,7 +898,9 @@ public class Client extends Observable implements Observer {
             default:
                 break;
         }
+    }
 
+    private void leaveErrorBreadcrumb(@NonNull Error error) {
         // Add a breadcrumb for this error occurring
         String exceptionMessage = error.getExceptionMessage();
         Map<String, String> message = Collections.singletonMap("message", exceptionMessage);
@@ -1222,6 +1224,7 @@ public class Client extends Observable implements Observer {
         try {
             config.getDelivery().deliver(report, config);
             Logger.info("Sent 1 new error to Bugsnag");
+            leaveErrorBreadcrumb(error);
         } catch (DeliveryFailureException exception) {
             Logger.warn("Could not send error(s) to Bugsnag,"
                 + " saving to disk to send later", exception);


### PR DESCRIPTION
## Goal

Calling `bugsnag.notify(exc)` resulted in the creation of a self-referencing breadcrumb. For example, if notify was called once, this would be the result:

<img width="574" alt="screenshot 2018-12-06 at 16 07 08" src="https://user-images.githubusercontent.com/11800640/49595905-05e03300-f971-11e8-9e54-e51a5f58ad67.png">

This changeset fixes the behaviour so that breadcrumbs about previous errors are only added _after_ an error has been serialised.

## Changeset

The Android Notifier has [3 delivery styles when notifying](https://github.com/bugsnag/bugsnag-android/blob/master/sdk/src/main/java/com/bugsnag/android/Client.java#L873
): delivering immediately on the calling thread, delivering on a background thread, and writing on the calling thread then delivering on a background thread. The first two options can be called by users reporting handled exceptions, whereas the third option can only occur when an unhandled exception is propagated to our handler.

In the old implementation if the `DeliveryStyle` was `ASYNC`, a breadcrumb was left after the `Runnable` was submitted for execution. However, at this point there is no guarantee that the task would have been executed, and in practice this leads to a self-referencing breadcrumb.

The fix is to move the addition of the breadcrumb to the `delivery` method, so that the breadcrumb is added after the error is delivered (or stored on disk if delivery was not successful). `ASYNC_WITH_CACHE` does not need to add a breadcrumb, because the JVM should always terminate after this is called.

## Tests

Manually tested `bugsnag.notify(e)`, `bugsnag.notifyBlocking(e)`, and `throw RuntimeException()` to test each possible DeliveryStyle. For each style it was tested that:

- The first handled exception had no error breadcrumb
- The second handled exception had one error breadcrumb
- The third unhandled exception had two error breadcrumbs

Additionally airplane mode was used to fail delivery, to ensure that the breadcrumbs follow the correct behaviour for this mode also.