### PR TITLE
Prefer using zero-based array when converting collection

### DIFF
--- a/sdk/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -245,7 +245,7 @@ class ErrorReader {
             frames.add(readStackFrame(reader));
         }
         reader.endArray();
-        return frames.toArray(new StackTraceElement[frames.size()]);
+        return frames.toArray(new StackTraceElement[0]);
     }
 
     private static StackTraceElement readStackFrame(JsonReader reader) throws IOException {
@@ -396,7 +396,7 @@ class ErrorReader {
             }
         }
         reader.endArray();
-        return new ThreadState(threads.toArray(new CachedThread[threads.size()]));
+        return new ThreadState(threads.toArray(new CachedThread[0]));
     }
 
     private static CachedThread readThread(Configuration config,

--- a/sdk/src/main/java/com/bugsnag/android/MetaData.java
+++ b/sdk/src/main/java/com/bugsnag/android/MetaData.java
@@ -122,7 +122,7 @@ public class MetaData extends Observable implements JsonStream.Streamable {
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         MetaData newMeta = new MetaData(mergeMaps(stores.toArray(new Map[0])));
-        newMeta.setFilters(filters.toArray(new String[filters.size()]));
+        newMeta.setFilters(filters.toArray(new String[0]));
 
         return newMeta;
     }

--- a/sdk/src/main/java/com/bugsnag/android/ThreadState.java
+++ b/sdk/src/main/java/com/bugsnag/android/ThreadState.java
@@ -56,7 +56,7 @@ class ThreadState implements JsonStream.Streamable {
     private Thread[] sortThreadsById(Map<Thread, StackTraceElement[]> liveThreads) {
         Set<Thread> threadSet = liveThreads.keySet();
 
-        Thread[] threads = threadSet.toArray(new Thread[threadSet.size()]);
+        Thread[] threads = threadSet.toArray(new Thread[0]);
         Arrays.sort(threads, new Comparator<Thread>() {
             public int compare(@NonNull Thread lhs, @NonNull Thread rhs) {
                 return Long.valueOf(lhs.getId()).compareTo(rhs.getId());


### PR DESCRIPTION
There are two styles to convert a collection to an array: either using a pre-sized array (like c.toArray(new String[c.size()])) or using an empty array (like c.toArray(new String[0]).

In older Java versions using pre-sized array was recommended, as the reflection call which is necessary to create an array of proper size was quite slow. However since late updates of OpenJDK 6 this call was intrinsified, making the performance of the empty array version the same and sometimes even better, compared to the pre-sized version. Also passing pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray call which may result in extra nulls at the end of the array, if the collection was concurrently shrunk during the operation.