### PR TITLE
Added config option to disable capturing the device orientation

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -239,7 +239,8 @@ public class Client extends Observable implements Observer {
             }
         };
         try {
-            orientationListener.enable();
+            if (config.isCapturingDeviceOrientation())
+                orientationListener.enable();
         } catch (IllegalStateException ex) {
             Logger.warn("Failed to set up orientation tracking: " + ex);
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -47,6 +47,7 @@ public class Configuration extends Observable implements Observer {
     private long launchCrashThresholdMs = 5 * 1000;
     private boolean autoCaptureSessions = true;
     private boolean automaticallyCollectBreadcrumbs = true;
+    private boolean captureDeviceOrientation = true;
 
     private boolean detectAnrs = false;
     private boolean detectNdkCrashes;
@@ -573,6 +574,24 @@ public class Configuration extends Observable implements Observer {
      */
     public void setAutomaticallyCollectBreadcrumbs(boolean automaticallyCollectBreadcrumbs) {
         this.automaticallyCollectBreadcrumbs = automaticallyCollectBreadcrumbs;
+    }
+
+    /**
+     * Returns whether capturing the device orientation is enabled.
+     * @return true if orientation capturing is enabled, otherwise false.
+     */
+    public boolean isCapturingDeviceOrientation() {
+        return captureDeviceOrientation;
+    }
+
+    /**
+     * By default, the device orientation is captured.
+     * To disable this behavior, set this property to false.
+     *
+     * @param captureDeviceOrientation whether the device orientation should be captured or not
+     */
+    public void setCaptureDeviceOrientation(boolean captureDeviceOrientation) {
+        this.captureDeviceOrientation = captureDeviceOrientation;
     }
 
     /**


### PR DESCRIPTION
## Goal

To disable sending the device orientation for people with privacy concerns about this.

Refs #533

## Design

Add and check a new property to enable the orientation listener.

## Changeset

A property was added to the Configuration class, default set to true, and methods were added to the Configuration class to change the default and to query to current property state.

The configuration property is used is check if the orientation listener should be enabled on creating the Client object.

## Tests

Since the change is very straightforward, no tests were performed nor added.
