### PR TITLE
fix(ndk): Free cache instances when unneeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * [NDK] Fix possible null pointer dereference
 * [NDK] Fix possible memory leak if bugsnag-android-ndk fails to successfully
   parse a cached crash report
+* [NDK] Fix possible memory leak when using `bugsnag_leave_breadcrumb()` or
+  `bugsnag_notify()`
 
 ## 4.13.0 (2019-04-03)
 

--- a/ndk/src/main/jni/metadata.c
+++ b/ndk/src/main/jni/metadata.c
@@ -196,6 +196,7 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
     (*env)->ReleaseStringUTFChars(env, _key, key);
     (*env)->ReleaseStringUTFChars(env, _value, value);
   }
+  free(jni_cache);
   (*env)->DeleteLocalRef(env, keyset);
   (*env)->DeleteLocalRef(env, keylist);
 }
@@ -333,6 +334,7 @@ void bsg_populate_report(JNIEnv *env, bugsnag_report *report) {
   bsg_populate_app_data(env, jni_cache, report);
   bsg_populate_device_data(env, jni_cache, report);
   bsg_populate_user_data(env, jni_cache, report);
+  free(jni_cache);
 }
 void bsg_populate_metadata(JNIEnv *env, bugsnag_report *report,
                            jobject metadata) {
@@ -392,4 +394,5 @@ void bsg_populate_metadata(JNIEnv *env, bugsnag_report *report,
   } else {
     report->metadata.value_count = 0;
   }
+  free(jni_cache);
 }


### PR DESCRIPTION
## Goal

Fix possible memory leak when leaving breadcrumbs or calling `bugsnag_notify()`
