### PR TITLE
fix(ndk): Skip null metadata values from serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix abort() in native code when storing breadcrumbs with null values in
+  metadata
+  [#510](https://github.com/bugsnag/bugsnag-android/pull/510)
+
 ## 4.15.0 (2019-06-10)
 
 `bugsnag-android` now supports detecting and reporting C/C++ crashes without a separate library (previously `bugsnag-android-ndk` was required for native error reporting).

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/SomeException.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/SomeException.kt
@@ -1,0 +1,4 @@
+package com.bugsnag.android.mazerunner
+
+internal class SomeException() : Exception() {
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionWithoutMessage.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionWithoutMessage.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.SomeException
+
+/**
+ * Sends a handled exception to Bugsnag, which does not include session data.
+ */
+internal class HandledExceptionWithoutMessageScenario(config: Configuration,
+                                                      context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.notify(SomeException())
+    }
+}

--- a/features/handled_exception.feature
+++ b/features/handled_exception.feature
@@ -11,6 +11,17 @@ Scenario: Test handled Kotlin Exception
     And the exception "message" equals "HandledExceptionScenario"
     And the payload field "events.0.device.cpuAbi" is a non-empty array for request 0
 
+Scenario: Report a handled exception without a message
+    When I run "HandledExceptionWithoutMessageScenario"
+    Then I should receive a request
+    And the request is valid for the error reporting API
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the payload field "notifier.name" equals "Android Bugsnag Notifier"
+    And the payload field "events" is an array with 1 element
+    And the exception "errorClass" equals "com.bugsnag.android.mazerunner.SomeException"
+    And the event "exceptions.0.message" is null
+    And the payload field "events.0.device.cpuAbi" is a non-empty array for request 0
+
 Scenario: Test handled Java Exception
     When I run "HandledExceptionJavaScenario"
     Then I should receive a request

--- a/sdk/src/main/jni/metadata.c
+++ b/sdk/src/main/jni/metadata.c
@@ -189,14 +189,19 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
                                             jni_cache->arraylist_get, (jint)i);
     jstring _value =
         (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);
-    char *key = (char *)(*env)->GetStringUTFChars(env, _key, 0);
-    char *value = (char *)(*env)->GetStringUTFChars(env, _value, 0);
-    bsg_strncpy_safe(crumb->metadata[i].key, key,
-                     sizeof(crumb->metadata[i].key));
-    bsg_strncpy_safe(crumb->metadata[i].value, value,
-                     sizeof(crumb->metadata[i].value));
-    (*env)->ReleaseStringUTFChars(env, _key, key);
-    (*env)->ReleaseStringUTFChars(env, _value, value);
+    if (_value == NULL) {
+      (*env)->DeleteLocalRef(env, _key);
+      (*env)->DeleteLocalRef(env, _value);
+    } else {
+      char *key = (char *)(*env)->GetStringUTFChars(env, _key, 0);
+      char *value = (char *)(*env)->GetStringUTFChars(env, _value, 0);
+      bsg_strncpy_safe(crumb->metadata[i].key, key,
+                       sizeof(crumb->metadata[i].key));
+      bsg_strncpy_safe(crumb->metadata[i].value, value,
+                       sizeof(crumb->metadata[i].value));
+      (*env)->ReleaseStringUTFChars(env, _key, key);
+      (*env)->ReleaseStringUTFChars(env, _value, value);
+    }
   }
   free(jni_cache);
   (*env)->DeleteLocalRef(env, keyset);

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionWithoutMessage.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionWithoutMessage.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.SomeException
+
+/**
+ * Sends a handled exception to Bugsnag, which does not include session data.
+ */
+internal class HandledExceptionWithoutMessageScenario(config: Configuration,
+                                                      context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.notify(SomeException())
+    }
+}

--- a/tests/features/handled_exception.feature
+++ b/tests/features/handled_exception.feature
@@ -9,6 +9,15 @@ Scenario: Test handled Kotlin Exception
     And the exception "message" equals "HandledExceptionScenario"
     And the payload field "events.0.device.cpuAbi" is a non-empty array
 
+Scenario: Report a handled exception without a message
+    When I run "HandledExceptionWithoutMessageScenario"
+    Then I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 element
+    And the exception "errorClass" equals "com.bugsnag.android.mazerunner.SomeException"
+    And the event "exceptions.0.message" is null
+    And the payload field "events.0.device.cpuAbi" is a non-empty array
+
 Scenario: Test handled Java Exception
     When I run "HandledExceptionJavaScenario"
     Then I wait to receive a request


### PR DESCRIPTION
In the event that a metadata value is null, the patched section would
crash in `GetStringUTFChars()`. This is most easily reproduced by calling
notify/throwing on an exception with no message.

## Tests

* Manually tested by throwing an exception without a message. This would propagate null through `leaveErrorBreadcrumb()` which would then be serialized by the native layer.
