### PR TITLE
Remove unsupported armeabi from abiFilters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,15 @@ option:
 ./gradlew assembleRelease -PABI_FILTERS=x86,arm64-v8a
 ```
 
+To build for ARMv5 (`armeabi`):
+
+```shell
+./gradlew assembleRelease -PABI_FILTERS=armeabi
+```
+
+Note that `armeabi` has been removed in NDK r17 and requires the installation
+of an older NDK version.
+
 ## Testing
 
 Full details of how to build and run tests can be found in [the testing guide](`TESTING.md`)

--- a/bugsnag-plugin-android-anr/build.gradle
+++ b/bugsnag-plugin-android-anr/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         externalNativeBuild.cmake.arguments "-DANDROID_CPP_FEATURES=exceptions", "-DANDROID_STL=c++_static"
         ndk.abiFilters = project.hasProperty("ABI_FILTERS") ? project.ABI_FILTERS.split(",") :
-            ["arm64-v8a", "armeabi-v7a", "armeabi", "x86", "x86_64"]
+            ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
     }
     externalNativeBuild.cmake.path = "CMakeLists.txt"
 }

--- a/bugsnag-plugin-android-ndk/build.gradle
+++ b/bugsnag-plugin-android-ndk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         externalNativeBuild.cmake.arguments "-DANDROID_CPP_FEATURES=exceptions", "-DANDROID_STL=c++_static"
         ndk.abiFilters = project.hasProperty("ABI_FILTERS") ? project.ABI_FILTERS.split(",") :
-            ["arm64-v8a", "armeabi-v7a", "armeabi", "x86", "x86_64"]
+            ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
     }
     externalNativeBuild.cmake.path = "CMakeLists.txt"
 }

--- a/dockerfiles/Dockerfile.android-instrumentation-tests
+++ b/dockerfiles/Dockerfile.android-instrumentation-tests
@@ -33,5 +33,4 @@ ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 RUN ./gradlew
 
 # Everything above this point should be derived from android-base
-RUN sed --in-place="" --expression='s/"armeabi",//' bugsnag-plugin-android-anr/build.gradle bugsnag-plugin-android-ndk/build.gradle
 CMD ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh

--- a/dockerfiles/Dockerfile.android-jvm
+++ b/dockerfiles/Dockerfile.android-jvm
@@ -37,8 +37,3 @@ RUN apt-get install -y cppcheck
 
 COPY examples/sdk-app-example/ examples/sdk-app-example/
 COPY config/ config/
-
-RUN sed --in-place="" --expression="s/'armeabi',//" bugsnag-plugin-android-anr/build.gradle \
-    bugsnag-plugin-android-ndk/build.gradle examples/sdk-app-example/build.gradle
-
-


### PR DESCRIPTION
Trying to build or open the project in Android Studio is failing with:

```
ABIs [armeabi] are not supported for platform. Supported ABIs are [arm64-v8a, armeabi-v7a, x86, x86_64].
```

The reason is `armeabi` was removed from the NDK. See [NDK changelog](https://github.com/android/ndk/wiki/Changelog-r17)

> Support for ARMv5 (armeabi), MIPS, and MIPS64 has been removed. Attempting to build any of these ABIs will result in an error.

Also see:

- https://github.com/android/ndk/issues/961
- https://github.com/android/ndk/issues/911
- https://stackoverflow.com/questions/52233971/abis-armeabi-mips-are-not-supported-for-platform-android-ndk

There have been no new devices that only support `armeabi` but not `armeabi-v7a` **for 10 years or so**.

This PR removes the references to `armeabi` from the default list of `abiFilters`, allowing the build to pass again.

@kattrali - You already removed it from example app as part of #493, but in a0519a4cae3624a1b1c4ec05cd9659ca1f0a4a7d you're mentioning "Needed for lib release" - Can you elaborate on it?