### PR TITLE
Fix buildkite tags with slashes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,11 +6,11 @@ steps:
             - android-base
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH}
+            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH}
+            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - wait
@@ -21,11 +21,11 @@ steps:
           build:
             - android-linter
           cache-from:
-            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH}
+            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
             - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH}
+            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
             - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - label: ':docker: Build Android instrumentation image'
@@ -33,11 +33,11 @@ steps:
       - docker-compose#v2.6.0:
           build: android-instrumentation-tests
           cache-from:
-            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH}
+            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH}
+            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - label: ':docker: Build Android apk builder image'
@@ -45,11 +45,11 @@ steps:
       - docker-compose#v2.6.0:
           build: android-builder
           cache-from:
-            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH}v
+            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH}
+            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
     env:
       MAVEN_VERSION: "3.6.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,11 +6,11 @@ steps:
             - android-base
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
+            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
+            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - wait
@@ -21,11 +21,11 @@ steps:
           build:
             - android-linter
           cache-from:
-            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
+            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
+            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - label: ':docker: Build Android instrumentation image'
@@ -33,11 +33,11 @@ steps:
       - docker-compose#v2.6.0:
           build: android-instrumentation-tests
           cache-from:
-            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
+            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
+            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - label: ':docker: Build Android apk builder image'
@@ -45,11 +45,11 @@ steps:
       - docker-compose#v2.6.0:
           build: android-builder
           cache-from:
-            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
+            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
+            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
     env:
       MAVEN_VERSION: "3.6.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,11 +6,11 @@ steps:
             - android-base
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
+            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
+            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - wait
@@ -21,11 +21,11 @@ steps:
           build:
             - android-linter
           cache-from:
-            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
+            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
             - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
+            - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
             - android-linter:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - label: ':docker: Build Android instrumentation image'
@@ -33,11 +33,11 @@ steps:
       - docker-compose#v2.6.0:
           build: android-instrumentation-tests
           cache-from:
-            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
+            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
+            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - label: ':docker: Build Android apk builder image'
@@ -45,11 +45,11 @@ steps:
       - docker-compose#v2.6.0:
           build: android-builder
           cache-from:
-            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
+            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
-            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BUILDKITE_BRANCH/\//-}
+            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${${BUILDKITE_BRANCH/\//-}}
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
     env:
       MAVEN_VERSION: "3.6.1"


### PR DESCRIPTION
## Goal

Slashes were previously breaking builds due to docker-registry issues, so an environment script has been added that exports `BUILDKITE_BRANCH` as `BRANCH_NAME` with all `/` replaced by `-`.  This PR changes the `BUILDKITE_BRANCH` occurrences to `BRANCH_NAME`.