### PR TITLE
Add detection manifest options

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -193,6 +193,8 @@ public class ClientTest {
         assertEquals(config.getEnableExceptionHandler(), protoConfig.getEnableExceptionHandler());
         assertEquals(config.getPersistUserBetweenSessions(),
             protoConfig.getPersistUserBetweenSessions());
+        assertEquals(false, protoConfig.getDetectAnrs());
+        assertEquals(false, protoConfig.getDetectNdkCrashes());
     }
 
     @Test
@@ -213,6 +215,8 @@ public class ClientTest {
         data.putBoolean("com.bugsnag.android.ENABLE_EXCEPTION_HANDLER", false);
         data.putBoolean("com.bugsnag.android.PERSIST_USER_BETWEEN_SESSIONS", true);
         data.putBoolean("com.bugsnag.android.AUTO_CAPTURE_SESSIONS", true);
+        data.putBoolean("com.bugsnag.android.DETECT_ANRS", true);
+        data.putBoolean("com.bugsnag.android.DETECT_NDK_CRASHES", true);
 
         Configuration protoConfig = new Configuration("api-key");
         ConfigFactory.populateConfigFromManifest(protoConfig, data);
@@ -225,6 +229,8 @@ public class ClientTest {
         assertEquals(false, protoConfig.getEnableExceptionHandler());
         assertEquals(true, protoConfig.getPersistUserBetweenSessions());
         assertEquals(true, protoConfig.getAutoCaptureSessions());
+        assertEquals(true, protoConfig.getDetectAnrs());
+        assertEquals(true, protoConfig.getDetectNdkCrashes());
     }
 
     @SuppressWarnings("deprecation") // test backwards compatibility of client.setMaxBreadcrumbs

--- a/sdk/src/main/java/com/bugsnag/android/ConfigFactory.java
+++ b/sdk/src/main/java/com/bugsnag/android/ConfigFactory.java
@@ -22,6 +22,8 @@ class ConfigFactory {
     private static final String MF_AUTO_CAPTURE_SESSIONS =
         BUGSNAG_NAMESPACE + ".AUTO_CAPTURE_SESSIONS";
     private static final String MF_API_KEY = BUGSNAG_NAMESPACE + ".API_KEY";
+    private static final String MF_DETECT_NDK_CRASHES = BUGSNAG_NAMESPACE + ".DETECT_NDK_CRASHES";
+    private static final String MF_DETECT_ANRS = BUGSNAG_NAMESPACE + ".DETECT_ANRS";
     static final String MF_BUILD_UUID = BUGSNAG_NAMESPACE + ".BUILD_UUID";
 
     /**
@@ -101,6 +103,12 @@ class ConfigFactory {
         config.setPersistUserBetweenSessions(
             data.getBoolean(MF_PERSIST_USER_BETWEEN_SESSIONS, false));
 
+        if (data.containsKey(MF_DETECT_NDK_CRASHES)) {
+            config.setDetectNdkCrashes(data.getBoolean(MF_DETECT_NDK_CRASHES));
+        }
+        if (data.containsKey(MF_DETECT_ANRS)) {
+            config.setDetectAnrs(data.getBoolean(MF_DETECT_ANRS));
+        }
         if (data.containsKey(MF_AUTO_CAPTURE_SESSIONS)) {
             config.setAutoCaptureSessions(data.getBoolean(MF_AUTO_CAPTURE_SESSIONS));
         }


### PR DESCRIPTION
## Goal

Make detection options configurable via App Manifest

## Changeset

* Update ConfigFactory to load detectNdkCrashes and detectAnrs from manifest if provided

## Tests

* Added new test assertions for the default values and overrides via manifest
