### PR TITLE
Add detekt static analysis plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
 jobs:
   include:
   - stage: lint
-    script: ./gradlew lint checkstyle
+    script: ./gradlew lint checkstyle detekt
   # Run SDK unit tests against API 16:
   - stage: unit tests
     script: ./gradlew sdk:createDebugCoverageReport coveralls

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id("io.gitlab.arturbosch.detekt").version("1.0.0-RC14")
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'com.getkeepsafe.dexcount'
 apply plugin: 'maven-publish'
@@ -190,6 +194,17 @@ bintray {
 }
 
 apply from: "../checkstyle.gradle"
+
+detekt {
+    input = files("src")
+    filters = ".*/resources/.*,.*/build/.*"
+
+    reports {
+        html {
+            enabled = true
+        }
+    }
+}
 
 dexcount {
     includeClasses = true


### PR DESCRIPTION
## Goal

Our Java code uses checkstyle, but our Kotlin code is not statically analysed with the exception of Android Lint. Using [detekt](https://github.com/arturbosch/detekt) should allow us to detect if there are an excessive number of non-conventional Kotlin code smells.

## Changeset

- Added detekt to gradle build classpath
- Enabled detekt for all Kotlin source files in the sdk module

## Tests

Ran manually and verified that there are no existing issues with our Kotlin code.
