### PR TITLE
test: use correct session for timestamp comparison

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
@@ -51,7 +51,7 @@ public class SessionTrackingPayloadTest {
         FileUtils.clearFilesInDir(storageDir);
         session = generateSession();
         client = generateClient();
-        payload = generatePayloadFromSession(context, generateSession());
+        payload = generatePayloadFromSession(context, session);
         rootNode = streamableToJson(payload);
     }
 


### PR DESCRIPTION
## Goal

Fixes the flaky `testPayloadSerialisation()` case, where the timestamp comparison failed.

The cause of this was that the `payload` field generated a new session rather than using an existing field. If executed at the right time these could be serialized as different dates, failing the test.
