### PR TITLE
Use apt to download maven rather than curl

### DIFF
--- a/dockerfiles/Dockerfile.android-builder
+++ b/dockerfiles/Dockerfile.android-builder
@@ -34,11 +34,7 @@ RUN ./gradlew
 
 # Everything above this point should be derived from android-base
 
-RUN curl http://apache.mirror.anlx.net/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz > apache-maven-3.6.1.tar.gz
-
-RUN tar -xzvf apache-maven-3.6.1.tar.gz
-
-ENV PATH="${PATH}:/app/apache-maven-3.6.1/bin"
+RUN apt-get install maven
 
 # Setup signing
 RUN apt-get install -y gnupg1


### PR DESCRIPTION
Uses `apt` to install maven rather than curling the download page, which no longer resolves to a valid archive.