### PR TITLE
Buildkite: Ensure concurrency groups reflect reality

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -96,14 +96,38 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: NDK 16b SDK Instrumentation tests'
+  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
     timeout_in_minutes: 40
     plugins:
       - docker-compose#v2.6.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]'
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: "r16b"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
+    timeout_in_minutes: 40
+    plugins:
+      - docker-compose#v2.6.0:
+          run: android-instrumentation-tests
+    env:
+      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: "r16b"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
+    timeout_in_minutes: 40
+    plugins:
+      - docker-compose#v2.6.0:
+          run: android-instrumentation-tests
+    env:
+      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
       NDK_VERSION: "r16b"
     concurrency: 5
     concurrency_group: 'browserstack-app'
@@ -162,26 +186,74 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: NDK 12b SDK Instrumentation tests'
+  - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
     timeout_in_minutes: 40
     plugins:
       - docker-compose#v2.6.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]'
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
       NDK_VERSION: "r12b"
     concurrency: 5
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: NDK 19 SDK Instrumentation tests'
+  - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
     timeout_in_minutes: 40
     plugins:
       - docker-compose#v2.6.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]'
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: "r12b"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
+    timeout_in_minutes: 40
+    plugins:
+      - docker-compose#v2.6.0:
+          run: android-instrumentation-tests
+    env:
+      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: "r12b"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
+    timeout_in_minutes: 40
+    plugins:
+      - docker-compose#v2.6.0:
+          run: android-instrumentation-tests
+    env:
+      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: "r19"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
+    timeout_in_minutes: 40
+    plugins:
+      - docker-compose#v2.6.0:
+          run: android-instrumentation-tests
+    env:
+      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: "r19"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
+    timeout_in_minutes: 40
+    plugins:
+      - docker-compose#v2.6.0:
+          run: android-instrumentation-tests
+    env:
+      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
       NDK_VERSION: "r19"
     concurrency: 5
     concurrency_group: 'browserstack-app'


### PR DESCRIPTION
## Goal

Separates the Instrumentation steps into separate groups to avoid overrunning the concurrency limits in place.

This change should avoid having to look at BrowserStack device availability in Maze-Runner