### PR TITLE
Record storagemanager cache behaviour in internal error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## TBD
+
+* Record StorageManager cache behaviour in internal error reports
+  [#588](https://github.com/bugsnag/bugsnag-android/pull/588)
+
 * Buffer io when reading from cached error file
   [#573](https://github.com/bugsnag/bugsnag-android/pull/573)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -268,10 +268,11 @@ public class Client extends Observable implements Observer {
     void recordStorageCacheBehavior(MetaData metaData) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             File cacheDir = appContext.getCacheDir();
+            File errDir = new File(cacheDir, "bugsnag-errors");
 
             try {
-                boolean tombstone = storageManager.isCacheBehaviorTombstone(cacheDir);
-                boolean group = storageManager.isCacheBehaviorGroup(cacheDir);
+                boolean tombstone = storageManager.isCacheBehaviorTombstone(errDir);
+                boolean group = storageManager.isCacheBehaviorGroup(errDir);
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "cacheTombstone", tombstone);
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "cacheGroup", group);
             } catch (IOException exc) {

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalReportScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalReportScenario.kt
@@ -3,6 +3,8 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.os.Build
+import android.os.storage.StorageManager
 
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
@@ -20,10 +22,19 @@ internal class InternalReportScenario(config: Configuration,
 
         if (context is Activity) {
             eventMetaData = context.intent.getStringExtra("EVENT_METADATA")
+            val errDir = File(context.cacheDir, "bugsnag-errors")
+
+            if (eventMetaData == "tombstone" && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                errDir.mkdir()
+                val storageManager = context.getSystemService(Context.STORAGE_SERVICE) as StorageManager
+                storageManager.setCacheBehaviorGroup(errDir, true)
+                storageManager.setCacheBehaviorTombstone(errDir, true)
+            }
+
             if (eventMetaData != "non-crashy") {
                 disableAllDelivery(config)
             } else {
-                val files = File(context.cacheDir, "bugsnag-errors").listFiles()
+                val files = errDir.listFiles()
                 files.forEach { it.writeText("{[]}") }
             }
         }

--- a/features/internal_report.feature
+++ b/features/internal_report.feature
@@ -1,6 +1,7 @@
 Feature: Sending internal error reports
 
-Scenario: Send a report about an error triggered within the notifier
+@skip_above_android_7
+Scenario: Sending internal error reports on API <26
     When I run "InternalReportScenario"
     And I configure the app to run in the "non-crashy" state
     And I relaunch the app
@@ -12,11 +13,56 @@ Scenario: Send a report about an error triggered within the notifier
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
     And the event "device.osName" equals "android"
-    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is false
     And the event "metaData.BugsnagDiagnostics.filename" is not null
     And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
     And the event "metaData.BugsnagDiagnostics.apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
-    And the event "metaData.BugsnagDiagnostics.cacheGroup" is false
     And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"
     And the event "metaData.BugsnagDiagnostics.notifierVersion" is not null
     And the event "metaData.BugsnagDiagnostics.fileLength" equals 4
+    And the event "metaData.BugsnagDiagnostics.cacheGroup" is null
+    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is null
+
+@skip_below_android_8
+Scenario: Sending internal error reports on API >=26
+    When I run "InternalReportScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 1 request
+    And the "Bugsnag-Internal-Error" header equals "true"
+    And the payload field "apiKey" is null
+    And the event "context" equals "Crash Report Deserialization"
+    And the event "session" is null
+    And the event "breadcrumbs" is null
+    And the event "app.type" equals "android"
+    And the event "device.osName" equals "android"
+    And the event "metaData.BugsnagDiagnostics.filename" is not null
+    And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
+    And the event "metaData.BugsnagDiagnostics.apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"
+    And the event "metaData.BugsnagDiagnostics.notifierVersion" is not null
+    And the event "metaData.BugsnagDiagnostics.fileLength" equals 4
+    And the event "metaData.BugsnagDiagnostics.cacheGroup" is false
+    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is false
+
+@skip_below_android_8
+Scenario: Sending internal error reports with cache tombstone + groups enabled
+    When I configure the app to run in the "tombstone" state
+    And I run "InternalReportScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive 1 request
+    And the "Bugsnag-Internal-Error" header equals "true"
+    And the payload field "apiKey" is null
+    And the event "context" equals "Crash Report Deserialization"
+    And the event "session" is null
+    And the event "breadcrumbs" is null
+    And the event "app.type" equals "android"
+    And the event "device.osName" equals "android"
+    And the event "metaData.BugsnagDiagnostics.filename" is not null
+    And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
+    And the event "metaData.BugsnagDiagnostics.apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"
+    And the event "metaData.BugsnagDiagnostics.notifierVersion" is not null
+    And the event "metaData.BugsnagDiagnostics.fileLength" equals 4
+    And the event "metaData.BugsnagDiagnostics.cacheGroup" is true
+    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is true

--- a/features/internal_report.feature
+++ b/features/internal_report.feature
@@ -14,7 +14,7 @@ Scenario: Send a report about an error triggered within the notifier
     And the event "device.osName" equals "android"
     And the event "metaData.BugsnagDiagnostics.cacheTombstone" is false
     And the event "metaData.BugsnagDiagnostics.filename" is not null
-    And the event "metaData.BugsnagDiagnostics.notifierName" is not null
+    And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
     And the event "metaData.BugsnagDiagnostics.apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the event "metaData.BugsnagDiagnostics.cacheGroup" is false
     And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"

--- a/features/internal_report.feature
+++ b/features/internal_report.feature
@@ -2,7 +2,7 @@ Feature: Sending internal error reports
 
 Scenario: Send a report about an error triggered within the notifier
     When I run "InternalReportScenario"
-    And I set environment variable "EVENT_TYPE" to "EmptyReportScenario"
+    And I configure the app to run in the "non-crashy" state
     And I relaunch the app
     Then I should receive 1 request
     And the "Bugsnag-Internal-Error" header equals "true"
@@ -12,3 +12,11 @@ Scenario: Send a report about an error triggered within the notifier
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
     And the event "device.osName" equals "android"
+    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is false
+    And the event "metaData.BugsnagDiagnostics.filename" is not null
+    And the event "metaData.BugsnagDiagnostics.notifierName" is not null
+    And the event "metaData.BugsnagDiagnostics.apiKey" equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the event "metaData.BugsnagDiagnostics.cacheGroup" is false
+    And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"
+    And the event "metaData.BugsnagDiagnostics.notifierVersion" is not null
+    And the event "metaData.BugsnagDiagnostics.fileLength" equals 4

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 # Configure app environment
 RUNNING_CI = ENV['TRAVIS'] == 'true'
 
@@ -31,3 +33,18 @@ at_exit do
   ENV['DEVICE_ORIENTATION'] = 'portrait'
   run_required_commands([["features/scripts/rotate-device.sh"]])
 end
+
+Before('@skip_below_android_8') do |scenario|
+  skip_this_scenario("Skipping scenario") if get_api_level() < 26
+end
+
+Before('@skip_above_android_7') do |scenario|
+  skip_this_scenario("Skipping scenario") if get_api_level() >= 26
+end
+
+def get_api_level
+  stdout, stderr, status = Open3.capture3("adb shell getprop ro.build.version.sdk")
+  assert_true(status.success?)
+  return stdout.to_i
+end
+

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalReportScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalReportScenario.kt
@@ -1,6 +1,9 @@
 package com.bugsnag.android.mazerunner.scenarios
 
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
+
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import java.io.File
@@ -13,12 +16,24 @@ internal class InternalReportScenario(config: Configuration,
 
     init {
         config.setAutoCaptureSessions(false)
-        disableAllDelivery(config)
+        config.beforeSend { true }
+
+        if (context is Activity) {
+            eventMetaData = context.intent.getStringExtra("eventMetaData")
+            if (eventMetaData != "non-crashy") {
+                disableAllDelivery(config)
+            } else {
+                val files = File(context.cacheDir, "bugsnag-errors").listFiles()
+                files.forEach { it.writeText("{[]}") }
+            }
+        }
     }
 
     override fun run() {
         super.run()
-        Bugsnag.notify(java.lang.RuntimeException("Whoops"))
-    }
 
+        if (eventMetaData != "non-crashy") {
+            Bugsnag.notify(java.lang.RuntimeException("Whoops"))
+        }
+    }
 }

--- a/tests/features/internal_report.feature
+++ b/tests/features/internal_report.feature
@@ -1,7 +1,7 @@
 Feature: Sending internal error reports
 
 @skip_below_android_9
-Scenario: Sending internal error reports
+Scenario: Sending internal error reports below Android 9
     When I run "InternalReportScenario" and relaunch the app
     And I configure the app to run in the "non-crashy" state
     And I run "InternalReportScenario"
@@ -15,7 +15,7 @@ Scenario: Sending internal error reports
     And the event "device.osName" equals "android"
     And the event "metaData.BugsnagDiagnostics.cacheTombstone" is false
     And the event "metaData.BugsnagDiagnostics.filename" is not null
-    And the event "metaData.BugsnagDiagnostics.notifierName" is not null
+    And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
     And the event "metaData.BugsnagDiagnostics.apiKey" equals "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
     And the event "metaData.BugsnagDiagnostics.cacheGroup" is false
     And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"

--- a/tests/features/internal_report.feature
+++ b/tests/features/internal_report.feature
@@ -1,8 +1,10 @@
 Feature: Sending internal error reports
 
+@skip_below_android_9
 Scenario: Sending internal error reports
     When I run "InternalReportScenario" and relaunch the app
-    And I configure Bugsnag for "EmptyReportScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I run "InternalReportScenario"
     And I wait to receive a request
     And the "Bugsnag-Internal-Error" header equals "true"
     And the payload field "apiKey" is null
@@ -11,3 +13,11 @@ Scenario: Sending internal error reports
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
     And the event "device.osName" equals "android"
+    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is false
+    And the event "metaData.BugsnagDiagnostics.filename" is not null
+    And the event "metaData.BugsnagDiagnostics.notifierName" is not null
+    And the event "metaData.BugsnagDiagnostics.apiKey" equals "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+    And the event "metaData.BugsnagDiagnostics.cacheGroup" is false
+    And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"
+    And the event "metaData.BugsnagDiagnostics.notifierVersion" is not null
+    And the event "metaData.BugsnagDiagnostics.fileLength" equals 4

--- a/tests/features/internal_report.feature
+++ b/tests/features/internal_report.feature
@@ -1,7 +1,7 @@
 Feature: Sending internal error reports
 
-@skip_below_android_9
-Scenario: Sending internal error reports below Android 9
+@skip_above_android_7
+Scenario: Sending internal error reports on API <26
     When I run "InternalReportScenario" and relaunch the app
     And I configure the app to run in the "non-crashy" state
     And I run "InternalReportScenario"
@@ -13,11 +13,56 @@ Scenario: Sending internal error reports below Android 9
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
     And the event "device.osName" equals "android"
-    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is false
     And the event "metaData.BugsnagDiagnostics.filename" is not null
     And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
     And the event "metaData.BugsnagDiagnostics.apiKey" equals "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
-    And the event "metaData.BugsnagDiagnostics.cacheGroup" is false
     And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"
     And the event "metaData.BugsnagDiagnostics.notifierVersion" is not null
     And the event "metaData.BugsnagDiagnostics.fileLength" equals 4
+    And the event "metaData.BugsnagDiagnostics.cacheGroup" is null
+    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is null
+
+@skip_below_android_8
+Scenario: Sending internal error reports on API >=26
+    When I run "InternalReportScenario" and relaunch the app
+    And I configure the app to run in the "non-crashy" state
+    And I run "InternalReportScenario"
+    And I wait to receive a request
+    And the "Bugsnag-Internal-Error" header equals "true"
+    And the payload field "apiKey" is null
+    And the event "context" equals "Crash Report Deserialization"
+    And the event "session" is null
+    And the event "breadcrumbs" is null
+    And the event "app.type" equals "android"
+    And the event "device.osName" equals "android"
+    And the event "metaData.BugsnagDiagnostics.filename" is not null
+    And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
+    And the event "metaData.BugsnagDiagnostics.apiKey" equals "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+    And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"
+    And the event "metaData.BugsnagDiagnostics.notifierVersion" is not null
+    And the event "metaData.BugsnagDiagnostics.fileLength" equals 4
+    And the event "metaData.BugsnagDiagnostics.cacheGroup" is false
+    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is false
+
+@skip_below_android_8
+Scenario: Sending internal error reports with cache tombstone + groups enabled
+    And I configure the app to run in the "tombstone" state
+    When I run "InternalReportScenario" and relaunch the app
+    And I configure the app to run in the "non-crashy" state
+    And I run "InternalReportScenario"
+    And I wait to receive a request
+    And the "Bugsnag-Internal-Error" header equals "true"
+    And the payload field "apiKey" is null
+    And the event "context" equals "Crash Report Deserialization"
+    And the event "session" is null
+    And the event "breadcrumbs" is null
+    And the event "app.type" equals "android"
+    And the event "device.osName" equals "android"
+    And the event "metaData.BugsnagDiagnostics.filename" is not null
+    And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
+    And the event "metaData.BugsnagDiagnostics.apiKey" equals "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+    And the event "metaData.BugsnagDiagnostics.packageName" equals "com.bugsnag.android.mazerunner"
+    And the event "metaData.BugsnagDiagnostics.notifierVersion" is not null
+    And the event "metaData.BugsnagDiagnostics.fileLength" equals 4
+    And the event "metaData.BugsnagDiagnostics.cacheGroup" is true
+    And the event "metaData.BugsnagDiagnostics.cacheTombstone" is true

--- a/tests/features/support/env.rb
+++ b/tests/features/support/env.rb
@@ -16,6 +16,10 @@ Before('@skip_android_9') do |scenario|
   skip_this_scenario("Skipping scenario") if bs_device == 'ANDROID_9'
 end
 
+Before('@skip_below_android_9') do |scenario|
+  skip_this_scenario("Skipping scenario") if bs_device != 'ANDROID_9'
+end
+
 AfterConfiguration do |config|
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
   $driver.start_driver

--- a/tests/features/support/env.rb
+++ b/tests/features/support/env.rb
@@ -20,6 +20,14 @@ Before('@skip_below_android_9') do |scenario|
   skip_this_scenario("Skipping scenario") if bs_device != 'ANDROID_9'
 end
 
+Before('@skip_below_android_8') do |scenario|
+  skip_this_scenario("Skipping scenario") if bs_device != 'ANDROID_8' && bs_device != 'ANDROID_9'
+end
+
+Before('@skip_above_android_7') do |scenario|
+  skip_this_scenario("Skipping scenario") if bs_device == 'ANDROID_8' || bs_device == 'ANDROID_9'
+end
+
 AfterConfiguration do |config|
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
   $driver.start_driver


### PR DESCRIPTION
## Goal

Android API 26 introduced `setCacheBehaviorGroup`, which tells the OS to delete all the files in a given directory if space needs reclaiming. Coupled with `setCacheBehaviorTombstone` which truncates files to 0, this could explain the volume of minimal error reports reported by some customers.

We should record this information in our internal error diagnostics to debug the issue further.

## Tests

Tested against a local artefact on API 23 + 29 which had been altered to always call `recordStorageCacheBehavior` when notifying.
