### PR TITLE
Run instrumentation tests simultaneously with E2E tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -88,6 +88,17 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
 
+  - label: ':android: NDK 16b SDK Instrumentation tests'
+    plugins:
+      - docker-compose#v2.6.0:
+          run: android-instrumentation-tests
+    env:
+      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]'
+      NDK_VERSION: "r16b"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
   - label: ':android: Android 6 end-to-end tests'
     plugins:
       artifacts#v1.2.0:
@@ -144,17 +155,6 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]'
       NDK_VERSION: "r12b"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK Instrumentation tests'
-    plugins:
-      - docker-compose#v2.6.0:
-          run: android-instrumentation-tests
-    env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]'
-      NDK_VERSION: "r16b"
     concurrency: 5
     concurrency_group: 'browserstack-app'
 


### PR DESCRIPTION
## Goal

This changeset moves the order of jobs so that one E2E test, and one instrumentation test are the first to run. This should increase the speed of feedback when tests are broken, as we won't have to wait for five E2E jobs to complete before seeing the failing instrumentation test results.
