### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     ext.kotlin_version = '1.3.10'
-    ext.agpVersion = "3.2.1"
+    ext.agpVersion = '3.3.0'
 
     dependencies {
         classpath "com.android.tools.build:gradle:$agpVersion"

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$agpVersion"
-        classpath 'com.bugsnag:bugsnag-android-gradle-plugin:3.4.2'
+        classpath 'com.bugsnag:bugsnag-android-gradle-plugin:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -74,7 +74,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android-ndk:4.9.2'
+    implementation 'com.bugsnag:bugsnag-android-ndk:4.10.0'
     // If developing locally, replace the above line with the following:
     // implementation project(path: ':sdk', configuration: 'default')
     // api project(path: ':ndk', configuration: 'default')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 15 16:54:26 GMT 2018
+#Tue Jan 15 15:21:47 GMT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
## Changeset

Updates the Android Gradle Plugin + Gradle wrapper to the latest versions recommended by Android Studio 3.3. Additionally, the Bugsnag notifier + plugin dependencies have been updated to the latest available release in the example app.

This changeset should have no effect on the compile-time dependencies of the SDK or NDK artefacts.

## Tests

Ran existing on CI.
