### PR TITLE
build: Support building with custom ABIs from the command line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,16 @@ You can build new `.aar` files as follows:
 ./gradlew clean :build
 ```
 
-Files are generated into`build/outputs/aar`.
+Files are generated into`[module]/build/outputs/aar`.
 
+### Building with custom ABIs
+
+To build the NDK module with specific ABIs, use the `ABI_FILTERS` project
+option:
+
+```shell
+./gradlew clean :assemble -PABI_FILTERS=x86,arm64-v8a
+```
 
 ## Running Tests
 

--- a/ndk/build.gradle
+++ b/ndk/build.gradle
@@ -19,7 +19,11 @@ android {
         minSdkVersion Integer.parseInt(project.ANDROID_MIN_SDK_VERSION)
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk {
-            abiFilters 'arm64-v8a', 'armeabi-v7a', 'armeabi', 'x86', 'x86_64'
+            if (project.hasProperty("ABI_FILTERS")) {
+                abiFilters project.ABI_FILTERS.split(",")
+            } else {
+                abiFilters 'arm64-v8a', 'armeabi-v7a', 'armeabi', 'x86', 'x86_64'
+            }
         }
         consumerProguardFiles 'proguard-rules.pro'
         externalNativeBuild {


### PR DESCRIPTION
Some configurations (particularly unity) require specific ABIs be
included or excluded. With this change, it can be done via

    ./gradlew ndk:assemble -PABI_FILTERS=armeabi-v7a,x86

## Tests

Tested the change manually to ensure that when not specified, all supported ABIs build and when set, only the specified ABIs build.
