### PR TITLE
Fix incorrect session handledCount when notifying in quick succession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Prevent overwriting config.projectPackages if already set
   [#428](https://github.com/bugsnag/bugsnag-android/pull/428)
 
+* Fix incorrect session handledCount when notifying in quick succession
+  [#434](https://github.com/bugsnag/bugsnag-android/pull/434)
+
 ## 4.11.0 (2019-01-22)
 
 ### Enhancements

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeNotifyTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeNotifyTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 
 import android.support.test.filters.SmallTest
 import android.support.test.runner.AndroidJUnit4
+import com.bugsnag.android.BugsnagTestUtils.generateSessionTracker
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,7 +24,7 @@ class BeforeNotifyTest {
             false
         }
 
-        val error = Error.Builder(config, RuntimeException("Test"), null,
+        val error = Error.Builder(config, RuntimeException("Test"), generateSessionTracker(),
             Thread.currentThread(), false).build()
         beforeNotify.run(error)
         assertEquals(context, error.context)

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -72,7 +72,7 @@ public class ErrorStoreTest {
     @NonNull
     private Error writeErrorToStore() {
         Error error = new Error.Builder(config, new RuntimeException(),
-            null, Thread.currentThread(), false).build();
+            BugsnagTestUtils.generateSessionTracker(), Thread.currentThread(), false).build();
         errorStore.write(error);
         return error;
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ExceptionsTest.java
@@ -66,7 +66,8 @@ public class ExceptionsTest {
         StackTraceElement element = new StackTraceElement("Class", "method", "Class.java", 123);
         StackTraceElement[] frames = new StackTraceElement[]{element};
         Error error = new Error.Builder(config, "RuntimeException",
-            "Example message", frames, null, Thread.currentThread()).build();
+            "Example message", frames, BugsnagTestUtils.generateSessionTracker(),
+            Thread.currentThread()).build();
         Exceptions exceptions = new Exceptions(config, error.getException());
 
         JSONObject exceptionJson = streamableToJsonArray(exceptions).getJSONObject(0);

--- a/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateClient;
+import static com.bugsnag.android.BugsnagTestUtils.generateSessionTracker;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 
@@ -31,13 +33,13 @@ public class NullMetadataTest {
     @Before
     public void setUp() throws Exception {
         config = new Configuration("api-key");
-        BugsnagTestUtils.generateClient();
+        generateClient();
         throwable = new RuntimeException("Test");
     }
 
     @Test
     public void testErrorDefaultMetaData() throws Exception {
-        Error error = new Error.Builder(config, throwable, null,
+        Error error = new Error.Builder(config, throwable, generateSessionTracker(),
             Thread.currentThread(), false).build();
         validateDefaultMetadata(error.getMetaData());
     }
@@ -46,13 +48,14 @@ public class NullMetadataTest {
     public void testSecondErrorDefaultMetaData() throws Exception {
         Error error = new Error.Builder(config, "RuntimeException",
             "Something broke", new StackTraceElement[]{},
-            null, Thread.currentThread()).build();
+            generateSessionTracker(), Thread.currentThread()).build();
         validateDefaultMetadata(error.getMetaData());
     }
 
     @Test
     public void testErrorSetMetadataRef() throws Exception {
-        Error error = new Error.Builder(config, throwable, null,
+        Error error = new Error.Builder(config, throwable,
+            generateSessionTracker(),
             Thread.currentThread(), false).build();
         MetaData metaData = new MetaData();
         metaData.addToTab(TAB_KEY, "test", "data");
@@ -62,7 +65,8 @@ public class NullMetadataTest {
 
     @Test
     public void testErrorSetNullMetadata() throws Exception {
-        Error error = new Error.Builder(config, throwable, null,
+        Error error = new Error.Builder(config, throwable,
+            generateSessionTracker(),
             Thread.currentThread(), false).build();
         error.setMetaData(null);
         validateDefaultMetadata(error.getMetaData());
@@ -97,7 +101,7 @@ public class NullMetadataTest {
             }
         });
         Error error = new Error.Builder(config, new Throwable(),
-            null, Thread.currentThread(), false).build();
+            generateSessionTracker(), Thread.currentThread(), false).build();
         Client client = Bugsnag.getClient();
         client.notify(error, DeliveryStyle.SAME_THREAD, null);
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ReportTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ReportTest.java
@@ -31,7 +31,8 @@ public class ReportTest {
     public void setUp() throws Exception {
         Configuration config = new Configuration("example-api-key");
         RuntimeException exception = new RuntimeException("Something broke");
-        Error error = new Error.Builder(config, exception, null,
+        Error error = new Error.Builder(config, exception,
+            BugsnagTestUtils.generateSessionTracker(),
             Thread.currentThread(), false).build();
         report = new Report("api-key", error);
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTest.kt
@@ -21,14 +21,14 @@ class SessionTest {
 
     @Test
     fun handledIncrementCopiesSession() {
-        val copy = session.incrementHandledErrCount()
+        val copy = session.incrementHandledAndCopy()
         assertNotEquals(session, copy)
         validateSessionCopied(copy)
     }
 
     @Test
     fun unhandledIncrementCopiesSession() {
-        val copy = session.incrementUnhandledErrCount()
+        val copy = session.incrementUnhandledAndCopy()
         assertNotEquals(session, copy)
         validateSessionCopied(copy)
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTest.kt
@@ -1,0 +1,47 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import java.util.Date
+
+class SessionTest {
+
+    private val session = Session("123", Date(), User(), true)
+
+    /**
+     * Verifies that all the fields in session are copied into a new object correctly
+     */
+    @Test
+    fun copySession() {
+        val copy = Session.copySession(session)
+        assertNotEquals(session, copy)
+        validateSessionCopied(copy)
+    }
+
+    @Test
+    fun handledIncrementCopiesSession() {
+        val copy = session.incrementHandledErrCount()
+        assertNotEquals(session, copy)
+        validateSessionCopied(copy)
+    }
+
+    @Test
+    fun unhandledIncrementCopiesSession() {
+        val copy = session.incrementUnhandledErrCount()
+        assertNotEquals(session, copy)
+        validateSessionCopied(copy)
+    }
+
+    private fun validateSessionCopied(copy: Session) {
+        with(session) {
+            assertEquals(id, copy.id)
+            assertEquals(startedAt, copy.startedAt)
+            assertEquals(user, copy.user) // make a shallow copy
+            assertEquals(isAutoCaptured, copy.isAutoCaptured)
+            assertEquals(isTracked.get(), copy.isTracked.get())
+            assertEquals(session.unhandledCount, copy.unhandledCount)
+            assertEquals(session.handledCount, copy.handledCount)
+        }
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -2,7 +2,6 @@ package com.bugsnag.android;
 
 import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.generateSessionStore;
-import static com.bugsnag.android.BugsnagTestUtils.generateSessionTrackingApiClient;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
@@ -10,7 +9,6 @@ import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertNotEquals;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -80,11 +78,11 @@ public class SessionTrackerTest {
     @Test
     public void testIncrementCounts() throws Exception {
         sessionTracker.startNewSession(new Date(), user, false);
-        sessionTracker.incrementHandledError();
-        sessionTracker.incrementHandledError();
-        sessionTracker.incrementUnhandledError();
-        sessionTracker.incrementUnhandledError();
-        sessionTracker.incrementUnhandledError();
+        sessionTracker.incrementHandledAndCopy();
+        sessionTracker.incrementHandledAndCopy();
+        sessionTracker.incrementUnhandledAndCopy();
+        sessionTracker.incrementUnhandledAndCopy();
+        sessionTracker.incrementUnhandledAndCopy();
 
         Session session = sessionTracker.getCurrentSession();
         assertNotNull(session);

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -863,7 +863,7 @@ public class Client extends Observable implements Observer {
             callback.beforeNotify(report);
         }
 
-        if (sessionTracker.getCurrentSession() != null) {
+        if (!error.getHandledState().isUnhandled() && error.getSession() != null) {
             setChanged();
             notifyObservers(new NativeInterface.Message(
                 NativeInterface.MessageType.NOTIFY_HANDLED, error.getExceptionName()));

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -657,7 +657,7 @@ public class Client extends Observable implements Observer {
      * @param exception the exception to send to Bugsnag
      */
     public void notify(@NonNull Throwable exception) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .severityReasonType(HandledState.REASON_HANDLED_EXCEPTION)
             .build();
@@ -672,7 +672,7 @@ public class Client extends Observable implements Observer {
      *                  additional modification
      */
     public void notify(@NonNull Throwable exception, @Nullable Callback callback) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .severityReasonType(HandledState.REASON_HANDLED_EXCEPTION)
             .build();
@@ -693,7 +693,7 @@ public class Client extends Observable implements Observer {
                        @NonNull StackTraceElement[] stacktrace,
                        @Nullable Callback callback) {
         Error error = new Error.Builder(config, name, message, stacktrace,
-            sessionTracker.getCurrentSession(), Thread.currentThread())
+            sessionTracker, Thread.currentThread())
             .severityReasonType(HandledState.REASON_HANDLED_EXCEPTION)
             .build();
         notify(error, DeliveryStyle.ASYNC, callback);
@@ -707,7 +707,7 @@ public class Client extends Observable implements Observer {
      *                  Severity.WARNING or Severity.INFO
      */
     public void notify(@NonNull Throwable exception, @NonNull Severity severity) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .severity(severity)
             .build();
@@ -724,7 +724,7 @@ public class Client extends Observable implements Observer {
     @Deprecated
     public void notify(@NonNull Throwable exception,
                        @NonNull MetaData metaData) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .metaData(metaData)
             .severityReasonType(HandledState.REASON_HANDLED_EXCEPTION)
@@ -744,7 +744,7 @@ public class Client extends Observable implements Observer {
     @Deprecated
     public void notify(@NonNull Throwable exception, @NonNull Severity severity,
                        @NonNull MetaData metaData) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .metaData(metaData)
             .severity(severity)
@@ -769,7 +769,7 @@ public class Client extends Observable implements Observer {
                        @NonNull StackTraceElement[] stacktrace, @NonNull Severity severity,
                        @NonNull MetaData metaData) {
         Error error = new Error.Builder(config, name, message,
-            stacktrace, sessionTracker.getCurrentSession(), Thread.currentThread())
+            stacktrace, sessionTracker, Thread.currentThread())
             .severity(severity)
             .metaData(metaData)
             .build();
@@ -797,7 +797,7 @@ public class Client extends Observable implements Observer {
                        @NonNull Severity severity,
                        @NonNull MetaData metaData) {
         Error error = new Error.Builder(config, name, message,
-            stacktrace, sessionTracker.getCurrentSession(), Thread.currentThread())
+            stacktrace, sessionTracker, Thread.currentThread())
             .severity(severity)
             .metaData(metaData)
             .build();
@@ -863,19 +863,6 @@ public class Client extends Observable implements Observer {
             callback.beforeNotify(report);
         }
 
-        HandledState handledState = report.getError().getHandledState();
-
-        if (handledState.isUnhandled()) {
-            sessionTracker.incrementUnhandledError();
-        } else {
-            sessionTracker.incrementHandledError();
-            if (sessionTracker.getCurrentSession() != null) {
-                setChanged();
-                notifyObservers(new NativeInterface.Message(
-                            NativeInterface.MessageType.NOTIFY_HANDLED, error.getExceptionName()));
-            }
-        }
-
         switch (style) {
             case SAME_THREAD:
                 deliver(report, error);
@@ -919,7 +906,7 @@ public class Client extends Observable implements Observer {
      * @param exception the exception to send to Bugsnag
      */
     public void notifyBlocking(@NonNull Throwable exception) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .severityReasonType(HandledState.REASON_HANDLED_EXCEPTION)
             .build();
@@ -934,7 +921,7 @@ public class Client extends Observable implements Observer {
      *                  additional modification
      */
     public void notifyBlocking(@NonNull Throwable exception, @Nullable Callback callback) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .severityReasonType(HandledState.REASON_HANDLED_EXCEPTION)
             .build();
@@ -955,7 +942,7 @@ public class Client extends Observable implements Observer {
                                @NonNull StackTraceElement[] stacktrace,
                                @Nullable Callback callback) {
         Error error = new Error.Builder(config, name, message,
-            stacktrace, sessionTracker.getCurrentSession(), Thread.currentThread())
+            stacktrace, sessionTracker, Thread.currentThread())
             .severityReasonType(HandledState.REASON_HANDLED_EXCEPTION)
             .build();
         notify(error, DeliveryStyle.SAME_THREAD, callback);
@@ -971,7 +958,7 @@ public class Client extends Observable implements Observer {
     @Deprecated
     public void notifyBlocking(@NonNull Throwable exception,
                                @NonNull MetaData metaData) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .severityReasonType(HandledState.REASON_HANDLED_EXCEPTION)
             .metaData(metaData)
@@ -991,7 +978,7 @@ public class Client extends Observable implements Observer {
     @Deprecated
     public void notifyBlocking(@NonNull Throwable exception, @NonNull Severity severity,
                                @NonNull MetaData metaData) {
-        Error error = new Error.Builder(config, exception, sessionTracker.getCurrentSession(),
+        Error error = new Error.Builder(config, exception, sessionTracker,
             Thread.currentThread(), false)
             .metaData(metaData)
             .severity(severity)
@@ -1018,7 +1005,7 @@ public class Client extends Observable implements Observer {
                                @NonNull Severity severity,
                                @NonNull MetaData metaData) {
         Error error = new Error.Builder(config, name, message,
-            stacktrace, sessionTracker.getCurrentSession(), Thread.currentThread())
+            stacktrace, sessionTracker, Thread.currentThread())
             .severity(severity)
             .metaData(metaData)
             .build();
@@ -1046,7 +1033,7 @@ public class Client extends Observable implements Observer {
                                @NonNull Severity severity,
                                @NonNull MetaData metaData) {
         Error error = new Error.Builder(config, name, message,
-            stacktrace, sessionTracker.getCurrentSession(), Thread.currentThread())
+            stacktrace, sessionTracker, Thread.currentThread())
             .severity(severity)
             .metaData(metaData)
             .build();
@@ -1063,7 +1050,7 @@ public class Client extends Observable implements Observer {
      */
     public void notifyBlocking(@NonNull Throwable exception, @NonNull Severity severity) {
         Error error = new Error.Builder(config, exception,
-            sessionTracker.getCurrentSession(), Thread.currentThread(), false)
+            sessionTracker, Thread.currentThread(), false)
             .severity(severity)
             .build();
         notify(error, BLOCKING);
@@ -1092,7 +1079,7 @@ public class Client extends Observable implements Observer {
 
         @SuppressWarnings("WrongConstant")
         Error error = new Error.Builder(config, exception,
-            sessionTracker.getCurrentSession(), Thread.currentThread(), false)
+            sessionTracker, Thread.currentThread(), false)
             .severity(Severity.fromString(severity))
             .severityReasonType(severityReason)
             .attributeValue(logLevel)
@@ -1250,7 +1237,7 @@ public class Client extends Observable implements Observer {
                         @HandledState.SeverityReason String severityReason,
                         @Nullable String attributeValue, Thread thread) {
         Error error = new Error.Builder(config, exception,
-            sessionTracker.getCurrentSession(), thread, true)
+            sessionTracker, thread, true)
             .severity(severity)
             .metaData(metaData)
             .severityReasonType(severityReason)

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -863,6 +863,12 @@ public class Client extends Observable implements Observer {
             callback.beforeNotify(report);
         }
 
+        if (sessionTracker.getCurrentSession() != null) {
+            setChanged();
+            notifyObservers(new NativeInterface.Message(
+                NativeInterface.MessageType.NOTIFY_HANDLED, error.getExceptionName()));
+        }
+
         switch (style) {
             case SAME_THREAD:
                 deliver(report, error);

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -457,9 +457,9 @@ public class Error implements JsonStream.Streamable {
             }
             if (config.getAutoCaptureSessions() || !currentSession.isAutoCaptured()) {
                 if (handledState.isUnhandled()) {
-                    reportedSession = sessionTracker.incrementUnhandledError();
+                    reportedSession = sessionTracker.incrementUnhandledAndCopy();
                 } else {
-                    reportedSession = sessionTracker.incrementHandledError();
+                    reportedSession = sessionTracker.incrementHandledAndCopy();
                 }
             }
             return reportedSession;

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -385,7 +385,7 @@ public class Error implements JsonStream.Streamable {
     static class Builder {
         private final Configuration config;
         private final Throwable exception;
-        private final Session session;
+        private final SessionTracker sessionTracker;
         private final ThreadState threadState;
         private Severity severity = Severity.WARNING;
         private MetaData metaData;
@@ -396,7 +396,7 @@ public class Error implements JsonStream.Streamable {
 
         Builder(@NonNull Configuration config,
                 @NonNull Throwable exception,
-                @Nullable Session session,
+                SessionTracker sessionTracker,
                 @NonNull Thread thread,
                 boolean unhandled) {
             Throwable exc = unhandled ? exception : null;
@@ -404,19 +404,14 @@ public class Error implements JsonStream.Streamable {
             this.config = config;
             this.exception = exception;
             this.severityReasonType = HandledState.REASON_USER_SPECIFIED; // default
-
-            if (session != null
-                && !config.getAutoCaptureSessions() && session.isAutoCaptured()) {
-                this.session = null;
-            } else {
-                this.session = session;
-            }
+            this.sessionTracker = sessionTracker;
         }
 
         Builder(@NonNull Configuration config, @NonNull String name,
                 @NonNull String message, @NonNull StackTraceElement[] frames,
-                Session session, Thread thread) {
-            this(config, new BugsnagException(name, message, frames), session, thread, false);
+                SessionTracker sessionTracker, Thread thread) {
+            this(config, new BugsnagException(name, message, frames), sessionTracker,
+                thread, false);
         }
 
         Builder severityReasonType(@HandledState.SeverityReason String severityReasonType) {
@@ -442,6 +437,8 @@ public class Error implements JsonStream.Streamable {
         Error build() {
             HandledState handledState =
                 HandledState.newInstance(severityReasonType, severity, attributeValue);
+            Session session = getSession(handledState);
+
             Error error = new Error(config, exception, handledState,
                 severity, session, threadState);
 
@@ -449,6 +446,23 @@ public class Error implements JsonStream.Streamable {
                 error.setMetaData(metaData);
             }
             return error;
+        }
+
+        private Session getSession(HandledState handledState) {
+            Session currentSession = sessionTracker.getCurrentSession();
+            Session reportedSession = null;
+
+            if (currentSession == null) {
+                return null;
+            }
+            if (config.getAutoCaptureSessions() || !currentSession.isAutoCaptured()) {
+                if (handledState.isUnhandled()) {
+                    reportedSession = sessionTracker.incrementUnhandledError();
+                } else {
+                    reportedSession = sessionTracker.incrementHandledError();
+                }
+            }
+            return reportedSession;
         }
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/Session.java
+++ b/sdk/src/main/java/com/bugsnag/android/Session.java
@@ -63,12 +63,12 @@ class Session implements JsonStream.Streamable {
         return handledCount.intValue();
     }
 
-    Session incrementHandledErrCount() {
+    Session incrementHandledAndCopy() {
         handledCount.incrementAndGet();
         return copySession(this);
     }
 
-    Session incrementUnhandledErrCount() {
+    Session incrementUnhandledAndCopy() {
         unhandledCount.incrementAndGet();
         return copySession(this);
     }

--- a/sdk/src/main/java/com/bugsnag/android/Session.java
+++ b/sdk/src/main/java/com/bugsnag/android/Session.java
@@ -14,6 +14,14 @@ class Session implements JsonStream.Streamable {
     private final User user;
     private AtomicBoolean autoCaptured;
 
+    static Session copySession(Session session) {
+        Session copy = new Session(session.id, session.startedAt,
+            session.user, session.unhandledCount.get(), session.handledCount.get());
+        copy.tracked.set(session.tracked.get());
+        copy.autoCaptured.set(session.isAutoCaptured());
+        return copy;
+    }
+
     public Session(String id, Date startedAt, User user, boolean autoCaptured) {
         this.id = id;
         this.startedAt = new Date(startedAt.getTime());
@@ -55,12 +63,14 @@ class Session implements JsonStream.Streamable {
         return handledCount.intValue();
     }
 
-    void incrementHandledErrCount() {
+    Session incrementHandledErrCount() {
         handledCount.incrementAndGet();
+        return copySession(this);
     }
 
-    void incrementUnhandledErrCount() {
+    Session incrementUnhandledErrCount() {
         unhandledCount.incrementAndGet();
+        return copySession(this);
     }
 
     AtomicBoolean isTracked() {

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -144,18 +144,30 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         return currentSession.get();
     }
 
-    Session incrementUnhandledError() {
+    /**
+     * Increments the unhandled error count on the current session, then returns a deep-copy
+     * of the current session.
+     *
+     * @return a copy of the current session, or null if no session has been started.
+     */
+    Session incrementUnhandledAndCopy() {
         Session session = currentSession.get();
         if (session != null) {
-            return session.incrementUnhandledErrCount();
+            return session.incrementUnhandledAndCopy();
         }
         return null;
     }
 
-    Session incrementHandledError() {
+    /**
+     * Increments the handled error count on the current session, then returns a deep-copy
+     * of the current session.
+     *
+     * @return a copy of the current session, or null if no session has been started.
+     */
+    Session incrementHandledAndCopy() {
         Session session = currentSession.get();
         if (session != null) {
-            return session.incrementHandledErrCount();
+            return session.incrementHandledAndCopy();
         }
         return null;
     }

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -144,18 +144,20 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         return currentSession.get();
     }
 
-    void incrementUnhandledError() {
+    Session incrementUnhandledError() {
         Session session = currentSession.get();
         if (session != null) {
-            session.incrementUnhandledErrCount();
+            return session.incrementUnhandledErrCount();
         }
+        return null;
     }
 
-    void incrementHandledError() {
+    Session incrementHandledError() {
         Session session = currentSession.get();
         if (session != null) {
-            session.incrementHandledErrCount();
+            return session.incrementHandledErrCount();
         }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Goal

By default `bugsnag.notify()` captures error reports synchronously, then delivers them asynchronously. The delivery process serialises information about the current session into the error, including counts of handled/unhandled errors that have occurred in the session.

These counts were serialised in the async delivery, from a shared `session` object reference. This meant if `bugsnag.notify()` was called twice, the session object `handledCount` would be incremented twice, _then_ serialised with the incorrect counts.

This PR fixes this behaviour to ensure the counts are correct.

## Design

A defensive copy has been made of the session object when populating the error field, meaning mutations made by other errors do not affect the state of other reports.

## Changeset

- Updated `Error.Builder` (and calling code) to take a `SessionTracker` rather than `Session` (a lot of sites use this method, so it may be easier to inspect the PR by viewing individual commits)
- Added `copySession` method which copies a `Session` object
- Made `incrementHandledError` and `incrementUnhandledError` return a `Session` object which is a copy of `SessionTracker#currentSession`
- Move incrementing of handled/unhandled counts from `Client#notify` to `Error.Builder#build`, as this more accurately reflects where the error capture occurs.

## Tests

- Added a unit test for copying sessions

- This can be manually reproduced by notifying twice, and verifying that the `handledCount` equals 1 for one report, and 2 for the other report, rather than 2 for both.

```
bugsnag.notify(err)
bugsnag.notify(err)
```

