### PR TITLE
feat: Disable ANR detection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Disable ANR detection by default [#484](https://github.com/bugsnag/bugsnag-android/pull/484)
+
 ## 4.14.1 (2019-05-17)
 
 ### Bug fixes
@@ -85,7 +91,7 @@
 
 * Fix cached error deserialisation where the Throwable has a cause
   [#418](https://github.com/bugsnag/bugsnag-android/pull/418)
-  
+
 * Refactor error report deserialisation
   [#419](https://github.com/bugsnag/bugsnag-android/pull/419)
 

--- a/features/detect_anr.feature
+++ b/features/detect_anr.feature
@@ -25,3 +25,7 @@ Scenario: Test ANR wait time can be set to under default time
 Scenario: Test ANR wait time can be set to over default time
     When I run "AppNotRespondingLongerThresholdScenario"
     Then I should receive 0 requests
+
+Scenario: Test does not capture ANRs by default
+    When I run "AppNotRespondingDefaultsScenario"
+    Then I should receive 0 requests

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -42,10 +42,15 @@ class MainActivity : Activity() {
     }
 
     private fun prepareConfig(): Configuration {
+        val eventType = intent.getStringExtra("EVENT_TYPE")
         val config = Configuration(intent.getStringExtra("BUGSNAG_API_KEY"))
         val port = intent.getStringExtra("BUGSNAG_PORT")
         config.setEndpoints("${findHostname()}:$port", "${findHostname()}:$port")
-        config.detectAnrs = false
+
+        // Added to stop override of the default ANR state
+        if (eventType != "AppNotRespondingDefaultsScenario") {
+            config.detectAnrs = false
+        }
         return config
     }
 

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDefaultsScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDefaultsScenario.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Stops the app from responding for a time period
+ */
+internal class AppNotRespondingDefaultsScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        Thread.sleep(6000)
+    }
+
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/AnrConfigTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AnrConfigTest.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class AnrConfigTest {
@@ -10,7 +10,7 @@ class AnrConfigTest {
 
     @Test
     fun testDetectAnrDefault() {
-        assertTrue(config.detectAnrs)
+        assertFalse(config.detectAnrs)
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -48,7 +48,7 @@ public class Configuration extends Observable implements Observer {
     private boolean autoCaptureSessions = true;
     private boolean automaticallyCollectBreadcrumbs = true;
 
-    private boolean detectAnrs = !Debug.isDebuggerConnected();
+    private boolean detectAnrs = false;
     private long anrThresholdMs = 5000;
 
     @NonNull
@@ -657,11 +657,10 @@ public class Configuration extends Observable implements Observer {
 
     /**
      * Sets whether <a href="https://developer.android.com/topic/performance/vitals/anr">ANRs</a>
-     * should be reported to Bugsnag. By default, Bugsnag will record an ANR whenever the main
-     * thread has been blocked for 5000 milliseconds or longer, when no debugger is attached to
-     * the app.
+     * should be reported to Bugsnag. When enabled, Bugsnag will record an ANR whenever the main
+     * thread has been blocked for 5000 milliseconds or longer.
      * <p/>
-     * If you wish to disable ANR detection, you should set this property to false; if you wish to
+     * If you wish to enable ANR detection, you should set this property to true; if you wish to
      * configure the time threshold required to capture an ANR, you should use the
      * {@link #setAnrThresholdMs(long)} property.
      *
@@ -686,8 +685,8 @@ public class Configuration extends Observable implements Observer {
      * by Bugsnag. By default, Bugsnag will record an ANR whenever the main thread has been blocked
      * for 5000 milliseconds or longer.
      * <p/>
-     * If you wish to disable ANR detection completely, you should set the
-     * {@link #setDetectAnrs(boolean)} property to false.
+     * If you wish to enable ANR detection, you should set the {@link #setDetectAnrs(boolean)}
+     * property to true.
      * <p/>
      * Attempting to set this property to any value below 1000ms will result in the anrThresholdMs
      * being set as 1000ms.


### PR DESCRIPTION
## Goal

With the current implementation we're seeing too many false positives from the ANR detection.

## Changeset

Set the default value for `detectAnrs` to be `false` and update the javadoc config method descriptions.

## Tests

Unit and end-to-end tests were updated where necessary and all suites run to completion locally.