### PR TITLE
Pass tests by cleaning up `Client` instantiations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,6 @@ ext {
     supportTestVersion = "0.5"
     espressoVersion = "2.2.2"
     junitVersion = "4.12"
-    mockitoVersion = "1.10.19"
+    mockitoVersion = "2.28.2"
     bugsnagPluginVersion = "3.3.0"
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,6 +6,8 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
+    androidTestImplementation "org.mockito:mockito-android:$mockitoVersion"
+
     androidTestImplementation "com.android.support.test:runner:$supportTestVersion", {
         exclude group: "com.android.support", module: "support-annotations"
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/AppDataOverrideTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AppDataOverrideTest.kt
@@ -1,0 +1,41 @@
+package com.bugsnag.android
+
+import android.support.test.InstrumentationRegistry
+import com.bugsnag.android.BugsnagTestUtils.mapToJson
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class AppDataOverrideTest {
+
+    private var appData: MutableMap<String, Any>? = null
+
+    @Mock
+    internal var client: Client? = null
+
+    @Mock
+    internal var sessionTracker: SessionTracker? = null
+
+    @Before
+    fun setUp() {
+        val config = Configuration("api-key")
+        config.appVersion = "1.2.3"
+        config.releaseStage = "test-stage"
+
+        val context = InstrumentationRegistry.getContext()
+        val packageManager = context.packageManager
+        val obj = AppData(context, packageManager, config, sessionTracker)
+        this.appData = obj.appData
+    }
+
+    @Test
+    fun testAppVersionOverride() {
+        val appDataJson = mapToJson(appData)
+        assertEquals("1.2.3", appDataJson.get("version"))
+        assertEquals("test-stage", appDataJson.get("releaseStage"))
+    }
+}

--- a/sdk/src/androidTest/java/com/bugsnag/android/AppDataSummaryTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AppDataSummaryTest.java
@@ -2,7 +2,6 @@ package com.bugsnag.android;
 
 import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.mapToJson;
-import static com.bugsnag.android.BugsnagTestUtils.streamableToJson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -16,7 +15,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.Map;
 
 @RunWith(AndroidJUnit4.class)
@@ -25,39 +23,25 @@ public class AppDataSummaryTest {
 
     private Map<String, Object> appData;
 
-    /**
-     * Configures a new AppDataSummary for testing accessors + serialisation
-     *
-     * @throws Exception if setup failed
-     */
+    private Client client;
+
     @Before
     public void setUp() throws Exception {
-        AppData appData = new AppData(generateClient());
-        this.appData = appData.getAppDataSummary();
+        client = generateClient();
+        appData = new AppData(client).getAppDataSummary();
+    }
+
+    @After
+    public void tearDown() {
+        client.close();
     }
 
     @Test
-    public void testVersionCode() {
+    public void testAccessors() {
         assertEquals(1, appData.get("versionCode"));
-    }
-
-    @Test
-    public void testVersionName() {
         assertEquals("1.0", appData.get("version"));
-    }
-
-    @Test
-    public void testReleaseStage() {
         assertEquals("development", appData.get("releaseStage"));
-    }
-
-    @Test
-    public void testNotifierType() {
         assertEquals("android", appData.get("type"));
-    }
-
-    @Test
-    public void testCodeBundleId() {
         assertNull(appData.get("codeBundleId"));
     }
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/AppDataSummaryTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AppDataSummaryTest.java
@@ -1,39 +1,44 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.mapToJson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.support.test.InstrumentationRegistry;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Map;
 
-@RunWith(AndroidJUnit4.class)
-@SmallTest
+@RunWith(MockitoJUnitRunner.class)
 public class AppDataSummaryTest {
 
     private Map<String, Object> appData;
 
-    private Client client;
+    @Mock
+    Client client;
 
+    @Mock
+    SessionTracker sessionTracker;
+
+    /**
+     * Constructs an app data object
+     */
     @Before
     public void setUp() throws Exception {
-        client = generateClient();
-        appData = new AppData(client).getAppDataSummary();
-    }
-
-    @After
-    public void tearDown() {
-        client.close();
+        Context context = InstrumentationRegistry.getContext();
+        PackageManager packageManager = context.getPackageManager();
+        Configuration config = new Configuration("api-key");
+        AppData obj = new AppData(context, packageManager, config, sessionTracker);
+        this.appData = obj.getAppDataSummary();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/AppDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/AppDataTest.java
@@ -1,14 +1,13 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.mapToJson;
-import static com.bugsnag.android.BugsnagTestUtils.streamableToJson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -19,7 +18,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.Map;
 
 @RunWith(AndroidJUnit4.class)
@@ -38,37 +36,21 @@ public class AppDataTest {
     @Before
     public void setUp() throws Exception {
         config = new Configuration("some-api-key");
-        client = new Client(InstrumentationRegistry.getContext(), config);
+        client = generateClient(config);
         appData = new AppData(client).getAppData();
     }
 
     @After
-    public void tearDown() throws Exception {
-        client.getOrientationListener().disable();
+    public void tearDown() {
+        client.close();
     }
 
     @Test
-    public void testPackageName() {
+    public void testAccessors() {
         assertEquals("com.bugsnag.android.test", appData.get("packageName"));
-    }
-
-    @Test
-    public void testBuildUuid() {
         assertNull(appData.get("buildUUID"));
-    }
-
-    @Test
-    public void testDuration() {
         assertTrue(((Long) appData.get("duration")) > 0);
-    }
-
-    @Test
-    public void testDurationInForeground() {
         assertEquals(0L, appData.get("durationInForeground"));
-    }
-
-    @Test
-    public void testInForeground() {
         assertFalse((Boolean) appData.get("inForeground"));
     }
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -30,13 +31,13 @@ public class BeforeRecordBreadcrumbsTest {
     public void setUp() throws Exception {
         Configuration configuration = new Configuration("api-key");
         configuration.setAutomaticallyCollectBreadcrumbs(false);
-        client = new Client(InstrumentationRegistry.getContext(), configuration);
+        client = generateClient();
         assertEquals(0, client.breadcrumbs.store.size());
     }
 
     @After
-    public void tearDown() throws Exception {
-        client.getOrientationListener().disable();
+    public void tearDown() {
+        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BeforeSendTest.java
@@ -48,6 +48,7 @@ public class BeforeSendTest {
     @After
     public void tearDown() throws Exception {
         lastReport = null;
+        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbsTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/BreadcrumbsTest.kt
@@ -23,13 +23,19 @@ class BreadcrumbsTest {
 
     private lateinit var breadcrumbs: Breadcrumbs
     private lateinit var config: Configuration
+    private var client: Client? = null
 
     @Before
     fun setUp() {
         config = generateConfiguration()
         breadcrumbs = Breadcrumbs(config)
+        client = generateClient()
     }
 
+    @After
+    fun tearDown() {
+        client?.close()
+    }
 
     /**
      * Verifies that the breadcrumb message is truncated after the max limit is reached
@@ -169,9 +175,8 @@ class BreadcrumbsTest {
      */
     @Test
     fun testClientMethods() {
-        val client = generateClient()
-        client.leaveBreadcrumb("Hello World")
-        val store = client.breadcrumbs.store
+        client!!.leaveBreadcrumb("Hello World")
+        val store = client!!.breadcrumbs.store
         var count = 0
 
         for (breadcrumb in store) {

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
@@ -3,7 +3,6 @@ package com.bugsnag.android;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
@@ -35,8 +34,8 @@ public class ClientConfigTest {
     }
 
     @After
-    public void tearDown() throws Exception {
-        client.getOrientationListener().disable();
+    public void tearDown() {
+        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientNotifyTest.java
@@ -36,8 +36,8 @@ public class ClientNotifyTest {
     }
 
     @After
-    public void tearDown() throws Exception {
-        client.getOrientationListener().disable();
+    public void tearDown() {
+        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -55,7 +55,7 @@ public class ClientTest {
     public void tearDown() throws Exception {
         clearSharedPrefs();
         if (client != null) {
-            client.getOrientationListener().disable();
+            client.close();
             client = null;
         }
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -28,7 +28,7 @@ public class ConcurrentCallbackTest {
 
     @After
     public void tearDown() throws Exception {
-        client.getOrientationListener().disable();
+        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeliveryCompatTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeliveryCompatTest.java
@@ -20,6 +20,7 @@ public class DeliveryCompatTest {
     private DeliveryCompat deliveryCompat;
 
     private AtomicInteger customCount;
+    private Client client;
 
     /**
      * Generates a Delivery instance that increments a counter on each request
@@ -30,6 +31,12 @@ public class DeliveryCompatTest {
     public void setUp() throws Exception {
         customCount = new AtomicInteger();
         deliveryCompat = new DeliveryCompat();
+        client = BugsnagTestUtils.generateClient();
+    }
+
+    @After
+    public void tearDown() {
+        client.close();
     }
 
     @SuppressWarnings("deprecation")
@@ -75,7 +82,6 @@ public class DeliveryCompatTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testClientCompat() {
-        Client client = BugsnagTestUtils.generateClient();
         Delivery delivery = client.config.getDelivery();
         assertFalse(delivery instanceof DeliveryCompat);
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
@@ -11,6 +11,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +23,7 @@ import java.util.Map;
 public class DeviceDataSummaryTest {
 
     private Map<String, Object> deviceData;
+    private Client client;
 
     /**
      * Generates a device data object
@@ -29,27 +31,21 @@ public class DeviceDataSummaryTest {
     @Before
     public void setUp() throws Exception {
         Connectivity connectivity = BugsnagTestUtils.generateConnectivity();
-        DeviceData deviceData = new DeviceData(generateClient(), connectivity);
+        client = generateClient();
+        DeviceData deviceData = new DeviceData(client, connectivity);
         this.deviceData = deviceData.getDeviceDataSummary();
     }
 
+    @After
+    public void tearDown() {
+        client.close();
+    }
+
     @Test
-    public void testManufacturer() {
+    public void testAccessors() {
         assertNotNull(deviceData.get("manufacturer"));
-    }
-
-    @Test
-    public void testModel() {
         assertNotNull(deviceData.get("model"));
-    }
-
-    @Test
-    public void testOsName() {
         assertNotNull(deviceData.get("osName"));
-    }
-
-    @Test
-    public void testOsVersion() {
         assertNotNull(deviceData.get("osVersion"));
     }
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
@@ -1,29 +1,25 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.mapToJson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.support.test.InstrumentationRegistry;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.Map;
 
-@RunWith(AndroidJUnit4.class)
-@SmallTest
 public class DeviceDataSummaryTest {
 
     private Map<String, Object> deviceData;
-    private Client client;
 
     /**
      * Generates a device data object
@@ -31,14 +27,11 @@ public class DeviceDataSummaryTest {
     @Before
     public void setUp() throws Exception {
         Connectivity connectivity = BugsnagTestUtils.generateConnectivity();
-        client = generateClient();
-        DeviceData deviceData = new DeviceData(client, connectivity);
+        Context context = InstrumentationRegistry.getContext();
+        Resources resources = context.getResources();
+        SharedPreferences prefs = context.getSharedPreferences("", Context.MODE_PRIVATE);
+        DeviceData deviceData = new DeviceData(connectivity, context, resources, prefs);
         this.deviceData = deviceData.getDeviceDataSummary();
-    }
-
-    @After
-    public void tearDown() {
-        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -1,30 +1,26 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.mapToJson;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import android.support.test.filters.SmallTest;
-import android.support.test.runner.AndroidJUnit4;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.support.test.InstrumentationRegistry;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
 
-@RunWith(AndroidJUnit4.class)
-@SmallTest
 public class DeviceDataTest {
 
     private Map<String, Object> deviceData;
-    private Client client;
 
     /**
      * Generates a device data object
@@ -32,14 +28,11 @@ public class DeviceDataTest {
     @Before
     public void setUp() throws Exception {
         Connectivity connectivity = BugsnagTestUtils.generateConnectivity();
-        client = generateClient();
-        DeviceData deviceData = new DeviceData(client, connectivity);
+        Context context = InstrumentationRegistry.getContext();
+        Resources resources = context.getResources();
+        SharedPreferences prefs = context.getSharedPreferences("", Context.MODE_PRIVATE);
+        DeviceData deviceData = new DeviceData(connectivity, context, resources, prefs);
         this.deviceData = deviceData.getDeviceData();
-    }
-
-    @After
-    public void tearDown() {
-        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -10,6 +10,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +24,7 @@ import java.util.Map;
 public class DeviceDataTest {
 
     private Map<String, Object> deviceData;
+    private Client client;
 
     /**
      * Generates a device data object
@@ -30,27 +32,21 @@ public class DeviceDataTest {
     @Before
     public void setUp() throws Exception {
         Connectivity connectivity = BugsnagTestUtils.generateConnectivity();
-        DeviceData deviceData = new DeviceData(generateClient(), connectivity);
+        client = generateClient();
+        DeviceData deviceData = new DeviceData(client, connectivity);
         this.deviceData = deviceData.getDeviceData();
     }
 
+    @After
+    public void tearDown() {
+        client.close();
+    }
+
     @Test
-    public void testId() {
+    public void testAccessors() {
         assertNotNull(deviceData.get("id"));
-    }
-
-    @Test
-    public void testOrientation() {
         assertNotNull(deviceData.get("orientation"));
-    }
-
-    @Test
-    public void testFreeMemory() {
         assertTrue((Long) deviceData.get("freeMemory") > 0);
-    }
-
-    @Test
-    public void testTotalMemory() {
         assertTrue((Long) deviceData.get("totalMemory") > 0);
     }
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorReportApiClientTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorReportApiClientTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -20,31 +21,31 @@ import java.util.Map;
 public class ErrorReportApiClientTest {
 
     private FakeApiClient apiClient;
+    private Client client;
 
     @Before
     public void setUp() throws Exception {
         apiClient = new FakeApiClient();
-        Bugsnag.init(InstrumentationRegistry.getContext(), "123");
+        client = generateClient();
     }
 
     @After
-    public void tearDown() throws Exception {
-        Bugsnag.getClient().getOrientationListener().disable();
+    public void tearDown() {
+        client.close();
     }
 
     @SuppressWarnings("deprecation")
     @Test(expected = IllegalArgumentException.class)
     public void testApiClientNullValidation() {
-        Bugsnag.setErrorReportApiClient(null);
+        client.setErrorReportApiClient(null);
     }
 
     @SuppressWarnings("deprecation")
     @Test
     public void testPostReportCalled() {
-        Bugsnag.setErrorReportApiClient(apiClient);
+        client.setErrorReportApiClient(apiClient);
 
         assertNull(apiClient.report);
-        Client client = Bugsnag.getClient();
         client.notifyBlocking(new Throwable());
         assertNotNull(apiClient.report);
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -6,7 +6,6 @@ import static com.bugsnag.android.BugsnagTestUtils.streamableToJson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -16,6 +15,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +31,7 @@ public class ErrorTest {
 
     private Configuration config;
     private Error error;
+    private Client client;
 
     /**
      * Generates a new default error for use by tests
@@ -43,6 +44,17 @@ public class ErrorTest {
         RuntimeException exception = new RuntimeException("Example message");
         error = new Error.Builder(config, exception, generateSessionTracker(),
             Thread.currentThread(), false).build();
+        client = generateClient();
+    }
+
+    /**
+     * Tears down the client
+     */
+    @After
+    public void tearDown() {
+        if (client != null) {
+            client.close();
+        }
     }
 
     @Test
@@ -74,7 +86,6 @@ public class ErrorTest {
 
     @Test
     public void testBasicSerialization() throws JSONException, IOException {
-        Client client = generateClient();
         error.setAppData(client.getAppData().getAppData());
 
         JSONObject errorJson = streamableToJson(error);
@@ -379,7 +390,7 @@ public class ErrorTest {
     @Test
     public void testSetDeviceId() throws Throwable {
         Connectivity connectivity = BugsnagTestUtils.generateConnectivity();
-        DeviceData data = new DeviceData(generateClient(), connectivity);
+        DeviceData data = new DeviceData(client, connectivity);
         Map<String, Object> deviceData = data.getDeviceData();
         error.setDeviceData(deviceData);
         assertEquals(deviceData, error.getDeviceData());

--- a/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -10,6 +10,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.support.test.InstrumentationRegistry;
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -390,7 +394,11 @@ public class ErrorTest {
     @Test
     public void testSetDeviceId() throws Throwable {
         Connectivity connectivity = BugsnagTestUtils.generateConnectivity();
-        DeviceData data = new DeviceData(client, connectivity);
+        Context context = InstrumentationRegistry.getContext();
+        Resources resources = context.getResources();
+        SharedPreferences prefs = context.getSharedPreferences("", Context.MODE_PRIVATE);
+        DeviceData data = new DeviceData(connectivity, context, resources, prefs);
+
         Map<String, Object> deviceData = data.getDeviceData();
         error.setDeviceData(deviceData);
         assertEquals(deviceData, error.getDeviceData());

--- a/sdk/src/androidTest/java/com/bugsnag/android/ExceptionHandlerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ExceptionHandlerTest.java
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith;
 public class ExceptionHandlerTest {
 
     private Context context;
+    private Client client;
 
     /**
      * Sets the default exception handler to null to avoid any Bugsnag handlers created
@@ -31,11 +32,16 @@ public class ExceptionHandlerTest {
         context = InstrumentationRegistry.getContext();
         // Start in a clean state, since we've created clients before in tests
         Thread.setDefaultUncaughtExceptionHandler(null);
+        client = new Client(context, "api-key");
+    }
+
+    @After
+    public void tearDown() {
+        client.close();
     }
 
     @Test
     public void testEnableDisable() {
-        Client client = new Client(context, "api-key");
         assertTrue(Thread.getDefaultUncaughtExceptionHandler() instanceof ExceptionHandler);
 
         client.disableExceptionHandler();
@@ -44,7 +50,6 @@ public class ExceptionHandlerTest {
 
     @Test
     public void testMultipleClients() {
-        Client clientOne = new Client(context, "client-one");
         Client clientTwo = new Client(context, "client-two");
         Client clientThree = new Client(context, "client-two");
         clientThree.disableExceptionHandler();

--- a/sdk/src/androidTest/java/com/bugsnag/android/MetaDataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/MetaDataTest.java
@@ -37,8 +37,8 @@ public class MetaDataTest {
     }
 
     @After
-    public void tearDown() throws Exception {
-        client.getOrientationListener().disable();
+    public void tearDown() {
+        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
@@ -2,13 +2,26 @@ package com.bugsnag.android;
 
 import static org.junit.Assert.assertNotSame;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class NativeInterfaceTest {
 
+    private Client client;
+
+    @Before
+    public void setUp() throws Exception {
+        client = BugsnagTestUtils.generateClient();
+    }
+
+    @After
+    public void tearDown() {
+        client.close();
+    }
+
     @Test
     public void getMetaData() {
-        Client client = BugsnagTestUtils.generateClient();
         NativeInterface.setClient(client);
         assertNotSame(client.config.getMetaData().store, NativeInterface.getMetaData());
     }

--- a/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
@@ -39,6 +39,11 @@ public class NullMetadataTest {
         throwable = new RuntimeException("Test");
     }
 
+    @After
+    public void tearDown() {
+        client.close();
+    }
+
     @Test
     public void testErrorDefaultMetaData() throws Exception {
         Error error = new Error.Builder(config, throwable, generateSessionTracker(),

--- a/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -25,6 +25,7 @@ import java.util.Observer;
 @SmallTest
 @SuppressWarnings("unchecked")
 public class ObserverInterfaceTest {
+
     private Configuration config;
     private Client client;
     private BugsnagTestObserver observer;
@@ -42,6 +43,11 @@ public class ObserverInterfaceTest {
         client.disableExceptionHandler();
         observer = new BugsnagTestObserver();
         client.addObserver(observer);
+    }
+
+    @After
+    public void tearDown() {
+        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/ProjectPackagesTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ProjectPackagesTest.kt
@@ -14,6 +14,7 @@ class ProjectPackagesTest {
 
         val client = Client(InstrumentationRegistry.getContext(), configuration)
         assertArrayEquals(arrayOf("com.bugsnag.android.test"), client.config.projectPackages)
+        client.close()
     }
 
     @Test
@@ -22,5 +23,6 @@ class ProjectPackagesTest {
         configuration.projectPackages = arrayOf("com.foo.example")
         val client = Client(InstrumentationRegistry.getContext(), configuration)
         assertArrayEquals(arrayOf("com.foo.example"), client.config.projectPackages)
+        client.close()
     }
 }

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerStopResumeTest.kt
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerStopResumeTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import com.bugsnag.android.BugsnagTestUtils.generateClient
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateSessionStore
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -20,9 +21,17 @@ class SessionTrackerStopResumeTest {
     private val sessionStore = generateSessionStore()
     private lateinit var tracker: SessionTracker
 
+    private var client: Client? = null
+
     @Before
     fun setUp() {
-        tracker = SessionTracker(configuration, generateClient(), sessionStore)
+        client = generateClient()
+        tracker = SessionTracker(configuration, client, sessionStore)
+    }
+
+    @After
+    fun tearDown() {
+        client?.close()
     }
 
     /**

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -7,8 +7,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,6 +22,7 @@ public class SessionTrackerTest {
     private SessionTracker sessionTracker;
     private User user;
     private Configuration configuration;
+    private Client client;
 
     /**
      * Configures a session tracker that automatically captures sessions
@@ -32,10 +33,16 @@ public class SessionTrackerTest {
     public void setUp() throws Exception {
         configuration = new Configuration("test");
         configuration.setDelivery(BugsnagTestUtils.generateDelivery());
+        client = generateClient();
         sessionTracker
-            = new SessionTracker(configuration, generateClient(), generateSessionStore());
+            = new SessionTracker(configuration, client, generateSessionStore());
         configuration.setAutoCaptureSessions(true);
         user = new User();
+    }
+
+    @After
+    public void tearDown() {
+        client.close();
     }
 
     @Test
@@ -120,7 +127,7 @@ public class SessionTrackerTest {
     @Test
     public void testInForegroundDuration() throws Exception {
         long now = System.currentTimeMillis();
-        sessionTracker = new SessionTracker(configuration, generateClient(),
+        sessionTracker = new SessionTracker(configuration, client,
             0, generateSessionStore());
 
         sessionTracker.updateForegroundTracker(ACTIVITY_NAME, false, now);
@@ -138,7 +145,7 @@ public class SessionTrackerTest {
 
     @Test
     public void testZeroSessionTimeout() throws Exception {
-        sessionTracker = new SessionTracker(configuration, generateClient(),
+        sessionTracker = new SessionTracker(configuration, client,
             0, generateSessionStore());
 
         long now = System.currentTimeMillis();
@@ -153,7 +160,7 @@ public class SessionTrackerTest {
 
     @Test
     public void testSessionTimeout() throws Exception {
-        sessionTracker = new SessionTracker(configuration, generateClient(),
+        sessionTracker = new SessionTracker(configuration, client,
             100, generateSessionStore());
 
         long now = System.currentTimeMillis();

--- a/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
@@ -32,6 +32,7 @@ public class SessionTrackingPayloadTest {
     private File storageDir;
     private SessionTrackingPayload payload;
     private DeviceData deviceData;
+    private Client client;
 
     /**
      * Configures a session tracking payload and session store, ensuring that 0 files are present
@@ -48,13 +49,13 @@ public class SessionTrackingPayloadTest {
         storageDir = new File(sessionStore.storeDirectory);
         FileUtils.clearFilesInDir(storageDir);
         session = generateSession();
+        client = generateClient();
         payload = generatePayloadFromSession(context, generateSession());
         rootNode = streamableToJson(payload);
     }
 
     private SessionTrackingPayload generatePayloadFromSession(Context context,
                                                   Session session) throws Exception {
-        Client client = generateClient();
         appData = client.getAppData();
         deviceData = client.deviceData;
         return new SessionTrackingPayload(session, null, appData, deviceData);
@@ -66,8 +67,9 @@ public class SessionTrackingPayloadTest {
      * @throws Exception if the operation fails
      */
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         FileUtils.clearFilesInDir(storageDir);
+        client.close();
     }
 
     @Test

--- a/sdk/src/androidTest/java/com/bugsnag/android/UniqueBeforeNotifyTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/UniqueBeforeNotifyTest.java
@@ -47,9 +47,9 @@ public class UniqueBeforeNotifyTest {
      * lol why is this comment required
      */
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         callbackCount = 0;
-        client.getOrientationListener().disable();
+        client.close();
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -143,7 +143,7 @@ public class Client extends Observable implements Observer {
         // Set up and collect constant app and device diagnostics
         sharedPrefs = appContext.getSharedPreferences(SHARED_PREF_KEY, Context.MODE_PRIVATE);
 
-        appData = new AppData(this);
+        appData = new AppData(appContext, appContext.getPackageManager(), config, sessionTracker);
         deviceData = new DeviceData(this, connectivity);
 
         // Set up breadcrumbs

--- a/sdk/src/main/java/com/bugsnag/android/Client.java
+++ b/sdk/src/main/java/com/bugsnag/android/Client.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Resources;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -144,7 +145,8 @@ public class Client extends Observable implements Observer {
         sharedPrefs = appContext.getSharedPreferences(SHARED_PREF_KEY, Context.MODE_PRIVATE);
 
         appData = new AppData(appContext, appContext.getPackageManager(), config, sessionTracker);
-        deviceData = new DeviceData(this, connectivity);
+        Resources resources = appContext.getResources();
+        deviceData = new DeviceData(connectivity, this.appContext, resources, sharedPrefs);
 
         // Set up breadcrumbs
         breadcrumbs = new Breadcrumbs(configuration);

--- a/sdk/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
+++ b/sdk/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
@@ -33,7 +33,7 @@ internal class ConnectivityCompat(
 
     override fun registerForNetworkChanges() = connectivity.registerForNetworkChanges()
     override fun hasNetworkConnection() = connectivity.hasNetworkConnection()
-    override fun unregisterForNetworkChanges() = connectivity.registerForNetworkChanges()
+    override fun unregisterForNetworkChanges() = connectivity.unregisterForNetworkChanges()
     override fun retrieveNetworkAccessState() = connectivity.retrieveNetworkAccessState()
 }
 

--- a/sdk/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/sdk/src/main/java/com/bugsnag/android/DeviceData.java
@@ -44,11 +44,11 @@ class DeviceData {
 
     private static final String INSTALL_ID_KEY = "install.iud";
 
-    private final Client client;
     private final boolean emulator;
     private final Context appContext;
     private final Connectivity connectivity;
     private final Resources resources;
+    private final SharedPreferences sharedPrefs;
     private final DisplayMetrics displayMetrics;
     private final String id;
     private final boolean rooted;
@@ -68,11 +68,12 @@ class DeviceData {
     @NonNull
     final String[] cpuAbi;
 
-    DeviceData(Client client, Connectivity connectivity) {
-        this.client = client;
-        this.appContext = client.appContext;
+    DeviceData(Connectivity connectivity, Context appContext, Resources resources,
+               SharedPreferences sharedPreferences) {
         this.connectivity = connectivity;
-        resources = appContext.getResources();
+        this.appContext = appContext;
+        this.resources = resources;
+        this.sharedPrefs = sharedPreferences;
 
         if (resources != null) {
             displayMetrics = resources.getDisplayMetrics();
@@ -231,12 +232,11 @@ class DeviceData {
      */
     @Nullable
     private String retrieveUniqueInstallId() {
-        SharedPreferences sharedPref = client.sharedPrefs;
-        String installId = sharedPref.getString(INSTALL_ID_KEY, null);
+        String installId = sharedPrefs.getString(INSTALL_ID_KEY, null);
 
         if (installId == null) {
             installId = UUID.randomUUID().toString();
-            sharedPref.edit().putString(INSTALL_ID_KEY, installId).apply();
+            sharedPrefs.edit().putString(INSTALL_ID_KEY, installId).apply();
         }
         return installId;
     }


### PR DESCRIPTION
## Goal

Passes unit tests which are failing in #501 after the addition of a class that registers a `NetworkCallback` within client.

This adds a teardown step to all unit tests which instantiate a `Client` so that this `NetworkCallback` is deregistered, preventing the Android Framework from throwing an exception due to too many listeners being registered. This is not a real-world scenario but breaks our tests.

Additionally this sets up the Mockito mocking framework so that we can avoid mocking `Client` in future.

## Changeset

This PR is split into 4 commits: one adds the latest Mockito dependency, the next adds teardown methods to existing tests, and the remaining two refactor the `AppData`/`DeviceData` tests to use a mocking framework rather than instantiating a `Client`.

The `DeviceData` and `AppData` classes previously took a `Client` as a constructor parameter. This has been removed in favour of injecting each dependency individually, which allows mocking and educes the many responsibilities that `Client` currently has.
