### PR TITLE
Cache result of device root check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Bug fixes
+
+* Cache result of device root check
+  [#411](https://github.com/bugsnag/bugsnag-android/pull/411)
+
 ## 4.10.0 (2019-01-07)
 
 * Improve kotlin support by allowing property access

--- a/sdk/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeviceData.java
@@ -52,6 +52,7 @@ class DeviceData {
     private final Resources resources;
     private final DisplayMetrics displayMetrics;
     private final String id;
+    private final boolean rooted;
 
     @Nullable
     Float screenDensity;
@@ -86,13 +87,14 @@ class DeviceData {
         cpuAbi = getCpuAbi();
         emulator = isEmulator();
         id = retrieveUniqueInstallId();
+        rooted = isRooted();
     }
 
     Map<String, Object> getDeviceDataSummary() {
         Map<String, Object> map = new HashMap<>();
         map.put("manufacturer", Build.MANUFACTURER);
         map.put("model", Build.MODEL);
-        map.put("jailbroken", isRooted());
+        map.put("jailbroken", rooted);
         map.put("osName", "android");
         map.put("osVersion", Build.VERSION.RELEASE);
         map.put("cpuAbi", cpuAbi);


### PR DESCRIPTION
## Goal

By default, we should cache the result of whether the device is rooted or not, as the result is unlikely to change between app launches and the calculation requires IO.

## Changeset

Cached the result of the root check in a field when `DeviceData` is constructed.

## Tests

Enabled StrictMode in the example app and verified that only one stacktrace was logged on initialisation, when filtering by 'isRooted'.
