### PR TITLE
JVM tests: Ensure tests aren't run twice

### DIFF
--- a/scripts/run-linter.sh
+++ b/scripts/run-linter.sh
@@ -1,4 +1,4 @@
-./gradlew lint checkstyle detekt test && \
+./gradlew lint checkstyle detekt && \
 cppcheck --enable=warning,performance bugsnag-plugin-android-anr/src/main/jni && \
 cppcheck --enable=warning,performance bugsnag-plugin-android-ndk/src/main/jni -i \
 bugsnag-plugin-android-ndk/src/main/jni/deps -i bugsnag-plugin-android-ndk/src/main/jni/external


### PR DESCRIPTION
## Goal

Currently JVM tests are run twice, once in the linter and once in the separate image.