### PR TITLE
Add failureReason array to enable diagnostics in error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Add failureReason array to enable diagnostics in error reports
+  [#566](https://github.com/bugsnag/bugsnag-android/pull/5566)
+
 ## 4.18.0 (2019-08-15)
 
 * Migrate dependencies to androidx

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ErrorTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ErrorTest.java
@@ -17,6 +17,7 @@ import android.content.res.Resources;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SmallTest;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.After;
@@ -88,6 +89,7 @@ public class ErrorTest {
         assertNotNull(errorJson.get("threads"));
         assertNotNull(errorJson.get("exceptions"));
         assertNotNull(errorJson.get("app"));
+        assertFalse(errorJson.has("failureReason"));
     }
 
     @Test
@@ -414,6 +416,16 @@ public class ErrorTest {
 
         JSONObject errorJson = streamableToJson(error);
         assertFalse(errorJson.has("session"));
+    }
+
+    @Test
+    public void testFailureReason() throws JSONException, IOException {
+        error.addFailureReason("Something went wrong");
+        error.addFailureReason("Whoops!");
+        JSONObject json = streamableToJson(error);
+        JSONArray failureReason = json.getJSONArray("failureReason");
+        assertEquals("Something went wrong", failureReason.get(0));
+        assertEquals("Whoops!", failureReason.get(1));
     }
 
     private void validateEmptyAttributes(JSONObject severityReason) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
@@ -4,7 +4,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,6 +40,8 @@ public class Error implements JsonStream.Streamable {
 
     @Nullable
     private String context;
+
+    private List<String> failureReasons = new ArrayList<>();
 
     @NonNull
     final Configuration config;
@@ -106,6 +110,15 @@ public class Error implements JsonStream.Streamable {
 
         if (config.getSendThreads()) {
             writer.name("threads").value(threadState);
+        }
+
+        if (!failureReasons.isEmpty()) {
+            writer.name("failureReason").beginArray();
+
+            for (String reason : failureReasons) {
+                writer.value(reason);
+            }
+            writer.endArray();
         }
 
         if (session != null) {
@@ -417,6 +430,10 @@ public class Error implements JsonStream.Streamable {
         if (exceptions != null) {
             exceptions.setProjectPackages(projectPackages);
         }
+    }
+
+    void addFailureReason(String failureReason) {
+        failureReasons.add(failureReason);
     }
 
     static class Builder {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -174,6 +174,8 @@ class ErrorStore extends FileStore<Error> {
                 Error minimalError = generateErrorFromFilename(errorFile.getName());
 
                 if (minimalError != null) {
+                    minimalError.addFailureReason(exception.getMessage());
+                    minimalError.addFailureReason("File length: " + errorFile.length());
                     delegate.onErrorReadFailure(minimalError);
                 }
             }


### PR DESCRIPTION
## Goal

Adds an array for internal use when debugging notifier issues. As an additional diagnostic tool we now record the exception message from when a minimal report is created, along with its file length, which should tell us whether the report was an empty file or invalid JSON.

## Changeset

Adds a `failureReason` array of strings to the error payload.