### PR TITLE
fix(unity): Sync session info to ndk

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -136,6 +136,11 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         Session session = null;
         if (date != null && sessionId != null) {
             session = new Session(sessionId, date, user, unhandledCount, handledCount);
+            notifySessionStartObserver(session);
+        } else {
+            setChanged();
+            notifyObservers(new NativeInterface.Message(
+                NativeInterface.MessageType.STOP_SESSION, null));
         }
         currentSession.set(session);
         return session;


### PR DESCRIPTION
Small tweak to the Unity session syncing logic to account for both the NDK and the stop/resume sessions changes.