### PR TITLE
Make config.metadata publicly accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Make config.metadata publicly accessible
+ [#406](https://github.com/bugsnag/bugsnag-android/pull/406)
+
 * Prevent errors from leaving a self-referencing breadcrumb
  [#391](https://github.com/bugsnag/bugsnag-android/pull/391)
 

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -428,7 +428,7 @@ public class Configuration extends Observable implements Observer {
      * @return meta data
      */
     @NonNull
-    protected MetaData getMetaData() {
+    public MetaData getMetaData() {
         return metaData;
     }
 
@@ -437,7 +437,7 @@ public class Configuration extends Observable implements Observer {
      *
      * @param metaData meta data
      */
-    protected void setMetaData(@NonNull MetaData metaData) {
+    public void setMetaData(@NonNull MetaData metaData) {
         this.metaData.deleteObserver(this);
         //noinspection ConstantConditions
         if (metaData == null) {


### PR DESCRIPTION
## Goal

The accessors for `metadata` in `Configuration` are currently `protected`, so are not accessible despite being documented as such. Altering their visibility to `public` will allow these methods to be used as part of our API.
