### PR TITLE
Prevent unnecessary free disk calculations on initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Bug fixes
+
+* Prevent unnecessary free disk calculations on initialisation
+ [#409](https://github.com/bugsnag/bugsnag-android/pull/409)
+
 ## 4.10.0 (2019-01-07)
 
 * Improve kotlin support by allowing property access

--- a/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -217,19 +217,24 @@ public class NativeBridge implements Observer {
                 return;
             }
             String reportPath = reportDirectory + UUID.randomUUID().toString() + ".crash";
-            String[] abis = (String[])NativeInterface.getDeviceData().get("cpuAbi");
-            boolean is32bit = true;
-            for (String abi : abis) {
-                if (abi.contains("64")) {
-                    is32bit = false;
-                    break;
-                }
-            }
-            install(reportPath, true, Build.VERSION.SDK_INT, is32bit);
+            install(reportPath, true, Build.VERSION.SDK_INT, is32bit());
             installed.set(true);
         } finally {
             lock.unlock();
         }
+    }
+
+    private boolean is32bit() {
+        String[] abis = NativeInterface.getCpuAbi();
+
+        boolean is32bit = true;
+        for (String abi : abis) {
+            if (abi.contains("64")) {
+                is32bit = false;
+                break;
+            }
+        }
+        return is32bit;
     }
 
     private void handleAddBreadcrumb(Object arg) {

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -146,7 +146,7 @@ public class Client extends Observable implements Observer {
         // Set sensible defaults
         setProjectPackages(appContext.getPackageName());
 
-        String deviceId = getStringFromMap("id", deviceData.getDeviceData());
+        String deviceId = deviceData.getId();
 
         if (config.getPersistUserBetweenSessions()) {
             // Check to see if a user was stored in the SharedPreferences

--- a/sdk/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeviceData.java
@@ -127,6 +127,10 @@ class DeviceData {
         return map;
     }
 
+    String getId() {
+        return id;
+    }
+
     /**
      * Check if the current Android device is rooted
      */

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -16,6 +16,7 @@ import java.util.Queue;
  * Used as the entry point for native code to allow proguard to obfuscate other areas if needed
  */
 public class NativeInterface {
+
     public enum MessageType {
         /**
          * Add a breadcrumb. The Message object should be the breadcrumb
@@ -231,6 +232,14 @@ public class NativeInterface {
         deviceData.putAll(source.getDeviceMetaData());
         deviceData.putAll(source.getDeviceData()); // wat
         return deviceData;
+    }
+
+    /**
+     * Retrieve the CPU ABI(s) for the current device
+     */
+    @NonNull
+    public static String[] getCpuAbi() {
+        return getClient().deviceData.cpuAbi;
     }
 
     /**


### PR DESCRIPTION
## Goal

On initialisation of bugsnag-android, `calculateFreeDisk` was indirectly invoked, which performs IO on the main thread. This triggers unnecessary [StrictMode](https://developer.android.com/reference/android/os/StrictMode) violations, which can be observed by integrating the SDK into any app, and viewing logcat output on launch.

## Design

`getDeviceData()` triggers these calculations. In the case of initialisation, the free disk information is not actually required, so the `DeviceData` class was adapted to add accessors for only the necessary information.

It's worth noting that there will still be a violation when notifying of an error, as we need to calculate the freeDisk information each time at this point.

## Changeset

Added accessors for `device.id` and `device.cpuAbi`.

## Tests

Enabled StrictMode in the example app and verified that stacktraces were no longer logged on initialisation, when filtering by 'calculateFreeDisk'.
