### PR TITLE
test: fix flaky instrumentation test

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataTest.java
@@ -54,7 +54,7 @@ public class AppDataTest {
     public void testAccessors() {
         assertEquals("com.bugsnag.android.core.test", appData.get("packageName"));
         assertNull(appData.get("buildUUID"));
-        assertTrue(((Long) appData.get("duration")) > 0);
+        assertTrue(((Long) appData.get("duration")) >= 0);
         assertEquals(500L, appData.get("durationInForeground"));
         assertTrue((Boolean) appData.get("inForeground"));
     }
@@ -70,7 +70,7 @@ public class AppDataTest {
         assertEquals("android", appDataJson.get("type"));
         assertEquals("com.bugsnag.android.core.test", appDataJson.get("id"));
         assertNotNull(appDataJson.get("buildUUID"));
-        assertTrue(((Long) appData.get("duration")) > 0);
+        assertTrue(((Long) appData.get("duration")) >= 0);
         assertEquals(500L, appData.get("durationInForeground"));
         assertTrue(appDataJson.getBoolean("inForeground"));
     }


### PR DESCRIPTION
## Goal

`AppData` uses `SystemClock.elapsedRealTime()` to calculate the duration that is populated in the JSON payload. On browserstack it appears the unit tests are fast enough that this can sometimes equal zero, and fail the test. This changeset fixes that flakiness.
