### PR TITLE
Prevent internal error reporting of FileNotFoundException during Delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Prevent internal error reporting of FileNotFoundException during Delivery
+  [#594](https://github.com/bugsnag/bugsnag-android/pull/594)
+
 ## 4.19.1 (2019-09-03)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -174,7 +175,7 @@ class ErrorStore extends FileStore<Error> {
             Logger.warn("Could not send previously saved error(s)"
                 + " to Bugsnag, will try again later", exception);
         } catch (Exception exception) {
-            if (delegate != null) {
+            if (delegate != null && !(exception instanceof FileNotFoundException)) {
                 delegate.onErrorReadFailure(exception, errorFile);
             }
             deleteStoredFiles(Collections.singleton(errorFile));

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -161,8 +161,10 @@ class ErrorStore extends FileStore<Error> {
             cancelQueuedFiles(Collections.singleton(errorFile));
             Logger.warn("Could not send previously saved error(s)"
                 + " to Bugsnag, will try again later", exception);
+        } catch (FileNotFoundException exc) {
+            Logger.warn("Ignoring empty file - oldest report on disk was deleted", exc);
         } catch (Exception exception) {
-            if (delegate != null && !(exception instanceof FileNotFoundException)) {
+            if (delegate != null) {
                 delegate.onErrorIOFailure(exception, errorFile, "Crash Report Deserialization");
             }
             deleteStoredFiles(Collections.singleton(errorFile));


### PR DESCRIPTION
## Goal

`FileNotFoundException` can occur due to a race where the oldest file is deleted from disk, and the
`Error` object sends a cached file directly in the request. If this does occur, we should suppress
internal error reports as it is a known issue that we cannot handle.

## Design

It is worth noting that redesigning the `ErrorStore` so that the `File` is always deserialized into an `Error` object would prevent this scenario from occurring.

However, given the complexity of these changes and incidence of this situation, it was seen as more appropriate to avoid sending an internal error report instead.