### PR TITLE
fix(config): Avoid NPE if setting metadata to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix potential null pointer exception if `setMetaData` is called with a null
+  value
+
 ## 4.19.0 (2019-08-27)
 
 * Report internal SDK errors to bugsnag

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/NullMetadataTest.java
@@ -42,6 +42,13 @@ public class NullMetadataTest {
     }
 
     @Test
+    public void testConfigSetNullMetadata() throws Exception {
+        Configuration configuration = new Configuration("test");
+        configuration.setMetaData(null);
+        validateDefaultMetadata(configuration.getMetaData());
+    }
+
+    @Test
     public void testErrorDefaultMetaData() throws Exception {
         Error error = new Error.Builder(config, throwable, generateSessionTracker(),
             Thread.currentThread(), false).build();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -483,7 +483,7 @@ public class Configuration extends Observable implements Observer {
         }
         this.setChanged();
         this.notifyObservers(new NativeInterface.Message(
-                    NativeInterface.MessageType.UPDATE_METADATA, metaData.store));
+                    NativeInterface.MessageType.UPDATE_METADATA, this.metaData.store));
         this.metaData.addObserver(this);
     }
 


### PR DESCRIPTION
I came across this when testing something else - if config.metadata is set to null, it causes an NPE. I then realized there was a test for this prior to #513, which I completely glossed over. So I added back the test and fixed the issue.