### PR TITLE
Simplify test teardown using a RunListener

### DIFF
--- a/sdk/src/androidTest/AndroidManifest.xml
+++ b/sdk/src/androidTest/AndroidManifest.xml
@@ -8,4 +8,12 @@
 
   <application android:label="Bugsnag Android Tests"></application>
 
+  <instrumentation
+    android:name="android.support.test.runner.AndroidJUnitRunner"
+    android:targetPackage="com.bugsnag.android">
+    <meta-data
+      android:name="listener"
+      android:value="com.bugsnag.android.TestRunListener" />
+  </instrumentation>
+
 </manifest>

--- a/sdk/src/androidTest/java/com/bugsnag/android/AppDataSummaryTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AppDataSummaryTest.java
@@ -36,11 +36,6 @@ public class AppDataSummaryTest {
         this.appData = appData.getAppDataSummary();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testVersionCode() {
         assertEquals(1, appData.get("versionCode"));

--- a/sdk/src/androidTest/java/com/bugsnag/android/AppDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AppDataTest.java
@@ -42,11 +42,6 @@ public class AppDataTest {
         appData = new AppData(client).getAppData();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testPackageName() {
         assertEquals("com.bugsnag.android.test", appData.get("packageName"));

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
@@ -34,11 +34,6 @@ public class BeforeRecordBreadcrumbsTest {
         assertEquals(0, client.breadcrumbs.store.size());
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void noCallback() throws Exception {
         client.leaveBreadcrumb("Hello");

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendTest.java
@@ -47,7 +47,6 @@ public class BeforeSendTest {
     @After
     public void tearDown() throws Exception {
         lastReport = null;
-        Async.cancelTasks();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbLifecycleCrashTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbLifecycleCrashTest.java
@@ -29,11 +29,6 @@ public class BreadcrumbLifecycleCrashTest {
         sessionTracker = new SessionTracker(configuration, null, sessionStore);
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testLifecycleBreadcrumbCrash() {
         // should not crash with a null client

--- a/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbsTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbsTest.kt
@@ -30,10 +30,6 @@ class BreadcrumbsTest {
         breadcrumbs = Breadcrumbs(config)
     }
 
-    @After
-    fun tearDown() {
-        Async.cancelTasks()
-    }
 
     /**
      * Verifies that the breadcrumb message is truncated after the max limit is reached

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
@@ -33,11 +33,6 @@ public class ClientConfigTest {
         client = new Client(context, config);
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testSetReleaseStage() throws Exception {
         client.setReleaseStage("beta");

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
@@ -34,11 +34,6 @@ public class ClientNotifyTest {
         client.setErrorReportApiClient(apiClient);
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testNotifyBlockingDefaultSeverity() {
         client.notifyBlocking(new RuntimeException("Testing"));

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -51,7 +51,6 @@ public class ClientTest {
     @After
     public void tearDown() throws Exception {
         clearSharedPrefs();
-        Async.cancelTasks();
     }
 
     private void clearSharedPrefs() {

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -26,11 +26,6 @@ public class ConcurrentCallbackTest {
         client = BugsnagTestUtils.generateClient();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testClientNotifyModification() throws Exception {
         final Collection<BeforeNotify> beforeNotifyTasks = client.config.getBeforeNotifyTasks();

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
@@ -28,11 +28,6 @@ public class ConfigurationTest {
         config = new Configuration("api-key");
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testEndpoints() {
         String notify = "https://notify.myexample.com";

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeliveryCompatTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeliveryCompatTest.java
@@ -30,11 +30,6 @@ public class DeliveryCompatTest {
         deliveryCompat = new DeliveryCompat();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @SuppressWarnings("deprecation")
     @Test
     public void deliverReport() throws Exception {

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
@@ -33,11 +33,6 @@ public class DeviceDataSummaryTest {
         this.deviceData = deviceData.getDeviceDataSummary();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testManufacturer() {
         assertNotNull(deviceData.get("manufacturer"));

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -33,11 +33,6 @@ public class DeviceDataTest {
         this.deviceData = deviceData.getDeviceData();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testId() {
         assertNotNull(deviceData.get("id"));

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorReportApiClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorReportApiClientTest.java
@@ -26,11 +26,6 @@ public class ErrorReportApiClientTest {
         Bugsnag.init(InstrumentationRegistry.getContext(), "123");
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @SuppressWarnings("deprecation")
     @Test(expected = IllegalArgumentException.class)
     public void testApiClientNullValidation() {

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -44,11 +44,6 @@ public class ErrorTest {
         error = new Error.Builder(config, exception, null, Thread.currentThread(), false).build();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testShouldIgnoreClass() {
         config.setIgnoreClasses(new String[]{"java.io.IOException"});

--- a/sdk/src/androidTest/java/com/bugsnag/android/ExceptionHandlerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ExceptionHandlerTest.java
@@ -33,11 +33,6 @@ public class ExceptionHandlerTest {
         Thread.setDefaultUncaughtExceptionHandler(null);
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testEnableDisable() {
         Client client = new Client(context, "api-key");

--- a/sdk/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
@@ -29,11 +29,6 @@ public class ExceptionsTest {
         config = new Configuration("api-key");
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testBasicException() throws JSONException, IOException {
         Exceptions exceptions = new Exceptions(config, new RuntimeException("oops"));

--- a/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/JsonStreamTest.java
@@ -43,11 +43,6 @@ public class JsonStreamTest {
         file.delete();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testSaneValues() throws JSONException, IOException {
         final Long nullLong = null;

--- a/sdk/src/androidTest/java/com/bugsnag/android/MetaDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/MetaDataTest.java
@@ -36,11 +36,6 @@ public class MetaDataTest {
         client = BugsnagTestUtils.generateClient();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testBasicSerialization() throws JSONException, IOException {
         MetaData metaData = new MetaData();

--- a/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
@@ -35,11 +35,6 @@ public class NullMetadataTest {
         throwable = new RuntimeException("Test");
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testErrorDefaultMetaData() throws Exception {
         Error error = new Error.Builder(config, throwable, null,

--- a/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -43,11 +43,6 @@ public class ObserverInterfaceTest {
         client.addObserver(observer);
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testUpdateMetadataFromClientSendsMessage() {
         MetaData metadata = new MetaData(new HashMap<String, Object>());

--- a/sdk/src/androidTest/java/com/bugsnag/android/ReportTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ReportTest.java
@@ -36,11 +36,6 @@ public class ReportTest {
         report = new Report("api-key", error);
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void testInMemoryError() throws JSONException, IOException {
         JSONObject reportJson = streamableToJson(report);

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -45,7 +45,6 @@ public class SessionStoreTest {
      */
     @After
     public void tearDown() throws Exception {
-        Async.cancelTasks();
         FileUtils.clearFilesInDir(storageDir);
     }
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -39,11 +39,6 @@ public class SessionTrackerTest {
         user = new User();
     }
 
-    @After
-    public void tearDown() throws Exception {
-        Async.cancelTasks();
-    }
-
     @Test
     public void startNewSession() throws Exception {
         assertNotNull(sessionTracker);

--- a/sdk/src/androidTest/java/com/bugsnag/android/TestRunListener.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/TestRunListener.kt
@@ -1,0 +1,12 @@
+package com.bugsnag.android
+
+import org.junit.runner.Description
+import org.junit.runner.notification.RunListener
+
+class TestRunListener : RunListener() {
+
+    override fun testFinished(description: Description) {
+        super.testFinished(description)
+        Async.cancelTasks()
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/UniqueBeforeNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/UniqueBeforeNotifyTest.java
@@ -44,7 +44,6 @@ public class UniqueBeforeNotifyTest {
     @After
     public void tearDown() throws Exception {
         callbackCount = 0;
-        Async.cancelTasks();
     }
 
     @Test


### PR DESCRIPTION
## Goal
Our instrumentation tests currently need to cancel asynchronous tasks which are started within the `Client` constructor, at the end of each test run. The code that achieves this is currently spread out across multiple classes and easy to forget to add to new tests.

## Design
JUnit offers a `RunListener` interface, which has a method that is invoked after each test is completed. Specifying this is preferable to using `@After` for teardown, as we only need to cancel asynchronous tasks from one place.

## Changeset

Added a custom `RunListener`, which can be [invoked after each test finishes](https://developer.android.com/reference/android/support/test/runner/AndroidJUnitRunner#typical-usage). This cancels tasks which have been submitted to the Executor.