### PR TITLE
Add stopSession() and resumeSession() to Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Enhancements
+
+* Add stopSession() and resumeSession() to Client
+[#429](https://github.com/bugsnag/bugsnag-android/pull/429)
+
 ## 4.11.0 (2019-01-22)
 
 ### Enhancements

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 24f53756011b1247a166b70fe65ddf1c40b4fc89
+  revision: 6f5af2c98c6fa1cfb07d6466a5cf3eaca5dcbc90
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)
       cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)
+      os (~> 1.0.0)
       rack (~> 2.0.0)
       rake (~> 12.3.0)
       test-unit (~> 3.2.0)
@@ -34,17 +35,18 @@ GEM
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
     gherkin (5.1.0)
-    method_source (0.9.0)
+    method_source (0.9.2)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
+    os (1.0.0)
     power_assert (1.1.3)
-    pry (0.11.3)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.5)
-    rake (12.3.1)
-    test-unit (3.2.8)
+    rack (2.0.6)
+    rake (12.3.2)
+    test-unit (3.2.9)
       power_assert
 
 PLATFORMS
@@ -55,4 +57,4 @@ DEPENDENCIES
   pry
 
 BUNDLED WITH
-   1.16.2
+   1.16.1

--- a/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
+++ b/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
@@ -18,6 +18,26 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXAutoContextScenario_activate(JN
 }
 
 JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXStartSessionScenario_crash(JNIEnv *env,
+                                                                            jobject instance,
+                                                                            jint value) {
+    int x = 22;
+    if (x > 0)
+        __builtin_trap();
+    return 338;
+}
+
+JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXStopSessionScenario_crash(JNIEnv *env,
+                                                                           jobject instance,
+                                                                           jint value) {
+    int x = 22552;
+    if (x > 0)
+        __builtin_trap();
+    return 555;
+}
+
+JNIEXPORT int JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXUpdateContextCrashScenario_crash(JNIEnv *env,
                                                                          jobject instance,
                                                                          jint value) {

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
 import android.content.Context;
+import android.os.Handler;
 
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
@@ -13,6 +14,8 @@ public class CXXStartSessionScenario extends Scenario {
         System.loadLibrary("monochrome");
         System.loadLibrary("entrypoint");
     }
+
+    private Handler handler = new Handler();
 
     public native int crash(int counter);
 
@@ -28,7 +31,13 @@ public class CXXStartSessionScenario extends Scenario {
 
         if (metadata == null || !metadata.equals("non-crashy")) {
             Bugsnag.getClient().startSession();
-            crash(0);
+
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    crash(0);
+                }
+            }, 8000);
         }
     }
 }

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
@@ -1,0 +1,34 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import android.support.annotation.NonNull;
+
+public class CXXStartSessionScenario extends Scenario {
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native int crash(int counter);
+
+    public CXXStartSessionScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+
+        if (metadata == null || !metadata.equals("non-crashy")) {
+            Bugsnag.getClient().startSession();
+            crash(0);
+        }
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStopSessionScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStopSessionScenario.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
 import android.content.Context;
+import android.os.Handler;
 
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
@@ -13,6 +14,8 @@ public class CXXStopSessionScenario extends Scenario {
         System.loadLibrary("monochrome");
         System.loadLibrary("entrypoint");
     }
+
+    private Handler handler = new Handler();
 
     public native int crash(int counter);
 
@@ -29,7 +32,13 @@ public class CXXStopSessionScenario extends Scenario {
         if (metadata == null || !metadata.equals("non-crashy")) {
             Bugsnag.getClient().startSession();
             Bugsnag.getClient().stopSession();
-            crash(0);
+
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    crash(0);
+                }
+            }, 8000);
         }
     }
 }

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStopSessionScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStopSessionScenario.java
@@ -1,0 +1,35 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import android.support.annotation.NonNull;
+
+public class CXXStopSessionScenario extends Scenario {
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native int crash(int counter);
+
+    public CXXStopSessionScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+
+        if (metadata == null || !metadata.equals("non-crashy")) {
+            Bugsnag.getClient().startSession();
+            Bugsnag.getClient().stopSession();
+            crash(0);
+        }
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NewSessionScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/NewSessionScenario.kt
@@ -1,0 +1,37 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import android.os.Handler
+import android.os.HandlerThread
+
+/**
+ * Sends an exception after stopping the session
+ */
+internal class NewSessionScenario(config: Configuration,
+                                      context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        val client = Bugsnag.getClient()
+        val thread = HandlerThread("HandlerThread")
+        thread.start()
+
+        Handler(thread.looper).post {
+            // send 1st exception which should include session info
+            client.startSession()
+            client.notifyBlocking(generateException())
+
+            // stop tracking the existing session
+            client.stopSession()
+
+            // send 2nd exception which should contain new session info
+            client.startSession()
+            client.notifyBlocking(generateException())
+        }
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ResumedSessionScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/ResumedSessionScenario.kt
@@ -1,0 +1,35 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import android.os.Handler
+import android.os.HandlerThread
+
+/**
+ * Sends 2 exceptions, 1 before resuming a session, and 1 after resuming a session.
+ */
+internal class ResumedSessionScenario(config: Configuration,
+                                      context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        val client = Bugsnag.getClient()
+        val thread = HandlerThread("HandlerThread")
+        thread.start()
+
+        Handler(thread.looper).post {
+            // send 1st exception
+            client.startSession()
+            client.notifyBlocking(generateException())
+
+            // send 2nd exception after resuming a session
+            client.stopSession()
+            client.resumeSession()
+            client.notifyBlocking(generateException())
+        }
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StoppedSessionScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/StoppedSessionScenario.kt
@@ -1,0 +1,34 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import android.os.Handler
+import android.os.HandlerThread
+
+/**
+ * Sends an exception after stopping the session
+ */
+internal class StoppedSessionScenario(config: Configuration,
+                                      context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        val client = Bugsnag.getClient()
+        val thread = HandlerThread("HandlerThread")
+        thread.start()
+
+        Handler(thread.looper).post {
+            // send 1st exception which should include session info
+            client.startSession()
+            client.notifyBlocking(generateException())
+
+            // send 2nd exception which should not include session info
+            client.stopSession()
+            client.notifyBlocking(generateException())
+        }
+    }
+}

--- a/features/native_session_tracking.feature
+++ b/features/native_session_tracking.feature
@@ -2,6 +2,8 @@ Feature: NDK Session Tracking
 
 Scenario: Stopped session is not in payload of unhandled NDK error
     When I run "CXXStopSessionScenario"
+    And I wait a bit
+    And I wait a bit
     And I configure the app to run in the "non-crashy" state
     And I relaunch the app
     Then I should receive 2 requests
@@ -11,6 +13,8 @@ Scenario: Stopped session is not in payload of unhandled NDK error
 
 Scenario: Started session is in payload of unhandled NDK error
     When I run "CXXStartSessionScenario"
+    And I wait a bit
+    And I wait a bit
     And I configure the app to run in the "non-crashy" state
     And I relaunch the app
     Then I should receive 2 requests

--- a/features/native_session_tracking.feature
+++ b/features/native_session_tracking.feature
@@ -1,0 +1,19 @@
+Feature: NDK Session Tracking
+
+Scenario: Started session is in payload of unhandled NDK error
+    When I run "CXXStartSessionScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 2 requests
+    And the request 0 is a valid for the session tracking API
+    And the request 1 is a valid for the error reporting API
+    And the payload field "events.0.session.events.unhandled" equals 1 for request 1
+
+Scenario: Stopped session is not in payload of unhandled NDK error
+    When I run "CXXStopSessionScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 2 requests
+    And the request 0 is a valid for the session tracking API
+    And the request 1 is a valid for the error reporting API
+    And the payload field "events.0.session" is null for request 1

--- a/features/native_session_tracking.feature
+++ b/features/native_session_tracking.feature
@@ -1,14 +1,5 @@
 Feature: NDK Session Tracking
 
-Scenario: Started session is in payload of unhandled NDK error
-    When I run "CXXStartSessionScenario"
-    And I configure the app to run in the "non-crashy" state
-    And I relaunch the app
-    Then I should receive 2 requests
-    And the request 0 is a valid for the session tracking API
-    And the request 1 is a valid for the error reporting API
-    And the payload field "events.0.session.events.unhandled" equals 1 for request 1
-
 Scenario: Stopped session is not in payload of unhandled NDK error
     When I run "CXXStopSessionScenario"
     And I configure the app to run in the "non-crashy" state
@@ -17,3 +8,12 @@ Scenario: Stopped session is not in payload of unhandled NDK error
     And the request 0 is a valid for the session tracking API
     And the request 1 is a valid for the error reporting API
     And the payload field "events.0.session" is null for request 1
+
+Scenario: Started session is in payload of unhandled NDK error
+    When I run "CXXStartSessionScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 2 requests
+    And the request 0 is a valid for the session tracking API
+    And the request 1 is a valid for the error reporting API
+    And the payload field "events.0.session.events.unhandled" equals 1 for request 1

--- a/features/session_stopping.feature
+++ b/features/session_stopping.feature
@@ -1,0 +1,32 @@
+Feature: Stopping and resuming sessions
+
+Scenario: When a session is stopped the error has no session information
+    When I run "StoppedSessionScenario"
+    Then I should receive 3 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the error reporting API
+    And the request 2 is valid for the error reporting API
+    And the payload field "events.0.session" is not null for request 1
+    And the payload field "events.0.session" is null for request 2
+
+Scenario: When a session is resumed the error uses the previous session information
+    When I run "ResumedSessionScenario"
+    Then I should receive 3 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the error reporting API
+    And the request 2 is valid for the error reporting API
+    And the payload field "events.0.session.events.handled" equals 1 for request 1
+    And the payload field "events.0.session.events.handled" equals 2 for request 2
+    And the payload field "events.0.session.id" of request 1 equals the payload field "events.0.session.id" of request 2
+    And the payload field "events.0.session.startedAt" of request 1 equals the payload field "events.0.session.startedAt" of request 2
+
+Scenario: When a new session is started the error uses different session information
+    When I run "NewSessionScenario"
+    Then I should receive 4 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the error reporting API
+    And the request 2 is valid for the session tracking API
+    And the request 3 is valid for the error reporting API
+    And the payload field "events.0.session.events.handled" equals 1 for request 1
+    And the payload field "events.0.session.events.handled" equals 1 for request 3
+    And the payload field "events.0.session.id" of request 1 does not equal the payload field "events.0.session.id" of request 3

--- a/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -54,7 +54,9 @@ public class NativeBridge implements Observer {
 
     public static native void removeMetadata(String tab, String key);
 
-    public static native void startedSession(String sessionID, String key);
+    public static native void startedSession(String sessionID, String key, int handledCount);
+
+    public static native void stoppedSession();
 
     public static native void updateAppVersion(String appVersion);
 
@@ -130,6 +132,9 @@ public class NativeBridge implements Observer {
                 break;
             case START_SESSION:
                 handleStartSession(arg);
+                break;
+            case STOP_SESSION:
+                stoppedSession();
                 break;
             case UPDATE_APP_VERSION:
                 handleAppVersionChange(arg);
@@ -313,17 +318,24 @@ public class NativeBridge implements Observer {
         if (arg instanceof List) {
             @SuppressWarnings("unchecked")
             List<Object> metadata = (List<Object>)arg;
-            if (metadata.size() == 2) {
+            if (metadata.size() == 3) {
                 Object id = metadata.get(0);
                 Object startTime = metadata.get(1);
-                if (id instanceof String && startTime instanceof String) {
-                    startedSession((String)id, (String)startTime);
+                Object handledCount = metadata.get(2);
+
+                if (id instanceof String && startTime instanceof String
+                    && handledCount instanceof Integer) {
+                    startedSession((String)id, (String)startTime, (Integer) handledCount);
                     return;
                 }
             }
         }
 
         warn("START_SESSION object is invalid: " + arg);
+    }
+
+    private void handleStopSession() {
+        stoppedSession();
     }
 
     private void handleReleaseStageChange(Object arg) {

--- a/ndk/src/main/jni/bugsnag_ndk.c
+++ b/ndk/src/main/jni/bugsnag_ndk.c
@@ -121,22 +121,40 @@ Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
   if (bsg_global_env == NULL)
     return;
   bsg_request_env_write_lock();
-  bsg_global_env->next_report.handled_events++;
+  bugsnag_report *report = &bsg_global_env->next_report;
+
+  if (bugsnag_report_has_session(report)) {
+    report->handled_events++;
+  }
   bsg_release_env_write_lock();
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
-    JNIEnv *env, jobject _this, jstring session_id_, jstring start_date_) {
+    JNIEnv *env, jobject _this, jstring session_id_, jstring start_date_, jint handled_count) {
   if (bsg_global_env == NULL || session_id_ == NULL)
     return;
   char *session_id = (char *)(*env)->GetStringUTFChars(env, session_id_, 0);
   char *started_at = (char *)(*env)->GetStringUTFChars(env, start_date_, 0);
   bsg_request_env_write_lock();
   bugsnag_report_start_session(&bsg_global_env->next_report, session_id,
-                               started_at);
+                               started_at, handled_count);
+
   bsg_release_env_write_lock();
   (*env)->ReleaseStringUTFChars(env, session_id_, session_id);
   (*env)->ReleaseStringUTFChars(env, start_date_, started_at);
+}
+
+JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_stoppedSession(
+    JNIEnv *env, jobject _this) {
+    if (bsg_global_env == NULL) {
+        return;
+    }
+    bsg_request_env_write_lock();
+    bugsnag_report *report = &bsg_global_env->next_report;
+    memset(report->session_id, 0, strlen(report->session_id));
+    memset(report->session_start, 0, strlen(report->session_start));
+    report->handled_events = 0;
+    bsg_release_env_write_lock();
 }
 
 JNIEXPORT void JNICALL

--- a/ndk/src/main/jni/report.c
+++ b/ndk/src/main/jni/report.c
@@ -83,11 +83,11 @@ void bugsnag_report_remove_metadata_tab(bugsnag_report *report, char *section) {
 }
 
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
-                                  char *started_at) {
+                                  char *started_at, int handled_count) {
   bsg_strncpy_safe(report->session_id, session_id, sizeof(report->session_id));
   bsg_strncpy_safe(report->session_start, started_at,
                    sizeof(report->session_start));
-  report->handled_events = 0;
+  report->handled_events = handled_count;
 }
 
 void bugsnag_report_set_context(bugsnag_report *report, char *value) {
@@ -157,4 +157,8 @@ void bugsnag_report_add_breadcrumb(bugsnag_report *report,
 void bugsnag_report_clear_breadcrumbs(bugsnag_report *report) {
   report->crumb_count = 0;
   report->crumb_first_index = 0;
+}
+
+bool bugsnag_report_has_session(bugsnag_report *report) {
+    return strlen(report->session_id) > 0;
 }

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -315,7 +315,9 @@ void bugsnag_report_set_user_email(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_id(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_name(bugsnag_report *report, char *value);
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
-                                  char *started_at);
+                                  char *started_at, int handled_count);
+bool bugsnag_report_has_session(bugsnag_report *report);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ndk/src/main/jni/utils/serializer.c
+++ b/ndk/src/main/jni/utils/serializer.c
@@ -255,13 +255,14 @@ char *bsg_serialize_report_to_json_string(bugsnag_report *report) {
       json_object_dotset_string(event, "user.email", report->user.email);
     if (strlen(report->user.id) > 0)
       json_object_dotset_string(event, "user.id", report->user.id);
-    if (strlen(report->session_id) > 0) {
-      json_object_dotset_string(event, "session.startedAt",
-                                report->session_start);
-      json_object_dotset_string(event, "session.id", report->session_id);
-      json_object_dotset_number(event, "session.events.handled",
-                                report->handled_events);
-      json_object_dotset_number(event, "session.events.unhandled", 1);
+
+    if (bugsnag_report_has_session(report)) {
+        json_object_dotset_string(event, "session.startedAt",
+                                  report->session_start);
+        json_object_dotset_string(event, "session.id", report->session_id);
+        json_object_dotset_number(event, "session.events.handled",
+                                  report->handled_events);
+        json_object_dotset_number(event, "session.events.unhandled", 1);
     }
 
     json_object_set_string(exception, "errorClass", report->exception.name);

--- a/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.support.test.InstrumentationRegistry;
@@ -152,9 +153,18 @@ public class ObserverInterfaceTest {
         client.startSession();
         List<Object> sessionInfo = (List<Object>)findMessageInQueue(
                 NativeInterface.MessageType.START_SESSION, List.class);
-        assertEquals(2, sessionInfo.size());
+        assertEquals(3, sessionInfo.size());
         assertTrue(sessionInfo.get(0) instanceof String);
         assertTrue(sessionInfo.get(1) instanceof String);
+        assertTrue(sessionInfo.get(2) instanceof Integer);
+    }
+
+    @Test
+    public void testStopSessionSendsmessage() {
+        client.startSession();
+        client.stopSession();
+        Object msg = findMessageInQueue(NativeInterface.MessageType.STOP_SESSION, null);
+        assertNull(msg);
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerStopResumeTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerStopResumeTest.kt
@@ -1,0 +1,123 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.BugsnagTestUtils.generateClient
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
+import com.bugsnag.android.BugsnagTestUtils.generateSessionStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SessionTrackerStopResumeTest {
+
+    private val configuration = generateConfiguration().also {
+        it.autoCaptureSessions = false
+    }
+    private val sessionStore = generateSessionStore()
+    private lateinit var tracker: SessionTracker
+
+    @Before
+    fun setUp() {
+        tracker = SessionTracker(configuration, generateClient(), sessionStore)
+    }
+
+    /**
+     * Verifies that a session can be resumed after it is stopped
+     */
+    @Test
+    fun resumeFromStoppedSession() {
+        tracker.startSession(false)
+        val originalSession = tracker.currentSession
+        assertNotNull(originalSession)
+
+        tracker.stopSession()
+        assertNull(tracker.currentSession)
+
+        assertTrue(tracker.resumeSession())
+        assertEquals(originalSession, tracker.currentSession)
+    }
+
+    /**
+     * Verifies that a new session is started when calling [SessionTracker.resumeSession],
+     * if there is no stopped session
+     */
+    @Test
+    fun resumeWithNoStoppedSession() {
+        assertNull(tracker.currentSession)
+        assertFalse(tracker.resumeSession())
+        assertNotNull(tracker.currentSession)
+    }
+
+    /**
+     * Verifies that a new session can be created after the previous one is stopped
+     */
+    @Test
+    fun startNewAfterStoppedSession() {
+        tracker.startSession(false)
+        val originalSession = tracker.currentSession
+
+        tracker.stopSession()
+        tracker.startSession(false)
+        assertNotEquals(originalSession, tracker.currentSession)
+    }
+
+    /**
+     * Verifies that calling [SessionTracker.resumeSession] multiple times only starts one session
+     */
+    @Test
+    fun multipleResumesHaveNoEffect() {
+        tracker.startSession(false)
+        val original = tracker.currentSession
+        tracker.stopSession()
+
+        assertTrue(tracker.resumeSession())
+        assertEquals(original, tracker.currentSession)
+
+        assertFalse(tracker.resumeSession())
+        assertEquals(original, tracker.currentSession)
+    }
+
+    /**
+     * Verifies that calling [SessionTracker.stopSession] multiple times only stops one session
+     */
+    @Test
+    fun multipleStopsHaveNoEffect() {
+        tracker.startSession(false)
+        assertNotNull(tracker.currentSession)
+
+        tracker.stopSession()
+        assertNull(tracker.currentSession)
+
+        tracker.stopSession()
+        assertNull(tracker.currentSession)
+    }
+
+    /**
+     * Verifies that if a handled or unhandled error occurs when a session is stopped, the
+     * error count is not updated
+     */
+    @Test
+    fun stoppedSessionDoesNotIncrement() {
+        tracker.startSession(false)
+        tracker.incrementHandledError()
+        tracker.incrementUnhandledError()
+        assertEquals(1, tracker.currentSession?.handledCount)
+        assertEquals(1, tracker.currentSession?.unhandledCount)
+
+        tracker.stopSession()
+        tracker.incrementHandledError()
+        tracker.incrementUnhandledError()
+        tracker.resumeSession()
+        assertEquals(1, tracker.currentSession?.handledCount)
+        assertEquals(1, tracker.currentSession?.unhandledCount)
+
+        tracker.incrementHandledError()
+        tracker.incrementUnhandledError()
+        assertEquals(2, tracker.currentSession?.handledCount)
+        assertEquals(2, tracker.currentSession?.unhandledCount)
+    }
+}

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -678,6 +678,14 @@ public final class Bugsnag {
         getClient().startSession();
     }
 
+    public static boolean resumeSession() {
+        return getClient().resumeSession();
+    }
+
+    public static void stopSession() {
+        getClient().stopSession();
+    }
+
     /**
      * Get the current Bugsnag Client instance.
      */

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -668,20 +668,66 @@ public final class Bugsnag {
     }
 
     /**
-     * Manually starts tracking a new session.
+     * Starts tracking a new session. You should disable automatic session tracking via
+     * {@link #setAutoCaptureSessions(boolean)} if you call this method.
+     * <p/>
+     * You should call this at the appropriate time in your application when you wish to start a
+     * session. Any subsequent errors which occur in your application will still be reported to
+     * Bugsnag but will not count towards your application's
+     * <a href="https://docs.bugsnag.com/product/releases/releases-dashboard/#stability-score">
+     * stability score</a>. This will start a new session even if there is already an existing
+     * session; you should call {@link #resumeSession()} if you only want to start a session
+     * when one doesn't already exist.
      *
-     * Automatic session tracking can be enabled via
-     * {@link Configuration#setAutoCaptureSessions(boolean)}, which will automatically create a new
-     * session everytime the app enters the foreground.
+     * @see #resumeSession()
+     * @see #stopSession()
+     * @see Configuration#setAutoCaptureSessions(boolean)
      */
     public static void startSession() {
         getClient().startSession();
     }
 
+    /**
+     * Resumes a session which has previously been stopped, or starts a new session if none exists.
+     * If a session has already been resumed or started and has not been stopped, calling this
+     * method will have no effect. You should disable automatic session tracking via
+     * {@link #setAutoCaptureSessions(boolean)} if you call this method.
+     * <p/>
+     * It's important to note that sessions are stored in memory for the lifetime of the
+     * application process and are not persisted on disk. Therefore calling this method on app
+     * startup would start a new session, rather than continuing any previous session.
+     * <p/>
+     * You should call this at the appropriate time in your application when you wish to resume
+     * a previously started session. Any subsequent errors which occur in your application will
+     * still be reported to Bugsnag but will not count towards your application's
+     * <a href="https://docs.bugsnag.com/product/releases/releases-dashboard/#stability-score">
+     * stability score</a>.
+     *
+     * @see #startSession()
+     * @see #stopSession()
+     * @see Configuration#setAutoCaptureSessions(boolean)
+     *
+     * @return true if a previous session was resumed, false if a new session was started.
+     */
     public static boolean resumeSession() {
         return getClient().resumeSession();
     }
 
+    /**
+     * Stops tracking a session. You should disable automatic session tracking via
+     * {@link #setAutoCaptureSessions(boolean)} if you call this method.
+     * <p/>
+     * You should call this at the appropriate time in your application when you wish to stop a
+     * session. Any subsequent errors which occur in your application will still be reported to
+     * Bugsnag but will not count towards your application's
+     * <a href="https://docs.bugsnag.com/product/releases/releases-dashboard/#stability-score">
+     * stability score</a>. This can be advantageous if, for example, you do not wish the
+     * stability score to include crashes in a background service.
+     *
+     * @see #startSession()
+     * @see #resumeSession()
+     * @see Configuration#setAutoCaptureSessions(boolean)
+     */
     public static void stopSession() {
         getClient().stopSession();
     }

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -282,20 +282,66 @@ public class Client extends Observable implements Observer {
     }
 
     /**
-     * Manually starts tracking a new session.
+     * Starts tracking a new session. You should disable automatic session tracking via
+     * {@link #setAutoCaptureSessions(boolean)} if you call this method.
+     * <p/>
+     * You should call this at the appropriate time in your application when you wish to start a
+     * session. Any subsequent errors which occur in your application will still be reported to
+     * Bugsnag but will not count towards your application's
+     * <a href="https://docs.bugsnag.com/product/releases/releases-dashboard/#stability-score">
+     * stability score</a>. This will start a new session even if there is already an existing
+     * session; you should call {@link #resumeSession()} if you only want to start a session
+     * when one doesn't already exist.
      *
-     * Automatic session tracking can be enabled via
-     * {@link Configuration#setAutoCaptureSessions(boolean)}, which will automatically create a new
-     * session everytime the app enters the foreground.
+     * @see #resumeSession()
+     * @see #stopSession()
+     * @see Configuration#setAutoCaptureSessions(boolean)
      */
     public void startSession() {
         sessionTracker.startSession(false);
     }
 
+    /**
+     * Stops tracking a session. You should disable automatic session tracking via
+     * {@link #setAutoCaptureSessions(boolean)} if you call this method.
+     * <p/>
+     * You should call this at the appropriate time in your application when you wish to stop a
+     * session. Any subsequent errors which occur in your application will still be reported to
+     * Bugsnag but will not count towards your application's
+     * <a href="https://docs.bugsnag.com/product/releases/releases-dashboard/#stability-score">
+     * stability score</a>. This can be advantageous if, for example, you do not wish the
+     * stability score to include crashes in a background service.
+     *
+     * @see #startSession()
+     * @see #resumeSession()
+     * @see Configuration#setAutoCaptureSessions(boolean)
+     */
     public final void stopSession() {
         sessionTracker.stopSession();
     }
 
+    /**
+     * Resumes a session which has previously been stopped, or starts a new session if none exists.
+     * If a session has already been resumed or started and has not been stopped, calling this
+     * method will have no effect. You should disable automatic session tracking via
+     * {@link #setAutoCaptureSessions(boolean)} if you call this method.
+     * <p/>
+     * It's important to note that sessions are stored in memory for the lifetime of the
+     * application process and are not persisted on disk. Therefore calling this method on app
+     * startup would start a new session, rather than continuing any previous session.
+     * <p/>
+     * You should call this at the appropriate time in your application when you wish to resume
+     * a previously started session. Any subsequent errors which occur in your application will
+     * still be reported to Bugsnag but will not count towards your application's
+     * <a href="https://docs.bugsnag.com/product/releases/releases-dashboard/#stability-score">
+     * stability score</a>.
+     *
+     * @see #startSession()
+     * @see #stopSession()
+     * @see Configuration#setAutoCaptureSessions(boolean)
+     *
+     * @return true if a previous session was resumed, false if a new session was started.
+     */
     public final boolean resumeSession() {
         return sessionTracker.resumeSession();
     }

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -289,7 +289,15 @@ public class Client extends Observable implements Observer {
      * session everytime the app enters the foreground.
      */
     public void startSession() {
-        sessionTracker.startNewSession(new Date(), user, false);
+        sessionTracker.startSession(false);
+    }
+
+    public final void stopSession() {
+        sessionTracker.stopSession();
+    }
+
+    public final boolean resumeSession() {
+        return sessionTracker.resumeSession();
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -59,6 +59,12 @@ public class NativeInterface {
          * containing [id, startDateIsoString]
          */
         START_SESSION,
+
+        /**
+         * A session was stopped.
+         */
+        STOP_SESSION,
+
         /**
          * Set a new app version. The Message object should be the new app
          * version

--- a/sdk/src/main/java/com/bugsnag/android/Session.java
+++ b/sdk/src/main/java/com/bugsnag/android/Session.java
@@ -34,6 +34,7 @@ class Session implements JsonStream.Streamable {
     private AtomicInteger unhandledCount = new AtomicInteger();
     private AtomicInteger handledCount = new AtomicInteger();
     private AtomicBoolean tracked = new AtomicBoolean(false);
+    final AtomicBoolean isStopped = new AtomicBoolean(false);
 
     String getId() {
         return id;


### PR DESCRIPTION
## Goal
Adds the ability to stop and resume sessions. This prevents the handled/unhandled error count from incrementing when a session is in the stopped state, which may be desirable if a user manually tracks sessions and does not care about crashes that occur in the background.

## Changeset

Added the public interface for stopping/resuming a session, along with the initial implementation, unit test coverage, and docs.

__NOTE__: NDK support was added in #432 and mazerunner scenarios have been added in #430.