### PR TITLE
Prevent Bugsnag.init from instantiating more than one client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Prevent errors from leaving a self-referencing breadcrumb
  [#391](https://github.com/bugsnag/bugsnag-android/pull/391)
 
+* Prevent Bugsnag.init from instantiating more than one client
+ [#403](https://github.com/bugsnag/bugsnag-android/pull/403)
+
+
 ## 4.9.3 (2018-11-29)
 
 ### Bug fixes

--- a/features/bugsnag_init.feature
+++ b/features/bugsnag_init.feature
@@ -1,0 +1,7 @@
+Feature: Reporting app version
+
+Scenario: Test handled Android Exception
+    When I run "BugsnagInitScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the event "metaData.client.count" equals 1

--- a/features/fixtures/mazerunner/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
             </intent-filter>
         </activity>
         <activity android:name=".SecondActivity"/>
+        <meta-data
+            android:name="com.bugsnag.android.API_KEY"
+            android:value="YOUR-API-KEY-HERE" />
     </application>
 
 </manifest>

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/BugsnagInitScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/BugsnagInitScenario.kt
@@ -1,0 +1,39 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Client
+import com.bugsnag.android.Configuration
+import java.lang.RuntimeException
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+
+internal class BugsnagInitScenario(
+    config: Configuration,
+    context: Context
+) : Scenario(config, context) {
+
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        val threadPool = Executors.newFixedThreadPool(8)
+        val callables = mutableListOf<Callable<Client?>>()
+
+        IntRange(1, 25).forEach {
+            callables.add(Callable { Bugsnag.init(context) })
+            callables.add(Callable { Bugsnag.init(context, config.apiKey) })
+            callables.add(Callable { Bugsnag.init(context, config.apiKey, false) })
+            callables.add(Callable { Bugsnag.init(context, Configuration(config.apiKey)) })
+        }
+
+        val futures = threadPool.invokeAll(callables)
+        val uniqueClients = futures.map { it.get() }.distinct()
+
+        val bugsnag = uniqueClients.first()!!
+        bugsnag.addToTab("client", "count", uniqueClients.size)
+        bugsnag.notify(RuntimeException())
+    }
+
+}

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -106,9 +106,9 @@ public final class Bugsnag {
     }
 
     private static void logClientInitWarning() {
-        Logger.warn("It appears that Bugsnag.init() was called more than once. Subsequent " +
-            "calls have no effect, but may indicate that Bugsnag is not integrated in an" +
-            " Application subclass, which can lead to undesired behaviour.");
+        Logger.warn("It appears that Bugsnag.init() was called more than once. Subsequent "
+            + "calls have no effect, but may indicate that Bugsnag is not integrated in an"
+            + " Application subclass, which can lead to undesired behaviour.");
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -22,7 +22,7 @@ public final class Bugsnag {
     private static final Object lock = new Object();
 
     @SuppressLint("StaticFieldLeak")
-    static volatile Client client;
+    static Client client;
 
     private Bugsnag() {
     }

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -34,15 +34,7 @@ public final class Bugsnag {
      */
     @NonNull
     public static Client init(@NonNull Context androidContext) {
-        synchronized (lock) {
-            if (client == null) {
-                client = new Client(androidContext);
-                NativeInterface.configureClientObservers(client);
-            } else {
-                logClientInitWarning();
-            }
-        }
-        return client;
+        return init(androidContext, null, true);
     }
 
     /**
@@ -53,15 +45,7 @@ public final class Bugsnag {
      */
     @NonNull
     public static Client init(@NonNull Context androidContext, @Nullable String apiKey) {
-        synchronized (lock) {
-            if (client == null) {
-                client = new Client(androidContext, apiKey);
-                NativeInterface.configureClientObservers(client);
-            } else {
-                logClientInitWarning();
-            }
-        }
-        return client;
+        return init(androidContext, apiKey, true);
     }
 
     /**
@@ -75,15 +59,9 @@ public final class Bugsnag {
     public static Client init(@NonNull Context androidContext,
                               @Nullable String apiKey,
                               boolean enableExceptionHandler) {
-        synchronized (lock) {
-            if (client == null) {
-                client = new Client(androidContext, apiKey, enableExceptionHandler);
-                NativeInterface.configureClientObservers(client);
-            } else {
-                logClientInitWarning();
-            }
-        }
-        return client;
+        Configuration config
+            = ConfigFactory.createNewConfiguration(androidContext, apiKey, enableExceptionHandler);
+        return init(androidContext, config);
     }
 
     /**


### PR DESCRIPTION
## Goal

If `Bugsnag.init` is called multiple times, multiple `Client` objects will be instantiated. This is generally not the desired behaviour, could lead to undesired side-effects, and is also a very expensive operation (approx 100ms for each initialisation on a test device).

For a real world example, if `Bugsnag.init` is called from within `onCreate` in an `Activity` rather than an `Application` subclass, it's possible that multiple clients could be instantiated over the [app's lifecycle](https://developer.android.com/guide/components/activities/intro-activities#mtal).

This changeset alters `Bugsnag.init` so that it will only instantiate a `Client` if one hasn't been created already. For exceptional cases where a user needs to instantiate multiple `Client` objects, it remains possible to do so by invoking the `Client` constructor directly.

## Changeset

- Synchronized initialisation code within the `Bugsnag.init` methods, so that only one thread can attempt initialisation at a time.
- Only created a new `Client` object if the existing field is null, and otherwise return the existing instance.
- Log a warning if the existing client field is not null, as this most likely indicates the integration is not following our latest recommendations.

## Tests

- Ran the example app with two `Bugsnag.init` calls, and verified that a warning was logged.
- Created a mazerunner test which repeatedly invokes all method variants of `Bugsnag.init` on multiple threads, and verifies only one client was created.
<!-- How was it tested? -->
