### PR TITLE
Make fields final where possible

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/CachedThread.java
+++ b/sdk/src/main/java/com/bugsnag/android/CachedThread.java
@@ -8,12 +8,12 @@ import java.io.IOException;
  * A representation of a thread recorded in a {@link Report}
  */
 class CachedThread implements JsonStream.Streamable {
-    private long id;
-    private String name;
-    private String type;
-    private boolean isErrorReportingThread;
-    private StackTraceElement[] frames;
-    private Configuration config;
+    private final long id;
+    private final String name;
+    private final String type;
+    private final boolean isErrorReportingThread;
+    private final StackTraceElement[] frames;
+    private final Configuration config;
 
     CachedThread(Configuration config, long id, String name, String type,
                  boolean isErrorReportingThread, StackTraceElement[] frames) {

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -75,7 +75,7 @@ public class Client extends Observable implements Observer {
 
     final EventReceiver eventReceiver;
     final SessionTracker sessionTracker;
-    SharedPreferences sharedPrefs;
+    final SharedPreferences sharedPrefs;
 
     private final OrientationEventListener orientationListener;
 

--- a/sdk/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeviceData.java
@@ -55,19 +55,19 @@ class DeviceData {
     private final boolean rooted;
 
     @Nullable
-    Float screenDensity;
+    final Float screenDensity;
 
     @Nullable
-    Integer dpi;
+    final Integer dpi;
 
     @Nullable
-    String screenResolution;
+    final String screenResolution;
 
     @NonNull
-    String locale;
+    final String locale;
 
     @NonNull
-    String[] cpuAbi;
+    final String[] cpuAbi;
 
     DeviceData(Client client) {
         this.client = client;

--- a/sdk/src/main/java/com/bugsnag/android/Session.java
+++ b/sdk/src/main/java/com/bugsnag/android/Session.java
@@ -12,7 +12,7 @@ class Session implements JsonStream.Streamable {
     private final String id;
     private final Date startedAt;
     private final User user;
-    private AtomicBoolean autoCaptured;
+    private final AtomicBoolean autoCaptured;
 
     static Session copySession(Session session) {
         Session copy = new Session(session.id, session.startedAt,

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -38,12 +38,12 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     final SessionStore sessionStore;
 
     // This most recent time an Activity was stopped.
-    private AtomicLong lastExitedForegroundMs = new AtomicLong(0);
+    private final AtomicLong lastExitedForegroundMs = new AtomicLong(0);
 
     // The first Activity in this 'session' was started at this time.
-    private AtomicLong lastEnteredForegroundMs = new AtomicLong(0);
-    private AtomicReference<Session> currentSession = new AtomicReference<>();
-    private Semaphore flushingRequest = new Semaphore(1);
+    private final AtomicLong lastEnteredForegroundMs = new AtomicLong(0);
+    private final AtomicReference<Session> currentSession = new AtomicReference<>();
+    private final Semaphore flushingRequest = new Semaphore(1);
 
     SessionTracker(Configuration configuration, Client client, SessionStore sessionStore) {
         this(configuration, client, DEFAULT_TIMEOUT_MS, sessionStore);


### PR DESCRIPTION
Marking fields as final guarantees that the reference cannot be modified after initialisation. While it's still possible to mutate any fields on the object itself, this is a good first step towards thread safety, and fields should be final by default.