### PR TITLE
Set autoCapture as false by default

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -45,7 +45,7 @@ public class Configuration extends Observable implements Observer {
     private boolean enableExceptionHandler = true;
     private boolean persistUserBetweenSessions = false;
     private long launchCrashThresholdMs = 5 * 1000;
-    private boolean autoCaptureSessions = true;
+    private boolean autoCaptureSessions = false;
     private boolean automaticallyCollectBreadcrumbs = true;
 
     private boolean detectAnrs = false;


### PR DESCRIPTION
Following the docs:

https://github.com/bugsnag/bugsnag-android/blob/8f490e66a287d0b55a3c114f7c3b7e45c5c4dcae/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java#L449-L459

it appears that auto capture should be false by default.

Even if you have some other function that sets it false upon init, it would be worth having the actual variable as false by default.