### PR TITLE
[Android] Fix support for native crashes containing multiple text encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 4.15.x
 
+* Fix possible crash when recording reports and breadcrumbs containing values
+  using different text encodings or UTF-8 control characters, followed by a 
+  C/C++ crash.
+  [#584](https://github.com/bugsnag/bugsnag-android/pull/584)
 * Fix crash when calling `NativeInterface.clearTab()` (from an integration
   library)
   [#582](https://github.com/bugsnag/bugsnag-android/pull/582)

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -125,6 +126,9 @@ public class NativeInterface {
          */
         UPDATE_USER_ID,
     }
+
+    // The default charset on Android is always UTF-8
+    private static Charset UTF8Charset = Charset.defaultCharset();
 
     /**
      * Wrapper for messages sent to native observers
@@ -273,11 +277,43 @@ public class NativeInterface {
     }
 
     /**
+     * Sets the user
+     *
+     * @param idBytes id
+     * @param emailBytes email
+     * @param nameBytes name
+     */
+    @SuppressWarnings("unused")
+    public static void setUser(@Nullable final byte[] idBytes,
+                               @Nullable final byte[] emailBytes,
+                               @Nullable final byte[] nameBytes) {
+        String id = idBytes == null ? null : new String(idBytes, UTF8Charset);
+        String email = emailBytes == null ? null : new String(emailBytes, UTF8Charset);
+        String name = nameBytes == null ? null : new String(nameBytes, UTF8Charset);
+        setUser(id, email, name);
+    }
+
+    /**
      * Leave a "breadcrumb" log message
      */
     public static void leaveBreadcrumb(@NonNull final String name,
                                        @NonNull final BreadcrumbType type) {
-        getClient().leaveBreadcrumb(name, type, new HashMap<String, String>());
+        if (name == null) {
+            return;
+        }
+        getClient().leaveBreadcrumb(name, type, Collections.<String, String>emptyMap());
+    }
+
+    /**
+     * Leave a "breadcrumb" log message
+     */
+    public static void leaveBreadcrumb(@NonNull final byte[] nameBytes,
+                                       @NonNull final BreadcrumbType type) {
+        if (nameBytes == null) {
+            return;
+        }
+        String name = new String(nameBytes, UTF8Charset);
+        getClient().leaveBreadcrumb(name, type, Collections.<String, String>emptyMap());
     }
 
     /**
@@ -442,6 +478,26 @@ public class NativeInterface {
     /**
      * Notifies using the Android SDK
      *
+     * @param nameBytes the error name
+     * @param messageBytes the error message
+     * @param severity the error severity
+     * @param stacktrace a stacktrace
+     */
+    public static void notify(@NonNull final byte[] nameBytes,
+                              @NonNull final byte[] messageBytes,
+                              @NonNull final Severity severity,
+                              @NonNull final StackTraceElement[] stacktrace) {
+        if (nameBytes == null || messageBytes == null || stacktrace == null) {
+            return;
+        }
+        String name = new String(nameBytes, UTF8Charset);
+        String message = new String(messageBytes, UTF8Charset);
+        notify(name, message, severity, stacktrace);
+    }
+
+    /**
+     * Notifies using the Android SDK
+     *
      * @param name the error name
      * @param message the error message
      * @param severity the error severity
@@ -451,7 +507,9 @@ public class NativeInterface {
                               @NonNull final String message,
                               @NonNull final Severity severity,
                               @NonNull final StackTraceElement[] stacktrace) {
-
+        if (name == null || message == null || stacktrace == null) {
+            return;
+        }
         getClient().notify(name, message, stacktrace, new Callback() {
             @Override
             public void beforeNotify(@NonNull Report report) {

--- a/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/sdk/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -6,6 +6,7 @@ import android.annotation.SuppressLint;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -411,15 +412,24 @@ public class NativeInterface {
                                                            unhandledCount, handledCount);
     }
 
-    /**
-     * Deliver a report, serialized as an event JSON payload.
+    /** Deliver a report, serialized as an event JSON payload.
      *
-     * @param releaseStage The release stage in which the event was captured. Used to determin
-     *                     whether the report should be discarded, based on configured release
-     *                     stages
+     * @param releaseStageBytes The release stage in which the event was
+     *                          captured. Used to determine whether the report
+     *                          should be discarded, based on configured release 
+     *                          stages
+     * @param payloadBytes The raw JSON payload of the event
      */
     @SuppressWarnings("unused")
-    public static void deliverReport(@Nullable String releaseStage, @NonNull String payload) {
+    public static void deliverReport(@Nullable byte[] releaseStageBytes, 
+                                     @NonNull byte[] payloadBytes) {
+        if (payloadBytes == null) {
+            return;
+        }
+        String payload = new String(payloadBytes, UTF8Charset);
+        String releaseStage = releaseStageBytes == null
+            ? null
+            : new String(releaseStageBytes, UTF8Charset);
         Client client = getClient();
         if (releaseStage == null
             || releaseStage.length() == 0

--- a/sdk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/sdk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -12,7 +12,10 @@ import android.util.Log;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.UUID;
@@ -271,8 +274,16 @@ public class NativeBridge implements Observer {
     private void handleAddBreadcrumb(Object arg) {
         if (arg instanceof Breadcrumb) {
             Breadcrumb crumb = (Breadcrumb) arg;
+            Map<String, String> metadata = new HashMap<>();
+            if (crumb.getMetadata() != null) {
+                for (Map.Entry<String, String> entry : crumb.getMetadata().entrySet()) {
+                    if (entry.getValue() != null) {
+                        metadata.put(makeSafe(entry.getKey()), makeSafe(entry.getValue()));
+                    }
+                }
+            }
             addBreadcrumb(crumb.getName(), crumb.getType().toString(),
-                crumb.getTimestamp(), crumb.getMetadata());
+                crumb.getTimestamp(), metadata);
         } else {
             warn("Attempted to add non-breadcrumb: " + arg);
         }
@@ -284,25 +295,26 @@ public class NativeBridge implements Observer {
             List<Object> values = (List<Object>) arg;
             if (values.size() == 3 && values.get(METADATA_SECTION) instanceof String
                 && values.get(METADATA_KEY) instanceof String) {
+                String section = makeSafe((String)values.get(METADATA_SECTION));
+                String key = makeSafe((String)values.get(METADATA_KEY));
                 if (values.get(METADATA_VALUE) instanceof String) {
-                    addMetadataString((String) values.get(METADATA_SECTION),
-                        (String) values.get(METADATA_KEY),
-                        (String) values.get(METADATA_VALUE));
+                    addMetadataString(section, key,
+                        makeSafe((String) values.get(METADATA_VALUE)));
                     return;
                 } else if (values.get(METADATA_VALUE) instanceof Boolean) {
-                    addMetadataBoolean((String) values.get(METADATA_SECTION),
-                        (String) values.get(METADATA_KEY),
+                    addMetadataBoolean(section, key,
                         (Boolean) values.get(METADATA_VALUE));
                     return;
                 } else if (values.get(METADATA_VALUE) instanceof Number) {
-                    addMetadataDouble((String) values.get(METADATA_SECTION),
-                        (String) values.get(METADATA_KEY),
+                    addMetadataDouble(section, key,
                         ((Number) values.get(METADATA_VALUE)).doubleValue());
                     return;
                 }
-            } else if (values.size() == 2) {
-                removeMetadata((String)values.get(METADATA_SECTION),
-                    (String)values.get(METADATA_KEY));
+            } else if (values.size() == 2 && values.get(METADATA_SECTION) instanceof String
+                && values.get(METADATA_KEY) instanceof String) {
+                String section = makeSafe((String)values.get(METADATA_SECTION));
+                String key = makeSafe((String)values.get(METADATA_KEY));
+                removeMetadata(section, key);
                 return;
             }
         }
@@ -312,7 +324,7 @@ public class NativeBridge implements Observer {
 
     private void handleClearMetadataTab(Object arg) {
         if (arg instanceof String) {
-            clearMetadataTab((String)arg);
+            clearMetadataTab(makeSafe((String)arg));
         } else {
             warn("CLEAR_METADATA_TAB object is invalid: " + arg);
         }
@@ -320,7 +332,7 @@ public class NativeBridge implements Observer {
 
     private void handleAppVersionChange(Object arg) {
         if (arg instanceof String) {
-            updateAppVersion((String)arg);
+            updateAppVersion(makeSafe((String)arg));
         } else {
             warn("UPDATE_APP_VERSION object is invalid: " + arg);
         }
@@ -331,8 +343,8 @@ public class NativeBridge implements Observer {
             @SuppressWarnings("unchecked")
             List<String> metadata = (List<String>)arg;
             if (metadata.size() == 2) {
-                removeMetadata(metadata.get(METADATA_SECTION),
-                    metadata.get(METADATA_KEY));
+                removeMetadata(makeSafe(metadata.get(METADATA_SECTION)),
+                    makeSafe(metadata.get(METADATA_KEY)));
                 return;
             }
         }
@@ -368,7 +380,7 @@ public class NativeBridge implements Observer {
 
     private void handleReleaseStageChange(Object arg) {
         if (arg instanceof String) {
-            updateReleaseStage((String)arg);
+            updateReleaseStage(makeSafe((String)arg));
         } else {
             warn("UPDATE_RELEASE_STAGE object is invalid: " + arg);
         }
@@ -389,7 +401,7 @@ public class NativeBridge implements Observer {
             @SuppressWarnings("unchecked")
             List<Object> metadata = (List<Object>)arg;
             if (metadata.size() == 2) {
-                updateInForeground((boolean) metadata.get(0), (String) metadata.get(1));
+                updateInForeground((boolean) metadata.get(0), makeSafe((String) metadata.get(1)));
                 return;
             }
         }
@@ -401,7 +413,7 @@ public class NativeBridge implements Observer {
         if (arg == null) {
             updateUserId("");
         } else if (arg instanceof String) {
-            updateUserId((String)arg);
+            updateUserId(makeSafe((String)arg));
         } else {
             warn("UPDATE_USER_ID object is invalid: " + arg);
         }
@@ -411,7 +423,7 @@ public class NativeBridge implements Observer {
         if (arg == null) {
             updateUserName("");
         } else if (arg instanceof String) {
-            updateUserName((String)arg);
+            updateUserName(makeSafe((String)arg));
         } else {
             warn("UPDATE_USER_NAME object is invalid: " + arg);
         }
@@ -421,7 +433,7 @@ public class NativeBridge implements Observer {
         if (arg == null) {
             updateUserEmail("");
         } else if (arg instanceof String) {
-            updateUserEmail((String)arg);
+            updateUserEmail(makeSafe((String)arg));
         } else {
             warn("UPDATE_USER_EMAIL object is invalid: " + arg);
         }
@@ -431,7 +443,7 @@ public class NativeBridge implements Observer {
         if (arg == null) {
             updateBuildUUID("");
         } else if (arg instanceof String) {
-            updateBuildUUID((String)arg);
+            updateBuildUUID(makeSafe((String)arg));
         } else {
             warn("UPDATE_BUILD_UUID object is invalid: " + arg);
         }
@@ -441,7 +453,7 @@ public class NativeBridge implements Observer {
         if (arg == null) {
             updateContext("");
         } else if (arg instanceof String) {
-            updateContext((String)arg);
+            updateContext(makeSafe((String)arg));
         } else {
             warn("UPDATE_CONTEXT object is invalid: " + arg);
         }
@@ -461,6 +473,17 @@ public class NativeBridge implements Observer {
         } else {
             warn("UPDATE_METADATA object is invalid: " + arg);
         }
+    }
+
+    /**
+     * Ensure the string is safe to be passed to native layer by forcing the encoding
+     * to UTF-8.
+     */
+    private String makeSafe(String text) {
+        // The Android platform default charset is always UTF-8
+        return text == null 
+            ? null
+            : new String(text.getBytes(Charset.defaultCharset()));
     }
 
     private void warn(String message) {

--- a/sdk/src/main/jni/bugsnag.c
+++ b/sdk/src/main/jni/bugsnag.c
@@ -3,6 +3,7 @@
 #include "bugsnag_ndk.h"
 #include "report.h"
 #include "utils/stack_unwinder.h"
+#include "utils/string.h"
 #include "metadata.h"
 #include <jni.h>
 #include <stdio.h>
@@ -60,6 +61,18 @@ jfieldID bsg_parse_jseverity(JNIEnv *env, bsg_severity_t severity,
   }
 }
 
+jbyteArray bsg_byte_ary_from_string(JNIEnv *env, char *text) {
+  size_t text_length = bsg_strlen(text);
+  jbyteArray jtext = (*env)->NewByteArray(env, text_length);
+  (*env)->SetByteArrayRegion(env, jtext, 0, text_length, (jbyte *)text);
+
+  return jtext;
+}
+
+void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
+  (*env)->ReleaseByteArrayElements(env, array, (jbyte *)original_text, 0);
+}
+
 void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
                         bsg_severity_t severity) {
   bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
@@ -70,8 +83,7 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
       (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
   jmethodID notify_method = (*env)->GetStaticMethodID(
       env, interface_class, "notify",
-      "(Ljava/lang/String;Ljava/lang/String;Lcom/bugsnag/android/"
-      "Severity;[Ljava/lang/StackTraceElement;)V");
+      "([B[BLcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
   jclass trace_class = (*env)->FindClass(env, "java/lang/StackTraceElement");
   jclass severity_class =
       (*env)->FindClass(env, "com/bugsnag/android/Severity");
@@ -109,8 +121,8 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
   jobject jseverity = (*env)->GetStaticObjectField(
       env, severity_class, bsg_parse_jseverity(env, severity, severity_class));
 
-  jstring jname = (*env)->NewStringUTF(env, name);
-  jstring jmessage = (*env)->NewStringUTF(env, message);
+  jbyteArray jname = bsg_byte_ary_from_string(env, name);
+  jbyteArray jmessage = bsg_byte_ary_from_string(env, message);
 
   // set application's binary arch
   bugsnag_set_binary_arch(env);
@@ -118,6 +130,10 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
   (*env)->CallStaticVoidMethod(env, interface_class, notify_method, jname,
                                jmessage, jseverity, trace);
 
+  bsg_release_byte_ary(env, jname, name);
+  bsg_release_byte_ary(env, jmessage, message);
+  (*env)->DeleteLocalRef(env, jname);
+  (*env)->DeleteLocalRef(env, jmessage);
   (*env)->DeleteLocalRef(env, trace_class);
   (*env)->DeleteLocalRef(env, trace);
   (*env)->DeleteLocalRef(env, severity_class);
@@ -142,15 +158,18 @@ void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
       (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
   jmethodID set_user_method = (*env)->GetStaticMethodID(
       env, interface_class, "setUser",
-      "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
+      "([B[B[B)V");
 
-  jstring jid = (*env)->NewStringUTF(env, id);
-  jstring jemail = (*env)->NewStringUTF(env, email);
-  jstring jname = (*env)->NewStringUTF(env, name);
+  jbyteArray jid = bsg_byte_ary_from_string(env, id);
+  jbyteArray jemail = bsg_byte_ary_from_string(env, email);
+  jbyteArray jname = bsg_byte_ary_from_string(env, name);
 
   (*env)->CallStaticVoidMethod(env, interface_class, set_user_method, jid,
                                jemail, jname);
 
+  bsg_release_byte_ary(env, jid, id);
+  bsg_release_byte_ary(env, jemail, email);
+  bsg_release_byte_ary(env, jname, name);
   (*env)->DeleteLocalRef(env, jid);
   (*env)->DeleteLocalRef(env, jemail);
   (*env)->DeleteLocalRef(env, jname);
@@ -185,16 +204,16 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *name,
       (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
   jmethodID leave_breadcrumb_method = (*env)->GetStaticMethodID(
       env, interface_class, "leaveBreadcrumb",
-      "(Ljava/lang/String;Lcom/bugsnag/android/BreadcrumbType;)V");
+      "([BLcom/bugsnag/android/BreadcrumbType;)V");
   jclass type_class =
       (*env)->FindClass(env, "com/bugsnag/android/BreadcrumbType");
 
   jobject jtype = (*env)->GetStaticObjectField(
       env, type_class, bsg_parse_jcrumb_type(env, type, type_class));
-  jstring jname = (*env)->NewStringUTF(env, name);
+  jbyteArray jname = bsg_byte_ary_from_string(env, name);
   (*env)->CallStaticVoidMethod(env, interface_class, leave_breadcrumb_method,
                                jname, jtype);
-
+  bsg_release_byte_ary(env, jname, name);
   (*env)->DeleteLocalRef(env, jtype);
   (*env)->DeleteLocalRef(env, jname);
 

--- a/sdk/src/main/jni/bugsnag_ndk.c
+++ b/sdk/src/main/jni/bugsnag_ndk.c
@@ -100,9 +100,15 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
           (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
       jmethodID jdeliver_method =
           (*env)->GetStaticMethodID(env, interface_class, "deliverReport",
-                                    "(Ljava/lang/String;Ljava/lang/String;)V");
-      jstring jpayload = (*env)->NewStringUTF(env, payload);
-      jstring jstage = (*env)->NewStringUTF(env, report->app.release_stage);
+                                    "([B[B)V");
+      size_t payload_length = bsg_strlen(payload);
+      jbyteArray jpayload = (*env)->NewByteArray(env, payload_length);
+      (*env)->SetByteArrayRegion(env, jpayload, 0, payload_length, (jbyte *)payload);
+
+      size_t stage_length = bsg_strlen(report->app.release_stage);
+      jbyteArray jstage = (*env)->NewByteArray(env, stage_length);
+      (*env)->SetByteArrayRegion(env, jstage, 0, stage_length, (jbyte *)report->app.release_stage);
+
       (*env)->CallStaticVoidMethod(env, interface_class, jdeliver_method,
                                    jstage, jpayload);
       (*env)->DeleteLocalRef(env, jpayload);

--- a/sdk/src/main/jni/bugsnag_ndk.c
+++ b/sdk/src/main/jni/bugsnag_ndk.c
@@ -111,6 +111,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
 
       (*env)->CallStaticVoidMethod(env, interface_class, jdeliver_method,
                                    jstage, jpayload);
+      (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload, 0);
+      (*env)->ReleaseByteArrayElements(env, jstage, (jbyte *)report->app.release_stage, 0);
       (*env)->DeleteLocalRef(env, jpayload);
       (*env)->DeleteLocalRef(env, jstage);
       free(payload);


### PR DESCRIPTION
## Goal

Fix a possible crash in `NativeBridge.deliverReportAtPath()` arising from the report payload or release stage containing bytes which cannot be encoded as Modified UTF-8.

## Design

NewStringUTF() is not safe to use unless you control the input 100% of
the time. It uses the Modified UTF-8 charset, which may exclude possible 
characters, crashing with "illegal byte" errors. This issue can be mitigated 
by passing the raw byte array to the JVM layer, and then decoding the 
string as UTF-8. Using the `String(bytes[], Charset)` constructor bypasses
possible exceptions, instead replacing unknown bytes with the
unidentified character marker.

This fixes a possible crash where a string value is added to a report
using an encoding other than ASCII or Unicode variants (such as 
SHIFT-JIS, EUC-*, etc) which then cannot be decoded as UTF-8. For 
example, half-width kana in EUC-JP is represented by 0x8E followed by
a value between 0xA1 and 0xDF.

## Changeset

* Changed the parameters of `NativeInterface.deliverReport()` to accept byte arrays instead of Strings (removing usage of `NewStringUTF` from the report decoding process)
* Re-encoded strings passed to `NativeBridge` functions as UTF-8 before passing them to the native layer. This replaces any malformed or unmappable bytes with the unidentifier character marker.

## Tests

### Reproduction case

1. Using a third-party keyboard in a non-ASCII language, enter text which is added to metadata or breadcrumbs (Alternate version: crash the app, replacing a random set of bytes in a report with `\0x8e\0xde`)
2. Cause a C/C++ crash
3. Relaunch the app

A crash can occur in `deliverReportAtPath()` when attempting to construct a string with byte sequences containing control characters.


* Tested this change manually on ARMv7 (device), ARM64 (device), and x86 64-bit (emulator) within a Unity app with text inputs to cause the crash.


This change will also need to be cherry-picked to `master`.
