### PR TITLE
Query available cache size before writing report to disk

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -60,7 +60,7 @@ class ErrorStore extends FileStore<Error> {
     };
 
     ErrorStore(@NonNull Configuration config, @NonNull Context appContext, Delegate delegate) {
-        super(config, appContext, "/bugsnag-errors/", 128, ERROR_REPORT_COMPARATOR);
+        super(config, appContext, "/bugsnag-errors/", 64, ERROR_REPORT_COMPARATOR);
         this.delegate = delegate;
     }
 
@@ -219,7 +219,7 @@ class ErrorStore extends FileStore<Error> {
         String uuid = UUID.randomUUID().toString();
         long timestamp = System.currentTimeMillis();
         return String.format(Locale.US, "%s%d_%s%s.json",
-                storeDirectory, timestamp, uuid, suffix);
+            storeDirectory, timestamp, uuid, suffix);
     }
 
     boolean isStartupCrash(long durationMs) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -219,7 +219,7 @@ class ErrorStore extends FileStore<Error> {
         String uuid = UUID.randomUUID().toString();
         long timestamp = System.currentTimeMillis();
         return String.format(Locale.US, "%s%d_%s%s.json",
-            storeDirectory, timestamp, uuid, suffix);
+                storeDirectory, timestamp, uuid, suffix);
     }
 
     boolean isStartupCrash(long durationMs) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -59,9 +59,10 @@ abstract class FileStore<T extends JsonStream.Streamable> {
         if (storeDirectory == null) {
             return;
         }
+        lock.lock();
         String filename = getFilename(content);
         discardOldestFileIfNeeded();
-        lock.lock();
+
         Writer out = null;
         try {
             FileOutputStream fos = new FileOutputStream(filename);
@@ -88,11 +89,11 @@ abstract class FileStore<T extends JsonStream.Streamable> {
         if (storeDirectory == null) {
             return null;
         }
+        lock.lock();
         discardOldestFileIfNeeded();
         String filename = getFilename(streamable);
 
         JsonStream stream = null;
-        lock.lock();
 
         try {
             FileOutputStream fos = new FileOutputStream(filename);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -73,7 +73,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             out.write(content);
         } catch (Exception exception) {
             Logger.warn(String.format("Couldn't save unsent payload to disk (%s) ",
-                    filename), exception);
+                filename), exception);
         } finally {
             try {
                 if (out != null) {
@@ -81,7 +81,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
                 }
             } catch (Exception exception) {
                 Logger.warn(String.format("Failed to close unsent payload writer (%s) ",
-                        filename), exception);
+                    filename), exception);
             }
             lock.unlock();
         }
@@ -107,7 +107,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             return filename;
         } catch (Exception exception) {
             Logger.warn(String.format("Couldn't save unsent payload to disk (%s) ",
-                    filename), exception);
+                filename), exception);
         } finally {
             IOUtils.closeQuietly(stream);
             lock.unlock();
@@ -123,11 +123,11 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             if (files != null) {
                 int fileCount = files.length;
 
-                @SuppressLint("UsableSpace")
+                @SuppressLint("UsableSpace") // storagemanager API only available in API 26+
                 long usableSpace = storeDirectory.getUsableSpace();
                 boolean isLowSpace = usableSpace <= LOW_SPACE_BYTE_THRESHOLD && usableSpace != 0L;
 
-                // if low on space, delete up to 64 files from cache
+                // if low on space, delete oldest half of files from store
                 int deletionThreshold = isLowSpace ? maxStoreCount / 2 : maxStoreCount;
 
                 if (fileCount >= deletionThreshold) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
@@ -35,14 +35,14 @@ class SessionStore extends FileStore<Session> {
 
     SessionStore(@NonNull Configuration config, @NonNull Context appContext) {
         super(config, appContext, "/bugsnag-sessions/",
-            128, SESSION_COMPARATOR);
+            64, SESSION_COMPARATOR);
     }
 
     @NonNull
     @Override
     String getFilename(Object object) {
         return String.format(Locale.US, "%s%s%d.json",
-                storeDirectory, UUID.randomUUID().toString(), System.currentTimeMillis());
+            storeDirectory, UUID.randomUUID().toString(), System.currentTimeMillis());
     }
 
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
@@ -42,7 +42,7 @@ class SessionStore extends FileStore<Session> {
     @Override
     String getFilename(Object object) {
         return String.format(Locale.US, "%s%s%d.json",
-            storeDirectory, UUID.randomUUID().toString(), System.currentTimeMillis());
+                storeDirectory, UUID.randomUUID().toString(), System.currentTimeMillis());
     }
 
 }


### PR DESCRIPTION
## Goal

Currently `FileStore` writes an arbitrary 128 files to disk, which was a decision made in #97. When additional metadata is added to a report and the system is low on space, this may have the effect of making it more likely for the OS to reclaim space from our application. 

## Changeset

The changeset makes several alterations which will reduce the likelihood of our cached files being deleted by the OS:

- Reduced max file count from 128 to 64. A typical error reports weigh around ~12Kb, which should fit into <1Mb storage if no additional metadata etc is added to a report
- Cached `context.cacheDir` and the `bugsnag-errors` directory File as fields, reducing duplication
- Moved `discardOldFilesIfNeeded()` into lock, reducing the potential for a `Report` serializing a cached `Error` to suffer a `FileNotFoundException`
- Called [`getUsableSpace()`](https://developer.android.com/reference/java/io/File#getUsableSpace()) to determine whether < 10Mb is available for use in the cache directory, and if so, delete old files.

## Discussion

`getCacheQuotaBytes()` and `getCacheSizeBytes()` are available on API 26+ which would allow us to determine whether we are over the cache quota more precisely. However, the documentation warns that these calls can take several seconds to complete, and would not resolve any caching issues on older devices, leading to the approach in this PR.

See: https://developer.android.com/reference/android/os/storage/StorageManager