### PR TITLE
Make internally used setNotifierType method package-private

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -521,7 +521,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
      * Intended for internal use only - sets the type of the notifier (e.g. Android, React Native)
      * @param notifierType the notifier type
      */
-    public void setNotifierType(@NonNull String notifierType) {
+    void setNotifierType(@NonNull String notifierType) {
         this.notifierType = notifierType;
     }
 
@@ -539,7 +539,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
     }
 
     @NonNull
-    public String getNotifierType() {
+    String getNotifierType() {
         return notifierType;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ private void configureAndroidProject(Project proj) {
     lintOptions.warningsAsErrors = true
     lintOptions.checkAllWarnings = true
     lintOptions.baseline new File(proj.projectDir, "lint-baseline.xml")
+    lintOptions.disable "GradleDependency", "NewerVersionAvailable"
 
     def defaultConfig = proj.android.defaultConfig
     defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/mazerunner-scenarios/lint-baseline.xml
+++ b/mazerunner-scenarios/lint-baseline.xml
@@ -1,26 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <issues format="5" by="lint 3.4.2" client="gradle" variant="all" version="3.4.2">
 
-    <issue
-        id="GradleDynamicVersion"
-        message="Avoid using + in version numbers; can lead to unpredictable and unrepeatable builds (com.bugsnag:bugsnag-android:+)"
-        errorLine1="    compileOnly &quot;com.bugsnag:bugsnag-android:+&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle"
-            line="35"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="NewerVersionAvailable"
-        message="A newer version of io.gitlab.arturbosch.detekt:detekt-gradle-plugin than 1.0.0-RC16 is available: 1.0.0.RC9"
-        errorLine1="        classpath &quot;io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC16&quot;"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle"
-            line="15"
-            column="9"/>
-    </issue>
-
 </issues>


### PR DESCRIPTION
`setNotifierType` is not intended for public use so can be made package-private. If other notifiers need to use it, they should access it via a class in the `com.bugsnag.android` package, rather than exposing it in our public API.

This also disables two lint inspections which fail the CI build whenever a new version of a Gradle dependency is available, and removes the existing baseline warning for this inspection. Android Studio automatically notifies us of new gradle dependency versions so we don't need to fail every branch whenever a new version of a plugin/dependency is released.