### PR TITLE
Prevent overwrite of signal mask when installing ANR handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+* Prevent overwrite of signal mask when installing ANR handler
+  [#520](https://github.com/bugsnag/bugsnag-android/pull/520)
+
 ## 4.16.0 (2019-07-09)
 
 This release adds a compile-time dependency on the Kotlin standard library. This should not affect

--- a/sdk/src/main/jni/handlers/anr_handler.c
+++ b/sdk/src/main/jni/handlers/anr_handler.c
@@ -64,7 +64,7 @@ bool bsg_handler_install_anr(void *byte_buffer) {
   sigemptyset(&bsg_anr_sigmask);
   sigaddset(&bsg_anr_sigmask, SIGQUIT);
 
-  int mask_status = pthread_sigmask(SIG_SETMASK, &bsg_anr_sigmask, NULL);
+  int mask_status = pthread_sigmask(SIG_BLOCK, &bsg_anr_sigmask, NULL);
   if (mask_status != 0) {
     BUGSNAG_LOG("Failed to mask SIGQUIT: %s", strerror(mask_status));
   } else {


### PR DESCRIPTION
## Goal

Fixes a bug reported in #502 where the process crashes with `SIGPIPE` if the network connection is lost during a request and ANR detection is enabled.

## Design

The following may be useful for further reading: https://www.gnu.org/software/libc/manual/html_node/Signal-Handling.html#Signal-Handling

Our current implementation installs a `SIGQUIT` handler to record when an ANR occurred. When this handler is installed we update the thread mask to block any concurrent `SIGQUIT` signals. After the handler is installed, the thread mask is updated to unblock `SIGQUIT`, so that we can handle incoming signals once more.

However, one apparent issue with the current implementation is that it overwrites all pre-existing values in the thread mask, by using the `SIG_SETMASK` option when calling `pthread_sigmask`. This has the effect of setting _only_ `SIGQUIT` in the thread mask, meaning any previously default values such as `SIGPIPE` are no longer blocked.

This has the obvious effect of crashing the app when writing to a broken network socket, as typically `SIGPIPE` would be ignored and return an `errno` instead, rather than terminating the process. Other signals may also be affected by this, which we have not yet observed.

## Proposed Fix

We should use `SIG_BLOCK` instead of `SIG_SETMASK`. `SIG_BLOCK` sets the thread mask to a union of the existing values and the `set` parameter, meaning that after the handler is installed the previous mask values will be restored.

An alternative approach would be to ignore `SIGPIPE` using `sigaction` but this would not address the underlying issue.

## Tests

I first verified the behaviour by following the instructions in this example app: https://github.com/fxdemolisher/bugsnag-android-crash-minimal-repro

I then modified the example app to use an artefact with this changeset from mavenLocal, and verified that the app no longer crashed. I also verified that a `SIGSEGV` and ANR could still be reported as normal.
