### PR TITLE
Remove renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
Renovate only updates the gradle wrapper's properties file and not the actual jar itself. In addition [updating Gradle dependencies](https://renovatebot.com/docs/java/) in Android projects, meaning we gain little value out of the bot presently. We should therefore remove it as we have a small number of dependencies anyway, and Android Studio already automatically prompts us to update them so we're not losing any observability around new updates.
