### PR TITLE
Prevent internal error reporting of FileNotFoundException during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Prevent internal error reporting of FileNotFoundException during serialization
+  [#605](https://github.com/bugsnag/bugsnag-android/pull/605)
+
 ## 4.20.0 (2019-09-25)
 
 * Record StorageManager cache behaviour in internal error reports

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -117,6 +118,8 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             stream.value(streamable);
             Logger.info(String.format("Saved unsent payload to disk (%s) ", filename));
             return filename;
+        } catch (FileNotFoundException exc) {
+            Logger.warn("Ignoring empty file - oldest report on disk was deleted", exc);
         } catch (Exception exc) {
             if (delegate != null) {
                 delegate.onErrorIOFailure(exc, new File(filename), "Crash report serialization");

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -119,7 +119,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             Logger.info(String.format("Saved unsent payload to disk (%s) ", filename));
             return filename;
         } catch (FileNotFoundException exc) {
-            Logger.warn("Ignoring empty file - oldest report on disk was deleted", exc);
+            Logger.warn("Ignoring FileNotFoundException - unable to create file", exc);
         } catch (Exception exc) {
             if (delegate != null) {
                 delegate.onErrorIOFailure(exc, new File(filename), "Crash report serialization");


### PR DESCRIPTION
## Goal

`FileNotFoundException` can occur when opening a `FileOutputStream` if it wasn't possible to open the file for reasons beyond our control. If this does occur, we should suppress
internal error reports as it is a known issue that we cannot handle.

See releated PR #594 