### PR TITLE
Send minimal error report if cached file is corrupted/empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Send minimal error report if cached file is corrupted/empty
+[#500](https://github.com/bugsnag/bugsnag-android/pull/500)
+
 ## 4.15.0 (2019-06-10)
 
 `bugsnag-android` now supports detecting and reporting C/C++ crashes without a separate library (previously `bugsnag-android-ndk` was required for native error reporting).

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CorruptedReportScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CorruptedReportScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import java.io.File
+
+/**
+ * Verifies that if a report is corrupted, minimal information is still sent to bugsnag.
+ */
+internal class CorruptedReportScenario(config: Configuration,
+                                       context: Context) : Scenario(config, context) {
+
+    init {
+        config.setAutoCaptureSessions(false)
+        val files = File(context.cacheDir, "bugsnag-errors").listFiles()
+        files.forEach { it.writeText("{\"exceptions\":[{\"stacktrace\":[") }
+
+        val nativeFiles = File(context.cacheDir, "bugsnag-native").listFiles()
+        nativeFiles.forEach { it.writeText("{\"exceptions\":[{\"stacktrace\":[") }
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
@@ -1,0 +1,19 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import java.io.File
+
+/**
+ * Verifies that if a report is empty, minimal information is still sent to bugsnag.
+ */
+internal class EmptyReportScenario(config: Configuration,
+                                   context: Context) : Scenario(config, context) {
+
+    init {
+        config.setAutoCaptureSessions(false)
+        val files = File(context.cacheDir, "bugsnag-errors").listFiles()
+        files.forEach { it.writeText("") }
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MinimalHandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MinimalHandledExceptionScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import java.io.File
+
+/**
+ * Sends a handled exception to Bugsnag, which does not include session data.
+ */
+internal class MinimalHandledExceptionScenario(config: Configuration,
+                                               context: Context) : Scenario(config, context) {
+
+    init {
+        config.setAutoCaptureSessions(false)
+        disableAllDelivery(config)
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.notify(java.lang.RuntimeException("Whoops"))
+    }
+
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MinimalUnhandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MinimalUnhandledExceptionScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+import java.io.File
+
+/**
+ * Sends an unhandled exception to Bugsnag.
+ */
+internal class MinimalUnhandledExceptionScenario(config: Configuration,
+                                                 context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+        disableAllDelivery(config)
+    }
+
+    override fun run() {
+        super.run()
+        throw java.lang.IllegalStateException("Whoops")
+    }
+
+}

--- a/features/minimal_report.feature
+++ b/features/minimal_report.feature
@@ -1,0 +1,27 @@
+Feature: Minimal error information is reported for corrupted/empty files
+
+Scenario: Minimal error report for a Handled Exception with an empty file
+    When I run "MinimalHandledExceptionScenario"
+    And I set environment variable "EVENT_TYPE" to "EmptyReportScenario"
+    And I relaunch the app
+    Then I should receive 1 request
+    And the request is valid for the error reporting API
+    And the payload field "events.0.exceptions.0.stacktrace" is an array with 0 element
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the event "severity" equals "warning"
+    And the event "unhandled" is false
+    And the event "incomplete" is true
+    And the event "severityReason.type" equals "handledException"
+
+Scenario: Minimal error report for an Unhandled Exception with a corrupted file
+    When I run "MinimalUnhandledExceptionScenario"
+    And I set environment variable "EVENT_TYPE" to "CorruptedReportScenario"
+    And I relaunch the app
+    Then I should receive 1 request
+    And the request is valid for the error reporting API
+    And the payload field "events.0.exceptions.0.stacktrace" is an array with 0 element
+    And the exception "errorClass" equals "java.lang.IllegalStateException"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "incomplete" is true
+    And the event "severityReason.type" equals "unhandledException"

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorFilenameTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorFilenameTest.kt
@@ -11,6 +11,8 @@ import org.junit.Before
 import org.junit.Test
 import java.io.File
 
+class SuperCaliFragilisticExpiAlidociousBeanFactoryException: RuntimeException()
+
 class ErrorFilenameTest {
 
     private lateinit var errorStore: ErrorStore
@@ -40,6 +42,14 @@ class ErrorFilenameTest {
         val err = generateError(false, Severity.INFO, IllegalStateException("Whoops"))
         val filename = errorStore.calculateFilenameForError(err)
         assertEquals("i-h-java.lang.IllegalStateException", filename)
+    }
+
+    @Test
+    fun testCalculateTruncatedFilename() {
+        val err = generateError(false, Severity.INFO,
+            SuperCaliFragilisticExpiAlidociousBeanFactoryException())
+        val filename = errorStore.calculateFilenameForError(err)
+        assertEquals("i-h-com.bugsnag.android.SuperCaliFragilistic", filename)
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorFilenameTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorFilenameTest.kt
@@ -1,0 +1,146 @@
+package com.bugsnag.android
+
+import android.support.test.InstrumentationRegistry
+import com.bugsnag.android.ErrorStore.ERROR_REPORT_COMPARATOR
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+class ErrorFilenameTest {
+
+    private lateinit var errorStore: ErrorStore
+    private val config = Configuration("api-key")
+
+    /**
+     * Generates a client and ensures that its errorStore has 0 files persisted
+     *
+     * @throws Exception if initialisation failed
+     */
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        val context = InstrumentationRegistry.getContext()
+        errorStore = ErrorStore(config, context, null)
+    }
+
+    @Test
+    fun testCalculateFilenameUnhandled() {
+        val err = generateError(true, Severity.ERROR, RuntimeException())
+        val filename = errorStore.calculateFilenameForError(err)
+        assertEquals("e-u-java.lang.RuntimeException", filename)
+    }
+
+    @Test
+    fun testCalculateFilenameHandled() {
+        val err = generateError(false, Severity.INFO, IllegalStateException("Whoops"))
+        val filename = errorStore.calculateFilenameForError(err)
+        assertEquals("i-h-java.lang.IllegalStateException", filename)
+    }
+
+    @Test
+    fun testErrorFromInvalidFilename() {
+        val invalids = arrayOf(
+            null, "", "test.txt", "i-h.foo",
+            "1504255147933_683c6b92-b325-4987-80ad-77086509ca1e.json"
+        )
+        invalids.forEach { assertNull(errorStore.generateErrorFromFilename(it)) }
+    }
+
+    @Test
+    fun testUnhandledErrorFromFilename() {
+        val filename = "1504255147933_e-u-java.lang.RuntimeException_" +
+            "683c6b92-b325-4987-80ad-77086509ca1e.json"
+        val err = errorStore.generateErrorFromFilename(filename)
+        assertNotNull(err)
+        assertTrue(err.handledState.isUnhandled)
+        assertEquals(Severity.ERROR, err.severity)
+        assertEquals("java.lang.RuntimeException", err.exceptionName)
+    }
+
+    @Test
+    fun testHandledErrorFromFilename() {
+        val filename = "1504500000000_i-h-java.lang.IllegalStateException_" +
+            "683c6b92-b325-4987-80ad-77086509ca1e_startupcrash.json"
+        val err = errorStore.generateErrorFromFilename(filename)
+        assertNotNull(err)
+        assertFalse(err.handledState.isUnhandled)
+        assertEquals(Severity.INFO, err.severity)
+        assertEquals("java.lang.IllegalStateException", err.exceptionName)
+    }
+
+    @Test
+    fun testErrorWithoutClassFromFilename() {
+        val filename = "1504500000000_i-h-_" +
+            "683c6b92-b325-4987-80ad-77086509ca1e_startupcrash.json"
+        val err = errorStore.generateErrorFromFilename(filename)
+        assertNotNull(err)
+        assertFalse(err.handledState.isUnhandled)
+        assertEquals(Severity.INFO, err.severity)
+        assertEquals("", err.exceptionName)
+    }
+
+    @Test
+    fun testIsLaunchCrashReport() {
+        val valid =
+            arrayOf("1504255147933_e-u-java.lang.RuntimeException_30b7e350-dcd1-4032-969e-98d30be62bbc_startupcrash.json")
+        val invalid = arrayOf(
+            "",
+            ".json",
+            "abcdeAO.json",
+            "!@£)(%)(",
+            "1504255147933.txt",
+            "1504255147933.json"
+        )
+
+        for (s in valid) {
+            assertTrue(errorStore.isLaunchCrashReport(File(s)))
+        }
+        for (s in invalid) {
+            assertFalse(errorStore.isLaunchCrashReport(File(s)))
+        }
+    }
+
+    @Test
+    fun testComparator() {
+        val first = "1504255147933_e-u-java.lang.RuntimeException_" +
+            "683c6b92-b325-4987-80ad-77086509ca1e.json"
+        val second = "1505000000000_i-h-Exception_683c6b92-b325-4987-80ad-77086509ca1e.json"
+        val startup = "1504500000000_w-h-java.lang.IllegalStateException_683c6b92-b325-" +
+            "4987-80ad-77086509ca1e_startupcrash.json"
+
+        // handle defaults
+        assertEquals(0, ERROR_REPORT_COMPARATOR.compare(null, null).toLong())
+        assertEquals(-1, ERROR_REPORT_COMPARATOR.compare(File(""), null).toLong())
+        assertEquals(1, ERROR_REPORT_COMPARATOR.compare(null, File("")).toLong())
+
+        // same value should always be 0
+        assertEquals(0, ERROR_REPORT_COMPARATOR.compare(File(first), File(first)).toLong())
+        assertEquals(0, ERROR_REPORT_COMPARATOR.compare(File(startup), File(startup)).toLong())
+
+        // first is before second
+        assertTrue(ERROR_REPORT_COMPARATOR.compare(File(first), File(second)) < 0)
+        assertTrue(ERROR_REPORT_COMPARATOR.compare(File(second), File(first)) > 0)
+
+        // startup is handled correctly
+        assertTrue(ERROR_REPORT_COMPARATOR.compare(File(first), File(startup)) < 0)
+        assertTrue(ERROR_REPORT_COMPARATOR.compare(File(second), File(startup)) > 0)
+    }
+
+    private fun generateError(unhandled: Boolean, severity: Severity, exc: Throwable): Error {
+        val currentThread = Thread.currentThread()
+        val sessionTracker = BugsnagTestUtils.generateSessionTracker()
+
+        val handledState = when {
+            unhandled -> HandledState.REASON_UNHANDLED_EXCEPTION
+            else -> HandledState.REASON_HANDLED_EXCEPTION
+        }
+        return Error.Builder(config, exc, sessionTracker, currentThread, unhandled)
+            .severityReasonType(handledState)
+            .severity(severity).build()
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorStoreTest.java
@@ -1,6 +1,5 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.ErrorStore.ERROR_REPORT_COMPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -11,17 +10,12 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Collections;
 import java.util.List;
 
@@ -63,45 +57,6 @@ public class ErrorStoreTest {
             BugsnagTestUtils.generateSessionTracker(), Thread.currentThread(), false).build();
         errorStore.write(error);
         return error;
-    }
-
-    @Test
-    public void testIsLaunchCrashReport() throws Exception {
-        String[] valid = {"1504255147933__30b7e350-dcd1-4032-969e-98d30be62bbc_startupcrash.json"};
-        String[] invalid = {"", ".json", "abcdeAO.json", "!@£)(%)(",
-            "1504255147933.txt", "1504255147933.json"};
-
-        for (String s : valid) {
-            assertTrue(errorStore.isLaunchCrashReport(new File(s)));
-        }
-        for (String s : invalid) {
-            assertFalse(errorStore.isLaunchCrashReport(new File(s)));
-        }
-    }
-
-    @Test
-    public void testComparator() throws Exception {
-        final String first = "1504255147933_683c6b92-b325-4987-80ad-77086509ca1e.json";
-        final String second = "1505000000000_683c6b92-b325-4987-80ad-77086509ca1e.json";
-        final String startup = "1504500000000_683c6b92-b325-"
-            + "4987-80ad-77086509ca1e_startupcrash.json";
-
-        // handle defaults
-        assertEquals(0, ERROR_REPORT_COMPARATOR.compare(null, null));
-        assertEquals(-1, ERROR_REPORT_COMPARATOR.compare(new File(""), null));
-        assertEquals(1, ERROR_REPORT_COMPARATOR.compare(null, new File("")));
-
-        // same value should always be 0
-        assertEquals(0, ERROR_REPORT_COMPARATOR.compare(new File(first), new File(first)));
-        assertEquals(0, ERROR_REPORT_COMPARATOR.compare(new File(startup), new File(startup)));
-
-        // first is before second
-        assertTrue(ERROR_REPORT_COMPARATOR.compare(new File(first), new File(second)) < 0);
-        assertTrue(ERROR_REPORT_COMPARATOR.compare(new File(second), new File(first)) > 0);
-
-        // startup is handled correctly
-        assertTrue(ERROR_REPORT_COMPARATOR.compare(new File(first), new File(startup)) < 0);
-        assertTrue(ERROR_REPORT_COMPARATOR.compare(new File(second), new File(startup)) > 0);
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -1341,13 +1341,7 @@ public class Client extends Observable implements Observer {
                 leaveErrorBreadcrumb(error);
             }
         } catch (Exception exception) {
-            // send a minimal error to bugsnag with no cache
-            Throwable exc = new RuntimeException("Failed to deliver bugsnag report", exception);
-            Error emptyError = new Error.Builder(config, exc,
-                null, Thread.currentThread(), false)
-                .severity(Severity.INFO)
-                .build();
-            notify(emptyError, DeliveryStyle.NO_CACHE, null);
+            Logger.warn("Problem sending error to Bugsnag", exception);
         }
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -189,17 +189,9 @@ public class Client extends Observable implements Observer {
         // Create the error store that is used in the exception handler
         errorStore = new ErrorStore(config, appContext, new ErrorStore.Delegate() {
             @Override
-            public void onErrorReadFailure(String filename) {
+            public void onErrorReadFailure(Error error) {
                 // send a minimal error to bugsnag with no cache
-                RuntimeException err = new RuntimeException();
-                Throwable exc = new RuntimeException("Failed to send cached bugsnag report", err);
-
-                // TODO use filename to populate these fields
-                Error emptyError = new Error.Builder(config, exc,
-                    null, Thread.currentThread(), false)
-                    .severity(Severity.INFO)
-                    .build();
-                Client.this.notify(emptyError, DeliveryStyle.NO_CACHE, null);
+                Client.this.notify(error, DeliveryStyle.NO_CACHE, null);
             }
         });
 

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -4,10 +4,8 @@ import static com.bugsnag.android.ConfigFactory.MF_BUILD_UUID;
 import static com.bugsnag.android.MapUtils.getStringFromMap;
 
 import com.bugsnag.android.NativeInterface.Message;
-import com.bugsnag.android.ndk.NativeBridge;
 
 import android.app.Activity;
-import android.app.ActivityManager;
 import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -18,7 +16,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -190,7 +187,21 @@ public class Client extends Observable implements Observer {
         }
 
         // Create the error store that is used in the exception handler
-        errorStore = new ErrorStore(config, appContext);
+        errorStore = new ErrorStore(config, appContext, new ErrorStore.Delegate() {
+            @Override
+            public void onErrorReadFailure(String filename) {
+                // send a minimal error to bugsnag with no cache
+                RuntimeException err = new RuntimeException();
+                Throwable exc = new RuntimeException("Failed to send cached bugsnag report", err);
+
+                // TODO use filename to populate these fields
+                Error emptyError = new Error.Builder(config, exc,
+                    null, Thread.currentThread(), false)
+                    .severity(Severity.INFO)
+                    .build();
+                Client.this.notify(emptyError, DeliveryStyle.NO_CACHE, null);
+            }
+        });
 
         // Install a default exception handler with this client
         if (config.getEnableExceptionHandler()) {
@@ -971,22 +982,12 @@ public class Client extends Observable implements Observer {
             case SAME_THREAD:
                 deliver(report, error);
                 break;
+            case NO_CACHE:
+                report.setCachingDisabled(true);
+                deliverReportAsync(error, report);
+                break;
             case ASYNC:
-                final Report finalReport = report;
-                final Error finalError = error;
-
-                // Attempt to send the report in the background
-                try {
-                    Async.run(new Runnable() {
-                        @Override
-                        public void run() {
-                            deliver(finalReport, finalError);
-                        }
-                    });
-                } catch (RejectedExecutionException exception) {
-                    errorStore.write(error);
-                    Logger.warn("Exceeded max queue count, saving to disk to send later");
-                }
+                deliverReportAsync(error, report);
                 break;
             case ASYNC_WITH_CACHE:
                 errorStore.write(error);
@@ -994,6 +995,24 @@ public class Client extends Observable implements Observer {
                 break;
             default:
                 break;
+        }
+    }
+
+    private void deliverReportAsync(@NonNull Error error, Report report) {
+        final Report finalReport = report;
+        final Error finalError = error;
+
+        // Attempt to send the report in the background
+        try {
+            Async.run(new Runnable() {
+                @Override
+                public void run() {
+                    deliver(finalReport, finalError);
+                }
+            });
+        } catch (RejectedExecutionException exception) {
+            errorStore.write(error);
+            Logger.warn("Exceeded max queue count, saving to disk to send later");
         }
     }
 
@@ -1323,12 +1342,20 @@ public class Client extends Observable implements Observer {
             Logger.info("Sent 1 new error to Bugsnag");
             leaveErrorBreadcrumb(error);
         } catch (DeliveryFailureException exception) {
-            Logger.warn("Could not send error(s) to Bugsnag,"
-                + " saving to disk to send later", exception);
-            errorStore.write(error);
-            leaveErrorBreadcrumb(error);
+            if (!report.isCachingDisabled()) {
+                Logger.warn("Could not send error(s) to Bugsnag,"
+                    + " saving to disk to send later", exception);
+                errorStore.write(error);
+                leaveErrorBreadcrumb(error);
+            }
         } catch (Exception exception) {
-            Logger.warn("Problem sending error to Bugsnag", exception);
+            // send a minimal error to bugsnag with no cache
+            Throwable exc = new RuntimeException("Failed to deliver bugsnag report", exception);
+            Error emptyError = new Error.Builder(config, exc,
+                null, Thread.currentThread(), false)
+                .severity(Severity.INFO)
+                .build();
+            notify(emptyError, DeliveryStyle.NO_CACHE, null);
         }
     }
 

--- a/sdk/src/main/java/com/bugsnag/android/DeliveryStyle.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeliveryStyle.java
@@ -4,5 +4,6 @@ package com.bugsnag.android;
 enum DeliveryStyle {
     SAME_THREAD,
     ASYNC,
-    ASYNC_WITH_CACHE
+    ASYNC_WITH_CACHE,
+    NO_CACHE
 }

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -48,6 +48,7 @@ public class Error implements JsonStream.Streamable {
     private final HandledState handledState;
     private final Session session;
     private final ThreadState threadState;
+    private boolean incomplete = false;
 
     Error(@NonNull Configuration config, @NonNull Throwable exception,
           HandledState handledState, @NonNull Severity severity,
@@ -76,6 +77,7 @@ public class Error implements JsonStream.Streamable {
         writer.name("severity").value(severity);
         writer.name("severityReason").value(handledState);
         writer.name("unhandled").value(handledState.isUnhandled());
+        writer.name("incomplete").value(incomplete);
 
         if (projectPackages != null) {
             writer.name("projectPackages").beginArray();
@@ -114,6 +116,14 @@ public class Error implements JsonStream.Streamable {
         }
 
         writer.endObject();
+    }
+
+    boolean isIncomplete() {
+        return incomplete;
+    }
+
+    void setIncomplete(boolean incomplete) {
+        this.incomplete = incomplete;
     }
 
     /**

--- a/sdk/src/main/java/com/bugsnag/android/Error.java
+++ b/sdk/src/main/java/com/bugsnag/android/Error.java
@@ -461,6 +461,9 @@ public class Error implements JsonStream.Streamable {
         }
 
         private Session getSession(HandledState handledState) {
+            if (sessionTracker == null) {
+                return null;
+            }
             Session currentSession = sessionTracker.getCurrentSession();
             Session reportedSession = null;
 

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -22,6 +22,8 @@ import java.util.concurrent.Semaphore;
 @ThreadSafe
 class ErrorStore extends FileStore<Error> {
 
+    private static final int MAX_ERR_CLASS_LEN = 40;
+
     interface Delegate {
 
         /**
@@ -195,6 +197,10 @@ class ErrorStore extends FileStore<Error> {
         char handled = error.getHandledState().isUnhandled() ? 'u' : 'h';
         char severity = error.getSeverity().getName().charAt(0);
         String errClass = error.getExceptionName();
+
+        if (errClass.length() > MAX_ERR_CLASS_LEN) {
+            errClass = errClass.substring(0, MAX_ERR_CLASS_LEN);
+        }
         return String.format("%s-%s-%s", severity, handled, errClass);
     }
 
@@ -262,8 +268,7 @@ class ErrorStore extends FileStore<Error> {
                 }
             }
         } else {
-            // NDK should always be U + E, as these errors are always fatal
-            encodedInfo = "e-u-";
+            encodedInfo = ""; // don't encode for NDK errors, as they are always 'e-u'
             suffix = "not-jvm";
         }
         String uuid = UUID.randomUUID().toString();

--- a/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/sdk/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -234,7 +234,9 @@ class ErrorStore extends FileStore<Error> {
                 errClass = encodedErr.substring(4);
             }
             BugsnagException exc = new BugsnagException(errClass, "", new StackTraceElement[]{});
-            return new Error(config, exc, handledState, severity, null, null);
+            Error error = new Error(config, exc, handledState, severity, null, null);
+            error.setIncomplete(true);
+            return error;
         } catch (IndexOutOfBoundsException exc) {
             // simplifies above implementation by avoiding need for several length checks.
             return null;
@@ -266,8 +268,8 @@ class ErrorStore extends FileStore<Error> {
         }
         String uuid = UUID.randomUUID().toString();
         long timestamp = System.currentTimeMillis();
-        return String.format(Locale.US, "%s%d%s_%s%s.json",
-                storeDirectory, timestamp, encodedInfo, uuid, suffix);
+        return String.format(Locale.US, "%s%d_%s_%s%s.json",
+            storeDirectory, timestamp, encodedInfo, uuid, suffix);
     }
 
     boolean isStartupCrash(long durationMs) {

--- a/sdk/src/main/java/com/bugsnag/android/Report.java
+++ b/sdk/src/main/java/com/bugsnag/android/Report.java
@@ -1,9 +1,7 @@
 package com.bugsnag.android;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
-import java.io.File;
 import java.io.IOException;
 
 /**
@@ -14,10 +12,7 @@ import java.io.IOException;
  */
 public class Report implements JsonStream.Streamable {
 
-    @Nullable
-    private final File errorFile;
-
-    @Nullable
+    @NonNull
     private final Error error;
 
     @NonNull
@@ -25,17 +20,10 @@ public class Report implements JsonStream.Streamable {
 
     @NonNull
     private String apiKey;
+    private transient boolean cachingDisabled;
 
-    Report(@NonNull String apiKey, @Nullable File errorFile) {
-        this.error = null;
-        this.errorFile = errorFile;
-        this.notifier = Notifier.getInstance();
-        this.apiKey = apiKey;
-    }
-
-    Report(@NonNull String apiKey, @Nullable Error error) {
+    Report(@NonNull String apiKey, @NonNull Error error) {
         this.error = error;
-        this.errorFile = null;
         this.notifier = Notifier.getInstance();
         this.apiKey = apiKey;
     }
@@ -55,13 +43,7 @@ public class Report implements JsonStream.Streamable {
         writer.name("events").beginArray();
 
         // Write in-memory event
-        if (error != null) {
-            writer.value(error);
-        } else if (errorFile != null) { // Write on-disk event
-            writer.value(errorFile);
-        } else {
-            Logger.warn("Expected error or errorFile, found empty payload instead");
-        }
+        writer.value(error);
 
         // End events array
         writer.endArray();
@@ -70,7 +52,7 @@ public class Report implements JsonStream.Streamable {
         writer.endObject();
     }
 
-    @Nullable
+    @NonNull
     public Error getError() {
         return error;
     }
@@ -115,5 +97,13 @@ public class Report implements JsonStream.Streamable {
     @NonNull
     public Notifier getNotifier() {
         return notifier;
+    }
+
+    boolean isCachingDisabled() {
+        return cachingDisabled;
+    }
+
+    void setCachingDisabled(boolean cachingDisabled) {
+        this.cachingDisabled = cachingDisabled;
     }
 }

--- a/sdk/src/main/java/com/bugsnag/android/Severity.java
+++ b/sdk/src/main/java/com/bugsnag/android/Severity.java
@@ -39,6 +39,19 @@ public enum Severity implements JsonStream.Streamable {
         }
     }
 
+    static Severity fromChar(char sevChar) {
+        switch (sevChar) {
+            case 'e':
+                return Severity.ERROR;
+            case 'w':
+                return Severity.WARNING;
+            case 'i':
+                return Severity.INFO;
+            default:  // something went wrong serialising the filename
+                return null;
+        }
+    }
+
     @NonNull
     public String getName() {
         return name;


### PR DESCRIPTION
## Goal

If a report cannot be delivered due to delivery failure, it is cached on disk. If this cached report cannot be deserialised, or is only partially written, e.g. due to lack of disk space, then currently no bugsnag report will be sent.

This changeset alters bugsnag-android to send a minimal error report for cached JVM exceptions only, by encoding basic error information in the filename.

## Changeset

- Updated `ErrorStore` to pass a `Delegate` that is invoked whenever a cached file cannot be deserialised
- Implemented `Delegate` in `Client` by sending a report with `DeliveryStyle.NO_CACHE` (this prevents minimal errors from generating other minimal errors if delivery fails and there's a serialisation bug in the notifier)
- Updated `Error` to include `incomplete` field that is set when a report is incomplete
- In the previous implementation cached files were only deserialised from JSON if a `beforeSend` callback was set; files are now always deserialised, which negates the need for `Report#errorFile`
- Added functions to the `ErrorStore` which encode and decode basic information about the error from the filename

## Tests

- Added a mazerunner scenario for a cached handled and unhandled JVM exception, where the file is either corrupted or entirely empty
- Adapted and added to existing unit test coverage for encoding/decoding of basic error info in the report's filename
- Manually verified that when a cached report is edited on disk and delivered to the dashboard:

<img width="458" alt="Screenshot 2019-06-13 at 14 07 47" src="https://user-images.githubusercontent.com/11800640/59435054-b299e200-8de4-11e9-9034-9ab407c11909.png">

