### PR TITLE
Allow overriding the versionCode via Configuration

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataSummaryTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataSummaryTest.java
@@ -37,6 +37,7 @@ public class AppDataSummaryTest {
         Context context = ApplicationProvider.getApplicationContext();
         PackageManager packageManager = context.getPackageManager();
         Configuration config = new Configuration("api-key");
+        config.setVersionCode(1);
         AppData obj = new AppData(context, packageManager, config, sessionTracker);
         this.appData = obj.getAppDataSummary();
     }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataTest.java
@@ -47,6 +47,7 @@ public class AppDataTest {
         Context context = ApplicationProvider.getApplicationContext();
         PackageManager packageManager = context.getPackageManager();
         Configuration config = new Configuration("api-key");
+        config.setVersionCode(1);
         AppData obj = new AppData(context, packageManager, config, sessionTracker);
         this.appData = obj.getAppData();
     }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -181,6 +181,7 @@ public class ClientTest {
         ConfigFactory.populateConfigFromManifest(protoConfig, data);
 
         assertEquals(config.getApiKey(), protoConfig.getApiKey());
+        assertEquals(config.getVersionCode(), protoConfig.getVersionCode());
         assertEquals(config.getBuildUUID(), protoConfig.getBuildUUID());
         assertEquals(config.getAppVersion(), protoConfig.getAppVersion());
         assertEquals(config.getReleaseStage(), protoConfig.getReleaseStage());
@@ -198,6 +199,7 @@ public class ClientTest {
     public void testFullManifestConfig() {
         String buildUuid = "123";
         String appVersion = "v1.0";
+        Integer versionCode = 27;
         String releaseStage = "debug";
         String endpoint = "http://example.com";
         String sessionEndpoint = "http://session-example.com";
@@ -205,6 +207,7 @@ public class ClientTest {
         Bundle data = new Bundle();
         data.putString("com.bugsnag.android.BUILD_UUID", buildUuid);
         data.putString("com.bugsnag.android.APP_VERSION", appVersion);
+        data.putInt("com.bugsnag.android.VERSION_CODE", versionCode);
         data.putString("com.bugsnag.android.RELEASE_STAGE", releaseStage);
         data.putString("com.bugsnag.android.SESSIONS_ENDPOINT", sessionEndpoint);
         data.putString("com.bugsnag.android.ENDPOINT", endpoint);
@@ -219,6 +222,7 @@ public class ClientTest {
         ConfigFactory.populateConfigFromManifest(protoConfig, data);
         assertEquals(buildUuid, protoConfig.getBuildUUID());
         assertEquals(appVersion, protoConfig.getAppVersion());
+        assertEquals(versionCode, protoConfig.getVersionCode());
         assertEquals(releaseStage, protoConfig.getReleaseStage());
         assertEquals(endpoint, protoConfig.getEndpoint());
         assertEquals(sessionEndpoint, protoConfig.getSessionEndpoint());

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppData.java
@@ -66,7 +66,7 @@ class AppData {
         map.put("type", calculateNotifierType());
         map.put("releaseStage", guessReleaseStage());
         map.put("version", calculateVersionName());
-        map.put("versionCode", calculateVersionCode());
+        map.put("versionCode", config.getVersionCode().intValue());
         map.put("codeBundleId", config.getCodeBundleId());
         return map;
     }
@@ -128,20 +128,6 @@ class AppData {
             return notifierType;
         } else {
             return "android";
-        }
-    }
-
-    /**
-     * The version code of the running Android app, from android:versionCode
-     * in AndroidManifest.xml
-     */
-    @Nullable
-    @SuppressWarnings("deprecation")
-    private Integer calculateVersionCode() {
-        if (packageInfo != null) {
-            return packageInfo.versionCode;
-        } else {
-            return null;
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -11,6 +11,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Build;
@@ -123,6 +124,7 @@ public class Client extends Observable implements Observer {
      * @param androidContext an Android context, usually <code>this</code>
      * @param configuration  a configuration for the Client
      */
+    @SuppressWarnings("deprecation") // ignore packageInfo.versionCode deprecation on API 28
     public Client(@NonNull Context androidContext, @NonNull Configuration configuration) {
         warnIfNotAppContext(androidContext);
         appContext = androidContext.getApplicationContext();
@@ -198,6 +200,18 @@ public class Client extends Observable implements Observer {
             }
             if (buildUuid != null) {
                 config.setBuildUUID(buildUuid);
+            }
+        }
+
+        //noinspection ConstantConditions
+        if (config.getVersionCode() == null) {
+            try {
+                PackageManager packageManager = appContext.getPackageManager();
+                String packageName = appContext.getPackageName();
+                PackageInfo packageInfo = packageManager.getPackageInfo(packageName, 0);
+                config.setVersionCode(packageInfo.versionCode);
+            } catch (PackageManager.NameNotFoundException exception) {
+                Logger.warn("Could not retrieve package/application information");
             }
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigFactory.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigFactory.java
@@ -11,6 +11,7 @@ class ConfigFactory {
 
     private static final String BUGSNAG_NAMESPACE = "com.bugsnag.android";
     private static final String MF_APP_VERSION = BUGSNAG_NAMESPACE + ".APP_VERSION";
+    private static final String MF_VERSION_CODE = BUGSNAG_NAMESPACE + ".VERSION_CODE";
     private static final String MF_ENDPOINT = BUGSNAG_NAMESPACE + ".ENDPOINT";
     private static final String MF_SESSIONS_ENDPOINT = BUGSNAG_NAMESPACE + ".SESSIONS_ENDPOINT";
     private static final String MF_RELEASE_STAGE = BUGSNAG_NAMESPACE + ".RELEASE_STAGE";
@@ -92,6 +93,9 @@ class ConfigFactory {
         config.setAppVersion(data.getString(MF_APP_VERSION));
         config.setReleaseStage(data.getString(MF_RELEASE_STAGE));
 
+        if (data.containsKey(MF_VERSION_CODE)) {
+            config.setVersionCode(data.getInt(MF_VERSION_CODE));
+        }
         if (data.containsKey(MF_ENDPOINT)) {
             String endpoint = data.getString(MF_ENDPOINT);
             String sessionEndpoint = data.getString(MF_SESSIONS_ENDPOINT);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -32,6 +32,7 @@ public class Configuration extends Observable implements Observer {
     private final String apiKey;
     private String buildUuid;
     private String appVersion;
+    private Integer versionCode;
     private String context;
     private volatile String endpoint = "https://notify.bugsnag.com";
     private volatile String sessionEndpoint = "https://sessions.bugsnag.com";
@@ -127,6 +128,26 @@ public class Configuration extends Observable implements Observer {
         setChanged();
         notifyObservers(new NativeInterface.Message(
                     NativeInterface.MessageType.UPDATE_APP_VERSION, appVersion));
+    }
+
+    /**
+     * Gets the version code sent to Bugsnag.
+     *
+     * @return Version Code
+     */
+    @NonNull
+    public Integer getVersionCode() {
+        return versionCode;
+    }
+
+    /**
+     * Set the version code sent to Bugsnag. By default we'll pull this
+     * from your AndroidManifest.xml
+     *
+     * @param versionCode the version code to send
+     */
+    public void setVersionCode(@NonNull Integer versionCode) {
+        this.versionCode = versionCode;
     }
 
     /**

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -238,4 +238,12 @@ public class ConfigurationTest {
     public void testSetNullDelivery() {
         config.setDelivery(null);
     }
+
+    @Test
+    public void testVersionCode() {
+        Configuration configuration = new Configuration("api-key");
+        assertNull(configuration.getVersionCode()); // populated in client ctor if null
+        configuration.setVersionCode("577");
+        assertEquals("577", configuration.getVersionCode());
+    }
 }


### PR DESCRIPTION
#  Goal

Allows overriding the `versionCode` either through a manifest meta-data element or programmatically on the `Configuration` object. This facilitates grouping for custom versioning schemes. By default, the `versionCode` still uses the `android:versionCode` manifest value once a `Client` has been instantiated.

## Changeset

Added integer `versionCode` field to `Configuration` which can also be read via the AndroidManifest `meta-data` element `com.bugsnag.android.VERSION_CODE`. By default if this value is not configured, the `Client` will set the `versionCode` to the value supplied in `android:versionCode` of the AndroidManifest.

## Tests

Ran the example app and confirmed that for a handled, unhandled, and NDK error, the versionCode reported in the dashboard differs for:

- the default `android:versionCode` value set in the manifest
- the `com.bugsnag.android.VERSION_CODE` value set in the manifest
- the value set on `config.versionCode`

Updated existing integration tests to verify that the value is loaded from the manifest and can be overridden.