### PR TITLE
Add detectNdkCrashes property to control NDK crash reporting

### DIFF
--- a/features/detect_ndk_crashes.feature
+++ b/features/detect_ndk_crashes.feature
@@ -1,0 +1,13 @@
+Feature: Verifies detectNdkCrashes controls when NDK crashes are reported
+
+Scenario: Crash reported when detectNdkCrashes enabled
+    When I run "DetectNdkEnabledScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 1 request
+
+Scenario: No crash reported when detectNdkCrashes disabled
+    When I run "DetectNdkDisabledScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 0 requests

--- a/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
+++ b/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
@@ -182,4 +182,24 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXJavaBreadcrumbNativeBreadcrumbS
     __builtin_trap();
   return 12167;
 }
+
+JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_DetectNdkDisabledScenario_crash(
+    JNIEnv *env,
+jobject instance) {
+int x = 47;
+if (x > 0)
+__builtin_trap();
+return 512345;
+}
+
+JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_DetectNdkEnabledScenario_crash(
+    JNIEnv *env,
+jobject instance) {
+int x = 47;
+if (x > 0)
+__builtin_trap();
+return 12633;
+}
 }

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/DetectNdkDisabledScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/DetectNdkDisabledScenario.java
@@ -1,0 +1,32 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+import com.bugsnag.android.Configuration;
+import android.support.annotation.NonNull;
+
+public class DetectNdkDisabledScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public DetectNdkDisabledScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        config.setDetectNdkCrashes(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/DetectNdkEnabledScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/DetectNdkEnabledScenario.java
@@ -1,0 +1,32 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+import com.bugsnag.android.Configuration;
+import android.support.annotation.NonNull;
+
+public class DetectNdkEnabledScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public DetectNdkEnabledScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        config.setDetectNdkCrashes(true);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,7 +4,7 @@ RUNNING_CI = ENV['TRAVIS'] == 'true'
 # Install latest versions of bugsnag-android
 run_required_commands([
   [
-    "./gradlew", "sdk:assembleRelease",
+    "./gradlew", "sdk:assembleRelease", "-PreleaseNdkArtefact=true",
     "-x", "lintVitalRelease",
     "-x", "countReleaseDexMethods"
   ],

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -43,13 +43,6 @@ android {
         baseline file("lint-baseline.xml")
     }
 
-    // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
-    libraryVariants.all { variant ->
-        variant.generateBuildConfigProvider.configure { task ->
-            task.enabled = false
-        }
-    }
-
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"
@@ -60,6 +53,11 @@ android {
         debug {
             testCoverageEnabled = true
         }
+    }
+
+    buildTypes.each { buildType ->
+        boolean detectNdkCrashes = project.hasProperty("releaseNdkArtefact")
+        buildType.buildConfigField("boolean", "DETECT_NDK_CRASHES", "$detectNdkCrashes")
     }
 
     testOptions.unitTests.all {

--- a/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/sdk/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -75,7 +75,6 @@ public final class Bugsnag {
         synchronized (lock) {
             if (client == null) {
                 client = new Client(androidContext, config);
-                NativeInterface.configureClientObservers(client);
             } else {
                 logClientInitWarning();
             }

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -4,6 +4,7 @@ import static com.bugsnag.android.ConfigFactory.MF_BUILD_UUID;
 import static com.bugsnag.android.MapUtils.getStringFromMap;
 
 import com.bugsnag.android.NativeInterface.Message;
+import com.bugsnag.android.ndk.NativeBridge;
 
 import android.app.Activity;
 import android.app.ActivityManager;
@@ -240,6 +241,10 @@ public class Client extends Observable implements Observer {
 
         // Flush any on-disk errors
         errorStore.flushOnLaunch();
+
+        if (config.getDetectNdkCrashes()) {
+            NativeInterface.configureClientObservers(this);
+        }
     }
 
     private void enableAnrDetection() {

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -242,7 +242,7 @@ public class Client extends Observable implements Observer {
         // Flush any on-disk errors
         errorStore.flushOnLaunch();
 
-        if (config.getDetectNdkCrashes()) {
+        if (config.getDetectNdkCrashes() || config.getDetectAnrs()) {
             NativeInterface.configureClientObservers(this);
         }
     }

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -49,6 +49,7 @@ public class Configuration extends Observable implements Observer {
     private boolean automaticallyCollectBreadcrumbs = true;
 
     private boolean detectAnrs = false;
+    private boolean detectNdkCrashes = BuildConfig.DETECT_NDK_CRASHES;
     private long anrThresholdMs = 5000;
 
     @NonNull
@@ -669,6 +670,26 @@ public class Configuration extends Observable implements Observer {
      */
     public void setDetectAnrs(boolean detectAnrs) {
         this.detectAnrs = detectAnrs;
+    }
+
+    /**
+     * @return whether NDK crashes will be reported by bugsnag
+     * @see #setDetectNdkCrashes(boolean)
+     */
+    public boolean getDetectNdkCrashes() {
+        return detectNdkCrashes;
+    }
+
+    /**
+     * Determines whether NDK crashes such as signals and exceptions should be reported by bugsnag.
+     *
+     * If you are using bugsnag-android this flag is false by default; if you are using
+     * bugsnag-android-ndk this flag is true by default.
+     *
+     * @param detectNdkCrashes whether NDK crashes should be reported
+     */
+    public void setDetectNdkCrashes(boolean detectNdkCrashes) {
+        this.detectNdkCrashes = detectNdkCrashes;
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.ndk.NativeBridge;
+
 import android.annotation.SuppressLint;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -10,7 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Observer;
 import java.util.Queue;
 
 /**
@@ -160,11 +161,7 @@ public class NativeInterface {
      * Caches a client instance for responding to future events
      */
     public static void setClient(@NonNull Client client) {
-        if (NativeInterface.client == client) {
-            return;
-        }
         NativeInterface.client = client;
-        configureClientObservers(client);
     }
 
     /**
@@ -172,21 +169,8 @@ public class NativeInterface {
      * @param client the client
      */
     public static void configureClientObservers(@NonNull Client client) {
-        try {
-            String className = "com.bugsnag.android.ndk.NativeBridge";
-            Class<?> clz = Class.forName(className);
-            Observer observer = (Observer) clz.newInstance();
-            client.addObserver(observer);
-        } catch (ClassNotFoundException exception) {
-            // ignore this one, will happen if the NDK plugin is not present
-            Logger.info("Bugsnag NDK integration not available");
-        } catch (InstantiationException exception) {
-            Logger.warn("Failed to instantiate NDK observer", exception);
-        } catch (IllegalAccessException exception) {
-            Logger.warn("Could not access NDK observer", exception);
-        }
-
-        // Configure NDK components
+        setClient(client);
+        client.addObserver(new NativeBridge());
         client.sendNativeSetupNotification();
     }
 


### PR DESCRIPTION
## Goal

Add `config.detectNdkCrashes` property, which controls whether the NDK integration is enabled or not. In the bugsnag-android artefact, this value should be disabled by default; in bugsnag-android-ndk it should be enabled.

## Changeset

- Built the NDK lib for the mazerunner fixture by default
- Add `BuildConfig.DETECT_NDK_CRASHES` which is set via a gradle command line parameter
- Add `detectNdkCrashes` property to `Configuration`
- Move NDK initialisation to within `Client` constructor
- Simplify `NativeInterface` to avoid complexity + cost of reflection, by instantiating `NativeBridge` directly

## Tests

Added mazerunner scenario for when NDK crash detection is explicitly enabled and disabled. The default value is covered by existing tests.
