### PR TITLE
Convert metadata to map when notifying the NDK observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Fix abort() in native code when storing breadcrumbs with null values in
   metadata
   [#510](https://github.com/bugsnag/bugsnag-android/pull/510)
+* Convert metadata to map when notifying the NDK observer 
+  [#513](https://github.com/bugsnag/bugsnag-android/pull/513)
 
 ## 4.15.0 (2019-06-10)
 

--- a/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
@@ -87,13 +87,6 @@ public class NullMetadataTest {
     }
 
     @Test
-    public void testConfigSetNullMetadata() throws Exception {
-        Configuration configuration = new Configuration("test");
-        configuration.setMetaData(null);
-        validateDefaultMetadata(configuration.getMetaData());
-    }
-
-    @Test
     public void testNotify() throws Exception {
         client.beforeNotify(new BeforeNotify() {
             @Override

--- a/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 
@@ -50,8 +51,8 @@ public class ObserverInterfaceTest {
         metadata.addToTab("foo", "bar", "baz");
         client.setMetaData(metadata);
         Object value = findMessageInQueue(
-                NativeInterface.MessageType.UPDATE_METADATA, MetaData.class);
-        assertEquals(metadata, value);
+                NativeInterface.MessageType.UPDATE_METADATA, Map.class);
+        assertEquals(metadata.store, value);
     }
 
     @Test
@@ -60,8 +61,8 @@ public class ObserverInterfaceTest {
         metadata.addToTab("foo", "bar", "baz");
         client.getConfig().setMetaData(metadata);
         Object value = findMessageInQueue(
-                NativeInterface.MessageType.UPDATE_METADATA, MetaData.class);
-        assertEquals(metadata, value);
+                NativeInterface.MessageType.UPDATE_METADATA, Map.class);
+        assertEquals(metadata.store, value);
     }
 
     @Test

--- a/sdk/src/main/java/com/bugsnag/android/Configuration.java
+++ b/sdk/src/main/java/com/bugsnag/android/Configuration.java
@@ -474,7 +474,7 @@ public class Configuration extends Observable implements Observer {
         }
         this.setChanged();
         this.notifyObservers(new NativeInterface.Message(
-                    NativeInterface.MessageType.UPDATE_METADATA, metaData));
+                    NativeInterface.MessageType.UPDATE_METADATA, metaData.store));
         this.metaData.addObserver(this);
     }
 

--- a/tests/features/custom_metadata.feature
+++ b/tests/features/custom_metadata.feature
@@ -1,0 +1,6 @@
+Feature: The NDK does not crash when custom metadata is set
+
+Scenario: Set custom metadata and send an observable event to the NDK
+    When I run "CustomMetaDataScenario"
+    Then I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomMetaDataScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomMetaDataScenario.kt
@@ -1,0 +1,20 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.MetaData
+
+/**
+ * Sets a new metadata on the object (regression testing for a previous NDK crash)
+ */
+internal class CustomMetaDataScenario(config: Configuration,
+                                      context: Context) : Scenario(config, context) {
+
+    override fun run() {
+        super.run()
+        Bugsnag.setMetaData(MetaData())
+        Bugsnag.notify(generateException())
+    }
+
+}


### PR DESCRIPTION
## Goal

Calling `Bugsnag.setMetaData(MetaData())` crashed the process if the NDK was enabled. This is because the method emits an observable event to the NDK, which was expected as a `Map` in the JNI but sent as a `MetaData`.

## Changeset

Altered the observable to emit a `Map` instead.

## Tests

Tested the change manually in an example app, and added a mazerunner scenario.
