### PR TITLE
Fix potential segfaults when adding breadcrumb with NDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+* Fix potential segfaults when adding breadcrumb with NDK
+  [#546](https://github.com/bugsnag/bugsnag-android/pull/546)
+
 ## 4.17.1 (2019-07-24)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -15,10 +16,11 @@ class BreadcrumbMutabilityTest {
         assertNotSame(data, breadcrumb.metadata)
     }
 
-    @Test(expected = UnsupportedOperationException::class)
+    @Test
     fun breadcrumbProtectsMetaData() {
         val data = mutableMapOf<String, String>()
         val breadcrumb = Breadcrumb("foo", BreadcrumbType.MANUAL, data)
         breadcrumb.metadata["a"] = "bar"
+        assertFalse(breadcrumb.metadata.isEmpty())
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BreadcrumbMutabilityTest {
+
+    @Test
+    fun breadcrumbCopiesMap() {
+        val data = mutableMapOf<String, String>()
+        val breadcrumb = Breadcrumb("foo", BreadcrumbType.MANUAL, data)
+        data["a"] = "bar"
+        assertTrue(breadcrumb.metadata.isEmpty())
+        assertNotSame(data, breadcrumb.metadata)
+    }
+
+    @Test(expected = UnsupportedOperationException::class)
+    fun breadcrumbProtectsMetaData() {
+        val data = mutableMapOf<String, String>()
+        val breadcrumb = Breadcrumb("foo", BreadcrumbType.MANUAL, data)
+        breadcrumb.metadata["a"] = "bar"
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -7,6 +7,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,10 +41,7 @@ public final class Breadcrumb implements JsonStream.Streamable {
     Breadcrumb(@NonNull String name,
                @NonNull BreadcrumbType type,
                @NonNull Map<String, String> metadata) {
-        this.timestamp = DateUtils.toIso8601(new Date());
-        this.type = type;
-        this.metadata = metadata;
-        this.name = name;
+        this(name, type, new Date(), metadata);
     }
 
     Breadcrumb(@NonNull String name,
@@ -52,8 +50,8 @@ public final class Breadcrumb implements JsonStream.Streamable {
                @NonNull Map<String, String> metadata) {
         this.timestamp = DateUtils.toIso8601(captureDate);
         this.type = type;
-        this.metadata = metadata;
         this.name = name;
+        this.metadata = new HashMap<>(metadata);
     }
 
     @NonNull
@@ -68,7 +66,7 @@ public final class Breadcrumb implements JsonStream.Streamable {
 
     @NonNull
     public Map<String, String> getMetadata() {
-        return metadata;
+        return Collections.unmodifiableMap(metadata);
     }
 
     @NonNull

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -66,7 +66,7 @@ public final class Breadcrumb implements JsonStream.Streamable {
 
     @NonNull
     public Map<String, String> getMetadata() {
-        return Collections.unmodifiableMap(metadata);
+        return metadata;
     }
 
     @NonNull

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -183,14 +183,14 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
   }
 
   bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
-  int mapSize = (int)(*env)->CallIntMethod(env, metadata, jni_cache->map_size);
+  int map_size = (int)(*env)->CallIntMethod(env, metadata, jni_cache->map_size);
   jobject keyset =
       (*env)->CallObjectMethod(env, metadata, jni_cache->map_key_set);
   jobject keylist = (*env)->NewObject(
       env, jni_cache->arraylist, jni_cache->arraylist_init_with_obj, keyset);
   size_t metadataSize = sizeof(crumb->metadata) / sizeof(bsg_char_metadata_pair);
 
-  for (int i = 0; i < mapSize && i < metadataSize; i++) {
+  for (int i = 0; i < map_size && i < metadataSize; i++) {
     jstring _key = (*env)->CallObjectMethod(env, keylist,
                                             jni_cache->arraylist_get, (jint)i);
     jstring _value =

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -193,7 +193,7 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
                                             jni_cache->arraylist_get, (jint)i);
     jstring _value =
         (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);
-    if (_value == NULL) {
+    if (_key == NULL || _value == NULL) {
       (*env)->DeleteLocalRef(env, _key);
       (*env)->DeleteLocalRef(env, _value);
     } else {

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -188,9 +188,9 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
       (*env)->CallObjectMethod(env, metadata, jni_cache->map_key_set);
   jobject keylist = (*env)->NewObject(
       env, jni_cache->arraylist, jni_cache->arraylist_init_with_obj, keyset);
-  size_t metadataSize = sizeof(crumb->metadata) / sizeof(bsg_char_metadata_pair);
+  size_t metadata_size = sizeof(crumb->metadata) / sizeof(bsg_char_metadata_pair);
 
-  for (int i = 0; i < map_size && i < metadataSize; i++) {
+  for (int i = 0; i < map_size && i < metadata_size; i++) {
     jstring _key = (*env)->CallObjectMethod(env, keylist,
                                             jni_cache->arraylist_get, (jint)i);
     jstring _value =

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -183,12 +183,14 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
   }
 
   bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
-  int size = (int)(*env)->CallIntMethod(env, metadata, jni_cache->map_size);
+  int mapSize = (int)(*env)->CallIntMethod(env, metadata, jni_cache->map_size);
   jobject keyset =
       (*env)->CallObjectMethod(env, metadata, jni_cache->map_key_set);
   jobject keylist = (*env)->NewObject(
       env, jni_cache->arraylist, jni_cache->arraylist_init_with_obj, keyset);
-  for (int i = 0; i < size && i < sizeof(crumb->metadata); i++) {
+  size_t metadataSize = sizeof(crumb->metadata) / sizeof(bsg_char_metadata_pair);
+
+  for (int i = 0; i < mapSize && i < metadataSize; i++) {
     jstring _key = (*env)->CallObjectMethod(env, keylist,
                                             jni_cache->arraylist_get, (jint)i);
     jstring _value =

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -178,6 +178,10 @@ int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
 
 void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
                                  jobject metadata) {
+  if (metadata == NULL) {
+    return;
+  }
+
   bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
   int size = (int)(*env)->CallIntMethod(env, metadata, jni_cache->map_size);
   jobject keyset =


### PR DESCRIPTION
## Goal

We have noticed infrequent crashes when adding a breadcrumb and NDK error detection is enabled. This changeset fixes some potential causes of this behaviour.

## Changeset

- Made `Breadcrumb` immutable by taking a defensive copy of the map parameter, and returning a decorated `Collection` from the getter that is unmodifiable.
- Corrected `sizeof` calculation when iterating through breadcrumb metadata
- Added null check for metadata and metadata keys in breadcrumbs

## Tests

- Added unit tests to verify `Breadcrumb` metadata immutability
- Tested leaving breadcrumbs with metadata in example app
