### PR TITLE
refactor: Convert fields to local variables

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/BlockedThreadDetector.java
+++ b/sdk/src/main/java/com/bugsnag/android/BlockedThreadDetector.java
@@ -36,7 +36,6 @@ final class BlockedThreadDetector {
     final long blockedThresholdMs;
     final Handler uiHandler;
     final Handler watchdogHandler;
-    private final HandlerThread watchdogHandlerThread;
     final Delegate delegate;
     final ActivityManager activityManager;
 
@@ -66,7 +65,7 @@ final class BlockedThreadDetector {
         this.uiHandler = new Handler(looper);
         this.activityManager = activityManager;
 
-        watchdogHandlerThread = new HandlerThread("bugsnag-anr-watchdog");
+        HandlerThread watchdogHandlerThread = new HandlerThread("bugsnag-anr-watchdog");
         watchdogHandlerThread.start();
         watchdogHandler = new Handler(watchdogHandlerThread.getLooper());
     }

--- a/sdk/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/sdk/src/main/java/com/bugsnag/android/Exceptions.java
@@ -10,13 +10,11 @@ import java.util.List;
  * Unwrap and serialize exception information and any "cause" exceptions.
  */
 class Exceptions implements JsonStream.Streamable {
-    private final Configuration config;
     private final Throwable exception;
     private String exceptionType;
     private String[] projectPackages;
 
     Exceptions(Configuration config, Throwable exception) {
-        this.config = config;
         this.exception = exception;
         exceptionType = Configuration.DEFAULT_EXCEPTION_TYPE;
         projectPackages = config.getProjectPackages();


### PR DESCRIPTION
If a field is not used within a class except for one location, it should be converted to a local variable as this confines it to the smallest possible scope.