### PR TITLE
Deserialize longs/doubles stored in StackFrame object

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ErrorReaderNumberTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ErrorReaderNumberTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.BugsnagTestUtils.streamableToJson
 import com.bugsnag.android.BugsnagTestUtils.streamableToJsonArray
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -32,10 +33,9 @@ class ErrorReaderNumberTest {
     }
 
     @Test
-    fun testReadErrorExceptionStacktrace() {
-        val stacktrace = streamableToJsonArray(error!!.exceptions)
-            .getJSONObject(0)
-            .getJSONArray("stacktrace")
+    fun readErrorExceptionStacktrace() {
+        val event = streamableToJsonArray(error!!.exceptions).getJSONObject(0)
+        val stacktrace = event.getJSONArray("stacktrace")
         assertEquals(3, stacktrace.length().toLong())
 
         val frame0 = stacktrace.getJSONObject(0)
@@ -46,5 +46,15 @@ class ErrorReaderNumberTest {
 
         val frame2 = stacktrace.getJSONObject(2)
         assertEquals(761, frame2.getInt("lineNumber").toLong())
+    }
+
+    @Test
+    fun readErrorThreadStacktrace() {
+        val thread = streamableToJson(error).getJSONArray("threads").getJSONObject(0)
+        assertEquals(11236722452451234, thread.getLong("id"))
+
+        val trace = thread.getJSONArray("stacktrace")
+        assertEquals(160923409125093, trace.getJSONObject(0).getLong("lineNumber"))
+        assertEquals(1566.5, trace.getJSONObject(1).getDouble("lineNumber"), 0.1)
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ErrorReaderNumberTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ErrorReaderNumberTest.kt
@@ -1,0 +1,50 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.BugsnagTestUtils.streamableToJsonArray
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.io.FileOutputStream
+
+class ErrorReaderNumberTest {
+
+    private var error: Error? = null
+
+    @Before
+    fun setUp() {
+        val classLoader = ErrorReaderNumberTest::class.java.classLoader
+        val input = classLoader!!.getResourceAsStream("stackframe_numbers.json")
+        val fixtureFile = File.createTempFile("error", ".json")
+        val output = FileOutputStream(fixtureFile)
+
+        output.use {
+            val buffer = ByteArray(1024)
+            var read = input.read(buffer)
+
+            while (read != -1) {
+                it.write(buffer, 0, read)
+                read = input.read(buffer)
+            }
+            it.flush()
+        }
+        error = ErrorReader.readError(Configuration("key"), fixtureFile)
+    }
+
+    @Test
+    fun testReadErrorExceptionStacktrace() {
+        val stacktrace = streamableToJsonArray(error!!.exceptions)
+            .getJSONObject(0)
+            .getJSONArray("stacktrace")
+        assertEquals(3, stacktrace.length().toLong())
+
+        val frame0 = stacktrace.getJSONObject(0)
+        assertEquals(2241790.1, frame0.getDouble("lineNumber"), 0.01)
+
+        val frame1 = stacktrace.getJSONObject(1)
+        assertEquals(150000000000, frame1.getLong("lineNumber"))
+
+        val frame2 = stacktrace.getJSONObject(2)
+        assertEquals(761, frame2.getInt("lineNumber").toLong())
+    }
+}

--- a/bugsnag-android-core/src/androidTest/resources/stackframe_numbers.json
+++ b/bugsnag-android-core/src/androidTest/resources/stackframe_numbers.json
@@ -132,19 +132,19 @@
   "groupingHash": "400-b",
   "threads": [
     {
-      "id": 1,
+      "id": 11236722452451234,
       "name": "main",
       "type": "android",
       "stacktrace": [
         {
           "method": "dalvik.system.VMStack.getThreadStackTrace",
           "file": "VMStack.java",
-          "lineNumber": -2
+          "lineNumber": 160923409125093
         },
         {
           "method": "java.lang.Thread.getStackTrace",
           "file": "Thread.java",
-          "lineNumber": 1566
+          "lineNumber": 1566.5
         },
         {
           "method": "com.bugsnag.android.ThreadState.<init>",

--- a/bugsnag-android-core/src/androidTest/resources/stackframe_numbers.json
+++ b/bugsnag-android-core/src/androidTest/resources/stackframe_numbers.json
@@ -1,0 +1,442 @@
+{
+  "exceptions": [
+    {
+      "stacktrace": [
+        {
+          "method": "_ZNK3art6Thread13DecodeJObjectEP8_jobject",
+          "file": "libmuraccis.so",
+          "lineNumber": 2241790.1
+        },
+        {
+          "method": "java.lang.Daemons$ReferenceQueueDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 150000000000
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ],
+      "errorClass": "SIGSEGV",
+      "message": "Segmentation violation (invalid memory reference)",
+      "type": "c"
+    }
+  ],
+  "breadcrumbs": [
+    {
+      "name": "MainActivity",
+      "timestamp": "2018-10-19T18:56:13Z",
+      "type": "navigation",
+      "metaData": {
+        "ActivityLifecycle": "onStart()"
+      }
+    },
+    {
+      "name": "MainActivity",
+      "timestamp": "2018-10-19T18:56:13Z",
+      "type": "navigation",
+      "metaData": {
+        "ActivityLifecycle": "onResume()"
+      }
+    },
+    {
+      "name": "RINGER_MODE_CHANGED",
+      "timestamp": "2018-10-19T18:56:13Z",
+      "type": "state",
+      "metaData": {
+        "Extra": "RINGER_MODE_CHANGED: 2",
+        "Intent Action": "android.media.RINGER_MODE_CHANGED"
+      }
+    }
+  ],
+  "context": "MainActivity",
+  "severity": "warning",
+  "unhandled": true,
+  "severityReason": {
+    "type": "signal",
+    "attributes": {
+      "signalType": "SIGSEGV"
+    }
+  },
+  "app": {
+    "version": "1.1.14",
+    "id": "com.bugsnag.android.mazerunner",
+    "type": "android",
+    "releaseStage": "beta4",
+    "versionCode": 34,
+    "buildUUID": "2338403b-4ca1-40f5-bdee-3b82c2cb305a",
+    "duration": 169,
+    "durationInForeground": 0,
+    "inForeground": true
+  },
+  "metaData": {
+    "app": {
+      "packageName": "com.bugsnag.android.mazerunner",
+      "versionName": "1.1.14",
+      "activeScreen": "MainActivity",
+      "name": "MazeRunner",
+      "lowMemory": false
+    },
+    "device": {
+      "osBuild": "sdk_phone_armv7-eng 5.0.2 LSY66K 3079185 test-keys",
+      "apiLevel": 21,
+      "brand": "O-Matic",
+      "emulator": false,
+      "jailbroken": true,
+      "locale": "en_US",
+      "locationStatus": "allowed",
+      "networkAccess": "cellular",
+      "dpi": 160,
+      "screenDensity": 1,
+      "screenResolution": "480x320",
+      "time": "2018-10-19T18:56:13Z"
+    },
+    "customer": {
+      "name": "Acme Co",
+      "id": 23423,
+      "accountee": false
+    }
+  },
+  "device": {
+    "osName": "android",
+    "id": "9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d",
+    "osVersion": "5.0.2",
+    "manufacturer": "Hudan",
+    "model": "sdk_phone_armv7",
+    "orientation": "portrait",
+    "totalMemory": 134217728,
+    "cpuAbi": [
+      "armeabi-v7a",
+      "armeabi"
+    ]
+  },
+  "session": {
+    "id": "225bcada-e0c8-15a0-0bba-0e3c7f43c13f",
+    "startedAt": "2018-10-19T18:56:13Z",
+    "events": {
+        "handled": 2,
+        "unhandled": 1
+    },
+    "user": {
+      "id": "9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d",
+      "name": "Rasputin",
+      "email": "ras@example.com"
+    }
+  },
+  "user": {
+    "id": "9659cc1f-fec8-47a3-8ad2-0e3c7e84c24d",
+    "name": "Rasputin",
+    "email": "ras@example.com"
+  },
+  "groupingHash": "400-b",
+  "threads": [
+    {
+      "id": 1,
+      "name": "main",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "dalvik.system.VMStack.getThreadStackTrace",
+          "file": "VMStack.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Thread.getStackTrace",
+          "file": "Thread.java",
+          "lineNumber": 1566
+        },
+        {
+          "method": "com.bugsnag.android.ThreadState.<init>",
+          "file": "ThreadState.java",
+          "lineNumber": 40
+        },
+        {
+          "method": "com.bugsnag.android.Error$Builder.<init>",
+          "file": "Error.java",
+          "lineNumber": 414
+        },
+        {
+          "method": "com.bugsnag.android.Client.notify",
+          "file": "Client.java",
+          "lineNumber": 678
+        },
+        {
+          "method": "com.bugsnag.android.Bugsnag.notify",
+          "file": "Bugsnag.java",
+          "lineNumber": 407
+        },
+        {
+          "method": "com.bugsnag.android.mazerunner.scenarios.AppVersionScenario.run",
+          "file": "AppVersionScenario.kt",
+          "lineNumber": 19,
+          "inProject": true
+        },
+        {
+          "method": "com.bugsnag.android.mazerunner.MainActivity$onCreate$1.run",
+          "file": "MainActivity.kt",
+          "lineNumber": 29,
+          "inProject": true
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 751
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 95
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 154
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 6119
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run",
+          "file": "ZygoteInit.java",
+          "lineNumber": 886
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 776
+        }
+      ],
+      "errorReportingThread": true
+    },
+    {
+      "id": 590,
+      "name": "ReferenceQueueDaemon",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Daemons$ReferenceQueueDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 150
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 591,
+      "name": "FinalizerDaemon",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 407
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 188
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 209
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 204
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 592,
+      "name": "FinalizerWatchdogDaemon",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded",
+          "file": "Daemons.java",
+          "lineNumber": 269
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 249
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 593,
+      "name": "HeapTaskDaemon",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "dalvik.system.VMRuntime.runHeapTasks",
+          "file": "VMRuntime.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Daemons$HeapTaskDaemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 433
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 598,
+      "name": "pool-1-thread-1",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Thread.parkFor$",
+          "file": "Thread.java",
+          "lineNumber": 2127
+        },
+        {
+          "method": "sun.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": 325
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 161
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 2035
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 413
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1058
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1118
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 607
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    },
+    {
+      "id": 599,
+      "name": "Bugsnag Thread #1",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Thread.parkFor$",
+          "file": "Thread.java",
+          "lineNumber": 2127
+        },
+        {
+          "method": "sun.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": 325
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 161
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 2035
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 413
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1058
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1118
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 607
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 761
+        }
+      ]
+    }
+  ]
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -262,7 +262,7 @@ class ErrorReader {
                         map.put(key, reader.nextString());
                         break;
                     case NUMBER:
-                        map.put(key, reader.nextLong());
+                        map.put(key, deserializeNumber(reader));
                         break;
                     default:
                         reader.skipValue();
@@ -487,19 +487,24 @@ class ErrorReader {
             case BOOLEAN:
                 return (T)(Boolean) reader.nextBoolean();
             case NUMBER:
-                try {
-                    return (T)(Integer) reader.nextInt();
-                } catch (NumberFormatException ex) {
-                    try {
-                        return (T)(Long) reader.nextLong();
-                    } catch (NumberFormatException ex2) {
-                        return (T)(Double) reader.nextDouble();
-                    }
-                }
+                return deserializeNumber(reader);
             case BEGIN_ARRAY:
                 return (T) jsonArrayToList(reader);
             default:
                 return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T deserializeNumber(JsonReader reader) throws IOException {
+        try {
+            return (T)(Integer) reader.nextInt();
+        } catch (NumberFormatException ex) {
+            try {
+                return (T)(Long) reader.nextLong();
+            } catch (NumberFormatException ex2) {
+                return (T)(Double) reader.nextDouble();
+            }
         }
     }
 }


### PR DESCRIPTION
## Goal

Some fields in the `StackFrame` object can be non-integers in some cases, but the current implementation assumes that they are always integers. This change uses existing code to deserialize numbers instead, which handles doubles/longs appropriately.

## Tests

Manually verified that it an error is read from a JSON file if the stackframe objects contain doubles/longs/ints.
