### PR TITLE
Support stopSession() and resumeSession() in NDK

### DIFF
--- a/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
+++ b/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
@@ -18,6 +18,26 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXAutoContextScenario_activate(JN
 }
 
 JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXStartSessionScenario_crash(JNIEnv *env,
+                                                                            jobject instance,
+                                                                            jint value) {
+    int x = 22;
+    if (x > 0)
+        __builtin_trap();
+    return 338;
+}
+
+JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXStopSessionScenario_crash(JNIEnv *env,
+                                                                           jobject instance,
+                                                                           jint value) {
+    int x = 22552;
+    if (x > 0)
+        __builtin_trap();
+    return 555;
+}
+
+JNIEXPORT int JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXUpdateContextCrashScenario_crash(JNIEnv *env,
                                                                          jobject instance,
                                                                          jint value) {

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
@@ -1,0 +1,34 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import android.support.annotation.NonNull;
+
+public class CXXStartSessionScenario extends Scenario {
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native int crash(int counter);
+
+    public CXXStartSessionScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+
+        if (metadata == null || !metadata.equals("non-crashy")) {
+            Bugsnag.getClient().startSession();
+            crash(0);
+        }
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStopSessionScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStopSessionScenario.java
@@ -1,0 +1,35 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import android.support.annotation.NonNull;
+
+public class CXXStopSessionScenario extends Scenario {
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native int crash(int counter);
+
+    public CXXStopSessionScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+
+        if (metadata == null || !metadata.equals("non-crashy")) {
+            Bugsnag.getClient().startSession();
+            Bugsnag.getClient().stopSession();
+            crash(0);
+        }
+    }
+}

--- a/features/native_session_tracking.feature
+++ b/features/native_session_tracking.feature
@@ -1,0 +1,19 @@
+Feature: NDK Session Tracking
+
+Scenario: Started session is in payload of unhandled NDK error
+    When I run "CXXStartSessionScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 2 requests
+    And the request 0 is a valid for the session tracking API
+    And the request 1 is a valid for the error reporting API
+    And the payload field "events.0.session.events.unhandled" equals 1 for request 1
+
+Scenario: Stopped session is not in payload of unhandled NDK error
+    When I run "CXXStopSessionScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 2 requests
+    And the request 0 is a valid for the session tracking API
+    And the request 1 is a valid for the error reporting API
+    And the payload field "events.0.session" is null for request 1

--- a/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -134,7 +134,7 @@ public class NativeBridge implements Observer {
                 handleStartSession(arg);
                 break;
             case STOP_SESSION:
-                handleStopSession();
+                stoppedSession();
                 break;
             case UPDATE_APP_VERSION:
                 handleAppVersionChange(arg);

--- a/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -56,6 +56,8 @@ public class NativeBridge implements Observer {
 
     public static native void startedSession(String sessionID, String key);
 
+    public static native void stoppedSession();
+
     public static native void updateAppVersion(String appVersion);
 
     public static native void updateBuildUUID(String uuid);
@@ -130,6 +132,9 @@ public class NativeBridge implements Observer {
                 break;
             case START_SESSION:
                 handleStartSession(arg);
+                break;
+            case STOP_SESSION:
+                handleStopSession();
                 break;
             case UPDATE_APP_VERSION:
                 handleAppVersionChange(arg);
@@ -324,6 +329,10 @@ public class NativeBridge implements Observer {
         }
 
         warn("START_SESSION object is invalid: " + arg);
+    }
+
+    private void handleStopSession() {
+        stoppedSession();
     }
 
     private void handleReleaseStageChange(Object arg) {

--- a/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -54,7 +54,7 @@ public class NativeBridge implements Observer {
 
     public static native void removeMetadata(String tab, String key);
 
-    public static native void startedSession(String sessionID, String key);
+    public static native void startedSession(String sessionID, String key, int handledCount);
 
     public static native void stoppedSession();
 
@@ -318,11 +318,14 @@ public class NativeBridge implements Observer {
         if (arg instanceof List) {
             @SuppressWarnings("unchecked")
             List<Object> metadata = (List<Object>)arg;
-            if (metadata.size() == 2) {
+            if (metadata.size() == 3) {
                 Object id = metadata.get(0);
                 Object startTime = metadata.get(1);
-                if (id instanceof String && startTime instanceof String) {
-                    startedSession((String)id, (String)startTime);
+                Object handledCount = metadata.get(2);
+
+                if (id instanceof String && startTime instanceof String
+                    && handledCount instanceof Integer) {
+                    startedSession((String)id, (String)startTime, (Integer) handledCount);
                     return;
                 }
             }

--- a/ndk/src/main/jni/bugsnag_ndk.c
+++ b/ndk/src/main/jni/bugsnag_ndk.c
@@ -123,7 +123,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
   bsg_request_env_write_lock();
   bugsnag_report *report = &bsg_global_env->next_report;
 
-  if (!report->stoppedSession) {
+  if (bugsnag_report_has_session(report)) {
     report->handled_events++;
   }
   bsg_release_env_write_lock();
@@ -151,7 +151,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_stoppedSession(
     }
     bsg_request_env_write_lock();
     bugsnag_report *report = &bsg_global_env->next_report;
-    report->stoppedSession = true;
+    memset(report->session_id, 0, strlen(report->session_id));
+    memset(report->session_start, 0, strlen(report->session_start));
+    report->handled_events = 0;
     bsg_release_env_write_lock();
 }
 

--- a/ndk/src/main/jni/bugsnag_ndk.c
+++ b/ndk/src/main/jni/bugsnag_ndk.c
@@ -123,21 +123,22 @@ Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
   bsg_request_env_write_lock();
   bugsnag_report *report = &bsg_global_env->next_report;
 
-  if (report->stoppedSession) {
+  if (!report->stoppedSession) {
     report->handled_events++;
   }
   bsg_release_env_write_lock();
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
-    JNIEnv *env, jobject _this, jstring session_id_, jstring start_date_) {
+    JNIEnv *env, jobject _this, jstring session_id_, jstring start_date_, jint handled_count) {
   if (bsg_global_env == NULL || session_id_ == NULL)
     return;
   char *session_id = (char *)(*env)->GetStringUTFChars(env, session_id_, 0);
   char *started_at = (char *)(*env)->GetStringUTFChars(env, start_date_, 0);
   bsg_request_env_write_lock();
   bugsnag_report_start_session(&bsg_global_env->next_report, session_id,
-                               started_at);
+                               started_at, handled_count);
+
   bsg_release_env_write_lock();
   (*env)->ReleaseStringUTFChars(env, session_id_, session_id);
   (*env)->ReleaseStringUTFChars(env, start_date_, started_at);

--- a/ndk/src/main/jni/bugsnag_ndk.c
+++ b/ndk/src/main/jni/bugsnag_ndk.c
@@ -121,7 +121,11 @@ Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
   if (bsg_global_env == NULL)
     return;
   bsg_request_env_write_lock();
-  bsg_global_env->next_report.handled_events++;
+  bugsnag_report *report = &bsg_global_env->next_report;
+
+  if (report->stoppedSession) {
+    report->handled_events++;
+  }
   bsg_release_env_write_lock();
 }
 
@@ -137,6 +141,17 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
   bsg_release_env_write_lock();
   (*env)->ReleaseStringUTFChars(env, session_id_, session_id);
   (*env)->ReleaseStringUTFChars(env, start_date_, started_at);
+}
+
+JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_stoppedSession(
+    JNIEnv *env, jobject _this) {
+    if (bsg_global_env == NULL) {
+        return;
+    }
+    bsg_request_env_write_lock();
+    bugsnag_report *report = &bsg_global_env->next_report;
+    report->stoppedSession = true;
+    bsg_release_env_write_lock();
 }
 
 JNIEXPORT void JNICALL

--- a/ndk/src/main/jni/metadata.c
+++ b/ndk/src/main/jni/metadata.c
@@ -332,7 +332,6 @@ void bsg_populate_report(JNIEnv *env, bugsnag_report *report) {
   bsg_populate_app_data(env, jni_cache, report);
   bsg_populate_device_data(env, jni_cache, report);
   bsg_populate_user_data(env, jni_cache, report);
-  report->stoppedSession = false;
 }
 void bsg_populate_metadata(JNIEnv *env, bugsnag_report *report,
                            jobject metadata) {

--- a/ndk/src/main/jni/metadata.c
+++ b/ndk/src/main/jni/metadata.c
@@ -332,6 +332,7 @@ void bsg_populate_report(JNIEnv *env, bugsnag_report *report) {
   bsg_populate_app_data(env, jni_cache, report);
   bsg_populate_device_data(env, jni_cache, report);
   bsg_populate_user_data(env, jni_cache, report);
+  report->stoppedSession = false;
 }
 void bsg_populate_metadata(JNIEnv *env, bugsnag_report *report,
                            jobject metadata) {

--- a/ndk/src/main/jni/report.c
+++ b/ndk/src/main/jni/report.c
@@ -88,7 +88,6 @@ void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
   bsg_strncpy_safe(report->session_start, started_at,
                    sizeof(report->session_start));
   report->handled_events = handled_count;
-  report->stoppedSession = false;
 }
 
 void bugsnag_report_set_context(bugsnag_report *report, char *value) {
@@ -158,4 +157,8 @@ void bugsnag_report_add_breadcrumb(bugsnag_report *report,
 void bugsnag_report_clear_breadcrumbs(bugsnag_report *report) {
   report->crumb_count = 0;
   report->crumb_first_index = 0;
+}
+
+bool bugsnag_report_has_session(bugsnag_report *report) {
+    return strlen(report->session_id) > 0;
 }

--- a/ndk/src/main/jni/report.c
+++ b/ndk/src/main/jni/report.c
@@ -83,11 +83,11 @@ void bugsnag_report_remove_metadata_tab(bugsnag_report *report, char *section) {
 }
 
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
-                                  char *started_at) {
+                                  char *started_at, int handled_count) {
   bsg_strncpy_safe(report->session_id, session_id, sizeof(report->session_id));
   bsg_strncpy_safe(report->session_start, started_at,
                    sizeof(report->session_start));
-  report->handled_events = 0;
+  report->handled_events = handled_count;
   report->stoppedSession = false;
 }
 

--- a/ndk/src/main/jni/report.c
+++ b/ndk/src/main/jni/report.c
@@ -88,6 +88,7 @@ void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
   bsg_strncpy_safe(report->session_start, started_at,
                    sizeof(report->session_start));
   report->handled_events = 0;
+  report->stoppedSession = false;
 }
 
 void bugsnag_report_set_context(bugsnag_report *report, char *value) {

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -292,6 +292,7 @@ typedef struct {
   char session_id[33];
   char session_start[33];
   int handled_events;
+  bool stoppedSession;
 } bugsnag_report;
 
 void bugsnag_report_add_metadata_double(bugsnag_report *report, char *section,

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -292,7 +292,6 @@ typedef struct {
   char session_id[33];
   char session_start[33];
   int handled_events;
-  bool stoppedSession;
 } bugsnag_report;
 
 void bugsnag_report_add_metadata_double(bugsnag_report *report, char *section,
@@ -317,6 +316,8 @@ void bugsnag_report_set_user_id(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_name(bugsnag_report *report, char *value);
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
                                   char *started_at, int handled_count);
+bool bugsnag_report_has_session(bugsnag_report *report);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -316,7 +316,7 @@ void bugsnag_report_set_user_email(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_id(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_name(bugsnag_report *report, char *value);
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
-                                  char *started_at);
+                                  char *started_at, int handled_count);
 #ifdef __cplusplus
 }
 #endif

--- a/ndk/src/main/jni/utils/serializer.c
+++ b/ndk/src/main/jni/utils/serializer.c
@@ -256,15 +256,13 @@ char *bsg_serialize_report_to_json_string(bugsnag_report *report) {
     if (strlen(report->user.id) > 0)
       json_object_dotset_string(event, "user.id", report->user.id);
 
-    if (!report->stoppedSession) {
-        if (strlen(report->session_id) > 0) {
-            json_object_dotset_string(event, "session.startedAt",
-                                      report->session_start);
-            json_object_dotset_string(event, "session.id", report->session_id);
-            json_object_dotset_number(event, "session.events.handled",
-                                      report->handled_events);
-            json_object_dotset_number(event, "session.events.unhandled", 1);
-        }
+    if (bugsnag_report_has_session(report)) {
+        json_object_dotset_string(event, "session.startedAt",
+                                  report->session_start);
+        json_object_dotset_string(event, "session.id", report->session_id);
+        json_object_dotset_number(event, "session.events.handled",
+                                  report->handled_events);
+        json_object_dotset_number(event, "session.events.unhandled", 1);
     }
 
     json_object_set_string(exception, "errorClass", report->exception.name);

--- a/ndk/src/main/jni/utils/serializer.c
+++ b/ndk/src/main/jni/utils/serializer.c
@@ -255,13 +255,16 @@ char *bsg_serialize_report_to_json_string(bugsnag_report *report) {
       json_object_dotset_string(event, "user.email", report->user.email);
     if (strlen(report->user.id) > 0)
       json_object_dotset_string(event, "user.id", report->user.id);
-    if (strlen(report->session_id) > 0) {
-      json_object_dotset_string(event, "session.startedAt",
-                                report->session_start);
-      json_object_dotset_string(event, "session.id", report->session_id);
-      json_object_dotset_number(event, "session.events.handled",
-                                report->handled_events);
-      json_object_dotset_number(event, "session.events.unhandled", 1);
+
+    if (!report->stoppedSession) {
+        if (strlen(report->session_id) > 0) {
+            json_object_dotset_string(event, "session.startedAt",
+                                      report->session_start);
+            json_object_dotset_string(event, "session.id", report->session_id);
+            json_object_dotset_number(event, "session.events.handled",
+                                      report->handled_events);
+            json_object_dotset_number(event, "session.events.unhandled", 1);
+        }
     }
 
     json_object_set_string(exception, "errorClass", report->exception.name);

--- a/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -152,9 +152,10 @@ public class ObserverInterfaceTest {
         client.startSession();
         List<Object> sessionInfo = (List<Object>)findMessageInQueue(
                 NativeInterface.MessageType.START_SESSION, List.class);
-        assertEquals(2, sessionInfo.size());
+        assertEquals(3, sessionInfo.size());
         assertTrue(sessionInfo.get(0) instanceof String);
         assertTrue(sessionInfo.get(1) instanceof String);
+        assertTrue(sessionInfo.get(2) instanceof Integer);
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.support.test.InstrumentationRegistry;
@@ -156,6 +157,14 @@ public class ObserverInterfaceTest {
         assertTrue(sessionInfo.get(0) instanceof String);
         assertTrue(sessionInfo.get(1) instanceof String);
         assertTrue(sessionInfo.get(2) instanceof Integer);
+    }
+
+    @Test
+    public void testStopSessionSendsmessage() {
+        client.startSession();
+        client.stopSession();
+        Object msg = findMessageInQueue(NativeInterface.MessageType.STOP_SESSION, null);
+        assertNull(msg);
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -59,6 +59,12 @@ public class NativeInterface {
          * containing [id, startDateIsoString]
          */
         START_SESSION,
+
+        /**
+         * A session was stopped.
+         */
+        STOP_SESSION,
+
         /**
          * Set a new app version. The Message object should be the new app
          * version

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -81,8 +81,8 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         return session;
     }
 
-    void startSession(boolean autoCaptured) {
-        startNewSession(new Date(), client.getUser(), autoCaptured);
+    Session startSession(boolean autoCaptured) {
+        return startNewSession(new Date(), client.getUser(), autoCaptured);
     }
 
     void stopSession() {
@@ -90,18 +90,33 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
 
         if (session != null) {
             session.isStopped.set(true);
+            setChanged();
+            notifyObservers(new NativeInterface.Message(
+                NativeInterface.MessageType.STOP_SESSION, null));
         }
     }
 
     boolean resumeSession() {
         Session session = currentSession.get();
+        boolean resumed;
 
         if (session == null) {
-            startSession(false);
-            return false;
+            session = startSession(false);
+            resumed = false;
         } else {
-            return session.isStopped.compareAndSet(true, false);
+            resumed = session.isStopped.compareAndSet(true, false);
         }
+
+        notifySessionStartObserver(session);
+        return resumed;
+    }
+
+    private void notifySessionStartObserver(Session session) {
+        setChanged();
+        String startedAt = DateUtils.toIso8601(session.getStartedAt());
+        notifyObservers(new NativeInterface.Message(
+            NativeInterface.MessageType.START_SESSION,
+            Arrays.asList(session.getId(), startedAt)));
     }
 
     /**
@@ -142,11 +157,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
                 // This is on the current thread but there isn't much else we can do
                 sessionStore.write(session);
             }
-            setChanged();
-            String startedAt = DateUtils.toIso8601(session.getStartedAt());
-            notifyObservers(new NativeInterface.Message(
-                        NativeInterface.MessageType.START_SESSION,
-                        Arrays.asList(session.getId(), startedAt)));
+            notifySessionStartObserver(session);
         }
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -116,7 +116,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         String startedAt = DateUtils.toIso8601(session.getStartedAt());
         notifyObservers(new NativeInterface.Message(
             NativeInterface.MessageType.START_SESSION,
-            Arrays.asList(session.getId(), startedAt)));
+            Arrays.asList(session.getId(), startedAt, session.getHandledCount())));
     }
 
     /**
@@ -131,6 +131,8 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         if (notifyForRelease
             && (configuration.getAutoCaptureSessions() || !session.isAutoCaptured())
             && session.isTracked().compareAndSet(false, true)) {
+            notifySessionStartObserver(session);
+
             try {
                 final String endpoint = configuration.getSessionEndpoint();
                 Async.run(new Runnable() {
@@ -157,7 +159,6 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
                 // This is on the current thread but there isn't much else we can do
                 sessionStore.write(session);
             }
-            notifySessionStartObserver(session);
         }
     }
 


### PR DESCRIPTION
## Goal

Adds the ability to stop and resume sessions in the NDK layer. When a session is stopped, session information will not be added to error payloads and handled/unhandled error counts will not be incremented.

For fatal NDK errors, we cannot call the JNI without crashing the process, so we write an error report to disk using C. This PR updates the serialisation code to handle the concept of a stopped session.

See #429 for the Java implementation, and further details.

## Changeset

- Emit a `SESSION_STARTED` observable event from `SessionTracker.java` when a session is started or resumed, which ultimately sets session information on the NDK payload.
- Add a `SESSION_STOPPED` observable event, which sets a boolean flag on `bugsnag_report` that prevents serialisation of session information in fatal NDK error reports
- Update the `SESSION_STARTED` event to also include the handled count, rather than assuming it will always equal 0.

## Tests
Added mazerunner scenarios to verify that session information is not present in error payloads of a stopped session.
