### PR TITLE
Add internal api for mutating session payload before sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Migrate version information to device.runtimeVersions
 [#472](https://github.com/bugsnag/bugsnag-android/pull/472)
 
+* Add internal api for mutating session payload before sending
+[#472](https://github.com/bugsnag/bugsnag-android/pull/474)
+
 ### Bug fixes
 
 * [NDK] Fix possible null pointer dereference

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendSessionTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendSessionTest.kt
@@ -19,6 +19,9 @@ class BeforeSendSessionTest {
         val latch = CountDownLatch(1)
         var data: SessionTrackingPayload? = null
 
+        client.config.addBeforeSendSession { it.device["foo"] = "bar" }
+        client.config.addBeforeSendSession { it.device["foo2"] = 5 }
+
         client.config.delivery = object : Delivery {
             override fun deliver(payload: SessionTrackingPayload, config: Configuration) {
                 data = payload
@@ -28,8 +31,6 @@ class BeforeSendSessionTest {
             override fun deliver(report: Report, config: Configuration) {}
         }
 
-        client.addBeforeSendSession { it.device["foo"] = "bar" }
-        client.addBeforeSendSession { it.device["foo2"] = 5 }
         sessionTracker.startSession(false)
         latch.await()
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendSessionTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendSessionTest.kt
@@ -1,0 +1,39 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+
+class BeforeSendSessionTest {
+
+    private val client = BugsnagTestUtils.generateClient()
+    private val sessionTracker = client.sessionTracker
+
+    @Before
+    fun setUp() {
+    }
+
+    @Test
+    fun testBeforeSendCallbackInvoked() {
+        val latch = CountDownLatch(1)
+        var data: SessionTrackingPayload? = null
+
+        client.config.delivery = object : Delivery {
+            override fun deliver(payload: SessionTrackingPayload, config: Configuration) {
+                data = payload
+                latch.countDown()
+            }
+
+            override fun deliver(report: Report, config: Configuration) {}
+        }
+
+        client.addBeforeSendSession { it.device["foo"] = "bar" }
+        client.addBeforeSendSession { it.device["foo2"] = 5 }
+        sessionTracker.startSession(false)
+        latch.await()
+
+        assertEquals("bar", data!!.device["foo"])
+        assertEquals(5, data!!.device["foo2"])
+    }
+}

--- a/sdk/src/main/java/com/bugsnag/android/BeforeSendSession.java
+++ b/sdk/src/main/java/com/bugsnag/android/BeforeSendSession.java
@@ -1,0 +1,5 @@
+package com.bugsnag.android;
+
+interface BeforeSendSession {
+    void beforeSendSession(SessionTrackingPayload payload);
+}

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -1472,4 +1472,8 @@ public class Client extends Observable implements Observer {
         getAppData().setBinaryArch(binaryArch);
     }
 
+    void addBeforeSendSession(BeforeSendSession beforeSendSession) {
+        sessionTracker.addBeforeSendSession(beforeSendSession);
+    }
+
 }

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -1427,6 +1427,7 @@ public class Client extends Observable implements Observer {
                 Logger.warn("Receiver not registered");
             }
         }
+
         super.finalize();
     }
 
@@ -1470,10 +1471,6 @@ public class Client extends Observable implements Observer {
 
     void setBinaryArch(String binaryArch) {
         getAppData().setBinaryArch(binaryArch);
-    }
-
-    void addBeforeSendSession(BeforeSendSession beforeSendSession) {
-        sessionTracker.addBeforeSendSession(beforeSendSession);
     }
 
 }

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -58,6 +58,8 @@ public class Configuration extends Observable implements Observer {
     private final Collection<BeforeSend> beforeSendTasks = new ConcurrentLinkedQueue<>();
     private final Collection<BeforeRecordBreadcrumb> beforeRecordBreadcrumbTasks
         = new ConcurrentLinkedQueue<>();
+    private final Collection<BeforeSendSession> sessionCallbacks = new ConcurrentLinkedQueue<>();
+
     private String codeBundleId;
     private String notifierType;
 
@@ -825,5 +827,13 @@ public class Configuration extends Observable implements Observer {
     @NonNull
     protected Collection<BeforeRecordBreadcrumb> getBeforeRecordBreadcrumbTasks() {
         return beforeRecordBreadcrumbTasks;
+    }
+
+    void addBeforeSendSession(BeforeSendSession beforeSendSession) {
+        sessionCallbacks.add(beforeSendSession);
+    }
+
+    Collection<BeforeSendSession> getSessionCallbacks() {
+        return sessionCallbacks;
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -45,7 +45,6 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     private AtomicReference<Session> currentSession = new AtomicReference<>();
     private Semaphore flushingRequest = new Semaphore(1);
     private final ForegroundDetector foregroundDetector;
-    final Collection<BeforeSendSession> sessionCallbacks = new ConcurrentLinkedQueue<>();
 
     SessionTracker(Configuration configuration, Client client, SessionStore sessionStore) {
         this(configuration, client, DEFAULT_TIMEOUT_MS, sessionStore);
@@ -180,8 +179,8 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
                                 client.appData, client.deviceData);
 
                         try {
-                            for (BeforeSendSession callback : sessionCallbacks) {
-                                callback.beforeSendSession(payload);
+                            for (BeforeSendSession mutator : configuration.getSessionCallbacks()) {
+                                mutator.beforeSendSession(payload);
                             }
 
                             configuration.getDelivery().deliver(payload, configuration);
@@ -433,9 +432,5 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
             String[] activities = foregroundActivities.toArray(new String[size]);
             return activities[size - 1];
         }
-    }
-
-    void addBeforeSendSession(BeforeSendSession beforeSendSession) {
-        sessionCallbacks.add(beforeSendSession);
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/SessionTrackingPayload.java
+++ b/sdk/src/main/java/com/bugsnag/android/SessionTrackingPayload.java
@@ -49,4 +49,8 @@ public class SessionTrackingPayload implements JsonStream.Streamable {
     Session getSession() {
         return session;
     }
+
+    Map<String, Object> getDevice() {
+        return deviceDataSummary;
+    }
 }


### PR DESCRIPTION
## Goal

We require an internal API for mutating a session payload before it is sent, for notifiers such as React Native/Unity which need to write runtime version info.

## Changeset

- Added `BeforeSendSession` functional interface
- Invoked collection of send session callbacks prior to delivering a session for the first time

## Tests

Added a unit test that verifies the callback is invoked when sending a session
