### PR TITLE
test: optimise mazerunner fixture build speed

### DIFF
--- a/features/fixtures/mazerunner/build.gradle
+++ b/features/fixtures/mazerunner/build.gradle
@@ -62,6 +62,9 @@ android {
             jniLibs.srcDirs = ['libs']
         }
     }
+    lintOptions {
+        tasks.lint.enabled = false
+    }
 }
 
 dependencies {

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,7 +3,11 @@ RUNNING_CI = ENV['TRAVIS'] == 'true'
 
 # Install latest versions of bugsnag-android(-ndk)
 run_required_commands([
-  ["./gradlew", "clean", "sdk:assembleRelease", "ndk:assembleRelease"],
+  [
+    "./gradlew", "sdk:assembleRelease", "ndk:assembleRelease",
+    "-x", "lintVitalRelease",
+    "-x", "countReleaseDexMethods"
+  ],
   ["cp", "sdk/build/outputs/aar/bugsnag-android-*.aar",
    "features/fixtures/mazerunner/libs/bugsnag-android.aar"],
   ["cp", "ndk/build/outputs/aar/bugsnag-android-ndk-*.aar",
@@ -13,7 +17,10 @@ run_required_commands([
 # Build the harness app
 Dir.chdir('features/fixtures/mazerunner') do
   run_required_commands([
-    ["../../../gradlew", "clean", "assembleRelease"],
+    [
+      "../../../gradlew", "assembleRelease",
+      "-x", "lintVitalRelease"
+    ],
   ])
 end
 


### PR DESCRIPTION
Mazerunner previously took ~3 mins to run the `handled_exception.feature` when benchmarked on my machine. The majority of this time was spent performing a clean build and linting the example app, neither of which need to happen.

The build now reuses existing outputs and does not lint the fixture or count dex methods, resulting in an execution time of <1 minute for the scenario.

This will predominantly benefit local development, but should theoretically shave 5-10 minutes off CI as well.