### PR TITLE
Collect additional data in internal error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TBD
 
+* Collect additional data in internal error reports
+  [#612](https://github.com/bugsnag/bugsnag-android/pull/612)
+
 * Allow overriding the versionCode via Configuration
   [#610](https://github.com/bugsnag/bugsnag-android/pull/610)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppData.java
@@ -111,7 +111,7 @@ class AppData {
      *
      * @return the duration in ms
      */
-    private long calculateDurationInForeground() {
+    long calculateDurationInForeground() {
         long nowMs = System.currentTimeMillis();
         return sessionTracker.getDurationInForegroundMs(nowMs);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -215,9 +215,6 @@ public class Client extends Observable implements Observer {
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "canWrite", errorFile.canWrite());
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "exists", errorFile.exists());
 
-                @SuppressLint("UsableSpace") // storagemanager alternative API requires API 26
-                        long usableSpace = appContext.getCacheDir().getUsableSpace();
-                metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "usableSpace", usableSpace);
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "filename", errorFile.getName());
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "fileLength", errorFile.length());
                 recordStorageCacheBehavior(metaData);
@@ -1018,8 +1015,15 @@ public class Client extends Observable implements Observer {
      * This is intended for internal use only, and reports will not be visible to end-users.
      */
     void reportInternalBugsnagError(@NonNull Error error) {
-        error.setAppData(appData.getAppDataSummary());
-        error.setDeviceData(deviceData.getDeviceDataSummary());
+        Map<String, Object> app = appData.getAppDataSummary();
+        app.put("duration", AppData.getDurationMs());
+        app.put("durationInForeground", appData.calculateDurationInForeground());
+        app.put("inForeground", sessionTracker.isInForeground());
+        error.setAppData(app);
+
+        Map<String, Object> device = deviceData.getDeviceDataSummary();
+        device.put("freeDisk", deviceData.calculateFreeDisk());
+        error.setDeviceData(device);
 
         MetaData metaData = error.getMetaData();
         Notifier notifier = Notifier.getInstance();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -215,6 +215,9 @@ public class Client extends Observable implements Observer {
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "canWrite", errorFile.canWrite());
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "exists", errorFile.exists());
 
+                @SuppressLint("UsableSpace") // storagemanager alternative API requires API 26
+                long usableSpace = appContext.getCacheDir().getUsableSpace();
+                metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "usableSpace", usableSpace);
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "filename", errorFile.getName());
                 metaData.addToTab(INTERNAL_DIAGNOSTICS_TAB, "fileLength", errorFile.length());
                 recordStorageCacheBehavior(metaData);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -256,7 +256,7 @@ class DeviceData {
      * Get the usable disk space on internal storage's data directory
      */
     @SuppressLint("UsableSpace")
-    private long calculateFreeDisk() {
+    long calculateFreeDisk() {
         // for this specific case we want the currently usable space, not
         // StorageManager#allocatableBytes() as the UsableSpace lint inspection suggests
         File dataDirectory = Environment.getDataDirectory();

--- a/features/internal_report.feature
+++ b/features/internal_report.feature
@@ -12,6 +12,10 @@ Scenario: Sending internal error reports on API <26
     And the event "session" is null
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
+    And the event "app.duration" is greater than 0
+    And the event "app.durationInForeground" is not null
+    And the event "app.inForeground" is true
+    And the event "device.freeDisk" is greater than 0
     And the event "device.osName" equals "android"
     And the event "metaData.BugsnagDiagnostics.filename" is not null
     And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
@@ -34,6 +38,10 @@ Scenario: Sending internal error reports on API >=26
     And the event "session" is null
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
+    And the event "app.duration" is greater than 0
+    And the event "app.durationInForeground" is not null
+    And the event "app.inForeground" is true
+    And the event "device.freeDisk" is greater than 0
     And the event "device.osName" equals "android"
     And the event "metaData.BugsnagDiagnostics.filename" is not null
     And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
@@ -57,6 +65,10 @@ Scenario: Sending internal error reports with cache tombstone + groups enabled
     And the event "session" is null
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
+    And the event "app.duration" is greater than 0
+    And the event "app.durationInForeground" is not null
+    And the event "app.inForeground" is true
+    And the event "device.freeDisk" is greater than 0
     And the event "device.osName" equals "android"
     And the event "metaData.BugsnagDiagnostics.filename" is not null
     And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"

--- a/tests/features/internal_report.feature
+++ b/tests/features/internal_report.feature
@@ -12,6 +12,10 @@ Scenario: Sending internal error reports on API <26
     And the event "session" is null
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
+    And the event "app.duration" is greater than 0
+    And the event "app.durationInForeground" is not null
+    And the event "app.inForeground" is true
+    And the event "device.freeDisk" is greater than 0
     And the event "device.osName" equals "android"
     And the event "metaData.BugsnagDiagnostics.filename" is not null
     And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
@@ -34,6 +38,10 @@ Scenario: Sending internal error reports on API >=26
     And the event "session" is null
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
+    And the event "app.duration" is greater than 0
+    And the event "app.durationInForeground" is not null
+    And the event "app.inForeground" is true
+    And the event "device.freeDisk" is greater than 0
     And the event "device.osName" equals "android"
     And the event "metaData.BugsnagDiagnostics.filename" is not null
     And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"
@@ -57,6 +65,10 @@ Scenario: Sending internal error reports with cache tombstone + groups enabled
     And the event "session" is null
     And the event "breadcrumbs" is null
     And the event "app.type" equals "android"
+    And the event "app.duration" is greater than 0
+    And the event "app.durationInForeground" is not null
+    And the event "app.inForeground" is true
+    And the event "device.freeDisk" is greater than 0
     And the event "device.osName" equals "android"
     And the event "metaData.BugsnagDiagnostics.filename" is not null
     And the event "metaData.BugsnagDiagnostics.notifierName" equals "Android Bugsnag Notifier"


### PR DESCRIPTION
## Changeset

Collects the following values under the app/device tabs, using existing collection methods from `AppData` and `DeviceData`:

```
app.duration
app.durationInForeground
app.inForeground
device.freeDisk
```

## Tests

Added to existing mazerunner scenarios to verify that internal reports contain the new fields
