### PR TITLE
fix: prevent NPE occurring when calling resumeSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Bug fixes
+
+* Prevent NPE occurring when calling resumeSession()
+[#444](https://github.com/bugsnag/bugsnag-android/pull/444)
+
 ## 4.12.0 (2019-02-27)
 
 ### Enhancements

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -107,7 +107,9 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
             resumed = session.isStopped.compareAndSet(true, false);
         }
 
-        notifySessionStartObserver(session);
+        if (session != null) {
+            notifySessionStartObserver(session);
+        }
         return resumed;
     }
 


### PR DESCRIPTION

## Goal

An NPE could occur in `resumeSession()` as it assumed the return value of `startSession()` was always non-null. This is not the case if the sessionEndpoint has been configured incorrectly, as no session would be created in this case.

## Tests

Manually installed the artefact before and after with the following initialisation code, confirming that no crash occurred after the NPE check was added:

```
val config = Configuration("api-key")
config.setEndpoints("http://localhost:1234", "")
Bugsnag.init(this, config)
Bugsnag.resumeSession()
```
