### PR TITLE
Buffer IO when reading cached error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Buffer IO when reading cached error reports
+  [#565](https://github.com/bugsnag/bugsnag-android/pull/565)
+
 ## 4.18.0 (2019-08-15)
 
 * Migrate dependencies to androidx

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import android.util.JsonReader;
 import androidx.annotation.NonNull;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -43,7 +44,7 @@ class ErrorReader {
             List<String> projectPackages = Collections.emptyList();
             boolean unhandled = false;
 
-            reader = new JsonReader(new FileReader(errorFile));
+            reader = new JsonReader(new BufferedReader(new FileReader(errorFile)));
             reader.beginObject();
             while (reader.hasNext()) {
                 switch (reader.nextName()) {


### PR DESCRIPTION
## Goal

`ErrorReader` uses a `FileReader` which is unbuffered, meaning when an error report is read from disk it takes far longer than is necessary. Wrapping this value with a `BufferedReader` should notably improve performance at no cost to the implementation.

## Tests

Relied on existing test coverage