### PR TITLE
flushOnLaunch() does not cancel previous requests if they timeout, leading to potential duplicate reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* flushOnLaunch() does not cancel previous requests if they timeout, leading to potential duplicate reports
+  [#593](https://github.com/bugsnag/bugsnag-android/pull/593)
+
 * Alter value collected for device.freeDisk to collect usable space in internal storage,
  rather than total space in internal/external storage
   [#589](https://github.com/bugsnag/bugsnag-android/pull/589)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -69,6 +69,10 @@ class ErrorStore extends FileStore<Error> {
             List<File> storedFiles = findStoredFiles();
             final List<File> crashReports = findLaunchCrashReports(storedFiles);
 
+            // cancel non-launch crash reports
+            storedFiles.removeAll(crashReports);
+            cancelQueuedFiles(storedFiles);
+
             if (!crashReports.isEmpty()) {
 
                 // Block the main thread for a 2 second interval as the app may crash very soon.
@@ -102,7 +106,6 @@ class ErrorStore extends FileStore<Error> {
                 }
                 Logger.info("Continuing with Bugsnag initialisation");
             }
-            cancelQueuedFiles(storedFiles); // cancel all previously found files
         }
 
         flushAsync(); // flush any remaining errors async that weren't delivered


### PR DESCRIPTION
## Goal

`cancelQueuedFiles()` prevents a file being sent again in a duplicate error report. This was
inappropriately called in `flushOnLaunch()` before `flushErrorReports()` completed in a background thread, which could result in duplicate error reports if `flushAsync()` was called while waiting for completion. 

This changeset removes the call and immediately cancels non-launch crash reports. The SDK not relies on `flushErrorReport()`, which cancels/deletes each file once the request has completed.