### PR TITLE
Improve kotlin support by allowing property access

### DIFF
--- a/sdk/lint-baseline.xml
+++ b/sdk/lint-baseline.xml
@@ -2,39 +2,6 @@
 <issues format="4" by="lint 3.2.1" client="gradle" variant="all" version="3.2.1">
 
     <issue
-        id="KotlinPropertyAccess"
-        message="This method should be called `getAutoCaptureSessions` such that `autoCaptureSessions` can be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
-        errorLine1="    public boolean shouldAutoCaptureSessions() {"
-        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="409"
-            column="20"/>
-    </issue>
-
-    <issue
-        id="KotlinPropertyAccess"
-        message="This getter should be public such that `codeBundleId` can be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
-        errorLine1="    String getCodeBundleId() {"
-        errorLine2="           ~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="558"
-            column="12"/>
-    </issue>
-
-    <issue
-        id="KotlinPropertyAccess"
-        message="This getter should be public such that `notifierType` can be accessed as a property from Kotlin; see https://android.github.io/kotlin-guides/interop.html#property-prefixes"
-        errorLine1="    String getNotifierType() {"
-        errorLine2="           ~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="562"
-            column="12"/>
-    </issue>
-
-    <issue
         id="UnknownNullness"
         message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
         errorLine1="    public BadResponseException(String msg, int responseCode) {"
@@ -1152,7 +1119,7 @@
         errorLine2="                                ~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="546"
+            line="557"
             column="33"/>
     </issue>
 
@@ -1163,8 +1130,30 @@
         errorLine2="                                ~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="554"
+            line="565"
             column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getCodeBundleId() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="569"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public String getNotifierType() {"
+        errorLine2="           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/Configuration.java"
+            line="573"
+            column="12"/>
     </issue>
 
     <issue
@@ -1174,7 +1163,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="627"
+            line="638"
             column="12"/>
     </issue>
 
@@ -1185,7 +1174,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="640"
+            line="651"
             column="12"/>
     </issue>
 
@@ -1196,7 +1185,7 @@
         errorLine2="                           ~~~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="669"
+            line="680"
             column="28"/>
     </issue>
 
@@ -1207,7 +1196,7 @@
         errorLine2="                                                  ~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="681"
+            line="692"
             column="51"/>
     </issue>
 
@@ -1218,7 +1207,7 @@
         errorLine2="                                        ~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="696"
+            line="707"
             column="41"/>
     </issue>
 
@@ -1229,7 +1218,7 @@
         errorLine2="                                ~~~~~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="710"
+            line="721"
             column="33"/>
     </issue>
 
@@ -1240,7 +1229,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="721"
+            line="732"
             column="43"/>
     </issue>
 
@@ -1251,7 +1240,7 @@
         errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/Configuration.java"
-            line="750"
+            line="761"
             column="15"/>
     </issue>
 
@@ -1830,11 +1819,22 @@
     <issue
         id="UnknownNullness"
         message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public static void setBinaryArch(final String binaryArch) {"
+        errorLine2="                                           ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/NativeInterface.java"
+            line="350"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
         errorLine1="    public static String getAppVersion() {"
         errorLine2="                  ~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/NativeInterface.java"
-            line="350"
+            line="357"
             column="19"/>
     </issue>
 
@@ -1845,7 +1845,7 @@
         errorLine2="                  ~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/NativeInterface.java"
-            line="357"
+            line="364"
             column="19"/>
     </issue>
 
@@ -1856,7 +1856,7 @@
         errorLine2="                                              ~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/NativeInterface.java"
-            line="364"
+            line="371"
             column="47"/>
     </issue>
 
@@ -1867,7 +1867,7 @@
         errorLine2="                                     ~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/NativeInterface.java"
-            line="376"
+            line="383"
             column="38"/>
     </issue>
 
@@ -1878,7 +1878,7 @@
         errorLine2="                                                          ~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/NativeInterface.java"
-            line="376"
+            line="383"
             column="59"/>
     </issue>
 
@@ -1889,7 +1889,7 @@
         errorLine2="                                    ~~~~~~~~">
         <location
             file="src/main/java/com/bugsnag/android/NativeInterface.java"
-            line="396"
+            line="403"
             column="37"/>
     </issue>
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
@@ -47,7 +47,7 @@ public class ClientConfigTest {
     @Test
     public void testSetAutoCaptureSessions() throws Exception {
         client.setAutoCaptureSessions(true);
-        assertEquals(true, config.shouldAutoCaptureSessions());
+        assertEquals(true, config.getAutoCaptureSessions());
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -218,7 +218,7 @@ public class ClientTest {
         assertEquals(false, protoConfig.getSendThreads());
         assertEquals(false, protoConfig.getEnableExceptionHandler());
         assertEquals(true, protoConfig.getPersistUserBetweenSessions());
-        assertEquals(true, protoConfig.shouldAutoCaptureSessions());
+        assertEquals(true, protoConfig.getAutoCaptureSessions());
     }
 
     @SuppressWarnings("deprecation") // test backwards compatibility of client.setMaxBreadcrumbs

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
@@ -58,15 +58,15 @@ public class ConfigurationTest {
     public void testInvalidSessionEndpoint() {
         //noinspection ConstantConditions
         config.setEndpoints("http://example.com", null);
-        assertFalse(config.shouldAutoCaptureSessions());
+        assertFalse(config.getAutoCaptureSessions());
         assertNull(config.getSessionEndpoint());
 
         config.setEndpoints("http://example.com", "");
-        assertFalse(config.shouldAutoCaptureSessions());
+        assertFalse(config.getAutoCaptureSessions());
         assertNull(config.getSessionEndpoint());
 
         config.setEndpoints("http://example.com", "http://sessions.example.com");
-        assertFalse(config.shouldAutoCaptureSessions());
+        assertFalse(config.getAutoCaptureSessions());
         assertEquals("http://sessions.example.com", config.getSessionEndpoint());
     }
 
@@ -74,7 +74,7 @@ public class ConfigurationTest {
     public void testAutoCaptureOverride() {
         config.setAutoCaptureSessions(false);
         config.setEndpoints("http://example.com", "http://example.com");
-        assertFalse(config.shouldAutoCaptureSessions());
+        assertFalse(config.getAutoCaptureSessions());
     }
 
     @SuppressWarnings("deprecation")
@@ -163,9 +163,9 @@ public class ConfigurationTest {
 
     @Test
     public void testAutoCaptureSessions() throws Exception {
-        assertTrue(config.shouldAutoCaptureSessions());
+        assertTrue(config.getAutoCaptureSessions());
         config.setAutoCaptureSessions(false);
-        assertFalse(config.shouldAutoCaptureSessions());
+        assertFalse(config.getAutoCaptureSessions());
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -405,8 +405,19 @@ public class Configuration extends Observable implements Observer {
      * Get whether or not User sessions are captured automatically.
      *
      * @return true if sessions are captured automatically
+     * @deprecated use {@link #getAutoCaptureSessions()}
      */
+    @Deprecated
     public boolean shouldAutoCaptureSessions() {
+        return getAutoCaptureSessions();
+    }
+
+    /**
+     * Get whether or not User sessions are captured automatically.
+     *
+     * @return true if sessions are captured automatically
+     */
+    public boolean getAutoCaptureSessions() {
         return autoCaptureSessions;
     }
 
@@ -555,11 +566,11 @@ public class Configuration extends Observable implements Observer {
         this.codeBundleId = codeBundleId;
     }
 
-    String getCodeBundleId() {
+    public String getCodeBundleId() {
         return codeBundleId;
     }
 
-    String getNotifierType() {
+    public String getNotifierType() {
         return notifierType;
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -404,7 +404,7 @@ public class Error implements JsonStream.Streamable {
             this.severityReasonType = HandledState.REASON_USER_SPECIFIED; // default
 
             if (session != null
-                && !config.shouldAutoCaptureSessions() && session.isAutoCaptured()) {
+                && !config.getAutoCaptureSessions() && session.isAutoCaptured()) {
                 this.session = null;
             } else {
                 this.session = session;

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -59,7 +59,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     /**
      * Starts a new session with the given date and user.
      * <p>
-     * A session will only be created if {@link Configuration#shouldAutoCaptureSessions()} returns
+     * A session will only be created if {@link Configuration#getAutoCaptureSessions()} returns
      * true.
      *
      * @param date the session start date
@@ -88,7 +88,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         boolean notifyForRelease = configuration.shouldNotifyForReleaseStage(getReleaseStage());
 
         if (notifyForRelease
-            && (configuration.shouldAutoCaptureSessions() || !session.isAutoCaptured())
+            && (configuration.getAutoCaptureSessions() || !session.isAutoCaptured())
             && session.isTracked().compareAndSet(false, true)) {
             try {
                 final String endpoint = configuration.getSessionEndpoint();
@@ -288,7 +288,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
             //FUTURE:SM Race condition between isEmpty and put
             if (foregroundActivities.isEmpty()
                 && noActivityRunningForMs >= timeoutMs
-                && configuration.shouldAutoCaptureSessions()) {
+                && configuration.getAutoCaptureSessions()) {
 
                 activityFirstStartedAtMs.set(nowMs);
                 startNewSession(new Date(nowMs), client.getUser(), true);


### PR DESCRIPTION

## Goal

If public getters/setters are available for a Java field, then this code can be called from Kotlin using the [property access syntax](https://kotlinlang.org/docs/reference/java-interop.html#getters-and-setters). This gives users the choice of using a more Kotlin-esque syntax:

```
config.autoCaptureSessions = false
```

while retaining backward compatibility with the previous interface:

```
config.setAutoCaptureSessions(false)
```

## Changeset

- A public getter and setter were added for the `autoCaptureSessions`, `codeBundleId`, and `notifierType` properties.
- `shouldAutoCaptureSessions()` was deprecated and forward onto `getAutoCaptureSessions()`
- Internal use of `shouldAutoCaptureSessions()` was changed to `getAutoCaptureSessions()` to avoid using deprecated code
- All `KotlinPropertyAccess` checks were removed from the lint_baseline file, which suppresses warnings.
- The lint_baseline file was regenerated to account for new violations added in #389, and changes in line numbers.

## Tests

Ran existing unit tests + mazerunner scenarios on CI.
