### PR TITLE
build: avoid upload errors when making release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ If you are a project maintainer, you can build and release a new version of
 - Merge any remaining PRs to master, ensuring the commit message matches the release tag (e.g. v4.0.0)
 - [ ] Update the version number and dex count badge by running `make VERSION=[number] bump`
 - [ ] Inspected the updated CHANGELOG, README, and version files to ensure they are correct
-- [ ] Release to GitHub, Maven Central, and Bintray by running `git tag vX.X.X && git push origin --tags && ./gradlew assembleRelease publish bintrayUpload`
+- [ ] Release to GitHub, Maven Central, and Bintray by running `git tag vX.X.X && git push origin --tags && ./gradlew ndk:assembleRelease sdk:assembleRelease publish bintrayUpload`
   - [ ] "Promote" the release build on Maven Central
     - Go to the [sonatype open source dashboard](https://oss.sonatype.org/index.html#stagingRepositories)
     - Click the search box at the top right, and type “com.bugsnag”


### PR DESCRIPTION
## Goal

When making a release the `failOnUploadError` flag causes the bugsnag gradle plugin to fail the build due to a placeholder API key being present in the example app. We should avoid this by only assembling the sdk + ndk modules.
