### PR TITLE
Add unhandled_events field to native payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.X.X (TBD)
+
+### Enhancements
+
+* Add unhandled_events field to native payload
+[#445](https://github.com/bugsnag/bugsnag-android/pull/445)
+
 ## 4.12.0 (2019-02-27)
 
 ### Enhancements

--- a/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -48,13 +48,16 @@ public class NativeBridge implements Observer {
 
     public static native void addHandledEvent();
 
+    public static native void addUnhandledEvent();
+
     public static native void clearBreadcrumbs();
 
     public static native void clearMetadataTab(String tab);
 
     public static native void removeMetadata(String tab, String key);
 
-    public static native void startedSession(String sessionID, String key, int handledCount);
+    public static native void startedSession(String sessionID, String key,
+                                             int handledCount, int unhandledCount);
 
     public static native void stoppedSession();
 
@@ -126,6 +129,9 @@ public class NativeBridge implements Observer {
                 break;
             case NOTIFY_HANDLED:
                 addHandledEvent();
+                break;
+            case NOTIFY_UNHANDLED:
+                addUnhandledEvent();
                 break;
             case REMOVE_METADATA:
                 handleRemoveMetadata(arg);
@@ -318,14 +324,16 @@ public class NativeBridge implements Observer {
         if (arg instanceof List) {
             @SuppressWarnings("unchecked")
             List<Object> metadata = (List<Object>)arg;
-            if (metadata.size() == 3) {
+            if (metadata.size() == 4) {
                 Object id = metadata.get(0);
                 Object startTime = metadata.get(1);
                 Object handledCount = metadata.get(2);
+                Object unhandledCount = metadata.get(3);
 
                 if (id instanceof String && startTime instanceof String
-                    && handledCount instanceof Integer) {
-                    startedSession((String)id, (String)startTime, (Integer) handledCount);
+                    && handledCount instanceof Integer && unhandledCount instanceof Integer) {
+                    startedSession((String)id, (String)startTime,
+                        (Integer) handledCount, (Integer) unhandledCount);
                     return;
                 }
             }

--- a/ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -87,6 +87,7 @@ void bsg_handle_cpp_terminate() {
 
   bsg_global_env->handling_crash = true;
   bsg_populate_report_as(bsg_global_env);
+  bsg_global_env->next_report.unhandled_events++;
   bsg_global_env->next_report.exception.frame_count = bsg_unwind_stack(
       bsg_global_env->unwind_style,
       bsg_global_env->next_report.exception.stacktrace, NULL, NULL);

--- a/ndk/src/main/jni/handlers/signal_handler.c
+++ b/ndk/src/main/jni/handlers/signal_handler.c
@@ -174,6 +174,7 @@ void bsg_handle_signal(int signum, siginfo_t *info,
 
   bsg_global_env->handling_crash = true;
   bsg_populate_report_as(bsg_global_env);
+  bsg_global_env->next_report.unhandled_events++;
   bsg_global_env->next_report.exception.frame_count = bsg_unwind_stack(
       bsg_global_env->signal_unwind_style,
       bsg_global_env->next_report.exception.stacktrace, info, user_context);

--- a/ndk/src/main/jni/report.c
+++ b/ndk/src/main/jni/report.c
@@ -83,11 +83,12 @@ void bugsnag_report_remove_metadata_tab(bugsnag_report *report, char *section) {
 }
 
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
-                                  char *started_at, int handled_count) {
+                                  char *started_at, int handled_count, int unhandled_count) {
   bsg_strncpy_safe(report->session_id, session_id, sizeof(report->session_id));
   bsg_strncpy_safe(report->session_start, started_at,
                    sizeof(report->session_start));
   report->handled_events = handled_count;
+  report->unhandled_events = unhandled_count;
 }
 
 void bugsnag_report_set_context(bugsnag_report *report, char *value) {

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -292,6 +292,7 @@ typedef struct {
   char session_id[33];
   char session_start[33];
   int handled_events;
+  int unhandled_events;
 } bugsnag_report;
 
 void bugsnag_report_add_metadata_double(bugsnag_report *report, char *section,
@@ -315,7 +316,7 @@ void bugsnag_report_set_user_email(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_id(bugsnag_report *report, char *value);
 void bugsnag_report_set_user_name(bugsnag_report *report, char *value);
 void bugsnag_report_start_session(bugsnag_report *report, char *session_id,
-                                  char *started_at, int handled_count);
+                                  char *started_at, int handled_count, int unhandled_count);
 bool bugsnag_report_has_session(bugsnag_report *report);
 
 #ifdef __cplusplus

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -31,7 +31,7 @@
 /**
  * Version of the bugsnag_report struct. Serialized to report header.
  */
-#define BUGSNAG_REPORT_VERSION 1
+#define BUGSNAG_REPORT_VERSION 2
 
 #define BUGSNAG_USER_INFO_LEN 64
 #ifdef __cplusplus

--- a/ndk/src/main/jni/utils/migrate.h
+++ b/ndk/src/main/jni/utils/migrate.h
@@ -1,0 +1,35 @@
+#ifndef BUGSNAG_MIGRATE_H
+#define BUGSNAG_MIGRATE_H
+
+#include "report.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    bsg_library notifier;
+    bsg_app_info app;
+    bsg_device_info device;
+    bsg_user user;
+    bsg_exception exception;
+    bugsnag_metadata metadata;
+
+    int crumb_count;
+    // Breadcrumbs are a ring; the first index moves as the
+    // structure is filled and replaced.
+    int crumb_first_index;
+    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+    char context[64];
+    bsg_severity_t severity;
+
+    char session_id[33];
+    char session_start[33];
+    int handled_events;
+} bugsnag_report_v1;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/ndk/src/main/jni/utils/serializer.c
+++ b/ndk/src/main/jni/utils/serializer.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <utils/migrate.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,18 +41,68 @@ bugsnag_report *bsg_deserialize_report_from_file(char *filepath) {
   return bsg_report_read(fd);
 }
 
+bugsnag_report_v1 *bsg_report_v1_read(int fd) {
+    size_t report_size = sizeof(bugsnag_report_v1);
+    bugsnag_report_v1 *report = malloc(report_size);
+
+    ssize_t len = read(fd, report, report_size);
+    if (len != report_size) {
+        return NULL;
+    }
+    return report;
+}
+
+bugsnag_report *bsg_report_v2_read(int fd) {
+    size_t report_size = sizeof(bugsnag_report);
+    bugsnag_report *report = malloc(report_size);
+
+    ssize_t len = read(fd, report, report_size);
+    if (len != report_size) {
+        return NULL;
+    }
+    return report;
+}
+
 bugsnag_report *bsg_report_read(int fd) {
   bsg_report_header *header = bsg_report_header_read(fd);
   if (header == NULL) {
     return NULL;
   }
-  // FUTURE: use header info to check version/endianness & migrate
-  free(header);
-  bugsnag_report *report = malloc(sizeof(bugsnag_report));
 
-  ssize_t len = read(fd, report, sizeof(bugsnag_report));
-  if (len != sizeof(bugsnag_report)) {
-    return NULL;
+  int report_version = header->version;
+  free(header);
+
+  bugsnag_report *report = NULL;
+
+  if (report_version == 1) { // 'report->unhandled_events' was added in v2
+      bugsnag_report_v1 *report_v1 = bsg_report_v1_read(fd);
+
+      if (report_v1 != NULL) {
+          report = malloc(sizeof(bugsnag_report));
+
+          report->notifier = report_v1->notifier;
+          report->app = report_v1->app;
+          report->device = report_v1->device;
+          report->user = report_v1->user;
+          report->exception = report_v1->exception;
+          report->metadata = report_v1->metadata;
+          report->crumb_count = report_v1->crumb_count;
+          report->crumb_first_index = report_v1->crumb_first_index;
+
+          size_t breadcrumb_size = sizeof(bugsnag_breadcrumb) * BUGSNAG_CRUMBS_MAX;
+          memcpy(&report->breadcrumbs, report_v1->breadcrumbs, breadcrumb_size);
+
+          strcpy(report->context, report_v1->context);
+          report->severity = report_v1->severity;
+          strcpy(report->session_id, report_v1->session_id);
+          strcpy(report->session_start, report_v1->session_start);
+          report->handled_events = report_v1->handled_events;
+          report->unhandled_events = 1;
+
+          free(report_v1);
+      }
+  } else {
+      report = bsg_report_v2_read(fd);
   }
   return report;
 }

--- a/ndk/src/main/jni/utils/serializer.c
+++ b/ndk/src/main/jni/utils/serializer.c
@@ -262,7 +262,7 @@ char *bsg_serialize_report_to_json_string(bugsnag_report *report) {
         json_object_dotset_string(event, "session.id", report->session_id);
         json_object_dotset_number(event, "session.events.handled",
                                   report->handled_events);
-        json_object_dotset_number(event, "session.events.unhandled", 1);
+        json_object_dotset_number(event, "session.events.unhandled", report->unhandled_events);
     }
 
     json_object_set_string(exception, "errorClass", report->exception.name);

--- a/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -153,10 +153,11 @@ public class ObserverInterfaceTest {
         client.startSession();
         List<Object> sessionInfo = (List<Object>)findMessageInQueue(
                 NativeInterface.MessageType.START_SESSION, List.class);
-        assertEquals(3, sessionInfo.size());
+        assertEquals(4, sessionInfo.size());
         assertTrue(sessionInfo.get(0) instanceof String);
         assertTrue(sessionInfo.get(1) instanceof String);
         assertTrue(sessionInfo.get(2) instanceof Integer);
+        assertTrue(sessionInfo.get(3) instanceof Integer);
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -917,10 +917,16 @@ public class Client extends Observable implements Observer {
             callback.beforeNotify(report);
         }
 
-        if (!error.getHandledState().isUnhandled() && error.getSession() != null) {
+        if (error.getSession() != null) {
             setChanged();
-            notifyObservers(new NativeInterface.Message(
-                NativeInterface.MessageType.NOTIFY_HANDLED, error.getExceptionName()));
+
+            if (error.getHandledState().isUnhandled()) {
+                notifyObservers(new Message(
+                    NativeInterface.MessageType.NOTIFY_UNHANDLED, null));
+            } else {
+                notifyObservers(new Message(
+                    NativeInterface.MessageType.NOTIFY_HANDLED, error.getExceptionName()));
+            }
         }
 
         switch (style) {

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -49,6 +49,10 @@ public class NativeInterface {
          */
         NOTIFY_HANDLED,
         /**
+         * Send a report for an unhandled error in the Java layer
+         */
+        NOTIFY_UNHANDLED,
+        /**
          * Remove a metadata value. The Message object should be a string array
          * containing [tab, key]
          */

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -116,7 +116,8 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         String startedAt = DateUtils.toIso8601(session.getStartedAt());
         notifyObservers(new NativeInterface.Message(
             NativeInterface.MessageType.START_SESSION,
-            Arrays.asList(session.getId(), startedAt, session.getHandledCount())));
+            Arrays.asList(session.getId(), startedAt,
+                session.getHandledCount(), session.getUnhandledCount())));
     }
 
     /**


### PR DESCRIPTION
## Goal
ANR detection delivered in #442 means that the number of unhandled events is no longer necessarily 1 in the latest version of the plugin. This requires a migration of existing payloads to fit the new struct, which adds an explicit `unhandled_events` field, rather than hardcoding 1.

## Changeset

- Added a `NOTIFY_UNHANDLED` message to the native bridge, which is invoked whenever an unhandled event occurs, and ultimately increments `report->unhandled_events`
- Added `unhandled_events` field to `bugsnag_report`, which is serialised rather than '1'
- Created copy of existing struct in `bugsnag_report_v1`
- When reading a report, check the header. If it is v1, read into `bugsnag_report_v1`, then copy the fields over to `bugsnag_report`.


## Tests
- Added test for session JSON serialisation in native reports
- Added test for payload migration
- Manually tested in an example app by:
  - Triggering a native crash with v4.12.0 and delivering a report
  - Triggering a native crash with v4.12.0, upgrading to a locally installed artefact, and _then_ delivering the v1 report
  - Triggering a native crash with a local artefact to test the v2 report

