### PR TITLE
refactor: Expose clearTab to the native interface

### DIFF
--- a/sdk/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
@@ -1,8 +1,12 @@
 package com.bugsnag.android;
 
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
+
+import java.util.Map;
 
 public class NativeInterfaceTest {
 
@@ -13,4 +17,38 @@ public class NativeInterfaceTest {
         assertNotSame(client.config.getMetaData().store, NativeInterface.getMetaData());
     }
 
+    @Test
+    public void addToTab() {
+        Client client = BugsnagTestUtils.generateClient();
+        NativeInterface.setClient(client);
+        NativeInterface.addToTab("app", "buildno", "0.1");
+        NativeInterface.addToTab("app", "args", "-print 1");
+        NativeInterface.addToTab("info", "cache", false);
+
+        Map<String, Object> metadata = NativeInterface.getMetaData();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> app = (Map<String, Object>)metadata.get("app");
+        assertSame("0.1", app.get("buildno"));
+        assertSame("-print 1", app.get("args"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> info = (Map<String, Object>)metadata.get("info");
+        assertSame(false, info.get("cache"));
+    }
+
+    @Test
+    public void clearTab() {
+        Client client = BugsnagTestUtils.generateClient();
+        NativeInterface.setClient(client);
+        NativeInterface.addToTab("app", "buildno", "0.1");
+        NativeInterface.addToTab("app", "args", "-print 1");
+        NativeInterface.addToTab("info", "cache", false);
+        NativeInterface.clearTab("info");
+
+        Map<String, Object> metadata = NativeInterface.getMetaData();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> app = (Map<String, Object>)metadata.get("app");
+        assertSame("0.1", app.get("buildno"));
+        assertSame("-print 1", app.get("args"));
+        assertNull(metadata.get("info"));
+    }
 }

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -291,6 +291,13 @@ public class NativeInterface {
     }
 
     /**
+     * Remove metadata from subsequent exception reports
+     */
+    public static void clearTab(@NonNull final String tab) {
+        getClient().clearTab(tab);
+    }
+
+    /**
      * Add metadata to subsequent exception reports
      */
     public static void addToTab(@NonNull final String tab,


### PR DESCRIPTION
## Goal

Support clearing metadata tabs from the native interface.

A changelog entry was omitted since this is an internal-facing change and `clearTab` is not new functionality.
