### PR TITLE
Specify maven central as a preferred repository over jcenter

### DIFF
--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -15,6 +16,7 @@ apply plugin: 'kotlin-android'
 
 repositories {
     google()
+    mavenCentral()
     jcenter()
 }
 

--- a/features/fixtures/mazerunner/build.gradle
+++ b/features/fixtures/mazerunner/build.gradle
@@ -1,5 +1,6 @@
 repositories {
     google()
+    mavenCentral()
     jcenter()
     flatDir {
         dirs 'libs'
@@ -10,6 +11,7 @@ apply plugin: 'com.android.application'
 buildscript {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     ext.kotlin_version = '1.2.30'

--- a/ndk/build.gradle
+++ b/ndk/build.gradle
@@ -6,8 +6,9 @@ apply plugin: 'com.jfrog.bintray'
 archivesBaseName = "bugsnag-android-ndk"
 
 repositories {
-    jcenter()
     google()
+    mavenCentral()
+    jcenter()
 }
 
 android {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'kotlin-android'
 
 repositories {
     google()
+    mavenCentral()
     jcenter()
 }
 


### PR DESCRIPTION
## Goal

Specifying `mavenCentral` as a repository in addition to `jcenter` makes it possible to perform a clean build of the project in the case where one provider suffers downtime.