### PR TITLE
chore: update example app build.gradle to conditionally use local artefact

### DIFF
--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -73,13 +73,21 @@ android {
     }
 }
 
+// set this value to true if you wish to test with a local artefact
+// it will instruct gradle to copy the SO files from the AAR to the correct build directory
+def usingLocalArtefact = false
+
 dependencies {
-    implementation 'com.bugsnag:bugsnag-android-ndk:4.10.0'
-    // If developing locally, replace the above line with the following:
-    // implementation project(path: ':sdk', configuration: 'default')
-    // api project(path: ':ndk', configuration: 'default')
+    if (usingLocalArtefact) {
+        implementation project(path: ':sdk', configuration: 'default')
+        api project(path: ':ndk', configuration: 'default')
+    } else {
+        implementation 'com.bugsnag:bugsnag-android-ndk:4.12.0'
+    }
+
     implementation 'com.android.support:appcompat-v7:27.0.0'
     implementation 'com.android.support:support-v4:27.0.0'
+
     kotlinExampleImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     androidTestImplementation "com.android.support.test:runner:0.5", {
         exclude group: 'com.android.support', module: 'support-annotations'
@@ -92,73 +100,9 @@ dependencies {
     }
 }
 
+apply from: 'checkstyle.gradle'
 apply plugin: 'com.bugsnag.android.gradle'
-bugsnag {
-    ndk true
-}
-apply plugin: 'checkstyle'
 
-checkstyle {
-    toolVersion = "6.16"
+if (usingLocalArtefact) {
+    apply from: 'ndk_local_setup.gradle'
 }
-task("checkstyle", type: Checkstyle) {
-    configFile rootProject.file("config/checkstyle/checkstyle.xml")
-    source "src/javaExample/java"
-    include "**/*.java"
-    classpath = files()
-}
-
-// Local development settings. Uncomment these if referencing
-// local dependencies:
-//assemble.dependsOn ":ndk:assemble"
-///**
-// * Gradle configuration for unpacking native API for CMake. Only required
-// * when building against local artifacts.
-// */
-//import org.gradle.api.DefaultTask
-//import org.gradle.api.tasks.TaskAction
-//
-//class BugsnagTestNdkSetupTask extends DefaultTask {
-//
-//    @TaskAction
-//    void setupNdkProject() {
-//        def artifactFile = findBugsnagNdkArchive()
-//        File dst = new File(project.buildDir, "/intermediates/bugsnag-libs")
-//
-//        project.copy {
-//            from project.zipTree(artifactFile)
-//            into(project.file(dst))
-//        }
-//    }
-//
-//    File findBugsnagNdkArchive() {
-//        for (def config in project.configurations) {
-//            try {
-//                def artifactFile = config.resolvedConfiguration.getFiles().find {
-//                    it.toString().contains("bugsnag-android-ndk")
-//                }
-//                if (artifactFile && artifactFile.exists()) {
-//                    return artifactFile
-//                }
-//            } catch (Exception e) {} // some configurations cannot be directly resolved
-//        }
-//        throw new Exception("SOLUTION: The bugsnag-android-ndk file was not found, please run `./gradlew ndk:assembleRelease`")
-//    }
-//}
-//
-//project.afterEvaluate {
-//    def cleanTasks = project.tasks.findAll {
-//        it.name.startsWith("externalNative") && it.name.contains("Clean")
-//    }
-//    def buildTasks = project.tasks.findAll {
-//        it.name.startsWith("externalNative") && it.name.contains("Build") && !it.name.contains("Clean")
-//    }
-//
-//    def ndkSetupTask = project.tasks.create("bugsnagInstallAllJniLibsTask", BugsnagTestNdkSetupTask)
-//
-//    buildTasks.forEach {
-//        ndkSetupTask.mustRunAfter(cleanTasks)
-//        it.dependsOn ndkSetupTask
-//        it.doFirst { ndkSetupTask }
-//    }
-//}

--- a/examples/sdk-app-example/checkstyle.gradle
+++ b/examples/sdk-app-example/checkstyle.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'checkstyle'
+
+checkstyle {
+    toolVersion = "6.16"
+}
+task("checkstyle", type: Checkstyle) {
+    configFile rootProject.file("config/checkstyle/checkstyle.xml")
+    source "src/javaExample/java"
+    include "**/*.java"
+    classpath = files()
+}

--- a/examples/sdk-app-example/ndk_local_setup.gradle
+++ b/examples/sdk-app-example/ndk_local_setup.gradle
@@ -1,0 +1,55 @@
+
+// Local development settings. Uncomment these if referencing
+// local dependencies:
+assemble.dependsOn ":ndk:assemble"
+/**
+ * Gradle configuration for unpacking native API for CMake. Only required
+ * when building against local artifacts.
+ */
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class BugsnagTestNdkSetupTask extends DefaultTask {
+
+    @TaskAction
+    void setupNdkProject() {
+        def artifactFile = findBugsnagNdkArchive()
+        File dst = new File(project.buildDir, "/intermediates/bugsnag-libs")
+
+        project.copy {
+            from project.zipTree(artifactFile)
+            into(project.file(dst))
+        }
+    }
+
+    File findBugsnagNdkArchive() {
+        for (def config in project.configurations) {
+            try {
+                def artifactFile = config.resolvedConfiguration.getFiles().find {
+                    it.toString().contains("bugsnag-android-ndk")
+                }
+                if (artifactFile && artifactFile.exists()) {
+                    return artifactFile
+                }
+            } catch (Exception e) {} // some configurations cannot be directly resolved
+        }
+        throw new Exception("SOLUTION: The bugsnag-android-ndk file was not found, please run `./gradlew ndk:assembleRelease`")
+    }
+}
+
+project.afterEvaluate {
+    def cleanTasks = project.tasks.findAll {
+        it.name.startsWith("externalNative") && it.name.contains("Clean")
+    }
+    def buildTasks = project.tasks.findAll {
+        it.name.startsWith("externalNative") && it.name.contains("Build") && !it.name.contains("Clean")
+    }
+
+    def ndkSetupTask = project.tasks.create("bugsnagInstallAllJniLibsTask", BugsnagTestNdkSetupTask)
+
+    buildTasks.forEach {
+        ndkSetupTask.mustRunAfter(cleanTasks)
+        it.dependsOn ndkSetupTask
+        it.doFirst { ndkSetupTask }
+    }
+}


### PR DESCRIPTION
## Goal

The example app has sporadically been unable to build due to being unable to find SO files from bugsnag-android-ndk. This alters the example app so that a previously commented out task can be switched on by a flag in the build.gradle.

## Tests

I could reproduce this behaviour by running a clean build without the bugsnag gradle plugin applied. After applying this task to the example project, the behaviour could not be reproduced.
