### PR TITLE
fix: Avoid duplicate handler installs

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -23,6 +23,9 @@ static bsg_environment *bsg_global_env;
 void bsg_handle_cpp_terminate();
 
 bool bsg_handler_install_cpp(bsg_environment *env) {
+  if (bsg_global_env != NULL) {
+    return true; // already installed
+  }
   static pthread_mutex_t bsg_cpp_handler_config = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&bsg_cpp_handler_config);
   bsg_global_terminate_previous = std::set_terminate(bsg_handle_cpp_terminate);

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -63,6 +63,9 @@ static const char bsg_native_signal_msgs[BSG_HANDLED_SIGNAL_COUNT + 1][60] = {
     "Segmentation violation (invalid memory reference)"};
 
 bool bsg_handler_install_signal(bsg_environment *env) {
+  if (bsg_global_env != NULL) {
+    return true; // already installed
+  }
   static pthread_mutex_t bsg_signal_handler_config = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&bsg_signal_handler_config);
   if (!bsg_configure_signal_stack()) {


### PR DESCRIPTION
Ports the following commit to master: https://github.com/bugsnag/bugsnag-android/commit/e0bfbf9cbfda7d1401d4209fbbeb102e002633f5