### PR TITLE
Call flush() when writing File in JSONStream

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JsonStream.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JsonStream.java
@@ -77,10 +77,9 @@ public class JsonStream extends JsonWriter {
             FileInputStream fis = new FileInputStream(file);
             input = new BufferedReader(new InputStreamReader(fis, "UTF-8"));
             IOUtils.copy(input, out);
+            out.flush();
         } finally {
             IOUtils.closeQuietly(input);
         }
-
-        out.flush();
     }
 }


### PR DESCRIPTION
## Goal

`flush()` has not been called in the right place since e16a4de, which could affect serialization of Files from the `JSONStream` class. This change ensures it is called before the streams are closed.

