### PR TITLE
Add ANR detection to bugsnag-android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Enhancements
+
+* Add ANR detection to bugsnag-android
+[#442](https://github.com/bugsnag/bugsnag-android/pull/442)
+
 ## 4.12.0 (2019-02-27)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Add ANR detection to bugsnag-android
 [#442](https://github.com/bugsnag/bugsnag-android/pull/442)
 
+* Add unhandled_events field to native payload
+[#445](https://github.com/bugsnag/bugsnag-android/pull/445)
+
 ## 4.12.0 (2019-02-27)
 
 ### Enhancements

--- a/examples/sdk-app-example/src/javaExample/java/com/bugsnag/android/example/ExampleActivity.java
+++ b/examples/sdk-app-example/src/javaExample/java/com/bugsnag/android/example/ExampleActivity.java
@@ -17,6 +17,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
@@ -52,6 +53,17 @@ public class ExampleActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 doCrash();
+            }
+        });
+
+        findViewById(R.id.btn_anr).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException ignored) {
+                    Log.d("Bugsnag", "Interrupted");
+                }
             }
         });
     }

--- a/examples/sdk-app-example/src/kotlinExample/java/com.bugsnag.android/example/ExampleActivity.kt
+++ b/examples/sdk-app-example/src/kotlinExample/java/com.bugsnag.android/example/ExampleActivity.kt
@@ -34,6 +34,8 @@ class ExampleActivity : AppCompatActivity() {
 
         val nativeBtn: View = findViewById(R.id.btn_native_crash)
         nativeBtn.setOnClickListener { doCrash() }
+
+        findViewById<View>(R.id.btn_anr).setOnClickListener { Thread.sleep(10000) }
     }
 
     private fun performAdditionalBugsnagSetup() {

--- a/examples/sdk-app-example/src/main/res/layout/main.xml
+++ b/examples/sdk-app-example/src/main/res/layout/main.xml
@@ -37,6 +37,13 @@
       android:layout_height="wrap_content"
       android:text="@string/trigger_native_crash" />
 
+    <Button
+      android:id="@+id/btn_anr"
+      style="@style/ButtonTheme"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/trigger_anr" />
+
     <View style="@style/separator" />
 
     <!-- Trigger handled exceptions -->

--- a/examples/sdk-app-example/src/main/res/values-fr/strings.xml
+++ b/examples/sdk-app-example/src/main/res/values-fr/strings.xml
@@ -4,6 +4,7 @@
   <string name="trigger_fatal_crash">FR</string>
   <string name="trigger_native_crash">FR</string>
   <string name="trigger_native_notify">FR</string>
+  <string name="trigger_anr">FR</string>
 
   <string name="handled_exceptions">FR</string>
   <string name="trigger_nonfatal_crash">FR</string>

--- a/examples/sdk-app-example/src/main/res/values/strings.xml
+++ b/examples/sdk-app-example/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
   <string name="unhandled_exceptions">Unhandled Exceptions</string>
   <string name="trigger_fatal_crash">Trigger a fatal crash</string>
   <string name="trigger_native_crash">Trigger a native crash</string>
+  <string name="trigger_anr">Trigger an ANR</string>
 
   <string name="handled_exceptions">Handled Exceptions</string>
   <string name="trigger_nonfatal_crash">Trigger a non-fatal crash</string>

--- a/features/detect_anr.feature
+++ b/features/detect_anr.feature
@@ -1,0 +1,27 @@
+Feature: Detects ANR
+
+Scenario: Test ANR detected with default timing
+    When I run "AppNotRespondingScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "errorClass" equals "ANR"
+    And the exception "message" equals "Application did not respond for at least 5000 ms"
+
+Scenario: Test ANR not detected when disabled
+    When I run "AppNotRespondingDisabledScenario"
+    Then I should receive 0 requests
+
+Scenario: Test ANR not detected under response time
+    When I run "AppNotRespondingShortScenario"
+    Then I should receive 0 requests
+
+Scenario: Test ANR wait time can be set to under default time
+    When I run "AppNotRespondingShorterThresholdScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "errorClass" equals "ANR"
+    And the exception "message" equals "Application did not respond for at least 2000 ms"
+
+Scenario: Test ANR wait time can be set to over default time
+    When I run "AppNotRespondingLongerThresholdScenario"
+    Then I should receive 0 requests

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -45,6 +45,7 @@ class MainActivity : Activity() {
         val config = Configuration(intent.getStringExtra("BUGSNAG_API_KEY"))
         val port = intent.getStringExtra("BUGSNAG_PORT")
         config.setEndpoints("${findHostname()}:$port", "${findHostname()}:$port")
+        config.detectAnrs = false
         return config
     }
 

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period with ANR detection disabled
+ */
+internal class AppNotRespondingDisabledScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = false
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(6000)
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingLongerThresholdScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingLongerThresholdScenario.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period after changing the threshold to be higher
+ */
+internal class AppNotRespondingLongerThresholdScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = true
+        config.anrThresholdMs = 8000L
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(6000)
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period
+ */
+internal class AppNotRespondingScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = true
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(6000)
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingShortScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingShortScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period shorter than the default
+ */
+internal class AppNotRespondingShortScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = true
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(3000)
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingShorterThresholdScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingShorterThresholdScenario.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period after changing the threshold to be lower
+ */
+internal class AppNotRespondingShorterThresholdScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        config.detectAnrs = true
+        config.anrThresholdMs = 2000L
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(3000)
+    }
+
+}

--- a/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -48,13 +48,16 @@ public class NativeBridge implements Observer {
 
     public static native void addHandledEvent();
 
+    public static native void addUnhandledEvent();
+
     public static native void clearBreadcrumbs();
 
     public static native void clearMetadataTab(String tab);
 
     public static native void removeMetadata(String tab, String key);
 
-    public static native void startedSession(String sessionID, String key, int handledCount);
+    public static native void startedSession(String sessionID, String key,
+                                             int handledCount, int unhandledCount);
 
     public static native void stoppedSession();
 
@@ -126,6 +129,9 @@ public class NativeBridge implements Observer {
                 break;
             case NOTIFY_HANDLED:
                 addHandledEvent();
+                break;
+            case NOTIFY_UNHANDLED:
+                addUnhandledEvent();
                 break;
             case REMOVE_METADATA:
                 handleRemoveMetadata(arg);
@@ -318,14 +324,16 @@ public class NativeBridge implements Observer {
         if (arg instanceof List) {
             @SuppressWarnings("unchecked")
             List<Object> metadata = (List<Object>)arg;
-            if (metadata.size() == 3) {
+            if (metadata.size() == 4) {
                 Object id = metadata.get(0);
                 Object startTime = metadata.get(1);
                 Object handledCount = metadata.get(2);
+                Object unhandledCount = metadata.get(3);
 
                 if (id instanceof String && startTime instanceof String
-                    && handledCount instanceof Integer) {
-                    startedSession((String)id, (String)startTime, (Integer) handledCount);
+                    && handledCount instanceof Integer && unhandledCount instanceof Integer) {
+                    startedSession((String)id, (String)startTime,
+                        (Integer) handledCount, (Integer) unhandledCount);
                     return;
                 }
             }

--- a/ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -87,6 +87,7 @@ void bsg_handle_cpp_terminate() {
 
   bsg_global_env->handling_crash = true;
   bsg_populate_report_as(bsg_global_env);
+  bsg_global_env->next_report.unhandled_events++;
   bsg_global_env->next_report.exception.frame_count = bsg_unwind_stack(
       bsg_global_env->unwind_style,
       bsg_global_env->next_report.exception.stacktrace, NULL, NULL);

--- a/ndk/src/main/jni/handlers/signal_handler.c
+++ b/ndk/src/main/jni/handlers/signal_handler.c
@@ -174,6 +174,7 @@ void bsg_handle_signal(int signum, siginfo_t *info,
 
   bsg_global_env->handling_crash = true;
   bsg_populate_report_as(bsg_global_env);
+  bsg_global_env->next_report.unhandled_events++;
   bsg_global_env->next_report.exception.frame_count = bsg_unwind_stack(
       bsg_global_env->signal_unwind_style,
       bsg_global_env->next_report.exception.stacktrace, info, user_context);

--- a/ndk/src/main/jni/report.c
+++ b/ndk/src/main/jni/report.c
@@ -83,11 +83,12 @@ void bugsnag_report_remove_metadata_tab(bugsnag_report *report, char *section) {
 }
 
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
-                                  char *started_at, int handled_count) {
+                                  char *started_at, int handled_count, int unhandled_count) {
   bsg_strncpy_safe(report->session_id, session_id, sizeof(report->session_id));
   bsg_strncpy_safe(report->session_start, started_at,
                    sizeof(report->session_start));
   report->handled_events = handled_count;
+  report->unhandled_events = unhandled_count;
 }
 
 void bugsnag_report_set_context(bugsnag_report *report, char *value) {

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -31,7 +31,7 @@
 /**
  * Version of the bugsnag_report struct. Serialized to report header.
  */
-#define BUGSNAG_REPORT_VERSION 1
+#define BUGSNAG_REPORT_VERSION 2
 
 #define BUGSNAG_USER_INFO_LEN 64
 #ifdef __cplusplus
@@ -292,6 +292,7 @@ typedef struct {
   char session_id[33];
   char session_start[33];
   int handled_events;
+  int unhandled_events;
 } bugsnag_report;
 
 void bugsnag_report_add_metadata_double(bugsnag_report *report, char *section,
@@ -315,7 +316,7 @@ void bugsnag_report_set_user_email(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_id(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_name(bugsnag_report *report, char *value);
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
-                                  char *started_at, int handled_count);
+                                  char *started_at, int handled_count, int unhandled_count);
 bool bugsnag_report_has_session(bugsnag_report *report);
 
 #ifdef __cplusplus

--- a/ndk/src/main/jni/utils/migrate.h
+++ b/ndk/src/main/jni/utils/migrate.h
@@ -1,0 +1,35 @@
+#ifndef BUGSNAG_MIGRATE_H
+#define BUGSNAG_MIGRATE_H
+
+#include "report.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    bsg_library notifier;
+    bsg_app_info app;
+    bsg_device_info device;
+    bsg_user user;
+    bsg_exception exception;
+    bugsnag_metadata metadata;
+
+    int crumb_count;
+    // Breadcrumbs are a ring; the first index moves as the
+    // structure is filled and replaced.
+    int crumb_first_index;
+    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+    char context[64];
+    bsg_severity_t severity;
+
+    char session_id[33];
+    char session_start[33];
+    int handled_events;
+} bugsnag_report_v1;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/sdk/src/androidTest/java/com/bugsnag/android/AnrConfigTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AnrConfigTest.kt
@@ -26,7 +26,7 @@ class AnrConfigTest {
 
         arrayOf(100, 99, 0, -5, Long.MIN_VALUE).forEach {
             config.anrThresholdMs = it
-            assertEquals(it, config.anrThresholdMs)
+            assertEquals(100, config.anrThresholdMs)
         }
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/AnrConfigTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AnrConfigTest.kt
@@ -1,0 +1,32 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnrConfigTest {
+
+    private val config = Configuration("api-key")
+
+    @Test
+    fun testDetectAnrDefault() {
+        assertTrue(config.detectAnrs)
+    }
+
+    /**
+     * Verifies that attempts to set the ANR threshold below 100ms set the value as 100ms
+     */
+    @Test
+    fun testAnrThresholdMs() {
+        val config = config
+        assertEquals(5000, config.anrThresholdMs)
+
+        config.anrThresholdMs = 10000
+        assertEquals(10000, config.anrThresholdMs)
+
+        arrayOf(100, 99, 0, -5, Long.MIN_VALUE).forEach {
+            config.anrThresholdMs = it
+            assertEquals(it, config.anrThresholdMs)
+        }
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/AnrConfigTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AnrConfigTest.kt
@@ -14,7 +14,7 @@ class AnrConfigTest {
     }
 
     /**
-     * Verifies that attempts to set the ANR threshold below 100ms set the value as 100ms
+     * Verifies that attempts to set the ANR threshold below 1000ms set the value as 1000ms
      */
     @Test
     fun testAnrThresholdMs() {
@@ -24,9 +24,9 @@ class AnrConfigTest {
         config.anrThresholdMs = 10000
         assertEquals(10000, config.anrThresholdMs)
 
-        arrayOf(100, 99, 0, -5, Long.MIN_VALUE).forEach {
+        arrayOf(1000, 999, 0, -5, Long.MIN_VALUE).forEach {
             config.anrThresholdMs = it
-            assertEquals(100, config.anrThresholdMs)
+            assertEquals(1000, config.anrThresholdMs)
         }
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/BlockedThreadDetectorTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BlockedThreadDetectorTest.kt
@@ -1,0 +1,34 @@
+package com.bugsnag.android
+
+import android.os.Looper
+import org.junit.Test
+
+class BlockedThreadDetectorTest {
+
+    private val looper = Looper.getMainLooper()
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testInvalidBlockedThresholdMs() {
+        BlockedThreadDetector(-1, 1, looper) {}
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testInvalidCheckIntervalMs() {
+        BlockedThreadDetector(1, -1, looper) {}
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testInvalidThread() {
+        BlockedThreadDetector(1, 1, null) {}
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testInvalidDelegate() {
+        BlockedThreadDetector(1, 1, looper, null)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testExcessiveCheckInterval() {
+        BlockedThreadDetector(100, 1000, looper) {}
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/BlockedThreadDetectorTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BlockedThreadDetectorTest.kt
@@ -26,9 +26,4 @@ class BlockedThreadDetectorTest {
     fun testInvalidDelegate() {
         BlockedThreadDetector(1, 1, looper, null)
     }
-
-    @Test(expected = IllegalArgumentException::class)
-    fun testExcessiveCheckInterval() {
-        BlockedThreadDetector(100, 1000, looper) {}
-    }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/BlockedThreadDetectorTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BlockedThreadDetectorTest.kt
@@ -9,21 +9,21 @@ class BlockedThreadDetectorTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testInvalidBlockedThresholdMs() {
-        BlockedThreadDetector(-1, 1, looper) {}
+        BlockedThreadDetector(-1, 1, looper, null) {}
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testInvalidCheckIntervalMs() {
-        BlockedThreadDetector(1, -1, looper) {}
+        BlockedThreadDetector(1, -1, looper, null) {}
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testInvalidThread() {
-        BlockedThreadDetector(1, 1, null) {}
+        BlockedThreadDetector(1, 1, null, null) {}
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testInvalidDelegate() {
-        BlockedThreadDetector(1, 1, looper, null)
+        BlockedThreadDetector(1, 1, looper, null, null)
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -153,10 +153,11 @@ public class ObserverInterfaceTest {
         client.startSession();
         List<Object> sessionInfo = (List<Object>)findMessageInQueue(
                 NativeInterface.MessageType.START_SESSION, List.class);
-        assertEquals(3, sessionInfo.size());
+        assertEquals(4, sessionInfo.size());
         assertTrue(sessionInfo.get(0) instanceof String);
         assertTrue(sessionInfo.get(1) instanceof String);
         assertTrue(sessionInfo.get(2) instanceof Integer);
+        assertTrue(sessionInfo.get(3) instanceof Integer);
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/BlockedThreadDetector.java
+++ b/sdk/src/main/java/com/bugsnag/android/BlockedThreadDetector.java
@@ -1,0 +1,106 @@
+package com.bugsnag.android;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+
+/**
+ * Detects whether a given thread is blocked by continuously posting a {@link Runnable} to it
+ * from a watcher thread, invoking a delegate if the message is not processed within
+ * a configured interval.
+ */
+final class BlockedThreadDetector {
+
+    private static final int DEFAULT_CHECK_INTERVAL_MS = 1000;
+
+    interface Delegate {
+
+        /**
+         * Invoked when a given thread has been unable to execute a {@link Runnable} within
+         * the {@link #blockedThresholdMs}
+         *
+         * @param thread the thread being monitored
+         */
+        void onThreadBlocked(Thread thread);
+    }
+
+    final Looper looper;
+    final long checkIntervalMs;
+    final long blockedThresholdMs;
+    final Handler handler;
+    final Delegate delegate;
+
+    volatile long lastUpdateMs;
+    volatile boolean isAlreadyBlocked = false;
+
+    BlockedThreadDetector(long blockedThresholdMs,
+                          Looper looper,
+                          Delegate delegate) {
+        this(blockedThresholdMs, DEFAULT_CHECK_INTERVAL_MS, looper, delegate);
+    }
+
+    BlockedThreadDetector(long blockedThresholdMs,
+                          long checkIntervalMs,
+                          Looper looper,
+                          Delegate delegate) {
+        if ((blockedThresholdMs <= 0 || checkIntervalMs <= 0
+            || looper == null || delegate == null
+            || checkIntervalMs > blockedThresholdMs)) {
+            throw new IllegalArgumentException();
+        }
+        this.blockedThresholdMs = blockedThresholdMs;
+        this.checkIntervalMs = checkIntervalMs;
+        this.looper = looper;
+        this.delegate = delegate;
+        this.handler = new Handler(looper);
+    }
+
+    void updateLivenessTimestamp() {
+        lastUpdateMs = SystemClock.elapsedRealtime();
+    }
+
+    void start() {
+        updateLivenessTimestamp();
+        handler.post(livenessCheck);
+        watcherThread.start();
+    }
+
+    final Runnable livenessCheck = new Runnable() {
+        @Override
+        public void run() {
+            updateLivenessTimestamp();
+            handler.postDelayed(this, checkIntervalMs);
+        }
+    };
+
+    final Thread watcherThread = new Thread() {
+        @Override
+        public void run() {
+            while (!isInterrupted()) {
+                // when we would next consider the app blocked if no timestamp updates take place
+                long now = SystemClock.elapsedRealtime();
+                long nextCheckIn = Math.max(lastUpdateMs + blockedThresholdMs - now, 0);
+
+                try {
+                    Thread.sleep(nextCheckIn); // throttle checks to the configured threshold
+                } catch (InterruptedException exc) {
+                    interrupt();
+                }
+                checkIfThreadBlocked();
+            }
+        }
+
+        private void checkIfThreadBlocked() {
+            long delta = SystemClock.elapsedRealtime() - lastUpdateMs;
+
+            if (delta > blockedThresholdMs) {
+                if (!isAlreadyBlocked) {
+                    delegate.onThreadBlocked(looper.getThread());
+                }
+                isAlreadyBlocked = true; // prevents duplicate reports for the same ANR
+            } else {
+                isAlreadyBlocked = false;
+            }
+        }
+    };
+}

--- a/sdk/src/main/java/com/bugsnag/android/BlockedThreadDetector.java
+++ b/sdk/src/main/java/com/bugsnag/android/BlockedThreadDetector.java
@@ -5,7 +5,11 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
+import android.os.Process;
 import android.os.SystemClock;
+import android.support.annotation.Nullable;
+
+import java.util.List;
 
 /**
  * Detects whether a given thread is blocked by continuously posting a {@link Runnable} to it
@@ -34,19 +38,22 @@ final class BlockedThreadDetector {
     final Handler watchdogHandler;
     private final HandlerThread watchdogHandlerThread;
     final Delegate delegate;
+    final ActivityManager activityManager;
 
     volatile long lastUpdateMs;
     volatile boolean isAlreadyBlocked = false;
 
     BlockedThreadDetector(long blockedThresholdMs,
                           Looper looper,
+                          ActivityManager activityManager,
                           Delegate delegate) {
-        this(blockedThresholdMs, MIN_CHECK_INTERVAL_MS, looper, delegate);
+        this(blockedThresholdMs, MIN_CHECK_INTERVAL_MS, looper, activityManager, delegate);
     }
 
     BlockedThreadDetector(long blockedThresholdMs,
                           long checkIntervalMs,
                           Looper looper,
+                          ActivityManager activityManager,
                           Delegate delegate) {
         if ((blockedThresholdMs <= 0 || checkIntervalMs <= 0
             || looper == null || delegate == null)) {
@@ -57,6 +64,7 @@ final class BlockedThreadDetector {
         this.looper = looper;
         this.delegate = delegate;
         this.uiHandler = new Handler(looper);
+        this.activityManager = activityManager;
 
         watchdogHandlerThread = new HandlerThread("bugsnag-anr-watchdog");
         watchdogHandlerThread.start();
@@ -109,13 +117,45 @@ final class BlockedThreadDetector {
     }
 
     private boolean isInForeground() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            ActivityManager.RunningAppProcessInfo info
-                = new ActivityManager.RunningAppProcessInfo();
-            ActivityManager.getMyMemoryState(info);
+        ActivityManager.RunningAppProcessInfo info = getProcessInfo();
+
+        if (info != null) {
             return info.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE;
-        } else {
+        } else { // prefer a potential false positive if process info not available
             return true;
         }
+    }
+
+    private ActivityManager.RunningAppProcessInfo getProcessInfo() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            ActivityManager.RunningAppProcessInfo info =
+                new ActivityManager.RunningAppProcessInfo();
+            ActivityManager.getMyMemoryState(info);
+            return info;
+        } else {
+            return getProcessInfoPreApi16();
+        }
+    }
+
+    @Nullable
+    private ActivityManager.RunningAppProcessInfo getProcessInfoPreApi16() {
+        List<ActivityManager.RunningAppProcessInfo> appProcesses;
+
+        try {
+            appProcesses = activityManager.getRunningAppProcesses();
+        } catch (SecurityException exc) {
+            return null;
+        }
+
+        if (appProcesses != null) {
+            int pid = Process.myPid();
+
+            for (ActivityManager.RunningAppProcessInfo appProcess : appProcesses) {
+                if (pid == appProcess.pid) {
+                    return appProcess;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/BlockedThreadDetector.java
+++ b/sdk/src/main/java/com/bugsnag/android/BlockedThreadDetector.java
@@ -11,7 +11,7 @@ import android.os.SystemClock;
  */
 final class BlockedThreadDetector {
 
-    private static final int DEFAULT_CHECK_INTERVAL_MS = 1000;
+    static final int MIN_CHECK_INTERVAL_MS = 1000;
 
     interface Delegate {
 
@@ -36,7 +36,7 @@ final class BlockedThreadDetector {
     BlockedThreadDetector(long blockedThresholdMs,
                           Looper looper,
                           Delegate delegate) {
-        this(blockedThresholdMs, DEFAULT_CHECK_INTERVAL_MS, looper, delegate);
+        this(blockedThresholdMs, MIN_CHECK_INTERVAL_MS, looper, delegate);
     }
 
     BlockedThreadDetector(long blockedThresholdMs,
@@ -44,8 +44,7 @@ final class BlockedThreadDetector {
                           Looper looper,
                           Delegate delegate) {
         if ((blockedThresholdMs <= 0 || checkIntervalMs <= 0
-            || looper == null || delegate == null
-            || checkIntervalMs > blockedThresholdMs)) {
+            || looper == null || delegate == null)) {
             throw new IllegalArgumentException();
         }
         this.blockedThresholdMs = blockedThresholdMs;

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -940,10 +940,16 @@ public class Client extends Observable implements Observer {
             callback.beforeNotify(report);
         }
 
-        if (!error.getHandledState().isUnhandled() && error.getSession() != null) {
+        if (error.getSession() != null) {
             setChanged();
-            notifyObservers(new NativeInterface.Message(
-                NativeInterface.MessageType.NOTIFY_HANDLED, error.getExceptionName()));
+
+            if (error.getHandledState().isUnhandled()) {
+                notifyObservers(new Message(
+                    NativeInterface.MessageType.NOTIFY_UNHANDLED, null));
+            } else {
+                notifyObservers(new Message(
+                    NativeInterface.MessageType.NOTIFY_HANDLED, error.getExceptionName()));
+            }
         }
 
         switch (style) {

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -6,6 +6,7 @@ import static com.bugsnag.android.MapUtils.getStringFromMap;
 import com.bugsnag.android.NativeInterface.Message;
 
 import android.app.Activity;
+import android.app.ActivityManager;
 import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -255,7 +256,12 @@ public class Client extends Observable implements Observer {
                     HandledState.REASON_ANR, null, thread);
             }
         };
-        BlockedThreadDetector detector = new BlockedThreadDetector(thresholdMs, looper, delegate);
+
+        ActivityManager activityManager =
+            (ActivityManager) appContext.getSystemService(Context.ACTIVITY_SERVICE);
+
+        BlockedThreadDetector detector =
+            new BlockedThreadDetector(thresholdMs, looper, activityManager, delegate);
         detector.start(); // begin monitoring for ANRs
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -694,7 +694,7 @@ public class Configuration extends Observable implements Observer {
      * @see #setDetectAnrs(boolean)
      */
     public void setAnrThresholdMs(long anrThresholdMs) {
-        this.anrThresholdMs = anrThresholdMs;
+        this.anrThresholdMs = anrThresholdMs < 100 ? 100 : anrThresholdMs;
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -687,14 +687,15 @@ public class Configuration extends Observable implements Observer {
      * If you wish to disable ANR detection completely, you should set the
      * {@link #setDetectAnrs(boolean)} property to false.
      * <p/>
-     * Attempting to set this property to any value below 100ms will result in the anrThresholdMs
-     * being set as 100ms.
+     * Attempting to set this property to any value below 1000ms will result in the anrThresholdMs
+     * being set as 1000ms.
      *
      * @param anrThresholdMs the threshold in ms at which ANRs should be detected
      * @see #setDetectAnrs(boolean)
      */
     public void setAnrThresholdMs(long anrThresholdMs) {
-        this.anrThresholdMs = anrThresholdMs < 100 ? 100 : anrThresholdMs;
+        this.anrThresholdMs = anrThresholdMs < BlockedThreadDetector.MIN_CHECK_INTERVAL_MS
+            ? BlockedThreadDetector.MIN_CHECK_INTERVAL_MS : anrThresholdMs;
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import android.content.Context;
+import android.os.Debug;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -46,6 +47,9 @@ public class Configuration extends Observable implements Observer {
     private long launchCrashThresholdMs = 5 * 1000;
     private boolean autoCaptureSessions = true;
     private boolean automaticallyCollectBreadcrumbs = true;
+
+    private boolean detectAnrs = !Debug.isDebuggerConnected();
+    private long anrThresholdMs = 5000;
 
     @NonNull
     private MetaData metaData;
@@ -639,6 +643,58 @@ public class Configuration extends Observable implements Observer {
             throw new IllegalArgumentException("Delivery cannot be null");
         }
         this.delivery = delivery;
+    }
+
+    /**
+     * @return whether ANRs will be captured or not
+     * @see #setDetectAnrs(boolean)
+     */
+    public boolean getDetectAnrs() {
+        return detectAnrs;
+    }
+
+    /**
+     * Sets whether <a href="https://developer.android.com/topic/performance/vitals/anr">ANRs</a>
+     * should be reported to Bugsnag. By default, Bugsnag will record an ANR whenever the main
+     * thread has been blocked for 5000 milliseconds or longer, when no debugger is attached to
+     * the app.
+     * <p/>
+     * If you wish to disable ANR detection, you should set this property to false; if you wish to
+     * configure the time threshold required to capture an ANR, you should use the
+     * {@link #setAnrThresholdMs(long)} property.
+     *
+     * @param detectAnrs whether ANRs should be captured or not
+     * @see #setAnrThresholdMs(long)
+     */
+    public void setDetectAnrs(boolean detectAnrs) {
+        this.detectAnrs = detectAnrs;
+    }
+
+    /**
+     * @return the threshold at which ANRs are detected, in ms
+     * @see #setAnrThresholdMs(long)
+     */
+    public long getAnrThresholdMs() {
+        return anrThresholdMs;
+    }
+
+    /**
+     * Sets the time in milliseconds at which an
+     * <a href="https://developer.android.com/topic/performance/vitals/anr">ANR</a> is detected
+     * by Bugsnag. By default, Bugsnag will record an ANR whenever the main thread has been blocked
+     * for 5000 milliseconds or longer.
+     * <p/>
+     * If you wish to disable ANR detection completely, you should set the
+     * {@link #setDetectAnrs(boolean)} property to false.
+     * <p/>
+     * Attempting to set this property to any value below 100ms will result in the anrThresholdMs
+     * being set as 100ms.
+     *
+     * @param anrThresholdMs the threshold in ms at which ANRs should be detected
+     * @see #setDetectAnrs(boolean)
+     */
+    public void setAnrThresholdMs(long anrThresholdMs) {
+        this.anrThresholdMs = anrThresholdMs;
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/HandledState.java
+++ b/sdk/src/main/java/com/bugsnag/android/HandledState.java
@@ -14,7 +14,7 @@ final class HandledState implements JsonStream.Streamable {
 
     @StringDef({REASON_UNHANDLED_EXCEPTION, REASON_STRICT_MODE, REASON_HANDLED_EXCEPTION,
         REASON_USER_SPECIFIED, REASON_CALLBACK_SPECIFIED, REASON_PROMISE_REJECTION,
-        REASON_LOG, REASON_SIGNAL})
+        REASON_LOG, REASON_SIGNAL, REASON_ANR})
     @Retention(RetentionPolicy.SOURCE)
     @interface SeverityReason {
     }
@@ -27,6 +27,7 @@ final class HandledState implements JsonStream.Streamable {
     static final String REASON_PROMISE_REJECTION = "unhandledPromiseRejection";
     static final String REASON_SIGNAL = "signal";
     static final String REASON_LOG = "log";
+    static final String REASON_ANR = "anrError";
 
     @SeverityReason
     private final String severityReasonType;
@@ -69,6 +70,8 @@ final class HandledState implements JsonStream.Streamable {
                 return new HandledState(severityReasonType, Severity.ERROR, true, null);
             case REASON_LOG:
                 return new HandledState(severityReasonType, severity, false, attributeValue);
+            case REASON_ANR:
+                return new HandledState(severityReasonType, Severity.ERROR, true, null);
             default:
                 String msg = String.format("Invalid argument '%s' for severityReason",
                     severityReasonType);

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -49,6 +49,10 @@ public class NativeInterface {
          */
         NOTIFY_HANDLED,
         /**
+         * Send a report for an unhandled error in the Java layer
+         */
+        NOTIFY_UNHANDLED,
+        /**
          * Remove a metadata value. The Message object should be a string array
          * containing [tab, key]
          */

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -116,7 +116,8 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         String startedAt = DateUtils.toIso8601(session.getStartedAt());
         notifyObservers(new NativeInterface.Message(
             NativeInterface.MessageType.START_SESSION,
-            Arrays.asList(session.getId(), startedAt, session.getHandledCount())));
+            Arrays.asList(session.getId(), startedAt,
+                session.getHandledCount(), session.getUnhandledCount())));
     }
 
     /**


### PR DESCRIPTION
## Goal

[ANRs](https://developer.android.com/topic/performance/vitals/anr) occur when an Android application has been blocking the main thread for a substantial amount of time, and typically means the user is about to close the app. Bugsnag should capture and report these events as unhandled errors.

## Changeset

- Added public boolean flag `config.detectAnrs`, which is enabled by default if the app does not have a debugger attached (this would cause false positives)
- Added `config.anrThresholdMs` which allows developers to control the threshold at which ANRs are detected (5000ms by default)
- Added "ANRError" as a severity reason
- Initialised a blocked thread detector within the normal `Client` initialisation, which reports an unhandled error when the main thread is blocked for 5000ms+

### ANR detection implementation

The `BlockedThreadDetector` uses a `Handler` to periodically post a `Runnable` on the main thread. This `Runnable` updates a timestamp obtained from `SystemClock.elapsedRealTime()`.

A separate watcher thread checks whether the timestamp has been updated in the last 5000ms. If this is not the case, then the main thread has been unable to process messages for 5 seconds and this is interpreted as an ANR.

## Discussion
ANR detection requires additional work that will be addressed in separate PRs:

- Performance of ANR detection should be benchmarked against the previous version of bugsnag-android to ensure there is no unacceptable degradataion
- Unity requires a public interface for configuration options
- The NDK requires alterations to how the `unhandledCount` is serialised.
- React Native requires a release with the latest version of bugsnag-android

## Tests

- Manually verified that an ANR is detected using the example app
- Added unit tests
- Added mazerunner scenarios which were reviewed in #440 
