### PR TITLE
Fix deserialization of custom stackframe fields in cached error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 4.19.1 (2019-09-03)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Fix deserialization of custom stackframe fields in cached error reports
+  [#576](https://github.com/bugsnag/bugsnag-android/pull/576)
+
 * Fix potential null pointer exception if `setMetaData` is called with a null
   value
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagExceptionTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagExceptionTest.kt
@@ -74,8 +74,8 @@ class BugsnagExceptionTest {
     @Test
     fun customStreamableSerialization() {
         val bugsnagException = BugsnagException(StreamableException())
-        val exc = jsonObjectFromException(bugsnagException)
-        assertEquals("Bar", exc.get("Foo"))
+        val exc = streamableToJsonArray(bugsnagException)
+        assertEquals("Bar", exc.getJSONObject(0)["Foo"])
     }
 
     @Test
@@ -111,16 +111,18 @@ class BugsnagExceptionTest {
     private fun jsonObjectFromException(bugsnagException: BugsnagException): JSONObject {
         val exceptions = Exceptions(config, bugsnagException)
         val json = streamableToJsonArray(exceptions)
-        val exc = json.get(0) as JSONObject
+        val exc = json.getJSONObject(0)
         return exc
     }
 }
 
 class StreamableException: Throwable(), JsonStream.Streamable {
     override fun toStream(stream: JsonStream) {
+        stream.beginArray()
         stream.beginObject()
         stream.name("Foo")
         stream.value("Bar")
         stream.endObject()
+        stream.endArray()
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ExceptionsTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ExceptionsTest.kt
@@ -61,7 +61,8 @@ class ExceptionsTest {
         ).build()
         val exceptions = Exceptions(config, BugsnagException(error.exception))
 
-        val exceptionJson = streamableToJsonArray(exceptions).getJSONObject(0)
+        val json = streamableToJsonArray(exceptions)
+        val exceptionJson = json.getJSONObject(0)
         assertEquals("RuntimeException", exceptionJson.get("errorClass"))
         assertEquals("Example message", exceptionJson.get("message"))
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
@@ -16,7 +16,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @FlakyTest(detail = "Checks a stacktrace's line number, so fails when lines are added/deleted.")
 @SmallTest
@@ -41,7 +43,7 @@ public class StacktraceTest {
         JSONArray stacktraceJson = streamableToJsonArray(stacktrace);
 
         JSONObject firstFrame = (JSONObject) stacktraceJson.get(0);
-        assertEquals(34, firstFrame.get("lineNumber"));
+        assertEquals(36, firstFrame.get("lineNumber"));
         assertEquals("com.bugsnag.android.StacktraceTest.setUp", firstFrame.get("method"));
         assertEquals("StacktraceTest.java", firstFrame.get("file"));
         assertFalse(firstFrame.has("inProject"));
@@ -70,6 +72,19 @@ public class StacktraceTest {
 
         StackTraceElement[] ary = new StackTraceElement[elements.size()];
         Stacktrace stacktrace = new Stacktrace(elements.toArray(ary), config.getProjectPackages());
+        JSONArray jsonArray = streamableToJsonArray(stacktrace);
+        assertEquals(200, jsonArray.length());
+    }
+
+    @Test
+    public void testStacktraceTrimmingListCtor() throws Throwable {
+        List<Map<String, Object>> elements = new ArrayList<>();
+
+        for (int k = 0; k < 1000; k++) {
+            elements.add(Collections.singletonMap("Foo", new Object()));
+        }
+
+        Stacktrace stacktrace = new Stacktrace(elements);
         JSONArray jsonArray = streamableToJsonArray(stacktrace);
         assertEquals(200, jsonArray.length());
     }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StacktraceTest.java
@@ -74,6 +74,8 @@ public class StacktraceTest {
         Stacktrace stacktrace = new Stacktrace(elements.toArray(ary), config.getProjectPackages());
         JSONArray jsonArray = streamableToJsonArray(stacktrace);
         assertEquals(200, jsonArray.length());
+        assertEquals(0, jsonArray.getJSONObject(0).getInt("lineNumber"));
+        assertEquals(199, jsonArray.getJSONObject(199).getInt("lineNumber"));
     }
 
     @Test
@@ -81,12 +83,14 @@ public class StacktraceTest {
         List<Map<String, Object>> elements = new ArrayList<>();
 
         for (int k = 0; k < 1000; k++) {
-            elements.add(Collections.singletonMap("Foo", new Object()));
+            elements.add(Collections.singletonMap("Foo", (Object) k));
         }
 
         Stacktrace stacktrace = new Stacktrace(elements);
         JSONArray jsonArray = streamableToJsonArray(stacktrace);
         assertEquals(200, jsonArray.length());
+        assertEquals(0, jsonArray.getJSONObject(0).getInt("Foo"));
+        assertEquals(199, jsonArray.getJSONObject(199).getInt("Foo"));
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagException.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagException.java
@@ -50,6 +50,7 @@ public class BugsnagException extends Throwable implements JsonStream.Streamable
             this.type = ((BugsnagException) exc).getType();
         } else if (exc instanceof JsonStream.Streamable) {
             this.streamable = (JsonStream.Streamable) exc;
+            this.name = "";
         } else {
             this.name = exc.getClass().getName();
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagException.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagException.java
@@ -2,6 +2,9 @@ package com.bugsnag.android;
 
 import androidx.annotation.NonNull;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Used to store information about an exception that was not provided with an exception object
  */
@@ -14,6 +17,7 @@ public class BugsnagException extends Throwable {
      */
     private String name;
     private String message;
+    private List<Map<String, Object>> customStackframes;
 
     private String type = Configuration.DEFAULT_EXCEPTION_TYPE;
 
@@ -44,6 +48,14 @@ public class BugsnagException extends Throwable {
         }
         setStackTrace(exc.getStackTrace());
         initCause(exc.getCause());
+    }
+
+    BugsnagException(@NonNull String name,
+                     @NonNull String message,
+                     @NonNull List<Map<String, Object>> customStackframes) {
+        super(message);
+        this.name = name;
+        this.customStackframes = customStackframes;
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagException.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagException.java
@@ -44,11 +44,7 @@ public class BugsnagException extends Throwable implements JsonStream.Streamable
     BugsnagException(@NonNull Throwable exc) {
         super(exc.getMessage());
 
-        if (exc instanceof BugsnagException) {
-            this.message = ((BugsnagException) exc).getMessage();
-            this.name = ((BugsnagException) exc).getName();
-            this.type = ((BugsnagException) exc).getType();
-        } else if (exc instanceof JsonStream.Streamable) {
+        if (exc instanceof JsonStream.Streamable) {
             this.streamable = (JsonStream.Streamable) exc;
             this.name = "";
         } else {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CachedThread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CachedThread.java
@@ -3,26 +3,38 @@ package com.bugsnag.android;
 import androidx.annotation.NonNull;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A representation of a thread recorded in a {@link Report}
  */
 class CachedThread implements JsonStream.Streamable {
+
     private final long id;
     private final String name;
     private final String type;
     private final boolean isErrorReportingThread;
-    private final StackTraceElement[] frames;
-    private final Configuration config;
+    private Stacktrace stacktrace;
 
     CachedThread(Configuration config, long id, String name, String type,
                  boolean isErrorReportingThread, StackTraceElement[] frames) {
+        this(id, name, type, isErrorReportingThread,
+                new Stacktrace(frames, config.getProjectPackages()));
+    }
+
+    CachedThread(long id, String name, String type,
+                 boolean isErrorReportingThread, List<Map<String, Object>> customFrames) {
+        this(id, name, type, isErrorReportingThread, new Stacktrace(customFrames));
+    }
+
+    private CachedThread(long id, String name, String type,
+                         boolean isErrorReportingThread, Stacktrace stackTrace) {
         this.id = id;
-        this.config = config;
         this.name = name;
         this.type = type;
         this.isErrorReportingThread = isErrorReportingThread;
-        this.frames = frames;
+        this.stacktrace = stackTrace;
     }
 
     @Override
@@ -31,7 +43,7 @@ class CachedThread implements JsonStream.Streamable {
         writer.name("id").value(id);
         writer.name("name").value(name);
         writer.name("type").value(type);
-        writer.name("stacktrace").value(new Stacktrace(frames, config.getProjectPackages()));
+        writer.name("stacktrace").value(stacktrace);
         if (isErrorReportingThread) {
             writer.name("errorReportingThread").value(true);
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -261,7 +261,7 @@ class ErrorReader {
                         map.put(key, reader.nextString());
                         break;
                     case NUMBER:
-                        map.put(key, reader.nextInt());
+                        map.put(key, reader.nextLong());
                         break;
                     default:
                         reader.skipValue();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -257,16 +257,17 @@ class ErrorReader {
             String key = reader.nextName();
             Object val = null;
 
-            try {
-                val = reader.nextString();
-            } catch (IllegalStateException exc) {
-                try {
+            switch (reader.peek()) {
+                case STRING:
+                    val = reader.nextString();
+                    break;
+                case NUMBER:
                     val = reader.nextInt();
-                } catch (IllegalStateException ignored) {
+                    break;
+                default:
                     reader.skipValue();
-                }
+                    break;
             }
-
             if (val != null) {
                 map.put(key, val);
             }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -253,24 +253,23 @@ class ErrorReader {
         Map<String, Object> map = new HashMap<>();
         reader.beginObject();
 
-        while (reader.hasNext()) {
-            String key = reader.nextName();
-            Object val = null;
-
-            switch (reader.peek()) {
-                case STRING:
-                    val = reader.nextString();
-                    break;
-                case NUMBER:
-                    val = reader.nextInt();
-                    break;
-                default:
-                    reader.skipValue();
-                    break;
+        try {
+            while (reader.hasNext()) {
+                String key = reader.nextName();
+                switch (reader.peek()) {
+                    case STRING:
+                        map.put(key, reader.nextString());
+                        break;
+                    case NUMBER:
+                        map.put(key, reader.nextInt());
+                        break;
+                    default:
+                        reader.skipValue();
+                        break;
+                }
             }
-            if (val != null) {
-                map.put(key, val);
-            }
+        } catch (IllegalStateException exc) {
+            Logger.warn("Failed to read stackframe", exc);
         }
         reader.endObject();
         return map;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -81,7 +81,7 @@ class ErrorReader {
                         severityReasonValues = readSeverityReason(reader);
                         break;
                     case "threads":
-                        threadState = readThreadState(config, reader);
+                        threadState = readThreadState(reader);
                         break;
                     case "unhandled":
                         unhandled = reader.nextBoolean();
@@ -211,7 +211,8 @@ class ErrorReader {
         String errorClass = null;
         String message = null;
         String type = Configuration.DEFAULT_EXCEPTION_TYPE;
-        StackTraceElement[] frames = new StackTraceElement[]{};
+        List<Map<String, Object>> frames = new ArrayList<>();
+
         while (reader.hasNext()) {
             switch (reader.nextName()) {
                 case "errorClass":
@@ -238,40 +239,40 @@ class ErrorReader {
     }
 
 
-    private static StackTraceElement[] readStackFrames(JsonReader reader) throws IOException {
-        ArrayList<StackTraceElement> frames = new ArrayList<>();
+    private static List<Map<String, Object>> readStackFrames(JsonReader reader) throws IOException {
+        List<Map<String, Object>> frames = new ArrayList<>();
         reader.beginArray();
         while (reader.hasNext()) {
             frames.add(readStackFrame(reader));
         }
         reader.endArray();
-        return frames.toArray(new StackTraceElement[0]);
+        return frames;
     }
 
-    private static StackTraceElement readStackFrame(JsonReader reader) throws IOException {
-        String method = null;
-        String file = null;
-        int lineNumber = 0;
+    private static Map<String, Object> readStackFrame(JsonReader reader) throws IOException {
+        Map<String, Object> map = new HashMap<>();
         reader.beginObject();
-        while (reader.hasNext()) {
-            switch (reader.nextName()) {
-                case "method":
-                    method = reader.nextString();
-                    break;
-                case "file":
-                    file = reader.nextString();
-                    break;
-                case "lineNumber":
-                    lineNumber = reader.nextInt();
-                    break;
-                default:
-                    reader.skipValue();
-                    break;
 
+        while (reader.hasNext()) {
+            String key = reader.nextName();
+            Object val = null;
+
+            try {
+                val = reader.nextString();
+            } catch (IllegalStateException exc) {
+                try {
+                    val = reader.nextInt();
+                } catch (IllegalStateException ignored) {
+                    reader.skipValue();
+                }
+            }
+
+            if (val != null) {
+                map.put(key, val);
             }
         }
         reader.endObject();
-        return new StackTraceElement("", method, file, lineNumber);
+        return map;
     }
 
     /**
@@ -395,12 +396,12 @@ class ErrorReader {
         return user;
     }
 
-    private static ThreadState readThreadState(Configuration config, JsonReader reader)
+    private static ThreadState readThreadState(JsonReader reader)
         throws IOException {
         List<CachedThread> threads = new ArrayList<>();
         reader.beginArray();
         while (reader.hasNext()) {
-            CachedThread cachedThread = readThread(config, reader);
+            CachedThread cachedThread = readThread(reader);
 
             if (cachedThread != null) {
                 threads.add(cachedThread);
@@ -410,13 +411,12 @@ class ErrorReader {
         return new ThreadState(threads.toArray(new CachedThread[0]));
     }
 
-    private static CachedThread readThread(Configuration config,
-                                           JsonReader reader) throws IOException {
+    private static CachedThread readThread(JsonReader reader) throws IOException {
         long id = 0;
         String name = null;
         String type = null;
         boolean errorReportingThread = false;
-        StackTraceElement[] frames = null;
+        List<Map<String, Object>> frames = null;
         reader.beginObject();
         while (reader.hasNext()) {
             switch (reader.nextName()) {
@@ -442,7 +442,7 @@ class ErrorReader {
         }
         reader.endObject();
         if (type != null && frames != null) {
-            return new CachedThread(config, id, name, type, errorReportingThread, frames);
+            return new CachedThread(id, name, type, errorReportingThread, frames);
         } else {
             return null;
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Exceptions.java
@@ -52,6 +52,7 @@ class Exceptions implements JsonStream.Streamable {
 
     void setExceptionType(@NonNull String type) {
         exceptionType = type;
+        exception.setType(exceptionType);
     }
 
     String[] getProjectPackages() {
@@ -60,6 +61,7 @@ class Exceptions implements JsonStream.Streamable {
 
     void setProjectPackages(String[] projectPackages) {
         this.projectPackages = projectPackages;
+        exception.setProjectPackages(projectPackages);
     }
 
     private void exceptionToStream(@NonNull JsonStream writer,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Exceptions.java
@@ -3,11 +3,13 @@ package com.bugsnag.android;
 import androidx.annotation.NonNull;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Unwrap and serialize exception information and any "cause" exceptions.
  */
-class Exceptions implements JsonStream.Streamable {
+class Exceptions implements JsonStream.Streamable { // TODO delete redundant class
     private final BugsnagException exception;
     private String exceptionType;
     private String[] projectPackages;
@@ -20,23 +22,7 @@ class Exceptions implements JsonStream.Streamable {
 
     @Override
     public void toStream(@NonNull JsonStream writer) throws IOException {
-        writer.beginArray();
-
-        // Unwrap any "cause" exceptions
-        Throwable currentEx = exception;
-        while (currentEx != null) {
-            if (currentEx instanceof JsonStream.Streamable) {
-                ((JsonStream.Streamable) currentEx).toStream(writer);
-            } else {
-                String exceptionName = getExceptionName(currentEx);
-                String localizedMessage = currentEx.getLocalizedMessage();
-                StackTraceElement[] stackTrace = currentEx.getStackTrace();
-                exceptionToStream(writer, exceptionName, localizedMessage, stackTrace);
-            }
-            currentEx = currentEx.getCause();
-        }
-
-        writer.endArray();
+        exception.toStream(writer);
     }
 
     BugsnagException getException() {
@@ -57,30 +43,5 @@ class Exceptions implements JsonStream.Streamable {
 
     void setProjectPackages(String[] projectPackages) {
         this.projectPackages = projectPackages;
-    }
-
-    /**
-     * Get the class name from the exception contained in this Error report.
-     */
-    private String getExceptionName(@NonNull Throwable throwable) {
-        if (throwable instanceof BugsnagException) {
-            return ((BugsnagException) throwable).getName();
-        } else {
-            return throwable.getClass().getName();
-        }
-    }
-
-    private void exceptionToStream(@NonNull JsonStream writer,
-                                   String name,
-                                   String message,
-                                   StackTraceElement[] frames) throws IOException {
-        writer.beginObject();
-        writer.name("errorClass").value(name);
-        writer.name("message").value(message);
-        writer.name("type").value(exceptionType);
-
-        Stacktrace stacktrace = new Stacktrace(frames, projectPackages);
-        writer.name("stacktrace").value(stacktrace);
-        writer.endObject();
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Exceptions.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Exceptions.java
@@ -9,7 +9,8 @@ import java.util.Map;
 /**
  * Unwrap and serialize exception information and any "cause" exceptions.
  */
-class Exceptions implements JsonStream.Streamable { // TODO delete redundant class
+class Exceptions implements JsonStream.Streamable {
+
     private final BugsnagException exception;
     private String exceptionType;
     private String[] projectPackages;
@@ -22,6 +23,7 @@ class Exceptions implements JsonStream.Streamable { // TODO delete redundant cla
 
     @Override
     public void toStream(@NonNull JsonStream writer) throws IOException {
+        exception.setProjectPackages(projectPackages);
         exception.toStream(writer);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 public class Notifier implements JsonStream.Streamable {
 
     private static final String NOTIFIER_NAME = "Android Bugsnag Notifier";
-    private static final String NOTIFIER_VERSION = "4.19.0";
+    private static final String NOTIFIER_VERSION = "4.19.1";
     private static final String NOTIFIER_URL = "https://bugsnag.com";
 
     @NonNull

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Report.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Report.java
@@ -28,14 +28,15 @@ public class Report implements JsonStream.Streamable {
     private transient boolean cachingDisabled;
 
     Report(@NonNull String apiKey, @NonNull Error error) {
-        this.error = error;
-        this.errorFile = null;
-        this.notifier = Notifier.getInstance();
-        this.apiKey = apiKey;
+        this(apiKey, null, error);
     }
 
     Report(@NonNull String apiKey, @Nullable File errorFile) {
-        this.error = null;
+        this(apiKey, errorFile, null);
+    }
+
+    private Report(@NonNull String apiKey, @Nullable File errorFile, @Nullable Error error) {
+        this.error = error;
         this.errorFile = errorFile;
         this.notifier = Notifier.getInstance();
         this.apiKey = apiKey;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.java
@@ -26,7 +26,7 @@ class Stacktrace implements JsonStream.Streamable {
     }
 
     Stacktrace(List<Map<String, Object>> frames) {
-        if (frames.size() >= STACKTRACE_TRIM_LENGTH) { // TODO test boundaries
+        if (frames.size() >= STACKTRACE_TRIM_LENGTH) {
             this.trace = frames.subList(0, STACKTRACE_TRIM_LENGTH);
         } else {
             this.trace = frames;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.java
@@ -79,6 +79,7 @@ class Stacktrace implements JsonStream.Streamable {
             }
             return map;
         } catch (Exception lineEx) {
+            Logger.warn("Failed to serialize stacktrace", lineEx);
             return null;
         }
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.java
@@ -1,11 +1,15 @@
 package com.bugsnag.android;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Serialize an exception stacktrace and mark frames as "in-project"
@@ -15,41 +19,68 @@ class Stacktrace implements JsonStream.Streamable {
 
     private static final int STACKTRACE_TRIM_LENGTH = 200;
 
-    private final List<String> projectPackages;
-    final StackTraceElement[] stacktrace;
+    private final List<Map<String, Object>> trace;
 
     Stacktrace(StackTraceElement[] stacktrace, String[] projectPackages) {
-        this.stacktrace = stacktrace;
-        this.projectPackages = sanitiseProjectPackages(projectPackages);
+        this.trace = serializeStacktrace(stacktrace, sanitiseProjectPackages(projectPackages));
+    }
+
+    Stacktrace(List<Map<String, Object>> frames) {
+        if (frames.size() >= STACKTRACE_TRIM_LENGTH) { // TODO test boundaries
+            this.trace = frames.subList(0, STACKTRACE_TRIM_LENGTH);
+        } else {
+            this.trace = frames;
+        }
     }
 
     @Override
     public void toStream(@NonNull JsonStream writer) throws IOException {
         writer.beginArray();
+        for (Map<String, Object> element : trace) {
+            writer.value(element);
+        }
+        writer.endArray();
+    }
 
-        for (int k = 0; k < stacktrace.length && k < STACKTRACE_TRIM_LENGTH; k++) {
-            StackTraceElement el = stacktrace[k];
-            try {
-                writer.beginObject();
-                if (el.getClassName().length() > 0) {
-                    writer.name("method").value(el.getClassName() + "." + el.getMethodName());
-                } else {
-                    writer.name("method").value(el.getMethodName());
-                }
-                writer.name("file").value(el.getFileName() == null ? "Unknown" : el.getFileName());
-                writer.name("lineNumber").value(el.getLineNumber());
+    private List<Map<String, Object>> serializeStacktrace(StackTraceElement[] trace,
+                                                          List<String> projectPackages) {
+        List<Map<String, Object>> list = new ArrayList<>();
 
-                if (inProject(el.getClassName(), projectPackages)) {
-                    writer.name("inProject").value(true);
-                }
+        for (int k = 0; k < trace.length && k < STACKTRACE_TRIM_LENGTH; k++) {
+            StackTraceElement el = trace[k];
+            Map<String, Object> frame = serializeStackframe(el, projectPackages);
 
-                writer.endObject();
-            } catch (Exception lineEx) {
-                Logger.warn("Failed to serialize stacktrace", lineEx);
+            if (frame != null) {
+                list.add(frame);
             }
         }
+        return list;
+    }
 
-        writer.endArray();
+    @Nullable
+    private Map<String, Object> serializeStackframe(StackTraceElement el,
+                                                    List<String> projectPackages) {
+        Map<String, Object> map = new HashMap<>();
+        try {
+            String methodName;
+            if (el.getClassName().length() > 0) {
+                methodName = el.getClassName() + "." + el.getMethodName();
+            } else {
+                methodName =  el.getMethodName();
+            }
+            map.put("method", methodName);
+
+            String filename = el.getFileName() == null ? "Unknown" : el.getFileName();
+            map.put("file", filename);
+            map.put("lineNumber", el.getLineNumber());
+
+            if (inProject(el.getClassName(), projectPackages)) {
+                map.put("inProject", true);
+            }
+            return map;
+        } catch (Exception lineEx) {
+            return null;
+        }
     }
 
     private static List<String> sanitiseProjectPackages(String[] projectPackages) {

--- a/features/before_send.feature
+++ b/features/before_send.feature
@@ -18,7 +18,6 @@ Feature: Run callbacks before reports delivered
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
         And the exception "errorClass" equals "java.lang.RuntimeException"
         And the exception "message" equals "Ruh-roh"
         And the event "context" equals "UNSET"

--- a/features/before_send.feature
+++ b/features/before_send.feature
@@ -5,7 +5,7 @@ Feature: Run callbacks before reports delivered
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGSEGV"
         And the exception "message" equals "Segmentation violation (invalid memory reference)"
         And the event "context" equals "!important"

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/CustomSerializedException.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/CustomSerializedException.java
@@ -1,0 +1,42 @@
+package com.bugsnag.android.mazerunner;
+
+import com.bugsnag.android.JsonStream;
+
+import java.io.IOException;
+
+public class CustomSerializedException extends Throwable implements JsonStream.Streamable {
+
+    @Override
+    public void toStream(JsonStream writer) throws IOException {
+        writer.beginObject();
+        writer.name("errorClass").value("Handled Error!");
+        writer.name("message").value("all work and no play");
+        writer.name("type").value("JS");
+        writer.name("specialField").value("layer cake");
+        writer.name("stacktrace");
+        writer.beginArray();
+
+        // Frame 0
+        writer.beginObject();
+        writer.name("method").value("foo()");
+        writer.name("file").value("src/Giraffe.js");
+        writer.name("lineNumber").value(200);
+        writer.name("extraNumber").value(43);
+        writer.endObject();
+
+        // Frame 1
+        writer.beginObject();
+        writer.name("method").value("bar()");
+        writer.name("file").value("parser.js");
+        writer.name("someAddress").value("0xea14616b0");
+        writer.endObject();
+
+        // Frame 2
+        writer.beginObject();
+        writer.name("someAddress").value("0x000000000");
+        writer.endObject();
+
+        writer.endArray();
+        writer.endObject();
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CachedHandledInternalNotifyScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CachedHandledInternalNotifyScenario.java
@@ -1,0 +1,42 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.app.Activity;
+import android.content.Context;
+
+import com.bugsnag.android.mazerunner.CustomSerializedException;
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import androidx.annotation.NonNull;
+
+import java.util.HashMap;
+
+public class CachedHandledInternalNotifyScenario extends Scenario {
+
+    private boolean shouldTestOfflineCaching = false;
+
+    public CachedHandledInternalNotifyScenario(@NonNull Configuration config, 
+                                               @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        Activity activity = (Activity)context;
+        String state = activity.getIntent().getStringExtra("EVENT_METADATA");
+        shouldTestOfflineCaching = state != null && state.equals("offline");
+        if (shouldTestOfflineCaching) {
+            disableAllDelivery(config);
+        }
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        if (shouldTestOfflineCaching) {
+            Bugsnag.internalClientNotify(new CustomSerializedException(),
+                    new HashMap<String, Object>() {{
+                        put("severity", "warning");
+                        put("severityReason", "handledException");
+                    }}, false, null);
+        }
+    }
+}
+

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
@@ -6,13 +6,15 @@ import com.bugsnag.android.Configuration
 import java.io.File
 
 /**
- * Verifies that if a report is empty, minimal information is still sent to bugsnag.
+ * Verifies that if a report is empty and a beforeSend callback is set,
+ * minimal information is still sent to bugsnag.
  */
 internal class EmptyReportScenario(config: Configuration,
                                    context: Context) : Scenario(config, context) {
 
     init {
         config.setAutoCaptureSessions(false)
+        config.beforeSend { true }
         val files = File(context.cacheDir, "bugsnag-errors").listFiles()
         files.forEach { it.writeText("") }
     }

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledInternalNotifyScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledInternalNotifyScenario.java
@@ -1,0 +1,30 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import com.bugsnag.android.mazerunner.CustomSerializedException;
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import androidx.annotation.NonNull;
+
+import java.util.HashMap;
+
+public class HandledInternalNotifyScenario extends Scenario {
+
+    public HandledInternalNotifyScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        Bugsnag.internalClientNotify(new CustomSerializedException(),
+                new HashMap<String, Object>() {{
+                    put("severity", "warning");
+                    put("severityReason", "handledException");
+                }}, false, null);
+    }
+}
+

--- a/features/internal_client.feature
+++ b/features/internal_client.feature
@@ -1,0 +1,55 @@
+Feature: Communicating events between notifiers
+
+    Other Bugsnag libraries include bugsnag-android as a dependency for
+    capturing native Java and C/C++ crashes, but may have additional events to
+    report, both handled and unhandled. These events should be reported
+    correctly when using bugsnag-android as the delivery layer.
+
+    Scenario: Report a handled event through internalNotify()
+        When I run "HandledInternalNotifyScenario"
+        Then I should receive a request
+        And the request is valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the event "unhandled" is false
+        And the exception "errorClass" equals "Handled Error!"
+        And the exception "message" equals "all work and no play"
+        And the exception "type" equals "JS"
+        And the exception "specialField" equals "layer cake"
+        And the "method" of stack frame 0 equals "foo()"
+        And the "file" of stack frame 0 equals "src/Giraffe.js"
+        And the "lineNumber" of stack frame 0 equals 200
+        And the "extraNumber" of stack frame 0 equals 43
+        And the "method" of stack frame 1 equals "bar()"
+        And the "file" of stack frame 1 equals "parser.js"
+        And the "someAddress" of stack frame 1 equals "0xea14616b0"
+        And the "lineNumber" of stack frame 1 is null
+        And the "method" of stack frame 2 is null
+        And the "file" of stack frame 2 is null
+        And the "lineNumber" of stack frame 2 is null
+        And the "someAddress" of stack frame 2 equals "0x000000000"
+
+    Scenario: Report a handled event through internalNotify() while offline
+        When I configure the app to run in the "offline" state
+        And I run "CachedHandledInternalNotifyScenario"
+        And I configure the app to run in the "online" state
+        And I relaunch the app
+        Then I should receive a request
+        And the request is valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+        And the event "unhandled" is false
+        And the exception "errorClass" equals "Handled Error!"
+        And the exception "message" equals "all work and no play"
+        And the exception "type" equals "JS"
+        And the exception "specialField" equals "layer cake"
+        And the "method" of stack frame 0 equals "foo()"
+        And the "file" of stack frame 0 equals "src/Giraffe.js"
+        And the "lineNumber" of stack frame 0 equals 200
+        And the "extraNumber" of stack frame 0 equals 43
+        And the "method" of stack frame 1 equals "bar()"
+        And the "file" of stack frame 1 equals "parser.js"
+        And the "someAddress" of stack frame 1 equals "0xea14616b0"
+        And the "lineNumber" of stack frame 1 is null
+        And the "method" of stack frame 2 is null
+        And the "file" of stack frame 2 is null
+        And the "lineNumber" of stack frame 2 is null
+        And the "someAddress" of stack frame 2 equals "0x000000000"

--- a/features/native_api.feature
+++ b/features/native_api.feature
@@ -4,7 +4,7 @@ Feature: Native API
         When I run "CXXUserInfoScenario"
         And I wait a bit
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "Connection lost"
         And the exception "message" equals "No antenna detected"
         And the event "severity" equals "info"
@@ -20,7 +20,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "SIGILL"
         And the event "severity" equals "error"
         And the event "user.name" equals "Strulyegha  Ghaumon  Rabelban  Snefkal  Angengtai  Samperris  D"
@@ -32,7 +32,7 @@ Feature: Native API
         When I run "CXXNotifyScenario"
         And I wait a bit
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the event "severity" equals "error"
         And the event "context" equals "MainActivity"
         And the exception "errorClass" equals "Vitamin C deficiency"
@@ -43,7 +43,7 @@ Feature: Native API
         When I run "CXXAutoContextScenario"
         And I wait a bit
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the event "severity" equals "info"
         And the event "context" equals "SecondActivity"
         And the exception "errorClass" equals "Hello hello"
@@ -56,7 +56,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the event "severity" equals "error"
         And the event "context" equals "Everest"
         And the exception "errorClass" equals "SIGILL"
@@ -66,7 +66,7 @@ Feature: Native API
         When I run "CXXBreadcrumbScenario"
         And I wait a bit
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the event "severity" equals "info"
         And the exception "errorClass" equals "Bean temperature loss"
         And the exception "message" equals "100% more microwave required"
@@ -78,7 +78,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the event has a "request" breadcrumb named "Substandard nacho error"
         And the exception "errorClass" equals "SIGILL"
         And the event "severity" equals "error"
@@ -91,7 +91,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive 4 requests
-        And the payload in request 3 contains a completed native report
+        And the payload in request 3 contains a completed handled native report
         And the event in request 3 contains session info
         And the payload field "events.0.session.events.unhandled" equals 1 for request 3
         And the payload field "events.0.session.events.handled" equals 2 for request 3
@@ -101,7 +101,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "SIGILL"
         And the event "severity" equals "error"
         And the event has a "log" breadcrumb named "Warm beer detected"
@@ -112,7 +112,7 @@ Feature: Native API
         When I run "CXXJavaBreadcrumbNativeNotifyScenario"
         And I wait a bit
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "Failed instantiation"
         And the exception "message" equals "Could not allocate"
         And the event "severity" equals "error"
@@ -125,7 +125,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "SIGILL"
         And the event "severity" equals "error"
         And the event has a "manual" breadcrumb with message "Bridge connector activated"
@@ -136,7 +136,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "java.lang.ArrayIndexOutOfBoundsException"
         And the exception "message" equals "length=2; index=2"
         And the event has a "log" breadcrumb named "Lack of cheese detected"
@@ -147,7 +147,7 @@ Feature: Native API
         When I run "CXXNativeBreadcrumbJavaNotifyScenario"
         And I wait a bit
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "java.lang.Exception"
         And the exception "message" equals "Did not like"
         And the event "severity" equals "warning"
@@ -159,7 +159,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "SIGILL"
         And the event "app.version" equals "22.312.749.78.300.810.24.167.32"
         And the event "context" equals "ObservableSessionInitializerStringParserStringSessionProxyGloba"
@@ -169,7 +169,7 @@ Feature: Native API
         When I run "CXXCustomMetadataNativeNotifyScenario"
         And I wait a bit
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "Twitter Overdose"
         And the exception "message" equals "Turn off the internet and go outside"
         And the event "severity" equals "info"
@@ -183,7 +183,7 @@ Feature: Native API
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "SIGILL"
         And the event "severity" equals "error"
         And the event "metaData.Riker Ipsum.examples" equals "I'll be sure to note that in my log. You enjoyed that. They wer"

--- a/features/native_crash_handling.feature
+++ b/features/native_crash_handling.feature
@@ -5,7 +5,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGILL"
         And the exception "message" equals "Illegal instruction"
         And the exception "type" equals "c"
@@ -30,7 +30,7 @@ Feature: Native crash reporting
         And I relaunch the app
         And I wait a bit
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception reflects a signal was raised
         And the exception "type" equals "c"
         And the event "severity" equals "error"
@@ -41,7 +41,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGILL"
         And the exception "message" equals "Illegal instruction"
         And the exception "type" equals "c"
@@ -86,7 +86,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGFPE"
         And the exception "message" equals "Floating-point exception"
         And the exception "type" equals "c"
@@ -98,7 +98,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals one of:
             | SIGABRT |
             | SIGSEGV |
@@ -114,7 +114,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGILL"
         And the exception "message" equals "Illegal instruction"
         And the exception "type" equals "c"
@@ -126,7 +126,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGSEGV"
         And the exception "message" equals "Segmentation violation (invalid memory reference)"
         And the exception "type" equals "c"
@@ -138,7 +138,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGABRT"
         And the exception "message" equals "Abort program"
         And the exception "type" equals "c"
@@ -150,7 +150,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGBUS"
         And the exception "message" equals "Bus error (bad memory access)"
         And the exception "type" equals "c"
@@ -162,7 +162,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGFPE"
         And the exception "message" equals "Floating-point exception"
         And the exception "type" equals "c"
@@ -174,7 +174,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGTRAP"
         And the exception "message" equals "Trace/breakpoint trap"
         And the exception "type" equals "c"
@@ -197,7 +197,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the exception "errorClass" equals one of:
@@ -216,7 +216,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the exception "errorClass" equals "PSt13runtime_error"
@@ -231,7 +231,7 @@ Feature: Native crash reporting
         And I configure the app to run in the "non-crashy" state
         And I relaunch the app
         Then I should receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the exception "errorClass" equals "i"

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -12,7 +12,7 @@ Scenario: Runtime versions included in NDK error
     And I configure the app to run in the "non-crashy" state
     And I relaunch the app
     Then I should receive a request
-    And the request payload contains a completed native report
+    And the request payload contains a completed unhandled native report
     And the payload field "events.0.device.runtimeVersions.androidApiLevel" is not null
     And the payload field "events.0.device.runtimeVersions.osBuild" is not null
 

--- a/features/steps/build_steps.rb
+++ b/features/steps/build_steps.rb
@@ -181,6 +181,9 @@ Then("the stacktrace in request {int} contains native frame information") do |re
   stack.each_with_index do |frame, index|
     assert_not_nil(frame['method'], "The method of frame #{index} is nil")
     assert_not_nil(frame['lineNumber'], "The lineNumber of frame #{index} is nil")
+    assert_not_nil(frame['symbolAddress'], "The symbolAddress of frame #{index} is nil")
+    assert_not_nil(frame['frameAddress'], "The frameAddress of frame #{index} is nil")
+    assert_not_nil(frame['loadAddress'], "The loadAddress of frame #{index} is nil")
   end
 end
 

--- a/features/steps/build_steps.rb
+++ b/features/steps/build_steps.rb
@@ -155,15 +155,31 @@ Then("the report contains the required fields") do
   step("the report in request 0 contains the required fields")
 end
 
-Then("the request payload contains a completed native report") do
-  step("the payload in request 0 contains a completed native report")
+Then("the request payload contains a completed handled native report") do
+  step("the payload in request 0 contains a completed handled native report")
 end
 
-Then("the payload in request {int} contains a completed native report") do |index|
+Then("the request payload contains a completed unhandled native report") do
+  step("the payload in request 0 contains a completed unhandled native report")
+end
+
+Then("the payload in request {int} contains a completed handled native report") do |index|
   steps %Q{
     And the report in request #{index} contains the required fields
     And the stacktrace in request #{index} contains native frame information
   }
+end
+
+Then("the payload in request {int} contains a completed unhandled native report") do |request_index|
+  steps %Q{
+    And the payload in request #{request_index} contains a completed handled native report
+  }
+  stack = read_key_path(find_request(request_index)[:body], "events.0.exceptions.0.stacktrace")
+    stack.each_with_index do |frame, index|
+      assert_not_nil(frame['symbolAddress'], "The symbolAddress of frame #{index} is nil")
+      assert_not_nil(frame['frameAddress'], "The frameAddress of frame #{index} is nil")
+      assert_not_nil(frame['loadAddress'], "The loadAddress of frame #{index} is nil")
+    end
 end
 
 Then("the event in request {int} contains session info") do |index|
@@ -181,9 +197,6 @@ Then("the stacktrace in request {int} contains native frame information") do |re
   stack.each_with_index do |frame, index|
     assert_not_nil(frame['method'], "The method of frame #{index} is nil")
     assert_not_nil(frame['lineNumber'], "The lineNumber of frame #{index} is nil")
-    assert_not_nil(frame['symbolAddress'], "The symbolAddress of frame #{index} is nil")
-    assert_not_nil(frame['frameAddress'], "The frameAddress of frame #{index} is nil")
-    assert_not_nil(frame['loadAddress'], "The loadAddress of frame #{index} is nil")
   end
 end
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=4.19.0
+VERSION_NAME=4.19.1
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git

--- a/tests/features/before_send.feature
+++ b/tests/features/before_send.feature
@@ -4,7 +4,7 @@ Feature: Run callbacks before reports delivered
         When I run "NativeBeforeSendScenario" and relaunch the app
         And I configure Bugsnag for "NativeBeforeSendScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGSEGV"
         And the exception "message" equals "Segmentation violation (invalid memory reference)"
         And the event "context" equals "!important"

--- a/tests/features/before_send.feature
+++ b/tests/features/before_send.feature
@@ -16,7 +16,6 @@ Feature: Run callbacks before reports delivered
         When I run "BeforeSendScenario" and relaunch the app
         And I configure Bugsnag for "BeforeSendScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
         And the exception "errorClass" equals "java.lang.RuntimeException"
         And the exception "message" equals "Ruh-roh"
         And the event "context" equals "UNSET"

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/CustomSerializedException.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/CustomSerializedException.java
@@ -1,0 +1,42 @@
+package com.bugsnag.android.mazerunner;
+
+import com.bugsnag.android.JsonStream;
+
+import java.io.IOException;
+
+public class CustomSerializedException extends Throwable implements JsonStream.Streamable {
+
+    @Override
+    public void toStream(JsonStream writer) throws IOException {
+        writer.beginObject();
+        writer.name("errorClass").value("Handled Error!");
+        writer.name("message").value("all work and no play");
+        writer.name("type").value("JS");
+        writer.name("specialField").value("layer cake");
+        writer.name("stacktrace");
+        writer.beginArray();
+
+        // Frame 0
+        writer.beginObject();
+        writer.name("method").value("foo()");
+        writer.name("file").value("src/Giraffe.js");
+        writer.name("lineNumber").value(200);
+        writer.name("extraNumber").value(43);
+        writer.endObject();
+
+        // Frame 1
+        writer.beginObject();
+        writer.name("method").value("bar()");
+        writer.name("file").value("parser.js");
+        writer.name("someAddress").value("0xea14616b0");
+        writer.endObject();
+
+        // Frame 2
+        writer.beginObject();
+        writer.name("someAddress").value("0x000000000");
+        writer.endObject();
+
+        writer.endArray();
+        writer.endObject();
+    }
+}

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CachedHandledInternalNotifyScenario.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CachedHandledInternalNotifyScenario.java
@@ -1,0 +1,42 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.app.Activity;
+import android.content.Context;
+
+import com.bugsnag.android.mazerunner.CustomSerializedException;
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import androidx.annotation.NonNull;
+
+import java.util.HashMap;
+
+public class CachedHandledInternalNotifyScenario extends Scenario {
+
+    private boolean shouldTestOfflineCaching = false;
+
+    public CachedHandledInternalNotifyScenario(@NonNull Configuration config, 
+                                               @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+        Activity activity = (Activity)context;
+        String state = activity.getIntent().getStringExtra("eventMetaData");
+        shouldTestOfflineCaching = state != null && state.equals("offline");
+        if (shouldTestOfflineCaching) {
+            disableAllDelivery(config);
+        }
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        if (shouldTestOfflineCaching) {
+            Bugsnag.internalClientNotify(new CustomSerializedException(),
+                    new HashMap<String, Object>() {{
+                        put("severity", "warning");
+                        put("severityReason", "handledException");
+                    }}, false, null);
+        }
+    }
+}
+

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
@@ -6,13 +6,15 @@ import com.bugsnag.android.Configuration
 import java.io.File
 
 /**
- * Verifies that if a report is empty, minimal information is still sent to bugsnag.
+ * Verifies that if a report is empty and a beforeSend callback is set,
+ * minimal information is still sent to bugsnag.
  */
 internal class EmptyReportScenario(config: Configuration,
                                    context: Context) : Scenario(config, context) {
 
     init {
         config.setAutoCaptureSessions(false)
+        config.beforeSend { true }
         val files = File(context.cacheDir, "bugsnag-errors").listFiles()
         files.forEach { it.writeText("") }
     }

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledInternalNotifyScenario.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledInternalNotifyScenario.java
@@ -1,0 +1,30 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import com.bugsnag.android.mazerunner.CustomSerializedException;
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import androidx.annotation.NonNull;
+
+import java.util.HashMap;
+
+public class HandledInternalNotifyScenario extends Scenario {
+
+    public HandledInternalNotifyScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoCaptureSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        Bugsnag.internalClientNotify(new CustomSerializedException(),
+                new HashMap<String, Object>() {{
+                    put("severity", "warning");
+                    put("severityReason", "handledException");
+                }}, false, null);
+    }
+}
+

--- a/tests/features/internal_client.feature
+++ b/tests/features/internal_client.feature
@@ -29,9 +29,9 @@ Feature: Communicating events between notifiers
 
     Scenario: Report a handled event through internalNotify() while offline
         When I configure the app to run in the "offline" state
-        And I run "CachedHandledInternalNotifyScenario"
+        And I run "CachedHandledInternalNotifyScenario" and relaunch the app
         And I configure the app to run in the "online" state
-        And I relaunch the app
+        And I run "CachedHandledInternalNotifyScenario"
         And I wait to receive a request
         And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
         And the event "unhandled" is false

--- a/tests/features/internal_client.feature
+++ b/tests/features/internal_client.feature
@@ -1,0 +1,53 @@
+Feature: Communicating events between notifiers
+
+    Other Bugsnag libraries include bugsnag-android as a dependency for
+    capturing native Java and C/C++ crashes, but may have additional events to
+    report, both handled and unhandled. These events should be reported
+    correctly when using bugsnag-android as the delivery layer.
+
+    Scenario: Report a handled event through internalNotify()
+        When I run "HandledInternalNotifyScenario"
+        Then I wait to receive a request
+        And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+        And the event "unhandled" is false
+        And the exception "errorClass" equals "Handled Error!"
+        And the exception "message" equals "all work and no play"
+        And the exception "type" equals "JS"
+        And the exception "specialField" equals "layer cake"
+        And the "method" of stack frame 0 equals "foo()"
+        And the "file" of stack frame 0 equals "src/Giraffe.js"
+        And the "lineNumber" of stack frame 0 equals 200
+        And the "extraNumber" of stack frame 0 equals 43
+        And the "method" of stack frame 1 equals "bar()"
+        And the "file" of stack frame 1 equals "parser.js"
+        And the "someAddress" of stack frame 1 equals "0xea14616b0"
+        And the "lineNumber" of stack frame 1 is null
+        And the "method" of stack frame 2 is null
+        And the "file" of stack frame 2 is null
+        And the "lineNumber" of stack frame 2 is null
+        And the "someAddress" of stack frame 2 equals "0x000000000"
+
+    Scenario: Report a handled event through internalNotify() while offline
+        When I configure the app to run in the "offline" state
+        And I run "CachedHandledInternalNotifyScenario"
+        And I configure the app to run in the "online" state
+        And I relaunch the app
+        And I wait to receive a request
+        And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+        And the event "unhandled" is false
+        And the exception "errorClass" equals "Handled Error!"
+        And the exception "message" equals "all work and no play"
+        And the exception "type" equals "JS"
+        And the exception "specialField" equals "layer cake"
+        And the "method" of stack frame 0 equals "foo()"
+        And the "file" of stack frame 0 equals "src/Giraffe.js"
+        And the "lineNumber" of stack frame 0 equals 200
+        And the "extraNumber" of stack frame 0 equals 43
+        And the "method" of stack frame 1 equals "bar()"
+        And the "file" of stack frame 1 equals "parser.js"
+        And the "someAddress" of stack frame 1 equals "0xea14616b0"
+        And the "lineNumber" of stack frame 1 is null
+        And the "method" of stack frame 2 is null
+        And the "file" of stack frame 2 is null
+        And the "lineNumber" of stack frame 2 is null
+        And the "someAddress" of stack frame 2 equals "0x000000000"

--- a/tests/features/native_api.feature
+++ b/tests/features/native_api.feature
@@ -3,7 +3,7 @@ Feature: Native API
     Scenario: Adding user information in C followed by notifying in C
         When I run "CXXUserInfoScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the exception "errorClass" equals "Connection lost"
         And the exception "message" equals "No antenna detected"
         And the event "severity" equals "info"
@@ -18,7 +18,7 @@ Feature: Native API
         And I run "CXXJavaUserInfoNativeCrashScenario" and relaunch the app
         And I configure Bugsnag for "CXXJavaUserInfoNativeCrashScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the exception "errorClass" equals one of:
           | SIGILL |
           | SIGTRAP |
@@ -31,7 +31,7 @@ Feature: Native API
     Scenario: Notifying in C
         When I run "CXXNotifyScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event "severity" equals "error"
         And the exception "errorClass" equals "Vitamin C deficiency"
         And the exception "message" equals "9 out of 10 adults do not get their 5-a-day"
@@ -40,7 +40,7 @@ Feature: Native API
     Scenario: Changing intents followed by notifying in C
         When I run "CXXAutoContextScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event "severity" equals "info"
         And the event "context" equals "SecondActivity"
         And the exception "errorClass" equals "Hello hello"
@@ -51,7 +51,7 @@ Feature: Native API
         When I run "CXXUpdateContextCrashScenario" and relaunch the app
         And I configure Bugsnag for "CXXUpdateContextCrashScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event "severity" equals "error"
         And the event "context" equals "Everest"
         And the exception "errorClass" equals one of:
@@ -62,7 +62,7 @@ Feature: Native API
     Scenario: Leaving a breadcrumb followed by notifying in C
         When I run "CXXBreadcrumbScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event "severity" equals "info"
         And the exception "errorClass" equals "Bean temperature loss"
         And the exception "message" equals "100% more microwave required"
@@ -73,7 +73,7 @@ Feature: Native API
         When I run "CXXNativeBreadcrumbNativeCrashScenario" and relaunch the app
         And I configure Bugsnag for "CXXNativeBreadcrumbNativeCrashScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event has a "request" breadcrumb named "Substandard nacho error"
         And the exception "errorClass" equals one of:
           | SIGILL |
@@ -88,7 +88,7 @@ Feature: Native API
         And I discard the oldest request
         And I discard the oldest request
         And I discard the oldest request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event contains session info
         And the payload field "events.0.session.events.unhandled" equals 1
         And the payload field "events.0.session.events.handled" equals 2
@@ -97,7 +97,7 @@ Feature: Native API
         When I run "CXXJavaBreadcrumbNativeBreadcrumbScenario" and relaunch the app
         And I configure Bugsnag for "CXXJavaBreadcrumbNativeBreadcrumbScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals one of:
           | SIGILL |
           | SIGTRAP |
@@ -109,7 +109,7 @@ Feature: Native API
     Scenario: Leaving breadcrumbs in Java and followed by notifying in C
         When I run "CXXJavaBreadcrumbNativeNotifyScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "Failed instantiation"
         And the exception "message" equals "Could not allocate"
         And the event "severity" equals "error"
@@ -121,7 +121,7 @@ Feature: Native API
         When I run "CXXJavaBreadcrumbNativeCrashScenario" and relaunch the app
         And I configure Bugsnag for "CXXJavaBreadcrumbNativeCrashScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals one of:
           | SIGILL |
           | SIGTRAP |
@@ -133,7 +133,7 @@ Feature: Native API
         When I run "CXXNativeBreadcrumbJavaCrashScenario" and relaunch the app
         And I configure Bugsnag for "CXXNativeBreadcrumbJavaCrashScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "java.lang.ArrayIndexOutOfBoundsException"
         And the exception "message" equals "length=2; index=2"
         And the event has a "log" breadcrumb named "Lack of cheese detected"
@@ -143,7 +143,7 @@ Feature: Native API
     Scenario: Leaving breadcrumbs in C followed by notifying in Java
         When I run "CXXNativeBreadcrumbJavaNotifyScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "java.lang.Exception"
         And the exception "message" equals "Did not like"
         And the event "severity" equals "warning"
@@ -154,7 +154,7 @@ Feature: Native API
         When I run "CXXExtraordinaryLongStringScenario" and relaunch the app
         And I configure Bugsnag for "CXXExtraordinaryLongStringScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals one of:
           | SIGILL |
           | SIGTRAP |
@@ -165,7 +165,7 @@ Feature: Native API
     Scenario: Add custom metadata followed by notifying in C
         When I run "CXXCustomMetadataNativeNotifyScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals "Twitter Overdose"
         And the exception "message" equals "Turn off the internet and go outside"
         And the event "severity" equals "info"
@@ -178,7 +178,7 @@ Feature: Native API
         When I run "CXXCustomMetadataNativeCrashScenario" and relaunch the app
         And I configure Bugsnag for "CXXCustomMetadataNativeCrashScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed handled native report
         And the exception "errorClass" equals one of:
           | SIGILL |
           | SIGTRAP |

--- a/tests/features/native_crash_handling.feature
+++ b/tests/features/native_crash_handling.feature
@@ -4,7 +4,7 @@ Feature: Native crash reporting
         When I run "CXXNullPointerScenario" and relaunch the app
         And I configure Bugsnag for "CXXNullPointerScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals one of:
           | SIGILL |
           | SIGTRAP |
@@ -30,7 +30,7 @@ Feature: Native crash reporting
         When I run "CXXStackoverflowScenario" and relaunch the app
         And I configure Bugsnag for "CXXStackoverflowScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception reflects a signal was raised
         And the exception "type" equals "c"
         And the event "severity" equals "error"
@@ -40,7 +40,7 @@ Feature: Native crash reporting
         When I run "CXXTrapScenario" and relaunch the app
         And I configure Bugsnag for "CXXTrapScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals one of:
           | SIGILL |
           | SIGTRAP |
@@ -85,7 +85,7 @@ Feature: Native crash reporting
         When I run "CXXAbortScenario" and relaunch the app
         And I configure Bugsnag for "CXXAbortScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals one of:
             | SIGABRT |
             | SIGSEGV |
@@ -100,7 +100,7 @@ Feature: Native crash reporting
         When I run "CXXSigillScenario" and relaunch the app
         And I configure Bugsnag for "CXXSigillScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGILL"
         And the exception "message" equals one of:
             | Illegal instruction   |
@@ -113,7 +113,7 @@ Feature: Native crash reporting
         When I run "CXXSigsegvScenario" and relaunch the app
         And I configure Bugsnag for "CXXSigsegvScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGSEGV"
         And the exception "message" equals "Segmentation violation (invalid memory reference)"
         And the exception "type" equals "c"
@@ -124,7 +124,7 @@ Feature: Native crash reporting
         When I run "CXXSigabrtScenario" and relaunch the app
         And I configure Bugsnag for "CXXSigabrtScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGABRT"
         And the exception "message" equals "Abort program"
         And the exception "type" equals "c"
@@ -135,7 +135,7 @@ Feature: Native crash reporting
         When I run "CXXSigbusScenario" and relaunch the app
         And I configure Bugsnag for "CXXSigbusScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGBUS"
         And the exception "message" equals "Bus error (bad memory access)"
         And the exception "type" equals "c"
@@ -146,7 +146,7 @@ Feature: Native crash reporting
         When I run "CXXSigfpeScenario" and relaunch the app
         And I configure Bugsnag for "CXXSigfpeScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGFPE"
         And the exception "message" equals "Floating-point exception"
         And the exception "type" equals "c"
@@ -157,7 +157,7 @@ Feature: Native crash reporting
         When I run "CXXSigtrapScenario" and relaunch the app
         And I configure Bugsnag for "CXXSigtrapScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGTRAP"
         And the exception "message" equals "Trace/breakpoint trap"
         And the exception "type" equals "c"
@@ -178,7 +178,7 @@ Feature: Native crash reporting
         When I run "CXXExternalStackElementScenario" and relaunch the app
         And I configure Bugsnag for "CXXExternalStackElementScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the exception "errorClass" equals one of:
@@ -196,7 +196,7 @@ Feature: Native crash reporting
         When I run "CXXExceptionScenario" and relaunch the app
         And I configure Bugsnag for "CXXExceptionScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the exception "errorClass" equals "PSt13runtime_error"
@@ -210,7 +210,7 @@ Feature: Native crash reporting
         When I run "CXXThrowSomethingScenario" and relaunch the app
         And I configure Bugsnag for "CXXThrowSomethingScenario"
         And I wait to receive a request
-        And the request payload contains a completed native report
+        And the request payload contains a completed unhandled native report
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the exception "errorClass" equals "i"

--- a/tests/features/native_event_tracking.feature
+++ b/tests/features/native_event_tracking.feature
@@ -3,7 +3,7 @@ Feature: Synchronizing app/device metadata in the native layer
     Scenario: Capture foreground state while in the foreground
         When I run "CXXDelayedNotifyScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event "app.inForeground" is true
         And the event "app.duration" is greater than 0
         And the event "unhandled" is false
@@ -12,7 +12,7 @@ Feature: Synchronizing app/device metadata in the native layer
         When I run "CXXDelayedNotifyScenario"
         And I send the app to the background for 10 seconds
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event "app.inForeground" is false
         And the event "app.durationInForeground" equals 0
         And the event "app.duration" is greater than 0
@@ -23,7 +23,7 @@ Feature: Synchronizing app/device metadata in the native layer
         When I run "CXXTrapScenario" and relaunch the app
         And I configure Bugsnag for "CXXStartSessionScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event "app.inForeground" is true
         And the event "app.durationInForeground" is not null
         And the event "app.duration" is not null
@@ -36,7 +36,7 @@ Feature: Synchronizing app/device metadata in the native layer
         And I relaunch the app
         And I configure Bugsnag for "CXXDelayedCrashScenario"
         And I wait to receive a request
-        Then the request payload contains a completed native report
+        Then the request payload contains a completed handled native report
         And the event "app.inForeground" is false
         And the event "app.duration" is greater than 0
         And the event "context" string is empty

--- a/tests/features/runtime_versions.feature
+++ b/tests/features/runtime_versions.feature
@@ -12,7 +12,7 @@ Scenario: Runtime versions included in NDK error
     And I run "CXXNullPointerScenario" and relaunch the app
     And I configure Bugsnag for "CXXNullPointerScenario"
     Then I wait to receive a request
-    And the request payload contains a completed native report
+    And the request payload contains a completed unhandled native report
     And the payload field "events.0.device.runtimeVersions.androidApiLevel" is not null
     And the payload field "events.0.device.runtimeVersions.osBuild" is not null
 

--- a/tests/features/steps/android_steps.rb
+++ b/tests/features/steps/android_steps.rb
@@ -160,5 +160,8 @@ Then("the stacktrace contains native frame information") do
   stack.each_with_index do |frame, index|
     assert_not_nil(frame['method'], "The method of frame #{index} is nil")
     assert_not_nil(frame['lineNumber'], "The lineNumber of frame #{index} is nil")
+    assert_not_nil(frame['symbolAddress'], "The symbolAddress of frame #{index} is nil")
+    assert_not_nil(frame['frameAddress'], "The frameAddress of frame #{index} is nil")
+    assert_not_nil(frame['loadAddress'], "The loadAddress of frame #{index} is nil")
   end
 end

--- a/tests/features/steps/android_steps.rb
+++ b/tests/features/steps/android_steps.rb
@@ -138,11 +138,24 @@ Then("the report contains the required fields") do
   }
 end
 
-Then("the request payload contains a completed native report") do
+Then("the request payload contains a completed handled native report") do
   steps %Q{
-    And the report contains the required fields
-    And the stacktrace contains native frame information
+      And the report contains the required fields
+      And the stacktrace contains native frame information
   }
+end
+
+Then("the request payload contains a completed unhandled native report") do
+  steps %Q{
+      And the report contains the required fields
+      And the stacktrace contains native frame information
+  }
+  stack = read_key_path(Server.current_request[:body], "events.0.exceptions.0.stacktrace")
+    stack.each_with_index do |frame, index|
+      assert_not_nil(frame['symbolAddress'], "The symbolAddress of frame #{index} is nil")
+      assert_not_nil(frame['frameAddress'], "The frameAddress of frame #{index} is nil")
+      assert_not_nil(frame['loadAddress'], "The loadAddress of frame #{index} is nil")
+    end
 end
 
 Then("the event contains session info") do
@@ -160,8 +173,5 @@ Then("the stacktrace contains native frame information") do
   stack.each_with_index do |frame, index|
     assert_not_nil(frame['method'], "The method of frame #{index} is nil")
     assert_not_nil(frame['lineNumber'], "The lineNumber of frame #{index} is nil")
-    assert_not_nil(frame['symbolAddress'], "The symbolAddress of frame #{index} is nil")
-    assert_not_nil(frame['frameAddress'], "The frameAddress of frame #{index} is nil")
-    assert_not_nil(frame['loadAddress'], "The loadAddress of frame #{index} is nil")
   end
 end


### PR DESCRIPTION
## Goal

This changeset fixes the deserialization of custom fields in a stackframe by `ErrorReader`, when an error report has been cached on disk. This caused several issues:

- Prevented delivery of JS exceptions in React Native where the method was null for some stackframes
- Missing `columnNumber` in React Native JS exceptions, reducing the available information for source mapping
- Missing `loadAddress`, `frameAddress`, and `symbolAddress` fields for NDK errors
- Stacktrace length was not trimmed for JS/NDK exceptions at the JVM deserialisation layer, meaning this could cause recursive stacktraces to be dropped by our API

## Changeset

If no `beforeSend` callback has been specified, skip deserialization of the error report and stream the file directly, to reduce unnecessary work and mitigate the impact of any other deserialisation bugs.

Generally speaking, the serialization has been changed to allow an arbitrary `List<Map<String, Object>>`, which contains the full stacktrace. Broken down across classes, this has had the following effects:

`CachedThread`:
- Instantiates a `Stacktrace` object eagerly in the constructor, rather than in the stream method
- Adds a secondary constructor which takes an arbitrary list of stackframes.

`ErrorReader`:
- Deserializes stackframes as a `List<Map>` rather than mapping data into a `StackTraceElement`. 

`Exceptions`:
- The `toStream` method now delegates to the `BugsnagException` class. The pre-existing implementation has been split across `BugsnagException` and `Stacktrace` respectively.

`Stacktrace`:
- Trim stacktrace length in the constructor rather than in the `toStream` method
- Add secondary constructor which provides a `List<Map>` for arbitrary stackframes
- Convert `StackTraceElement` to `List<Map>` by adapting the existing serialization code

`BugsnagException`:
- Implement `Streamable`. If the wrapped exception is of type `Streamable`, delegate the streaming to it
- Add a constructor which accepts `List<Map>` for serializing stackframes
- If a `List<Map>` has been supplied, construct the `Stacktrace` using that, rather than the throwable's stacktrace.

## Tests
- Added mazerunner scenarios with custom streamable exceptions
- Added and updated existing unit test coverage