### PR TITLE
Add missing old-report scenario

### DIFF
--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CorruptedOldReportScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CorruptedOldReportScenario.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import java.io.File
+
+/**
+ * Verifies that if a report is corrupted with an old filename,
+ * Bugsnag does not crash.
+ */
+internal class CorruptedOldReportScenario(config: Configuration,
+                                          context: Context) : Scenario(config, context) {
+
+    init {
+        config.setAutoCaptureSessions(false)
+        val files = File(context.cacheDir, "bugsnag-errors").listFiles()
+
+        // create an empty (invalid) file with an old name
+        files.forEach {
+            val dir = File(it.parent)
+            it.writeText("{\"exceptions\":[{\"stacktrace\":[")
+            it.renameTo(File(dir, "1504255147933_683c6b92-b325-4987-80ad-77086509ca1e.json"))
+        }
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.notify(generateException())
+    }
+}

--- a/tests/features/minimal_report.feature
+++ b/tests/features/minimal_report.feature
@@ -23,3 +23,11 @@ Scenario: Minimal error report for an Unhandled Exception with a corrupted file
     And the event "unhandled" is true
     And the event "incomplete" is true
     And the event "severityReason.type" equals "unhandledException"
+
+Scenario: Minimal error report with old filename
+    When I run "MinimalUnhandledExceptionScenario" and relaunch the app
+    And I run "CorruptedOldReportScenario"
+    And I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the event "unhandled" is false
+    And the event "incomplete" is false


### PR DESCRIPTION
## Goal

Adds the missing scenario present in the local maze-tests but not the BrowserStack enabled ones.

This should now pass both locally and on CI.