### PR TITLE
Ensure boolean object from map serialised as boolean primitive in JNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Ensure boolean object from map serialised as boolean primitive in JNI
+[#452](https://github.com/bugsnag/bugsnag-android/pull/452)
+
 * Prevent NPE occurring when calling resumeSession()
 [#444](https://github.com/bugsnag/bugsnag-android/pull/444)
 

--- a/ndk/src/main/jni/metadata.c
+++ b/ndk/src/main/jni/metadata.c
@@ -170,7 +170,8 @@ int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
 bool bsg_get_map_value_bool(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
                             const char *_key) {
   jstring key = (*env)->NewStringUTF(env, _key);
-  return (bool)(*env)->CallObjectMethod(env, map, jni_cache->hash_map_get, key);
+  jobject obj = (*env)->CallObjectMethod(env, map, jni_cache->hash_map_get, key);
+  return (*env)->CallBooleanMethod(env, obj, jni_cache->boolean_bool_value);
 }
 
 void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,


### PR DESCRIPTION
## Goal

Boolean metadata fields in fatal native crashes were always serialised as `true` due to a bug where a reference to a `java/lang/Boolean` object was cast to a `bool`. This fix calls `Boolean#booleanValue` instead, so that the true/false value is serialised correctly in native crashes.

## Tests

Tested the example app on an emulator and Nexus 5x, and verified that `app.emulator` was respectively true and false for a native crash.
