### PR TITLE
Tests: Added detect ANR scenarios, disabled ANR by default

### DIFF
--- a/features/detect_anr.feature
+++ b/features/detect_anr.feature
@@ -1,0 +1,27 @@
+Feature: Detects ANR
+
+Scenario: Test ANR detected with default timing
+    When I run "AppNotRespondingScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "errorClass" equals "ANR"
+    And the exception "message" equals "Application did not respond for at least 5000 ms"
+
+Scenario: Test ANR not detected when disabled
+    When I run "AppNotRespondingDisabledScenario"
+    Then I should receive 0 requests
+
+Scenario: Test ANR not detected under response time
+    When I run "AppNotRespondingShortScenario"
+    Then I should receive 0 requests
+
+Scenario: Test ANR wait time can be set to under default time
+    When I run "AppNotRespondingShorterThresholdScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "errorClass" equals "ANR"
+    And the exception "message" equals "Application did not respond for at least 2000 ms"
+
+Scenario: Test ANR wait time can be set to over default time
+    When I run "AppNotRespondingLongerThresholdScenario"
+    Then I should receive 0 requests

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -45,6 +45,7 @@ class MainActivity : Activity() {
         val config = Configuration(intent.getStringExtra("BUGSNAG_API_KEY"))
         val port = intent.getStringExtra("BUGSNAG_PORT")
         config.setEndpoints("${findHostname()}:$port", "${findHostname()}:$port")
+        config.detectAnrs = false
         return config
     }
 

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period with ANR detection disabled
+ */
+internal class AppNotRespondingDisabledScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = false
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(6000)
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingLongerThresholdScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingLongerThresholdScenario.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period after changing the threshold to be higher
+ */
+internal class AppNotRespondingLongerThresholdScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = true
+        config.anrThresholdMs = 8000L
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(6000)
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period
+ */
+internal class AppNotRespondingScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = true
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(6000)
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingShortScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingShortScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period shorter than the default
+ */
+internal class AppNotRespondingShortScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = true
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(3000)
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingShorterThresholdScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingShorterThresholdScenario.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period after changing the threshold to be lower
+ */
+internal class AppNotRespondingShorterThresholdScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = true
+        config.anrThresholdMs = 2000L
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(3000)
+    }
+
+}


### PR DESCRIPTION
## Goal

Adds testing scenarios for the ANR detection feature, including testing the threshold configuration.
Disables ANR by default in all other scenarios.
Adds Scenarios testing:
- ANR detection reports when enabled
- ANR detection doesn't report when disabled
- ANR detection doesn't report if response time is under threshold
- ANR detection reports if response time is over custom threshold (but under default)
- ANR doesn't report if response time is under custom threshold (but over default)
