### PR TITLE
fix: Add helper for syncing a unity session to native reports

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -1277,6 +1277,10 @@ public class Client extends Observable implements Observer {
         return orientationListener; // this only exists for tests
     }
 
+    SessionTracker getSessionTracker() {
+        return sessionTracker;
+    }
+
     private boolean runBeforeNotifyTasks(Error error) {
         for (BeforeNotify beforeNotify : config.getBeforeNotifyTasks()) {
             try {

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -393,6 +394,17 @@ public class NativeInterface {
      */
     public static void setNotifyReleaseStages(@Nullable String[] notifyReleaseStages) {
         getClient().getConfig().setNotifyReleaseStages(notifyReleaseStages);
+    }
+
+    /**
+     * Update the current session with a given start time, ID, and event counts
+     */
+    public static void registerSession(long startedAt, @NonNull String sessionId,
+                                       int unhandledCount, int handledCount) {
+        Client client = getClient();
+        User user = client.getUser();
+        client.getSessionTracker().registerExistingSession(new Date(startedAt), sessionId, user,
+                                                           unhandledCount, handledCount);
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -399,11 +399,12 @@ public class NativeInterface {
     /**
      * Update the current session with a given start time, ID, and event counts
      */
-    public static void registerSession(long startedAt, @NonNull String sessionId,
+    public static void registerSession(long startedAt, @Nullable String sessionId,
                                        int unhandledCount, int handledCount) {
         Client client = getClient();
         User user = client.getUser();
-        client.getSessionTracker().registerExistingSession(new Date(startedAt), sessionId, user,
+        Date startDate = startedAt > 0 ? new Date(startedAt) : null;
+        client.getSessionTracker().registerExistingSession(startDate, sessionId, user,
                                                            unhandledCount, handledCount);
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -79,6 +79,25 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     }
 
     /**
+     * Cache details of a previously captured session.
+     * Append session details to all subsequent reports.
+     *
+     * @param date           the session start date
+     * @param sessionId      the unique session identifier
+     * @param user           the session user (if any)
+     * @param unhandledCount the number of unhandled events which have occurred during the session
+     * @param handledCount   the number of handled events which have occurred during the session
+     * @return the session
+     */
+    @Nullable Session registerExistingSession(@NonNull Date date, @NonNull String sessionId,
+                                              @Nullable User user, int unhandledCount,
+                                              int handledCount) {
+        Session session = new Session(sessionId, date, user, unhandledCount, handledCount);
+        currentSession.set(session);
+        return session;
+    }
+
+    /**
      * Determines whether or not a session should be tracked. If this is true, the session will be
      * stored and sent to the Bugsnag API, otherwise no action will occur in this method.
      *

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -89,10 +89,13 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
      * @param handledCount   the number of handled events which have occurred during the session
      * @return the session
      */
-    @Nullable Session registerExistingSession(@NonNull Date date, @NonNull String sessionId,
+    @Nullable Session registerExistingSession(@Nullable Date date, @Nullable String sessionId,
                                               @Nullable User user, int unhandledCount,
                                               int handledCount) {
-        Session session = new Session(sessionId, date, user, unhandledCount, handledCount);
+        Session session = null;
+        if (date != null && sessionId != null) {
+            session = new Session(sessionId, date, user, unhandledCount, handledCount);
+        }
         currentSession.set(session);
         return session;
     }


### PR DESCRIPTION
## Goal

Allow registering a session with the `SessionTracker` to be propagated to crash reports. This allows the session to be tracked separately via bugsnag-unity while preserving the stability score.

Related to bugsnag/bugsnag-unity#138

## Changeset

Added a helper to `NativeInterface` to allow updating the current session.

## Tests

Tested manually as a part of bugsnag/bugsnag-unity#138
