### PR TITLE
immutable config: create Endpoints class, deprecate existing variants

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -187,8 +187,8 @@ public class ClientTest {
         assertEquals(config.getBuildUUID(), protoConfig.getBuildUUID());
         assertEquals(config.getAppVersion(), protoConfig.getAppVersion());
         assertEquals(config.getReleaseStage(), protoConfig.getReleaseStage());
-        assertEquals(config.getEndpoint(), protoConfig.getEndpoint());
-        assertEquals(config.getSessionEndpoint(), protoConfig.getSessionEndpoint());
+        assertEquals(config.getEndpoints().getNotify(), protoConfig.getEndpoints().getNotify());
+        assertEquals(config.getEndpoints().getSessions(), protoConfig.getEndpoints().getSessions());
         assertEquals(config.getSendThreads(), protoConfig.getSendThreads());
         assertEquals(config.getEnableExceptionHandler(), protoConfig.getEnableExceptionHandler());
         assertEquals(config.getPersistUserBetweenSessions(),
@@ -223,8 +223,8 @@ public class ClientTest {
         assertEquals(buildUuid, protoConfig.getBuildUUID());
         assertEquals(appVersion, protoConfig.getAppVersion());
         assertEquals(releaseStage, protoConfig.getReleaseStage());
-        assertEquals(endpoint, protoConfig.getEndpoint());
-        assertEquals(sessionEndpoint, protoConfig.getSessionEndpoint());
+        assertEquals(endpoint, protoConfig.getEndpoints().getNotify());
+        assertEquals(sessionEndpoint, protoConfig.getEndpoints().getSessions());
         assertEquals(false, protoConfig.getSendThreads());
         assertEquals(false, protoConfig.getEnableExceptionHandler());
         assertEquals(true, protoConfig.getPersistUserBetweenSessions());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ConfigurationTest.java
@@ -32,44 +32,10 @@ public class ConfigurationTest {
     public void testEndpoints() {
         String notify = "https://notify.myexample.com";
         String sessions = "https://sessions.myexample.com";
-        config.setEndpoints(notify, sessions);
+        config.setEndpoints(new Endpoints(notify, sessions));
 
-        assertEquals(notify, config.getEndpoint());
-        assertEquals(sessions, config.getSessionEndpoint());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testNullNotifyEndpoint() {
-        //noinspection ConstantConditions
-        config.setEndpoints(null, "http://example.com");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testEmptyNotifyEndpoint() {
-        config.setEndpoints("", "http://example.com");
-    }
-
-    @Test
-    public void testInvalidSessionEndpoint() {
-        //noinspection ConstantConditions
-        config.setEndpoints("http://example.com", null);
-        assertFalse(config.getAutoCaptureSessions());
-        assertNull(config.getSessionEndpoint());
-
-        config.setEndpoints("http://example.com", "");
-        assertFalse(config.getAutoCaptureSessions());
-        assertNull(config.getSessionEndpoint());
-
-        config.setEndpoints("http://example.com", "http://sessions.example.com");
-        assertFalse(config.getAutoCaptureSessions());
-        assertEquals("http://sessions.example.com", config.getSessionEndpoint());
-    }
-
-    @Test
-    public void testAutoCaptureOverride() {
-        config.setAutoCaptureSessions(false);
-        config.setEndpoints("http://example.com", "http://example.com");
-        assertFalse(config.getAutoCaptureSessions());
+        assertEquals(notify, config.getEndpoints().getNotify());
+        assertEquals(sessions, config.getEndpoints().getSessions());
     }
 
     @SuppressWarnings("deprecation")

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackerTest.java
@@ -163,14 +163,6 @@ public class SessionTrackerTest {
     }
 
     @Test
-    public void startSessionNoEndpoint() throws Exception {
-        assertNull(sessionTracker.getCurrentSession());
-        configuration.setEndpoints("http://localhost:1234", "");
-        sessionTracker.startNewSession(new Date(), user, false);
-        assertNull(sessionTracker.getCurrentSession());
-    }
-
-    @Test
     public void startSessionAutoCaptureEnabled() {
         assertNull(sessionTracker.getCurrentSession());
         sessionTracker.startNewSession(new Date(), user, false);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -119,14 +119,7 @@ public final class Bugsnag {
     }
 
     /**
-     * Set the endpoint to send data to. By default we'll send reports to
-     * the standard https://notify.bugsnag.com endpoint, but you can override
-     * this if you are using Bugsnag Enterprise to point to your own Bugsnag
-     * endpoint.
-     *
-     * @param endpoint the custom endpoint to send report to
-     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoints(String, String)}
-     * instead.
+     * @deprecated use {@link Configuration#setEndpoints(Endpoints)}
      */
     @Deprecated
     public static void setEndpoint(@NonNull final String endpoint) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigFactory.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigFactory.java
@@ -96,7 +96,7 @@ class ConfigFactory {
             String endpoint = data.getString(MF_ENDPOINT);
             String sessionEndpoint = data.getString(MF_SESSIONS_ENDPOINT);
             //noinspection ConstantConditions (pass in null/empty as this function will warn)
-            config.setEndpoints(endpoint, sessionEndpoint);
+            config.setEndpoints(new Endpoints(endpoint, sessionEndpoint));
         }
 
         config.setSendThreads(data.getBoolean(MF_SEND_THREADS, true));

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -33,8 +33,6 @@ public class Configuration extends Observable implements Observer {
     private String buildUuid;
     private String appVersion;
     private String context;
-    private volatile String endpoint = "https://notify.bugsnag.com";
-    private volatile String sessionEndpoint = "https://sessions.bugsnag.com";
 
     private String[] ignoreClasses;
     @Nullable
@@ -64,6 +62,7 @@ public class Configuration extends Observable implements Observer {
     private String notifierType;
 
     private Delivery delivery;
+    private Endpoints endpoints = new Endpoints();
     private int maxBreadcrumbs = DEFAULT_MAX_SIZE;
 
     /**
@@ -154,86 +153,69 @@ public class Configuration extends Observable implements Observer {
     }
 
     /**
-     * Get the endpoint to send data
-     *
-     * @return Endpoint
+     * @deprecated use {@link Configuration#getEndpoints()}
      */
+    @Deprecated
     @NonNull
     public String getEndpoint() {
-        return endpoint;
+        return endpoints.getNotify();
     }
 
     /**
-     * Set the endpoint to send data to. By default we'll send reports to
-     * the standard https://notify.bugsnag.com endpoint, but you can override
-     * this if you are using Bugsnag Enterprise to point to your own Bugsnag
-     * endpoint.
-     *
-     * @param endpoint the custom endpoint to send report to
-     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoints(String, String)}
+     * @deprecated use {@link Configuration#setEndpoints(Endpoints)}
      */
     @Deprecated
     public void setEndpoint(@NonNull String endpoint) {
-        this.endpoint = endpoint;
+        setEndpoints(new Endpoints(endpoint, getEndpoints().getSessions()));
+    }
+
+    /**
+     * @deprecated use {@link Configuration#setEndpoints(Endpoints)}
+     */
+    @Deprecated
+    public void setEndpoints(@NonNull String notify, @NonNull String sessions) {
+        setEndpoints(new Endpoints(notify, sessions));
     }
 
     /**
      * Set the endpoints to send data to. By default we'll send error reports to
      * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
-     * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoint.
+     * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoints.
      *
-     * Please note that it is recommended that you set both endpoints. If the notify endpoint is
-     * missing, an exception will be thrown. If the session endpoint is missing, a warning will be
-     * logged and sessions will not be sent automatically.
-     *
-     * @param notify the notify endpoint
-     * @param sessions the sessions endpoint
-     *
-     * @throws IllegalArgumentException if the notify endpoint is empty or null
+     * @param endpoints the notify and sessions endpoint
      */
-    public void setEndpoints(@NonNull String notify, @NonNull String sessions)
-        throws IllegalArgumentException {
-
-        if (TextUtils.isEmpty(notify)) {
-            throw new IllegalArgumentException("Notify endpoint cannot be empty or null.");
-        } else {
-            this.endpoint = notify;
-        }
-
-        boolean invalidSessionsEndpoint = TextUtils.isEmpty(sessions);
-
-        if (invalidSessionsEndpoint) {
-            Logger.warn("The session tracking endpoint has not been set. "
-                + "Session tracking is disabled");
-            this.sessionEndpoint = null;
-            this.autoCaptureSessions = false;
-        } else {
-            this.sessionEndpoint = sessions;
-        }
+    public void setEndpoints(@NonNull Endpoints endpoints) {
+        this.endpoints = endpoints;
     }
 
     /**
-     * Gets the Session Tracking API endpoint
+     * Retrieves the endpoints to send data to. By default we'll send error reports to
+     * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
+     * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoints.
      *
-     * @return the endpoint
+     * @return the notify and sessions endpoint
      */
     @NonNull
+    public Endpoints getEndpoints() {
+        return endpoints;
+    }
+
+
+    /**
+     * @deprecated use {@link Configuration#getEndpoints()}
+     */
+    @Deprecated
+    @NonNull
     public String getSessionEndpoint() {
-        return sessionEndpoint;
+        return endpoints.getSessions();
     }
 
     /**
-     * Set the endpoint to send Session Tracking data to. By default we'll send reports to
-     * the standard https://sessions.bugsnag.com endpoint, but you can override
-     * this if you are using Bugsnag Enterprise to point to your own Bugsnag
-     * endpoint.
-     *
-     * @param endpoint the custom endpoint to send session data to
-     * @deprecated use {@link com.bugsnag.android.Configuration#setEndpoints(String, String)}
+     * @deprecated use {@link Configuration#setEndpoints(Endpoints)}
      */
     @Deprecated
     public void setSessionEndpoint(@NonNull String endpoint) {
-        this.sessionEndpoint = endpoint;
+        setEndpoints(new Endpoints(getEndpoints().getNotify(), endpoint));
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.java
@@ -23,7 +23,7 @@ class DefaultDelivery implements Delivery {
     @Override
     public void deliver(@NonNull SessionTrackingPayload payload,
                         @NonNull Configuration config) throws DeliveryFailureException {
-        String endpoint = config.getSessionEndpoint();
+        String endpoint = config.getEndpoints().getSessions();
         int status = deliver(endpoint, payload, config.getSessionApiHeaders());
 
         if (status != 202) {
@@ -36,7 +36,7 @@ class DefaultDelivery implements Delivery {
     @Override
     public void deliver(@NonNull Report report,
                         @NonNull Configuration config) throws DeliveryFailureException {
-        String endpoint = config.getEndpoint();
+        String endpoint = config.getEndpoints().getNotify();
         int status = deliver(endpoint, report, config.getErrorApiHeaders());
 
         if (status / 100 != 2) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryCompat.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryCompat.java
@@ -21,7 +21,8 @@ class DeliveryCompat implements Delivery {
                         @NonNull Configuration config) throws DeliveryFailureException {
         if (sessionTrackingApiClient != null) {
             try {
-                sessionTrackingApiClient.postSessionTrackingPayload(config.getSessionEndpoint(),
+                String sessions = config.getEndpoints().getSessions();
+                sessionTrackingApiClient.postSessionTrackingPayload(sessions,
                     payload, config.getSessionApiHeaders());
             } catch (Throwable throwable) {
                 handleException(throwable);
@@ -34,7 +35,7 @@ class DeliveryCompat implements Delivery {
                         @NonNull Configuration config) throws DeliveryFailureException {
         if (errorReportApiClient != null) {
             try {
-                errorReportApiClient.postReport(config.getEndpoint(),
+                errorReportApiClient.postReport(config.getEndpoints().getNotify(),
                     report, config.getErrorApiHeaders());
             } catch (Throwable throwable) {
                 handleException(throwable);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Endpoints.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Endpoints.kt
@@ -1,0 +1,6 @@
+package com.bugsnag.android
+
+data class Endpoints(
+    val notify: String = "https://notify.bugsnag.com",
+    val sessions: String = "https://sessions.bugsnag.com"
+)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -319,7 +319,7 @@ public class NativeInterface {
      */
     @NonNull
     public static String getSessionEndpoint() {
-        return getClient().getConfig().getSessionEndpoint();
+        return getClient().getConfig().getEndpoints().getSessions();
     }
 
     /**
@@ -327,7 +327,7 @@ public class NativeInterface {
      */
     @NonNull
     public static String getEndpoint() {
-        return getClient().getConfig().getEndpoint();
+        return getClient().getConfig().getEndpoints().getNotify();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -73,11 +73,6 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     @VisibleForTesting
     Session startNewSession(@NonNull Date date, @Nullable User user,
                                       boolean autoCaptured) {
-        if (configuration.getSessionEndpoint() == null) {
-            Logger.warn("The session tracking endpoint has not been set. "
-                + "Session tracking is disabled");
-            return null;
-        }
         Session session = new Session(UUID.randomUUID().toString(), date, user, autoCaptured);
         currentSession.set(session);
         trackSessionIfNeeded(session);
@@ -167,7 +162,6 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
             notifySessionStartObserver(session);
 
             try {
-                final String endpoint = configuration.getSessionEndpoint();
                 Async.run(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
## Goal

Creates an `Endpoints` class which encapsulates the `notify` and `sessions` fields, and automatically rejects any `null` values for either of these parameters. 

## Changeset

- Added `Configuration#setEndpoints(Endpoints)` method
- Deprecated existing methods, added backwards compatibility
- Removed redundant unit tests which were added when we supported setting the `notify` and `sessions` fields non-atomically
