### PR TITLE
fix: prevent overwriting config.projectPackages if already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Bug fixes
+
+* Prevent overwriting config.projectPackages if already set
+  [#428](https://github.com/bugsnag/bugsnag-android/pull/428)
+
 ## 4.11.0 (2019-01-22)
 
 ### Enhancements

--- a/sdk/src/androidTest/java/com/bugsnag/android/ProjectPackagesTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ProjectPackagesTest.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android
+
+import android.support.test.InstrumentationRegistry
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ProjectPackagesTest {
+
+    @Test
+    fun testDefaultProjectPackages() {
+        val configuration = Configuration("api-key")
+        assertNull(configuration.projectPackages)
+
+        val client = Client(InstrumentationRegistry.getContext(), configuration)
+        assertArrayEquals(arrayOf("com.bugsnag.android.test"), client.config.projectPackages)
+    }
+
+    @Test
+    fun testProjectPackagesOverride() {
+        val configuration = Configuration("api-key")
+        configuration.projectPackages = arrayOf("com.foo.example")
+        val client = Client(InstrumentationRegistry.getContext(), configuration)
+        assertArrayEquals(arrayOf("com.foo.example"), client.config.projectPackages)
+    }
+}

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -143,8 +143,10 @@ public class Client extends Observable implements Observer {
         // Set up breadcrumbs
         breadcrumbs = new Breadcrumbs(configuration);
 
-        // Set sensible defaults
-        setProjectPackages(appContext.getPackageName());
+        // Set sensible defaults if project packages not already set
+        if (config.getProjectPackages() == null) {
+            setProjectPackages(appContext.getPackageName());
+        }
 
         String deviceId = deviceData.getId();
 


### PR DESCRIPTION
## Goal

`config.projectPackages` is overwritten via the `Client` constructor, as reported in #426. This is confusing when setting the value via the `Configuration` class and inconsistent with the behaviour of other fields. We should respect the value that users have set, and otherwise use a sensible default.

## Changeset

Added a null check when setting the `projectPackages` in the `Client` constructor.

## Tests

Added unit tests to verify that a default project package is set, and that a custom project package is not overwritten.
