### PR TITLE
Alter device.freeDisk to collect usable space in data directory

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import android.annotation.SuppressLint;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -253,25 +254,14 @@ class DeviceData {
     }
 
     /**
-     * Get the free disk space on the smallest disk
+     * Get the usable disk space on internal storage's data directory
      */
-    @Nullable
-    @SuppressWarnings("deprecation") // ignore blockSizeLong suggestions for now (requires API 18)
-    private Long calculateFreeDisk() {
-        try {
-            StatFs externalStat = new StatFs(Environment.getExternalStorageDirectory().getPath());
-            long externalBytesAvailable =
-                (long) externalStat.getBlockSize() * (long) externalStat.getBlockCount();
-
-            StatFs internalStat = new StatFs(Environment.getDataDirectory().getPath());
-            long internalBytesAvailable =
-                (long) internalStat.getBlockSize() * (long) internalStat.getBlockCount();
-
-            return Math.min(internalBytesAvailable, externalBytesAvailable);
-        } catch (Exception exception) {
-            Logger.warn("Could not get freeDisk");
-        }
-        return null;
+    @SuppressLint("UsableSpace")
+    private long calculateFreeDisk() {
+        // for this specific case we want the currently usable space, not
+        // StorageManager#allocatableBytes() as the UsableSpace lint inspection suggests
+        File dataDirectory = Environment.getDataDirectory();
+        return dataDirectory.getUsableSpace();
     }
 
     /**


### PR DESCRIPTION
## Goal

device.freeDisk currently collects the size of the external storage directory, which is not helpful
when debugging errors that occurred in a low disk space situation. This changeset gets the /data directory and calculates the [usable space](https://developer.android.com/reference/java/io/File#getUsableSpace()) in bytes (to non-root users) which is a more useful measure of the device's disk space.

## Tests

Verified that the reported value was approximately 5.1Gb on a physical Nexus 4 device.