### PR TITLE
Use packageInfo.longVersionCode to collect versionCode on API 28+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TBD
 
+* Use packageInfo.longVersionCode to collect versionCode on API 28+
+[#471](https://github.com/bugsnag/bugsnag-android/pull/471)
+
 ### Bug fixes
 
 * [NDK] Fix possible null pointer dereference

--- a/ndk/src/main/jni/metadata.c
+++ b/ndk/src/main/jni/metadata.c
@@ -243,7 +243,7 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   report->app.duration_in_foreground_ms_offset =
       bsg_get_map_value_long(env, jni_cache, data, "durationInForeground");
   report->app.version_code =
-      bsg_get_map_value_int(env, jni_cache, data, "versionCode");
+      bsg_get_map_value_long(env, jni_cache, data, "versionCode");
   report->app.in_foreground =
       bsg_get_map_value_bool(env, jni_cache, data, "inForeground");
 

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -61,7 +61,7 @@ typedef struct {
   char version[32];
   char version_name[32];
   char active_screen[64];
-  int version_code;
+  long version_code;
   char build_uuid[64];
   time_t duration;
   time_t duration_in_foreground;

--- a/ndk/src/main/jni/report.h
+++ b/ndk/src/main/jni/report.h
@@ -31,7 +31,7 @@
 /**
  * Version of the bugsnag_report struct. Serialized to report header.
  */
-#define BUGSNAG_REPORT_VERSION 2
+#define BUGSNAG_REPORT_VERSION 3
 
 #define BUGSNAG_USER_INFO_LEN 64
 #ifdef __cplusplus

--- a/ndk/src/main/jni/utils/migrate.h
+++ b/ndk/src/main/jni/utils/migrate.h
@@ -8,8 +8,29 @@ extern "C" {
 #endif
 
 typedef struct {
+    char name[64];
+    char id[64];
+    char package_name[64];
+    char release_stage[64];
+    char type[32];
+    char version[32];
+    char version_name[32];
+    char active_screen[64];
+    int version_code;
+    char build_uuid[64];
+    time_t duration;
+    time_t duration_in_foreground;
+    time_t duration_ms_offset;
+    time_t duration_in_foreground_ms_offset;
+    bool in_foreground;
+    bool low_memory;
+    size_t memory_usage;
+    char binaryArch[32];
+} bsg_app_info_v1;
+
+typedef struct {
     bsg_library notifier;
-    bsg_app_info app;
+    bsg_app_info_v1 app;
     bsg_device_info device;
     bsg_user user;
     bsg_exception exception;
@@ -28,6 +49,29 @@ typedef struct {
     char session_start[33];
     int handled_events;
 } bugsnag_report_v1;
+
+typedef struct {
+    bsg_library notifier;
+    bsg_app_info_v1 app;
+    bsg_device_info device;
+    bsg_user user;
+    bsg_exception exception;
+    bugsnag_metadata metadata;
+
+    int crumb_count;
+    // Breadcrumbs are a ring; the first index moves as the
+    // structure is filled and replaced.
+    int crumb_first_index;
+    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+    char context[64];
+    bsg_severity_t severity;
+
+    char session_id[33];
+    char session_start[33];
+    int handled_events;
+    int unhandled_events;
+} bugsnag_report_v2;
 
 #ifdef __cplusplus
 }

--- a/sdk/src/main/java/com/bugsnag/android/AppData.java
+++ b/sdk/src/main/java/com/bugsnag/android/AppData.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -137,7 +138,14 @@ class AppData {
     @SuppressWarnings("deprecation")
     private Integer calculateVersionCode() {
         if (packageInfo != null) {
-            return packageInfo.versionCode;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                // Android P added an android:versionCodeMajor field for anyone who ran out of
+                // space in android:versionCode. As it's stored in the upper 32 bits
+                // we want to ignore those, and retrieve the versionCode value only.
+                return (int) (packageInfo.getLongVersionCode() & 0x0000FFFFL);
+            } else {
+                return packageInfo.versionCode;
+            }
         } else {
             return null;
         }

--- a/sdk/src/main/java/com/bugsnag/android/AppData.java
+++ b/sdk/src/main/java/com/bugsnag/android/AppData.java
@@ -136,15 +136,14 @@ class AppData {
      */
     @Nullable
     @SuppressWarnings("deprecation")
-    private Integer calculateVersionCode() {
+    private Long calculateVersionCode() {
         if (packageInfo != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 // Android P added an android:versionCodeMajor field for anyone who ran out of
-                // space in android:versionCode. As it's stored in the upper 32 bits
-                // we want to ignore those, and retrieve the versionCode value only.
-                return (int) (packageInfo.getLongVersionCode() & 0x0000FFFFL);
+                // space in android:versionCode, which is stored in the upper 32 bits of this field.
+                return packageInfo.getLongVersionCode();
             } else {
-                return packageInfo.versionCode;
+                return (long) packageInfo.versionCode;
             }
         } else {
             return null;


### PR DESCRIPTION
## Goal
API 28 added an additional `android:versionCodeMajor` attribute, which can be used if an app has run out of space in the `android:versionCode` int, which must always be incremented on the Google Play store. 

The `PackageInfo` API we used to collect the version code previously has been deprecated in favour of [`longVersionCode`](https://developer.android.com/reference/android/content/pm/PackageInfo.html#getLongVersionCode()), which contains an amalgam of the versionCode + versionCodeMajor.

## Changeset

Altered the source of the versionCode collected in error reports, in API 28+.

## Tests

Verified that when running in an example app, the versionCode matches the value in the AndroidManifest for:

- API 28 with versionCodeMajor defined
- API 28 without versionCodeMajor defined
- API 26
