### PR TITLE
Attempt to fix mazerunner scenarios by disabling automatic session tracking

### DIFF
--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoContextScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoContextScenario.kt
@@ -14,6 +14,10 @@ import com.bugsnag.android.mazerunner.SecondActivity
  */
 internal class AutoContextScenario(config: Configuration,
                                    context: Context) : Scenario(config, context) {
+    init {
+        config.setAutoCaptureSessions(false)
+    }
+
     override fun run() {
         super.run()
         registerActivityLifecycleCallbacks()

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAutoContextScenario.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAutoContextScenario.java
@@ -22,6 +22,7 @@ public class CXXAutoContextScenario extends Scenario {
 
     public CXXAutoContextScenario(@NonNull Configuration config, @NonNull Context context) {
         super(config, context);
+        config.setAutoCaptureSessions(false);
     }
 
     @Override


### PR DESCRIPTION
##Goal

The scenarios under `tests/features` were out of sync with the scenarios under `features`. Updating the scenarios should fix issues where the tests fail on buildkite due to an unexpected request.