### PR TITLE
fix: remove RINGER_MODE_CHANGED action from broadcast receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Remove `RINGER_MODE_CHANGED` action from broadcast receiver
+[#481](https://github.com/bugsnag/bugsnag-android/pull/481)
+
 ## 4.14.0 (2019-05-07)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-* Remove `RINGER_MODE_CHANGED` action from broadcast receiver
+* Remove `RINGER_MODE_CHANGED` action from broadcast receiver, which a fixes `SecurityException` thrown in Instant Apps
 [#481](https://github.com/bugsnag/bugsnag-android/pull/481)
 
 ## 4.14.0 (2019-05-07)

--- a/sdk/src/main/java/com/bugsnag/android/EventReceiver.java
+++ b/sdk/src/main/java/com/bugsnag/android/EventReceiver.java
@@ -115,7 +115,6 @@ public class EventReceiver extends BroadcastReceiver {
         actions.put("android.intent.action.SCREEN_ON", BreadcrumbType.STATE);
         actions.put("android.intent.action.TIMEZONE_CHANGED", BreadcrumbType.STATE);
         actions.put("android.intent.action.TIME_SET", BreadcrumbType.STATE);
-        actions.put("android.media.RINGER_MODE_CHANGED", BreadcrumbType.STATE);
         actions.put("android.os.action.DEVICE_IDLE_MODE_CHANGED", BreadcrumbType.STATE);
         actions.put("android.os.action.POWER_SAVE_MODE_CHANGED", BreadcrumbType.STATE);
         return actions;


### PR DESCRIPTION
## Goal

The `RINGER_MODE_CHANGED` action causes a `SecurityException` to be thrown in [Instant Apps](https://developer.android.com/topic/google-play-instant/getting-started/first-instant-app), which crashes the app when running on API <23. We should support Instant Apps by removing this breadcrumb by default.

It's worth noting that bugsnag-android-ndk also seems to have some trouble loading the SO files, and therefore crashes on initialisation. This seems restricted to API <23, so we will address that in a separate PR if needed.

## Tests

Manually ran an Instant App enabled app on a Nexus 4 running API 21, before and after the fix. See #476 for further details on how to reproduce.
