### PR TITLE
Prevent SIGSEGV when passing NULL to bugsnag_set_user_env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Prevent SIGSEGV when passing NULL to bugsnag_set_user_env
+  [#599](https://github.com/bugsnag/bugsnag-android/pull/599)
+
 * Alter value collected for device.freeDisk to collect usable space in internal storage,
  rather than total space in internal/external storage
   [#589](https://github.com/bugsnag/bugsnag-android/pull/589)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@
 
 ### Bug fixes
 
-* Prevent SIGSEGV when passing NULL to bugsnag_set_user_env
-  [#599](https://github.com/bugsnag/bugsnag-android/pull/599)
-
 * Alter value collected for device.freeDisk to collect usable space in internal storage,
  rather than total space in internal/external storage
   [#589](https://github.com/bugsnag/bugsnag-android/pull/589)

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -62,6 +62,9 @@ jfieldID bsg_parse_jseverity(JNIEnv *env, bsg_severity_t severity,
 }
 
 jbyteArray bsg_byte_ary_from_string(JNIEnv *env, char *text) {
+  if (text == NULL) {
+    return NULL;
+  }
   size_t text_length = bsg_strlen(text);
   jbyteArray jtext = (*env)->NewByteArray(env, text_length);
   (*env)->SetByteArrayRegion(env, jtext, 0, text_length, (jbyte *)text);
@@ -70,7 +73,9 @@ jbyteArray bsg_byte_ary_from_string(JNIEnv *env, char *text) {
 }
 
 void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
-  (*env)->ReleaseByteArrayElements(env, array, (jbyte *)original_text, JNI_COMMIT);
+  if (array != NULL) {
+    (*env)->ReleaseByteArrayElements(env, array, (jbyte *)original_text, JNI_COMMIT);
+  }
 }
 
 void bugsnag_notify_env(JNIEnv *env, char *name, char *message,


### PR DESCRIPTION
## Goal

If `NULL` is passed as a parameter to `bugsnag_set_user_env` the process will crash with a SIGSEGV, because the method does not check for null.

This changeset adds a check for null in `bsg_byte_ary_from_string` and `bsg_release_byte_ary`. 

## Tests

The `CxxUserInfoScenario` in `native_api.feature` is now passing, whereas previously it was not. Also verified by passing NULL to all params in an example app.
