### PR TITLE
Wait for session scenarios to send session before crashing

### DIFF
--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
 import android.content.Context;
+import android.os.Handler;
 
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
@@ -13,6 +14,8 @@ public class CXXStartSessionScenario extends Scenario {
         System.loadLibrary("monochrome");
         System.loadLibrary("entrypoint");
     }
+
+    private Handler handler = new Handler();
 
     public native int crash(int counter);
 
@@ -28,7 +31,13 @@ public class CXXStartSessionScenario extends Scenario {
 
         if (metadata == null || !metadata.equals("non-crashy")) {
             Bugsnag.getClient().startSession();
-            crash(0);
+
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    crash(0);
+                }
+            }, 8000);
         }
     }
 }

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStopSessionScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStopSessionScenario.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
 import android.content.Context;
+import android.os.Handler;
 
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
@@ -13,6 +14,8 @@ public class CXXStopSessionScenario extends Scenario {
         System.loadLibrary("monochrome");
         System.loadLibrary("entrypoint");
     }
+
+    private Handler handler = new Handler();
 
     public native int crash(int counter);
 
@@ -29,7 +32,13 @@ public class CXXStopSessionScenario extends Scenario {
         if (metadata == null || !metadata.equals("non-crashy")) {
             Bugsnag.getClient().startSession();
             Bugsnag.getClient().stopSession();
-            crash(0);
+
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    crash(0);
+                }
+            }, 8000);
         }
     }
 }

--- a/features/native_session_tracking.feature
+++ b/features/native_session_tracking.feature
@@ -2,6 +2,8 @@ Feature: NDK Session Tracking
 
 Scenario: Stopped session is not in payload of unhandled NDK error
     When I run "CXXStopSessionScenario"
+    And I wait a bit
+    And I wait a bit
     And I configure the app to run in the "non-crashy" state
     And I relaunch the app
     Then I should receive 2 requests
@@ -11,6 +13,8 @@ Scenario: Stopped session is not in payload of unhandled NDK error
 
 Scenario: Started session is in payload of unhandled NDK error
     When I run "CXXStartSessionScenario"
+    And I wait a bit
+    And I wait a bit
     And I configure the app to run in the "non-crashy" state
     And I relaunch the app
     Then I should receive 2 requests


### PR DESCRIPTION
The E2E test job failed for Android 24 on CI only. I believe this is due to the native code killing the app before the session can be delivered, which is only an issue on Travis CI's slow ARM emulators.

The fix uses a handler to delay this crash for a reasonable period, meaning the session is always delivered in time. This mirrors the approach used in [previous](https://github.com/bugsnag/bugsnag-android/blob/master/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSessionInfoCrashScenario.java) [scenarios](https://github.com/bugsnag/bugsnag-android/blob/9f69368dd606d6522371b0150fa3ea260e41fb0b/features/native_api.feature).