### PR TITLE
Refactor error report deserialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Refactor error report deserialisation
+  [#419](https://github.com/bugsnag/bugsnag-android/pull/419)
+
 * Cache result of device root check
   [#411](https://github.com/bugsnag/bugsnag-android/pull/411)
   

--- a/sdk/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -242,32 +242,36 @@ class ErrorReader {
         ArrayList<StackTraceElement> frames = new ArrayList<>();
         reader.beginArray();
         while (reader.hasNext()) {
-            String method = null;
-            String file = null;
-            int lineNumber = 0;
-            reader.beginObject();
-            while (reader.hasNext()) {
-                switch (reader.nextName()) {
-                    case "method":
-                        method = reader.nextString();
-                        break;
-                    case "file":
-                        file = reader.nextString();
-                        break;
-                    case "lineNumber":
-                        lineNumber = reader.nextInt();
-                        break;
-                    default:
-                        reader.skipValue();
-                        break;
-
-                }
-            }
-            reader.endObject();
-            frames.add(new StackTraceElement("", method, file, lineNumber));
+            frames.add(readStackFrame(reader));
         }
         reader.endArray();
         return frames.toArray(new StackTraceElement[frames.size()]);
+    }
+
+    private static StackTraceElement readStackFrame(JsonReader reader) throws IOException {
+        String method = null;
+        String file = null;
+        int lineNumber = 0;
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "method":
+                    method = reader.nextString();
+                    break;
+                case "file":
+                    file = reader.nextString();
+                    break;
+                case "lineNumber":
+                    lineNumber = reader.nextInt();
+                    break;
+                default:
+                    reader.skipValue();
+                    break;
+
+            }
+        }
+        reader.endObject();
+        return new StackTraceElement("", method, file, lineNumber);
     }
 
     /**


### PR DESCRIPTION
## Goal

The `ErrorReader` class is hard to read in places which may have contributed to #418. This changeset attempts to improve readability by extracting methods so that each has a single responsibility.

## Changeset

Breadcrumbs, stackframes, and threads are all serialised as a JSON array in the error report. The current implementation completes something like the following steps in a single method:

```
// 1. old scheme
void readBreadcrumbs() {
    // create an array
    // iterate around array objects
    // deserialise a breadcrumb
    // end an array
}
```

The step of deserialising individual JSON objects has now been extracted to a separate method, like thus:

```
// 2. new scheme
void readBreadcrumbs() {
    // create an array
    // iterate around array objects
    breadcrumbs.add(readBreadcrumb())
    // end an array
}

Breadcrumb readBreadcrumb() {
    // deserialise a breadcrumb
}
```

This ensures each method only has a single responsibility and improves readability of the code.

## Tests

Ran existing tests, and performed testing as detailed in #418.
