### PR TITLE
fix(native): Add interface for clearing a tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.15.x
 
+* Fix crash when calling `NativeInterface.clearTab()` (from an integration
+  library)
+  [#582](https://github.com/bugsnag/bugsnag-android/pull/582)
 * Fix abort() in native code when storing breadcrumbs with null values in
   metadata
   [#510](https://github.com/bugsnag/bugsnag-android/pull/510)

--- a/sdk/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
+++ b/sdk/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
@@ -1,8 +1,11 @@
 package com.bugsnag.android;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 import org.junit.Test;
+
+import java.util.Map;
 
 public class NativeInterfaceTest {
 
@@ -13,4 +16,19 @@ public class NativeInterfaceTest {
         assertNotSame(client.config.getMetaData().store, NativeInterface.getMetaData());
     }
 
+    @Test
+    public void testClearTabClearsTheTab() {
+        // Creates a client object with the test context and no-op delivery
+        Client client = BugsnagTestUtils.generateClient();
+        NativeInterface.setClient(client);
+
+        client.addToTab("foo", "bar", "baz");
+        Map<String, Object> tab = client.getMetaData().getTab("foo");
+        assertEquals(1, tab.size());
+        assertEquals("baz", tab.get("bar"));
+
+        NativeInterface.clearTab("foo");
+        tab = client.getMetaData().getTab("foo");
+        assertEquals(0, tab.size());
+    }
 }

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -368,6 +368,15 @@ public class NativeInterface {
     }
 
     /**
+     * Remove a tab of app-wide diagnostic information
+     *
+     * @param tab the dashboard tab to remove diagnostic data from
+     */
+    public static void clearTab(@NonNull final String tab) {
+        getClient().clearTab(tab);
+    }
+
+    /**
      * Return the client report app version
      */
     @NonNull


### PR DESCRIPTION
The current revision is missing an interface for clearing a tab.

## Tests

* Manually and using a new automated test