### PR TITLE
Migrate metaData.device.cpuAbi to device.cpuAbi in JSON payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.X.X (TBD)
 
+* Migrate metaData.device.cpuAbi to device.cpuAbi in JSON payload
+ [#404](https://github.com/bugsnag/bugsnag-android/pull/404)
+
 * Added additional nullability annotations to public API
  [#395](https://github.com/bugsnag/bugsnag-android/pull/395)
 

--- a/features/handled_exception.feature
+++ b/features/handled_exception.feature
@@ -9,6 +9,7 @@ Scenario: Test handled Kotlin Exception
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "HandledExceptionScenario"
+    And the payload field "events.0.device.cpuAbi" is a non-empty array for request 0
 
 Scenario: Test handled Java Exception
     When I run "HandledExceptionJavaScenario"

--- a/features/native_api.feature
+++ b/features/native_api.feature
@@ -13,6 +13,7 @@ Feature: Native API
         And the event "user.email" is null
         And the event "unhandled" is false
         And the event "app.binaryArch" is not null
+        And the payload field "events.0.device.cpuAbi" is a non-empty array for request 0
 
     Scenario: Adding user information in Java followed by a C crash
         When I run "CXXJavaUserInfoNativeCrashScenario"

--- a/features/native_crash_handling.feature
+++ b/features/native_crash_handling.feature
@@ -12,6 +12,7 @@ Feature: Native crash reporting
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the event "app.binaryArch" is not null
+        And the payload field "events.0.device.cpuAbi" is a non-empty array for request 0
 
     # This scenario will not pass on API levels < 18, as stack corruption
     # is handled without calling atexit handlers, etc.

--- a/features/steps/build_steps.rb
+++ b/features/steps/build_steps.rb
@@ -139,7 +139,7 @@ Then("the report in request {int} contains the required fields") do |index|
     And the payload field "events.0.metaData.device.time" is not null for request #{index}
     And the payload field "events.0.severity" is not null for request #{index}
     And the payload field "events.0.severityReason.type" is not null for request #{index}
-    And the payload field "events.0.metaData.device.cpuAbi" is a non-empty array for request #{index}
+    And the payload field "events.0.device.cpuAbi" is a non-empty array for request #{index}
   }
 end
 

--- a/features/unhandled_exception.feature
+++ b/features/unhandled_exception.feature
@@ -10,6 +10,7 @@ Scenario: Test Unhandled Kotlin Exception without Session
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "UnhandledExceptionScenario"
     And the event "session" is null
+    And the payload field "events.0.device.cpuAbi" is a non-empty array for request 0
 
 Scenario: Test Unhandled Java Exception with Session
     When I run "UnhandledExceptionJavaScenario"

--- a/ndk/src/main/jni/utils/serializer.c
+++ b/ndk/src/main/jni/utils/serializer.c
@@ -184,6 +184,14 @@ char *bsg_serialize_report_to_json_string(bugsnag_report *report) {
     json_object_dotset_string(event, "device.model", report->device.model);
     json_object_dotset_string(event, "device.orientation",
                               report->device.orientation);
+
+    JSON_Value *abi_val = json_value_init_array();
+    JSON_Array *cpu_abis = json_value_get_array(abi_val);
+    json_object_dotset_value(event, "device.cpuAbi", abi_val);
+    for (int i = 0; i < report->device.cpu_abi_count; i++) {
+        json_array_append_string(cpu_abis, report->device.cpu_abi[i].value);
+    }
+
     json_object_dotset_string(event, "metaData.device.osBuild",
                               report->device.os_build);
     json_object_dotset_number(event, "device.totalMemory",
@@ -213,12 +221,6 @@ char *bsg_serialize_report_to_json_string(bugsnag_report *report) {
       strftime(report_time, sizeof report_time, "%FT%TZ",
                gmtime(&report->device.time));
       json_object_dotset_string(event, "metaData.device.time", report_time);
-    }
-    JSON_Value *abi_val = json_value_init_array();
-    JSON_Array *cpu_abis = json_value_get_array(abi_val);
-    json_object_dotset_value(event, "metaData.device.cpuAbi", abi_val);
-    for (int i = 0; i < report->device.cpu_abi_count; i++) {
-      json_array_append_string(cpu_abis, report->device.cpu_abi[i].value);
     }
 
     // Serialize custom metadata

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -333,7 +333,7 @@ public class ClientTest {
         Client client = generateClient();
         Map<String, Object> metaData = client.getDeviceData().getDeviceMetaData();
 
-        assertEquals(14, metaData.size());
+        assertEquals(13, metaData.size());
         assertNotNull(metaData.get("batteryLevel"));
         assertNotNull(metaData.get("charging"));
         assertNotNull(metaData.get("locationStatus"));
@@ -347,6 +347,5 @@ public class ClientTest {
         assertNotNull(metaData.get("dpi"));
         assertNotNull(metaData.get("emulator"));
         assertNotNull(metaData.get("screenResolution"));
-        assertNotNull(metaData.get("cpuAbi"));
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
@@ -66,6 +66,7 @@ public class DeviceDataSummaryTest {
         assertNotNull(deviceDataJson.getString("osVersion"));
         assertNotNull(deviceDataJson.getString("manufacturer"));
         assertNotNull(deviceDataJson.getString("model"));
+        assertNotNull(deviceDataJson.get("cpuAbi"));
         assertTrue(deviceDataJson.has("jailbroken"));
     }
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorReaderTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorReaderTest.java
@@ -139,6 +139,11 @@ public class ErrorReaderTest {
         assertEquals("sdk_phone_armv7", data.get("model"));
         assertEquals("portrait", data.get("orientation"));
         assertEquals(134217728, data.get("totalMemory"));
+
+        @SuppressWarnings("unchecked")
+        List<String> cpuAbi = (List<String>) data.get("cpuAbi");
+        assertEquals("armeabi-v7a", cpuAbi.get(0));
+        assertEquals("armeabi", cpuAbi.get(1));
     }
 
     @Test
@@ -174,10 +179,6 @@ public class ErrorReaderTest {
         assertEquals(1, metadata.getTab("device").get("screenDensity"));
         assertEquals("480x320", metadata.getTab("device").get("screenResolution"));
         assertEquals("2018-10-19T18:56:13Z", metadata.getTab("device").get("time"));
-        @SuppressWarnings("unchecked")
-        List<String> cpuAbi = (List<String>)metadata.getTab("device").get("cpuAbi");
-        assertEquals("armeabi-v7a", cpuAbi.get(0));
-        assertEquals("armeabi", cpuAbi.get(1));
     }
 
     @Test

--- a/sdk/src/androidTest/res/raw/error.json
+++ b/sdk/src/androidTest/res/raw/error.json
@@ -90,11 +90,7 @@
       "dpi": 160,
       "screenDensity": 1,
       "screenResolution": "480x320",
-      "time": "2018-10-19T18:56:13Z",
-      "cpuAbi": [
-        "armeabi-v7a",
-        "armeabi"
-      ]
+      "time": "2018-10-19T18:56:13Z"
     },
     "customer": {
       "name": "Acme Co",
@@ -109,7 +105,11 @@
     "manufacturer": "Hudan",
     "model": "sdk_phone_armv7",
     "orientation": "portrait",
-    "totalMemory": 134217728
+    "totalMemory": 134217728,
+    "cpuAbi": [
+      "armeabi-v7a",
+      "armeabi"
+    ]
   },
   "session": {
     "id": "225bcada-e0c8-15a0-0bba-0e3c7f43c13f",

--- a/sdk/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeviceData.java
@@ -95,6 +95,7 @@ class DeviceData {
         map.put("jailbroken", isRooted());
         map.put("osName", "android");
         map.put("osVersion", Build.VERSION.RELEASE);
+        map.put("cpuAbi", cpuAbi);
         return map;
     }
 
@@ -123,7 +124,6 @@ class DeviceData {
         map.put("dpi", dpi);
         map.put("emulator", emulator);
         map.put("screenResolution", screenResolution);
-        map.put("cpuAbi", cpuAbi);
         return map;
     }
 


### PR DESCRIPTION
## Goal

The `cpuAbi` field has been added to structured data within the payload, so should ideally be present at `device.cpuAbi`.

## Changeset

The cpuAbi array is now added into the `device` object for both the Java + C report serialisers.

## Tests
Existing unit tests for JVM serialisation have been updated, and additional steps have been added to mazerunner scenarios to validate the location of this field.

I also manually inspected the payload for handled/unhandled JVM + C crashes, and verified that the field only existed at `device.cpuAbi`.
