### PR TITLE
Buildkite tests: Enable ANRs

### DIFF
--- a/tests/features/detect_anr.feature
+++ b/tests/features/detect_anr.feature
@@ -3,7 +3,7 @@ Feature: Reporting App Not Responding events
 Scenario: Sleeping the main thread with pending touch events when detectAnrs = true
     When I run "AppNotRespondingScenario"
     And I wait for 2 seconds
-    And I tap the screen 20 times
+    And I tap the screen 3 times
     And I wait for 4 seconds
     And I clear any error dialogue
     Then I wait to receive a request
@@ -14,7 +14,7 @@ Scenario: Sleeping the main thread with pending touch events when detectAnrs = t
 Scenario: Sleeping the main thread with pending touch events when detectAnrs = true and detectNdkCrashes = false
     When I run "AppNotRespondingDisabledNdkScenario"
     And I wait for 2 seconds
-    And I tap the screen 20 times
+    And I tap the screen 3 times
     And I wait for 4 seconds
     And I clear any error dialogue
     Then I wait to receive a request
@@ -25,7 +25,7 @@ Scenario: Sleeping the main thread with pending touch events when detectAnrs = t
 Scenario: Sleeping the main thread with pending touch events
     When I run "AppNotRespondingDisabledScenario"
     And I wait for 2 seconds
-    And I tap the screen 20 times
+    And I tap the screen 3 times
     And I wait for 4 seconds
     And I clear any error dialogue
     Then I should receive no requests

--- a/tests/features/detect_anr.feature
+++ b/tests/features/detect_anr.feature
@@ -1,31 +1,31 @@
 Feature: Reporting App Not Responding events
 
-#Scenario: Sleeping the main thread with pending touch events when detectAnrs = true
-#    When I run "AppNotRespondingScenario"
-#    And I wait for 2 seconds
-#    And I swipe the screen
-#    And I wait for 4 seconds
-#    And I clear any error dialogue
-#    Then I wait to receive a request
-#    And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-#    And the exception "errorClass" equals "ANR"
-#    And the exception "message" equals "Application did not respond to UI input"
+Scenario: Sleeping the main thread with pending touch events when detectAnrs = true
+    When I run "AppNotRespondingScenario"
+    And I wait for 2 seconds
+    And I tap the screen 20 times
+    And I wait for 4 seconds
+    And I clear any error dialogue
+    Then I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "ANR"
+    And the exception "message" starts with " Input dispatching timed out"
 
-#Scenario: Sleeping the main thread with pending touch events when detectAnrs = true and detectNdkCrashes = false
-#    When I run "AppNotRespondingDisabledNdkScenario"
-#    And I wait for 2 seconds
-#    And I swipe the screen
-#    And I wait for 4 seconds
-#    And I clear any error dialogue
-#    Then I wait to receive a request
-#    And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-#    And the exception "errorClass" equals "ANR"
-#    And the exception "message" equals "Application did not respond to UI input"
+Scenario: Sleeping the main thread with pending touch events when detectAnrs = true and detectNdkCrashes = false
+    When I run "AppNotRespondingDisabledNdkScenario"
+    And I wait for 2 seconds
+    And I tap the screen 20 times
+    And I wait for 4 seconds
+    And I clear any error dialogue
+    Then I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "ANR"
+    And the exception "message" starts with " Input dispatching timed out"
 
-#Scenario: Sleeping the main thread with pending touch events
-#    When I run "AppNotRespondingDisabledScenario"
-#    And I wait for 2 seconds
-#    And I swipe the screen
-#    And I wait for 4 seconds
-#    And I clear any error dialogue
-#    Then I should receive no requests
+Scenario: Sleeping the main thread with pending touch events
+    When I run "AppNotRespondingDisabledScenario"
+    And I wait for 2 seconds
+    And I tap the screen 20 times
+    And I wait for 4 seconds
+    And I clear any error dialogue
+    Then I should receive no requests

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledNdkScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledNdkScenario.kt
@@ -19,7 +19,7 @@ internal class AppNotRespondingDisabledNdkScenario(config: Configuration,
         super.run()
         val main = Handler(Looper.getMainLooper())
         main.postDelayed({
-            Thread.sleep(5000)
+            Thread.sleep(50000)
         }, 1) // A moment of delay so there is something to 'tap' onscreen
     }
 }

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledScenario.kt
@@ -10,11 +10,16 @@ import com.bugsnag.android.Configuration
  */
 internal class AppNotRespondingDisabledScenario(config: Configuration,
                                   context: Context) : Scenario(config, context) {
+
+    init {
+        config.detectAnrs = false
+    }
+
     override fun run() {
         super.run()
         val main = Handler(Looper.getMainLooper())
         main.postDelayed({
-            Thread.sleep(5000)
+            Thread.sleep(50000)
         }, 1) // A moment of delay so there is something to 'tap' onscreen
     }
 

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
@@ -18,7 +18,7 @@ internal class AppNotRespondingScenario(config: Configuration,
         super.run()
         val main = Handler(Looper.getMainLooper())
         main.postDelayed({
-            Thread.sleep(5000)
+            Thread.sleep(50000)
         }, 1) // A moment of delay so there is something to 'tap' onscreen
     }
 }

--- a/tests/features/steps/android_steps.rb
+++ b/tests/features/steps/android_steps.rb
@@ -34,10 +34,13 @@ When("I relaunch the app") do
   $driver.launch_app
 end
 
-When("I swipe the screen") do
-  touch_action = Appium::TouchAction.new
-  touch_action.swipe(:start_x => 50, :start_y => 150, :end_x => 50, :end_y => 500)
-  touch_action.perform
+When("I tap the screen {int} times") do |count|
+  for i in 1..count do
+    touch_action = Appium::TouchAction.new
+    touch_action.tap({:x => 500, :y => 300})
+    touch_action.perform
+    sleep(1)
+  end
 end
 
 When("I configure the app to run in the {string} state") do |event_metadata|


### PR DESCRIPTION
## Goal

Enables ANR testing against real devices on BrowserStack.

There's potentially optimisation here by reducing the amount of times the screen is tapped in order to produce the correct response.