### PR TITLE
Update Breadcrumb functionality to match notifier spec

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
@@ -132,7 +132,7 @@ public class BeforeRecordBreadcrumbsTest {
             @Override
             public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
-                assertEquals("Hello", breadcrumb.getName());
+                assertEquals("Hello", breadcrumb.getMessage());
                 assertEquals(BreadcrumbType.MANUAL, breadcrumb.getType());
                 assertFalse(breadcrumb.getMetadata().isEmpty());
                 return true;

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BeforeRecordBreadcrumbsTest.java
@@ -103,7 +103,7 @@ public class BeforeRecordBreadcrumbsTest {
         });
 
         client.leaveBreadcrumb("Foo");
-        client.leaveBreadcrumb("Hello", BreadcrumbType.USER, new HashMap<String, String>());
+        client.leaveBreadcrumb("Hello", BreadcrumbType.USER, new HashMap<String, Object>());
         assertEquals(4, count[0]);
     }
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbFilterTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbFilterTest.kt
@@ -1,0 +1,34 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.BugsnagTestUtils.generateClient
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class BreadcrumbFilterTest {
+
+    private var client: Client? = null
+
+    @Before
+    fun setUp() {
+        val configuration = generateConfiguration()
+        configuration.enabledBreadcrumbTypes = setOf(BreadcrumbType.REQUEST)
+        client = generateClient(configuration)
+    }
+
+    @After
+    fun tearDown() {
+        client!!.close()
+    }
+
+    @Test
+    fun zeroBreadcrumbsReceived() {
+        client!!.leaveBreadcrumb("Hello")
+        assertEquals(0, client!!.breadcrumbs.store.size.toLong())
+
+        client!!.leaveBreadcrumb("Hello", BreadcrumbType.REQUEST, emptyMap())
+        assertEquals(1, client!!.breadcrumbs.store.size.toLong())
+    }
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbsSerializationTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbsSerializationTest.kt
@@ -6,14 +6,9 @@ import org.junit.Assert.assertEquals
 import androidx.test.filters.SmallTest
 import com.bugsnag.android.BugsnagTestUtils.*
 
-import org.json.JSONException
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-
-import java.io.IOException
-import java.util.HashMap
-import java.util.Locale
 
 @SmallTest
 class BreadcrumbsSerializationTest {
@@ -58,7 +53,7 @@ class BreadcrumbsSerializationTest {
         var count = 0
 
         for (breadcrumb in store) {
-            if (MANUAL == breadcrumb.type && "manual" == breadcrumb.name) {
+            if (MANUAL == breadcrumb.type && "manual" == breadcrumb.message) {
                 count++
                 assertEquals("Hello World", breadcrumb.metadata["message"])
             }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbsSerializationTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbsSerializationTest.kt
@@ -53,9 +53,8 @@ class BreadcrumbsSerializationTest {
         var count = 0
 
         for (breadcrumb in store) {
-            if (MANUAL == breadcrumb.type && "manual" == breadcrumb.message) {
+            if (MANUAL == breadcrumb.type && "manual" == breadcrumb.message && breadcrumb.metadata["message"] == "Hello World") {
                 count++
-                assertEquals("Hello World", breadcrumb.metadata["message"])
             }
         }
         assertEquals(1, count)

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -168,18 +168,18 @@ public class ClientTest {
     public void testMaxBreadcrumbs() {
         Configuration config = generateConfiguration();
         config.setAutoCaptureBreadcrumbs(false);
-        config.setMaxBreadcrumbs(1);
+        config.setMaxBreadcrumbs(2);
         client = generateClient(config);
-        assertEquals(0, client.breadcrumbs.store.size());
+        assertEquals(1, client.breadcrumbs.store.size());
 
         client.leaveBreadcrumb("test");
         client.leaveBreadcrumb("another");
-        assertEquals(1, client.breadcrumbs.store.size());
+        assertEquals(2, client.breadcrumbs.store.size());
 
         Breadcrumb poll = client.breadcrumbs.store.poll();
         assertEquals(BreadcrumbType.MANUAL, poll.getType());
         assertEquals("manual", poll.getMessage());
-        assertEquals("another", poll.getMetadata().get("message"));
+        assertEquals("test", poll.getMetadata().get("message"));
     }
 
     @Test
@@ -187,10 +187,10 @@ public class ClientTest {
         Configuration config = generateConfiguration();
         config.setAutoCaptureBreadcrumbs(false);
         client = generateClient(config);
-        assertEquals(0, client.breadcrumbs.store.size());
+        assertEquals(1, client.breadcrumbs.store.size());
 
         client.leaveBreadcrumb("test");
-        assertEquals(1, client.breadcrumbs.store.size());
+        assertEquals(2, client.breadcrumbs.store.size());
 
         client.clearBreadcrumbs();
         assertEquals(0, client.breadcrumbs.store.size());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SmallTest;
@@ -178,7 +178,7 @@ public class ClientTest {
 
         Breadcrumb poll = client.breadcrumbs.store.poll();
         assertEquals(BreadcrumbType.MANUAL, poll.getType());
-        assertEquals("manual", poll.getName());
+        assertEquals("manual", poll.getMessage());
         assertEquals("another", poll.getMetadata().get("message"));
     }
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -47,18 +47,18 @@ public class ConcurrentCallbackTest {
     @Test
     public void testClientBreadcrumbModification() throws Exception {
         Configuration config = (Configuration) client.getConfiguration();
-        final Collection<BeforeRecordBreadcrumb> breadcrumbTasks =
-                config.getBeforeRecordBreadcrumbTasks();
+        final Collection<OnBreadcrumb> breadcrumbTasks =
+                config.getBreadcrumbCallbacks();
 
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
-                breadcrumbTasks.add(new BeforeRecordBreadcrumbSkeleton());
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
+                breadcrumbTasks.add(new OnBreadcrumbSkeleton());
                 // modify the Set, when iterating to the next callback this should not crash
                 return true;
             }
         });
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumbSkeleton());
+        client.addOnBreadcrumb(new OnBreadcrumbSkeleton());
         client.leaveBreadcrumb("Whoops");
         client.notify(new RuntimeException());
     }
@@ -70,9 +70,9 @@ public class ConcurrentCallbackTest {
         }
     }
 
-    static class BeforeRecordBreadcrumbSkeleton implements BeforeRecordBreadcrumb {
+    static class OnBreadcrumbSkeleton implements OnBreadcrumb {
         @Override
-        public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+        public boolean run(@NonNull Breadcrumb breadcrumb) {
             return true;
         }
     }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -59,9 +59,9 @@ class ImmutableConfigTest {
             assertEquals(seed.loggingEnabled, loggingEnabled)
             assertEquals(seed.maxBreadcrumbs, maxBreadcrumbs)
             assertEquals(seed.persistUserBetweenSessions, persistUserBetweenSessions)
+            assertEquals(seed.enabledBreadcrumbTypes, BreadcrumbType.values().toSet())
         }
     }
-
 
     @Test
     fun convertWithOverrides() {
@@ -87,6 +87,7 @@ class ImmutableConfigTest {
         seed.loggingEnabled = false
         seed.maxBreadcrumbs = 37
         seed.persistUserBetweenSessions = true
+        seed.enabledBreadcrumbTypes = emptySet()
 
         // verify overrides are copied across
         with(convertToImmutableConfig(seed)) {
@@ -123,6 +124,7 @@ class ImmutableConfigTest {
             assertFalse(seed.loggingEnabled)
             assertEquals(37, seed.maxBreadcrumbs)
             assertTrue(seed.persistUserBetweenSessions)
+            assertTrue(seed.enabledBreadcrumbTypes.isEmpty())
         }
     }
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -50,7 +50,7 @@ class ManifestConfigLoaderTest {
             assertEquals(setOf("password"), filters)
 
             // misc
-            assertEquals(maxBreadcrumbs, 32)
+            assertEquals(maxBreadcrumbs, 25)
             assertEquals(launchCrashThresholdMs, 5000)
         }
     }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -231,7 +231,7 @@ public class ObserverInterfaceTest {
 
     @Test
     public void testLeaveBreadcrumbSendsMessage() {
-        client.leaveBreadcrumb("Rollback", BreadcrumbType.LOG, new HashMap<String, String>());
+        client.leaveBreadcrumb("Rollback", BreadcrumbType.LOG, new HashMap<String, Object>());
         Breadcrumb crumb = (Breadcrumb)findMessageInQueue(
                 NativeInterface.MessageType.ADD_BREADCRUMB, Breadcrumb.class);
         assertEquals(BreadcrumbType.LOG, crumb.getType());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -201,7 +201,7 @@ public class ObserverInterfaceTest {
         Breadcrumb crumb = (Breadcrumb)findMessageInQueue(
                 NativeInterface.MessageType.ADD_BREADCRUMB, Breadcrumb.class);
         assertEquals(BreadcrumbType.MANUAL, crumb.getType());
-        assertEquals("manual", crumb.getName());
+        assertEquals("manual", crumb.getMessage());
         assertEquals(1, crumb.getMetadata().size());
         assertEquals("Drift 4 units left", crumb.getMetadata().get("message"));
     }
@@ -212,7 +212,7 @@ public class ObserverInterfaceTest {
         Breadcrumb crumb = (Breadcrumb)findMessageInQueue(
                 NativeInterface.MessageType.ADD_BREADCRUMB, Breadcrumb.class);
         assertEquals(BreadcrumbType.MANUAL, crumb.getType());
-        assertEquals("manual", crumb.getName());
+        assertEquals("manual", crumb.getMessage());
         assertEquals(1, crumb.getMetadata().size());
         assertEquals("Drift 4 units left", crumb.getMetadata().get("message"));
     }
@@ -235,7 +235,7 @@ public class ObserverInterfaceTest {
         Breadcrumb crumb = (Breadcrumb)findMessageInQueue(
                 NativeInterface.MessageType.ADD_BREADCRUMB, Breadcrumb.class);
         assertEquals(BreadcrumbType.LOG, crumb.getType());
-        assertEquals("Rollback", crumb.getName());
+        assertEquals("Rollback", crumb.getMessage());
         assertEquals(0, crumb.getMetadata().size());
     }
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbsTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbsTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import java.util.HashMap;
 
 @SmallTest
-public class BeforeRecordBreadcrumbsTest {
+public class OnBreadcrumbsTest {
 
     private Client client;
 
@@ -44,9 +44,9 @@ public class BeforeRecordBreadcrumbsTest {
 
     @Test
     public void falseCallback() throws Exception {
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
                 return false;
             }
         });
@@ -56,9 +56,9 @@ public class BeforeRecordBreadcrumbsTest {
 
     @Test
     public void trueCallback() throws Exception {
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
                 return true;
             }
         });
@@ -68,15 +68,15 @@ public class BeforeRecordBreadcrumbsTest {
 
     @Test
     public void multipleCallbacks() throws Exception {
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
                 return true;
             }
         });
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
                 return false;
             }
         });
@@ -87,16 +87,16 @@ public class BeforeRecordBreadcrumbsTest {
     @Test
     public void ensureBothCalled() throws Exception {
         final int[] count = {0};
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
                 return true;
             }
         });
-        client.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
                 return true;
             }
@@ -111,26 +111,26 @@ public class BeforeRecordBreadcrumbsTest {
     public void ensureOnlyCalledOnce() throws Exception {
         final int[] count = {0};
 
-        BeforeRecordBreadcrumb beforeRecordBreadcrumb = new BeforeRecordBreadcrumb() {
+        OnBreadcrumb onBreadcrumb = new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
                 return true;
             }
         };
-        client.beforeRecordBreadcrumb(beforeRecordBreadcrumb);
-        client.beforeRecordBreadcrumb(beforeRecordBreadcrumb);
+        client.addOnBreadcrumb(onBreadcrumb);
+        client.addOnBreadcrumb(onBreadcrumb);
         client.leaveBreadcrumb("Foo");
         assertEquals(1, count[0]);
     }
 
     @Test
-    public void checkBreadrumbFields() throws Exception {
+    public void checkBreadcrumbFields() throws Exception {
         final int[] count = {0};
 
-        BeforeRecordBreadcrumb beforeRecordBreadcrumb = new BeforeRecordBreadcrumb() {
+        OnBreadcrumb onBreadcrumb = new OnBreadcrumb() {
             @Override
-            public boolean shouldRecord(@NonNull Breadcrumb breadcrumb) {
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
                 assertEquals("Hello", breadcrumb.getMessage());
                 assertEquals(BreadcrumbType.MANUAL, breadcrumb.getType());
@@ -138,9 +138,24 @@ public class BeforeRecordBreadcrumbsTest {
                 return true;
             }
         };
-        client.beforeRecordBreadcrumb(beforeRecordBreadcrumb);
+        client.addOnBreadcrumb(onBreadcrumb);
         client.leaveBreadcrumb("Hello");
         assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void removedCallback() throws Exception {
+        OnBreadcrumb cb = new OnBreadcrumb() {
+            @Override
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
+                return false;
+            }
+        };
+        client.addOnBreadcrumb(cb);
+        client.leaveBreadcrumb("Hello");
+        client.removeOnBreadcrumb(cb);
+        client.leaveBreadcrumb("Hello");
+        assertEquals(1, client.breadcrumbs.store.size());
     }
 
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbsTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbsTest.java
@@ -28,7 +28,7 @@ public class OnBreadcrumbsTest {
         Configuration configuration = new Configuration("api-key");
         configuration.setAutoCaptureBreadcrumbs(false);
         client = generateClient();
-        assertEquals(0, client.breadcrumbs.store.size());
+        assertEquals(1, client.breadcrumbs.store.size());
     }
 
     @After
@@ -39,7 +39,7 @@ public class OnBreadcrumbsTest {
     @Test
     public void noCallback() throws Exception {
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, client.breadcrumbs.store.size());
+        assertEquals(2, client.breadcrumbs.store.size());
     }
 
     @Test
@@ -51,7 +51,7 @@ public class OnBreadcrumbsTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(0, client.breadcrumbs.store.size());
+        assertEquals(1, client.breadcrumbs.store.size());
     }
 
     @Test
@@ -63,7 +63,7 @@ public class OnBreadcrumbsTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, client.breadcrumbs.store.size());
+        assertEquals(2, client.breadcrumbs.store.size());
     }
 
     @Test
@@ -81,12 +81,12 @@ public class OnBreadcrumbsTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(0, client.breadcrumbs.store.size());
+        assertEquals(1, client.breadcrumbs.store.size());
     }
 
     @Test
     public void ensureBothCalled() throws Exception {
-        final int[] count = {0};
+        final int[] count = {1};
         client.addOnBreadcrumb(new OnBreadcrumb() {
             @Override
             public boolean run(@NonNull Breadcrumb breadcrumb) {
@@ -104,12 +104,12 @@ public class OnBreadcrumbsTest {
 
         client.leaveBreadcrumb("Foo");
         client.leaveBreadcrumb("Hello", BreadcrumbType.USER, new HashMap<String, Object>());
-        assertEquals(4, count[0]);
+        assertEquals(5, count[0]);
     }
 
     @Test
     public void ensureOnlyCalledOnce() throws Exception {
-        final int[] count = {0};
+        final int[] count = {1};
 
         OnBreadcrumb onBreadcrumb = new OnBreadcrumb() {
             @Override
@@ -121,12 +121,12 @@ public class OnBreadcrumbsTest {
         client.addOnBreadcrumb(onBreadcrumb);
         client.addOnBreadcrumb(onBreadcrumb);
         client.leaveBreadcrumb("Foo");
-        assertEquals(1, count[0]);
+        assertEquals(2, count[0]);
     }
 
     @Test
     public void checkBreadcrumbFields() throws Exception {
-        final int[] count = {0};
+        final int[] count = {1};
 
         OnBreadcrumb onBreadcrumb = new OnBreadcrumb() {
             @Override
@@ -140,7 +140,7 @@ public class OnBreadcrumbsTest {
         };
         client.addOnBreadcrumb(onBreadcrumb);
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, count[0]);
+        assertEquals(2, count[0]);
     }
 
     @Test
@@ -155,7 +155,7 @@ public class OnBreadcrumbsTest {
         client.leaveBreadcrumb("Hello");
         client.removeOnBreadcrumb(cb);
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, client.breadcrumbs.store.size());
+        assertEquals(2, client.breadcrumbs.store.size());
     }
 
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -16,7 +16,7 @@ public final class Breadcrumb implements JsonStream.Streamable {
     private static final String DEFAULT_NAME = "manual";
     private static final String MESSAGE_METAKEY = "message";
     private static final String TIMESTAMP_KEY = "timestamp";
-    private static final String NAME_KEY = "name";
+    private static final String NAME_KEY = "message";
     private static final String METADATA_KEY = "metaData";
     private static final String TYPE_KEY = "type";
 
@@ -24,7 +24,7 @@ public final class Breadcrumb implements JsonStream.Streamable {
     private final String timestamp;
 
     @NonNull
-    private final String name;
+    private final String message;
 
     @NonNull
     private final BreadcrumbType type;
@@ -37,25 +37,25 @@ public final class Breadcrumb implements JsonStream.Streamable {
                 Collections.singletonMap(MESSAGE_METAKEY, message));
     }
 
-    Breadcrumb(@NonNull String name,
+    Breadcrumb(@NonNull String message,
                @NonNull BreadcrumbType type,
                @NonNull Map<String, String> metadata) {
-        this(name, type, new Date(), metadata);
+        this(message, type, new Date(), metadata);
     }
 
-    Breadcrumb(@NonNull String name,
+    Breadcrumb(@NonNull String message,
                @NonNull BreadcrumbType type,
                @NonNull Date captureDate,
                @NonNull Map<String, String> metadata) {
         this.timestamp = DateUtils.toIso8601(captureDate);
         this.type = type;
-        this.name = name;
+        this.message = message;
         this.metadata = new HashMap<>(metadata);
     }
 
     @NonNull
-    public String getName() {
-        return name;
+    public String getMessage() {
+        return message;
     }
 
     @NonNull
@@ -77,7 +77,7 @@ public final class Breadcrumb implements JsonStream.Streamable {
     public void toStream(@NonNull JsonStream writer) throws IOException {
         writer.beginObject();
         writer.name(TIMESTAMP_KEY).value(this.timestamp);
-        writer.name(NAME_KEY).value(this.name);
+        writer.name(NAME_KEY).value(this.message);
         writer.name(TYPE_KEY).value(this.type.toString());
         writer.name(METADATA_KEY);
         writer.beginObject();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -13,13 +13,6 @@ import java.util.Map;
 
 public final class Breadcrumb implements JsonStream.Streamable {
 
-    private static final String DEFAULT_NAME = "manual";
-    private static final String MESSAGE_METAKEY = "message";
-    private static final String TIMESTAMP_KEY = "timestamp";
-    private static final String NAME_KEY = "message";
-    private static final String METADATA_KEY = "metaData";
-    private static final String TYPE_KEY = "type";
-
     @NonNull
     private final String timestamp;
 
@@ -30,23 +23,23 @@ public final class Breadcrumb implements JsonStream.Streamable {
     private final BreadcrumbType type;
 
     @NonNull
-    private final Map<String, String> metadata;
+    private final Map<String, Object> metadata;
 
     Breadcrumb(@NonNull String message) {
-        this(DEFAULT_NAME, BreadcrumbType.MANUAL,
-                Collections.singletonMap(MESSAGE_METAKEY, message));
+        this("manual", BreadcrumbType.MANUAL,
+                Collections.<String, Object>singletonMap("message", message));
     }
 
     Breadcrumb(@NonNull String message,
                @NonNull BreadcrumbType type,
-               @NonNull Map<String, String> metadata) {
+               @NonNull Map<String, Object> metadata) {
         this(message, type, new Date(), metadata);
     }
 
     Breadcrumb(@NonNull String message,
                @NonNull BreadcrumbType type,
                @NonNull Date captureDate,
-               @NonNull Map<String, String> metadata) {
+               @NonNull Map<String, Object> metadata) {
         this.timestamp = DateUtils.toIso8601(captureDate);
         this.type = type;
         this.message = message;
@@ -64,7 +57,7 @@ public final class Breadcrumb implements JsonStream.Streamable {
     }
 
     @NonNull
-    public Map<String, String> getMetadata() {
+    public Map<String, Object> getMetadata() {
         return metadata;
     }
 
@@ -76,10 +69,10 @@ public final class Breadcrumb implements JsonStream.Streamable {
     @Override
     public void toStream(@NonNull JsonStream writer) throws IOException {
         writer.beginObject();
-        writer.name(TIMESTAMP_KEY).value(this.timestamp);
-        writer.name(NAME_KEY).value(this.message);
-        writer.name(TYPE_KEY).value(this.type.toString());
-        writer.name(METADATA_KEY);
+        writer.name("timestamp").value(timestamp);
+        writer.name("name").value(message);
+        writer.name("type").value(type.toString());
+        writer.name("metaData");
         writer.beginObject();
 
         // sort metadata alphabetically

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -13,7 +13,6 @@ import java.util.Map;
 
 public final class Breadcrumb implements JsonStream.Streamable {
 
-    private static final int MAX_MESSAGE_LENGTH = 140;
     private static final String DEFAULT_NAME = "manual";
     private static final String MESSAGE_METAKEY = "message";
     private static final String TIMESTAMP_KEY = "timestamp";
@@ -34,8 +33,8 @@ public final class Breadcrumb implements JsonStream.Streamable {
     private final Map<String, String> metadata;
 
     Breadcrumb(@NonNull String message) {
-        this(DEFAULT_NAME, BreadcrumbType.MANUAL, Collections.singletonMap(MESSAGE_METAKEY,
-            message.substring(0, Math.min(message.length(), MAX_MESSAGE_LENGTH))));
+        this(DEFAULT_NAME, BreadcrumbType.MANUAL,
+                Collections.singletonMap(MESSAGE_METAKEY, message));
     }
 
     Breadcrumb(@NonNull String name,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -345,7 +345,7 @@ public final class Bugsnag {
      * Leave a "breadcrumb" log message representing an action or event which
      * occurred in your app, to aid with debugging
      *
-     * @param message     A short label (max 32 chars)
+     * @param message     A short label
      * @param type     A category for the breadcrumb
      * @param metadata Additional diagnostic information about the app environment
      */

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -208,18 +208,21 @@ public final class Bugsnag {
      * <p>
      * For example:
      * <p>
-     * Bugsnag.beforeRecordBreadcrumb(new BeforeRecordBreadcrumb() {
-     * public boolean shouldRecord(Breadcrumb breadcrumb) {
+     * Bugsnag.onBreadcrumb(new OnBreadcrumb() {
+     * public boolean run(Breadcrumb breadcrumb) {
      * return false; // ignore the breadcrumb
      * }
      * })
      *
-     * @param beforeRecordBreadcrumb a callback to run before a breadcrumb is captured
-     * @see BeforeRecordBreadcrumb
+     * @param onBreadcrumb a callback to run before a breadcrumb is captured
+     * @see OnBreadcrumb
      */
-    public static void beforeRecordBreadcrumb(
-        @NonNull final BeforeRecordBreadcrumb beforeRecordBreadcrumb) {
-        getClient().beforeRecordBreadcrumb(beforeRecordBreadcrumb);
+    public static void addOnBreadcrumb(@NonNull final OnBreadcrumb onBreadcrumb) {
+        getClient().addOnBreadcrumb(onBreadcrumb);
+    }
+
+    public static void removeOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
+        getClient().removeOnBreadcrumb(onBreadcrumb);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -342,14 +342,14 @@ public final class Bugsnag {
      * Leave a "breadcrumb" log message representing an action or event which
      * occurred in your app, to aid with debugging
      *
-     * @param name     A short label (max 32 chars)
+     * @param message     A short label (max 32 chars)
      * @param type     A category for the breadcrumb
      * @param metadata Additional diagnostic information about the app environment
      */
-    public static void leaveBreadcrumb(@NonNull String name,
+    public static void leaveBreadcrumb(@NonNull String message,
                                        @NonNull BreadcrumbType type,
                                        @NonNull Map<String, String> metadata) {
-        getClient().leaveBreadcrumb(name, type, metadata);
+        getClient().leaveBreadcrumb(message, type, metadata);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -348,7 +348,7 @@ public final class Bugsnag {
      */
     public static void leaveBreadcrumb(@NonNull String message,
                                        @NonNull BreadcrumbType type,
-                                       @NonNull Map<String, String> metadata) {
+                                       @NonNull Map<String, Object> metadata) {
         getClient().leaveBreadcrumb(message, type, metadata);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -825,8 +825,8 @@ public class Client extends Observable implements Observer {
 
     private void leaveErrorBreadcrumb(@NonNull Error error) {
         // Add a breadcrumb for this error occurring
-        String exceptionMessage = error.getExceptionMessage();
-        Map<String, String> message = Collections.singletonMap("message", exceptionMessage);
+        String msg = error.getExceptionMessage();
+        Map<String, Object> message = Collections.<String, Object>singletonMap("message", msg);
         breadcrumbs.add(new Breadcrumb(error.getExceptionName(), BreadcrumbType.ERROR, message));
     }
 
@@ -1003,7 +1003,7 @@ public class Client extends Observable implements Observer {
      */
     public void leaveBreadcrumb(@NonNull String message,
                                 @NonNull BreadcrumbType type,
-                                @NonNull Map<String, String> metadata) {
+                                @NonNull Map<String, Object> metadata) {
         Breadcrumb crumb = new Breadcrumb(message, type, metadata);
 
         if (runBeforeBreadcrumbTasks(crumb)) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -990,11 +990,7 @@ public class Client extends Observable implements Observer {
      * @param message the log message to leave (max 140 chars)
      */
     public void leaveBreadcrumb(@NonNull String message) {
-        Breadcrumb crumb = new Breadcrumb(message);
-
-        if (runBeforeBreadcrumbTasks(crumb)) {
-            breadcrumbs.add(crumb);
-        }
+        leaveBreadcrumbInternal(new Breadcrumb(message));
     }
 
     /**
@@ -1004,8 +1000,10 @@ public class Client extends Observable implements Observer {
     public void leaveBreadcrumb(@NonNull String message,
                                 @NonNull BreadcrumbType type,
                                 @NonNull Map<String, Object> metadata) {
-        Breadcrumb crumb = new Breadcrumb(message, type, metadata);
+        leaveBreadcrumbInternal(new Breadcrumb(message, type, metadata));
+    }
 
+    private void leaveBreadcrumbInternal(Breadcrumb crumb) {
         if (runBeforeBreadcrumbTasks(crumb)) {
             breadcrumbs.add(crumb);
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -987,10 +987,10 @@ public class Client extends Observable implements Observer {
      * Leave a "breadcrumb" log message, representing an action that occurred
      * in your app, to aid with debugging.
      *
-     * @param breadcrumb the log message to leave (max 140 chars)
+     * @param message the log message to leave (max 140 chars)
      */
-    public void leaveBreadcrumb(@NonNull String breadcrumb) {
-        Breadcrumb crumb = new Breadcrumb(breadcrumb);
+    public void leaveBreadcrumb(@NonNull String message) {
+        Breadcrumb crumb = new Breadcrumb(message);
 
         if (runBeforeBreadcrumbTasks(crumb)) {
             breadcrumbs.add(crumb);
@@ -1001,10 +1001,10 @@ public class Client extends Observable implements Observer {
      * Leave a "breadcrumb" log message, representing an action which occurred
      * in your app, to aid with debugging.
      */
-    public void leaveBreadcrumb(@NonNull String name,
+    public void leaveBreadcrumb(@NonNull String message,
                                 @NonNull BreadcrumbType type,
                                 @NonNull Map<String, String> metadata) {
-        Breadcrumb crumb = new Breadcrumb(name, type, metadata);
+        Breadcrumb crumb = new Breadcrumb(message, type, metadata);
 
         if (runBeforeBreadcrumbTasks(crumb)) {
             breadcrumbs.add(crumb);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -223,6 +223,14 @@ public class Client extends Observable implements Observer {
             Logger.warn("Failed to set up orientation tracking: " + ex);
         }
 
+        // filter out any disabled breadcrumb types
+        addOnBreadcrumb(new OnBreadcrumb() {
+            @Override
+            public boolean run(@NonNull Breadcrumb breadcrumb) {
+                return immutableConfig.getEnabledBreadcrumbTypes().contains(breadcrumb.getType());
+            }
+        });
+
         // Flush any on-disk errors
         errorStore.flushOnLaunch();
         loadPlugins();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -234,6 +234,7 @@ public class Client extends Observable implements Observer {
         // Flush any on-disk errors
         errorStore.flushOnLaunch();
         loadPlugins();
+        leaveBreadcrumb("Bugsnag loaded");
     }
 
     void recordStorageCacheBehavior(MetaData metaData) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -6,14 +6,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Set;
@@ -59,7 +54,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
     private MetaData metaData;
     private final Collection<BeforeNotify> beforeNotifyTasks = new ConcurrentLinkedQueue<>();
     private final Collection<BeforeSend> beforeSendTasks = new ConcurrentLinkedQueue<>();
-    private final Collection<BeforeRecordBreadcrumb> beforeRecordBreadcrumbTasks
+    private final Collection<OnBreadcrumb> breadcrumbCallbacks
         = new ConcurrentLinkedQueue<>();
     private final Collection<BeforeSendSession> sessionCallbacks = new ConcurrentLinkedQueue<>();
 
@@ -748,12 +743,16 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
     /**
      * Adds a new before breadcrumb task
      *
-     * @param beforeRecordBreadcrumb the new before breadcrumb task
+     * @param onBreadcrumb the new before breadcrumb task
      */
-    protected void beforeRecordBreadcrumb(@NonNull BeforeRecordBreadcrumb beforeRecordBreadcrumb) {
-        if (!beforeRecordBreadcrumbTasks.contains(beforeRecordBreadcrumb)) {
-            beforeRecordBreadcrumbTasks.add(beforeRecordBreadcrumb);
+    void addOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
+        if (!breadcrumbCallbacks.contains(onBreadcrumb)) {
+            breadcrumbCallbacks.add(onBreadcrumb);
         }
+    }
+
+    void removeOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
+        breadcrumbCallbacks.remove(onBreadcrumb);
     }
 
     /**
@@ -762,8 +761,8 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
      * @return the before breadcrumb tasks
      */
     @NonNull
-    protected Collection<BeforeRecordBreadcrumb> getBeforeRecordBreadcrumbTasks() {
-        return beforeRecordBreadcrumbTasks;
+    Collection<OnBreadcrumb> getBreadcrumbCallbacks() {
+        return breadcrumbCallbacks;
     }
 
     void addBeforeSendSession(BeforeSendSession beforeSendSession) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,6 +37,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
     private final Set<String> ignoreClasses = new HashSet<>();
     private final Set<String> notifyReleaseStages = new HashSet<>();
     private final Set<String> projectPackages = new HashSet<>();
+    private final Set<BreadcrumbType> enabledBreadcrumbTypes = new HashSet<>();
 
     private String releaseStage;
     private boolean sendThreads = true;
@@ -58,6 +60,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
         = new ConcurrentLinkedQueue<>();
     private final Collection<BeforeSendSession> sessionCallbacks = new ConcurrentLinkedQueue<>();
 
+
     private String codeBundleId;
     private String notifierType;
 
@@ -77,6 +80,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
         this.apiKey = apiKey;
         this.metaData = new MetaData();
         this.metaData.addObserver(this);
+        enabledBreadcrumbTypes.addAll(Arrays.asList(BreadcrumbType.values()));
 
         try {
             // check if DETECT_NDK_CRASHES has been set in bugsnag-android or bugsnag-android-ndk
@@ -307,6 +311,16 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
     public void setNotifyReleaseStages(@NonNull Collection<String> notifyReleaseStages) {
         this.notifyReleaseStages.clear();
         this.notifyReleaseStages.addAll(notifyReleaseStages);
+    }
+
+    @NonNull
+    public Set<BreadcrumbType> getEnabledBreadcrumbTypes() {
+        return Collections.unmodifiableSet(enabledBreadcrumbTypes);
+    }
+
+    public void setEnabledBreadcrumbTypes(@NonNull Set<BreadcrumbType> enabledBreadcrumbTypes) {
+        this.enabledBreadcrumbTypes.clear();
+        this.enabledBreadcrumbTypes.addAll(enabledBreadcrumbTypes);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -28,7 +28,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
     private static final String HEADER_API_PAYLOAD_VERSION = "Bugsnag-Payload-Version";
     static final String HEADER_API_KEY = "Bugsnag-Api-Key";
     private static final String HEADER_BUGSNAG_SENT_AT = "Bugsnag-Sent-At";
-    private static final int DEFAULT_MAX_SIZE = 32;
+    private static final int DEFAULT_MAX_SIZE = 25;
     static final String DEFAULT_EXCEPTION_TYPE = "android";
 
     @NonNull

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -569,15 +569,17 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
 
     /**
      * Set the maximum number of breadcrumbs to keep and sent to Bugsnag.
-     * By default, we'll keep and send the 32 most recent breadcrumb log
+     * By default, we'll keep and send the 25 most recent breadcrumb log
      * messages.
      *
      * @param numBreadcrumbs max number of breadcrumb log messages to send
      */
     public void setMaxBreadcrumbs(int numBreadcrumbs) {
-        if (numBreadcrumbs < 0) {
-            Logger.warn("Ignoring invalid breadcrumb capacity. Must be >= 0.");
-            return;
+        if (numBreadcrumbs <= 0) {
+            numBreadcrumbs = 0;
+        }
+        if (numBreadcrumbs > 100) {
+            numBreadcrumbs = 100;
         }
         this.maxBreadcrumbs = numBreadcrumbs;
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorReader.java
@@ -145,7 +145,7 @@ class ErrorReader {
     private static Breadcrumb readBreadcrumb(JsonReader reader) throws IOException {
         String name = null;
         String type = null;
-        Map<String, String> metadata = new HashMap<>();
+        Map<String, Object> metadata = new HashMap<>();
         Date captureDate = null;
         reader.beginObject();
         while (reader.hasNext()) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventReceiver.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventReceiver.java
@@ -32,7 +32,7 @@ public class EventReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(@NonNull Context context, @NonNull Intent intent) {
         try {
-            Map<String, String> meta = new HashMap<>();
+            Map<String, Object> meta = new HashMap<>();
             String fullAction = intent.getAction();
             String shortAction = shortenActionNameIfNeeded(intent.getAction());
             meta.put(INTENT_ACTION_KEY, fullAction); // always add the Intent Action

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -14,6 +14,7 @@ internal data class ImmutableConfig(
     val ignoreClasses: Collection<String>,
     val notifyReleaseStages: Collection<String>,
     val projectPackages: Collection<String>,
+    val enabledBreadcrumbTypes: Set<BreadcrumbType>,
     val releaseStage: String?,
     val buildUuid: String?,
     val appVersion: String?,
@@ -100,6 +101,7 @@ internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
         persistUserBetweenSessions = config.persistUserBetweenSessions,
         launchCrashThresholdMs = config.launchCrashThresholdMs,
         loggingEnabled = config.loggingEnabled,
-        maxBreadcrumbs = config.maxBreadcrumbs
+        maxBreadcrumbs = config.maxBreadcrumbs,
+        enabledBreadcrumbTypes = config.enabledBreadcrumbTypes.toSet()
     )
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JsonWriter.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JsonWriter.java
@@ -110,7 +110,7 @@ import java.io.Writer;
  *
  *   public void writeUser(JsonWriter writer, User user) throws IOException {
  *     writer.beginObject();
- *     writer.name("name").value(user.getName());
+ *     writer.name("name").value(user.getMessage());
  *     writer.name("followers_count").value(user.getFollowersCount());
  *     writer.endObject();
  *   }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -273,12 +273,12 @@ public class NativeInterface {
     /**
      * Leaves a breadcrumb on the static client instance
      */
-    public static void leaveBreadcrumb(@NonNull String name,
+    public static void leaveBreadcrumb(@NonNull String message,
                                        @NonNull String type,
                                        @NonNull Map<String, String> metadata) {
         String typeName = type.toUpperCase(Locale.US);
         Map<String, String> map = metadata == null ? new HashMap<String, String>() : metadata;
-        getClient().leaveBreadcrumb(name, BreadcrumbType.valueOf(typeName), map);
+        getClient().leaveBreadcrumb(message, BreadcrumbType.valueOf(typeName), map);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -267,7 +267,7 @@ public class NativeInterface {
      */
     public static void leaveBreadcrumb(@NonNull final String name,
                                        @NonNull final BreadcrumbType type) {
-        getClient().leaveBreadcrumb(name, type, new HashMap<String, String>());
+        getClient().leaveBreadcrumb(name, type, new HashMap<String, Object>());
     }
 
     /**
@@ -275,9 +275,9 @@ public class NativeInterface {
      */
     public static void leaveBreadcrumb(@NonNull String message,
                                        @NonNull String type,
-                                       @NonNull Map<String, String> metadata) {
+                                       @NonNull Map<String, Object> metadata) {
         String typeName = type.toUpperCase(Locale.US);
-        Map<String, String> map = metadata == null ? new HashMap<String, String>() : metadata;
+        Map<String, Object> map = metadata == null ? new HashMap<String, Object>() : metadata;
         getClient().leaveBreadcrumb(message, BreadcrumbType.valueOf(typeName), map);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/OnBreadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/OnBreadcrumb.java
@@ -3,7 +3,7 @@ package com.bugsnag.android;
 import androidx.annotation.NonNull;
 
 /**
- * Add a "before breadcrumb" callback, to execute code before every
+ * Add a "on breadcrumb" callback, to execute code before every
  * breadcrumb captured by Bugsnag.
  * <p>
  * You can use this to modify breadcrumbs before they are stored by Bugsnag.
@@ -17,16 +17,16 @@ import androidx.annotation.NonNull;
  * }
  * })
  */
-public interface BeforeRecordBreadcrumb {
+public interface OnBreadcrumb {
 
     /**
-     * Runs the "before breadcrumb" callback. If the callback returns
-     * <code>false</code> any further BeforeRecordBreadcrumb callbacks will not be called
+     * Runs the "on breadcrumb" callback. If the callback returns
+     * <code>false</code> any further OnBreadcrumb callbacks will not be called
      * and the breadcrumb will not be captured by Bugsnag.
      *
      * @param breadcrumb the breadcrumb to be captured by Bugsnag
      * @see Breadcrumb
      */
-    boolean shouldRecord(@NonNull Breadcrumb breadcrumb);
+    boolean run(@NonNull Breadcrumb breadcrumb);
 
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -359,7 +359,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
 
     private void leaveBreadcrumb(String activityName, String lifecycleCallback) {
         if (configuration.getAutoCaptureBreadcrumbs()) {
-            Map<String, String> metadata = new HashMap<>();
+            Map<String, Object> metadata = new HashMap<>();
             metadata.put(KEY_LIFECYCLE_CALLBACK, lifecycleCallback);
 
             try {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
@@ -9,7 +9,7 @@ class BreadcrumbMutabilityTest {
 
     @Test
     fun breadcrumbCopiesMap() {
-        val data = mutableMapOf<String, String>()
+        val data = mutableMapOf<String, Any>()
         val breadcrumb = Breadcrumb("foo", BreadcrumbType.MANUAL, data)
         data["a"] = "bar"
         assertTrue(breadcrumb.metadata.isEmpty())
@@ -18,7 +18,7 @@ class BreadcrumbMutabilityTest {
 
     @Test
     fun breadcrumbProtectsMetaData() {
-        val data = mutableMapOf<String, String>()
+        val data = mutableMapOf<String, Any>()
         val breadcrumb = Breadcrumb("foo", BreadcrumbType.MANUAL, data)
         breadcrumb.metadata["a"] = "bar"
         assertFalse(breadcrumb.metadata.isEmpty())

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbsTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbsTest.kt
@@ -120,10 +120,7 @@ class BreadcrumbsTest {
         assertEquals(50, config.maxBreadcrumbs)
 
         config.maxBreadcrumbs = Int.MAX_VALUE
-        assertEquals(Int.MAX_VALUE, config.maxBreadcrumbs)
-
-        config.maxBreadcrumbs = 0
-        assertEquals(0, config.maxBreadcrumbs)
+        assertEquals(100, config.maxBreadcrumbs)
 
         config.maxBreadcrumbs = -5
         assertEquals(0, config.maxBreadcrumbs)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbsTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbsTest.kt
@@ -26,17 +26,15 @@ class BreadcrumbsTest {
     fun testMessageTruncation() {
         breadcrumbs.add(Breadcrumb("Started app"))
         breadcrumbs.add(Breadcrumb("Clicked a button"))
-        breadcrumbs.add(Breadcrumb("Lorem ipsum dolor sit amet, consectetur adipiscing elit,"
-            + " sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad "
-            + "minim veniam, quis nostrud exercitation ullamco laboris nisi"
-            + " ut aliquip ex ea commodo consequat."))
-
+        val longStr = ("Lorem ipsum dolor sit amet, consectetur adipiscing elit,"
+                + " sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad "
+                + "minim veniam, quis nostrud exercitation ullamco laboris nisi"
+                + " ut aliquip ex ea commodo consequat.")
+        breadcrumbs.add(Breadcrumb(longStr))
 
         val crumbs = breadcrumbs.store.toList()
         assertEquals(3, crumbs.size)
-        assertEquals("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do "
-            + "eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim",
-            crumbs[2].metadata["message"])
+        assertEquals(longStr, crumbs[2].metadata["message"])
     }
 
     /**

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbsTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbsTest.kt
@@ -114,7 +114,7 @@ class BreadcrumbsTest {
     @Test
     fun testMaxBreadcrumbAccessors() {
         val config = Configuration("api-key")
-        assertEquals(32, config.maxBreadcrumbs)
+        assertEquals(25, config.maxBreadcrumbs)
 
         config.maxBreadcrumbs = 50
         assertEquals(50, config.maxBreadcrumbs)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbsTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbsTest.kt
@@ -98,7 +98,7 @@ class BreadcrumbsTest {
      */
     @Test
     fun testPayloadSizeLimit() {
-        val metadata = HashMap<String, String>()
+        val metadata = HashMap<String, Any>()
         for (i in 0..399) {
             metadata[String.format(Locale.US, "%d", i)] = "!!"
         }

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
@@ -33,8 +33,8 @@ void bugsnag_set_user_env(JNIEnv *env, char* id, char* email, char* name);
  * Leave a breadcrumb, indicating an event of significance which will be logged in subsequent
  * error reports
  */
-void bugsnag_leave_breadcrumb(char *name, bsg_breadcrumb_t type);
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *name, bsg_breadcrumb_t type);
+void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_t type);
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message, bsg_breadcrumb_t type);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -262,7 +262,7 @@ public class NativeBridge implements Observer {
     private void handleAddBreadcrumb(Object arg) {
         if (arg instanceof Breadcrumb) {
             Breadcrumb crumb = (Breadcrumb) arg;
-            addBreadcrumb(crumb.getName(), crumb.getType().toString(),
+            addBreadcrumb(crumb.getMessage(), crumb.getType().toString(),
                 crumb.getTimestamp(), crumb.getMetadata());
         } else {
             warn("Attempted to add non-breadcrumb: " + arg);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -18,7 +18,7 @@ void bugsnag_init(JNIEnv *env) { bsg_global_jni_env = env; }
 void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
                         bsg_severity_t severity);
 void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name);
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *name,
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
                                   bsg_breadcrumb_t type);
 
 void bugsnag_notify(char *name, char *message, bsg_severity_t severity) {
@@ -38,9 +38,9 @@ void bugsnag_set_user(char *id, char *email, char *name) {
   }
 }
 
-void bugsnag_leave_breadcrumb(char *name, bsg_breadcrumb_t type) {
+void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_t type) {
   if (bsg_global_jni_env != NULL) {
-    bugsnag_leave_breadcrumb_env(bsg_global_jni_env, name, type);
+    bugsnag_leave_breadcrumb_env(bsg_global_jni_env, message, type);
   } else {
     BUGSNAG_LOG("Cannot bugsnag_leave_breadcrumb_env before initializing with "
                 "bugsnag_init");
@@ -179,7 +179,7 @@ jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bsg_breadcrumb_t type,
   }
 }
 
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *name,
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
                                   bsg_breadcrumb_t type) {
   jclass interface_class =
       (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
@@ -191,7 +191,7 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *name,
 
   jobject jtype = (*env)->GetStaticObjectField(
       env, type_class, bsg_parse_jcrumb_type(env, type, type_class));
-  jstring jname = (*env)->NewStringUTF(env, name);
+  jstring jname = (*env)->NewStringUTF(env, message);
   (*env)->CallStaticVoidMethod(env, interface_class, leave_breadcrumb_method,
                                jname, jtype);
 

--- a/features/breadcrumb.feature
+++ b/features/breadcrumb.feature
@@ -7,13 +7,19 @@ Scenario: Manually added breadcrumbs are sent in report
     And the exception "message" equals "BreadcrumbScenario"
     And the event "breadcrumbs" is not null
 
+    And the event "breadcrumbs.2.timestamp" is not null
+    And the event "breadcrumbs.2.name" equals "Another Breadcrumb"
+    And the event "breadcrumbs.2.type" equals "user"
+    And the event "breadcrumbs.2.metaData.Foo" equals "Bar"
+
     And the event "breadcrumbs.1.timestamp" is not null
-    And the event "breadcrumbs.1.name" equals "Another Breadcrumb"
-    And the event "breadcrumbs.1.type" equals "user"
-    And the event "breadcrumbs.1.metaData.Foo" equals "Bar"
+    And the event "breadcrumbs.1.name" equals "manual"
+    And the event "breadcrumbs.1.type" equals "manual"
+    And the event "breadcrumbs.1.metaData" is not null
+    And the event "breadcrumbs.1.metaData.message" equals "Hello Breadcrumb!"
 
     And the event "breadcrumbs.0.timestamp" is not null
     And the event "breadcrumbs.0.name" equals "manual"
     And the event "breadcrumbs.0.type" equals "manual"
     And the event "breadcrumbs.0.metaData" is not null
-    And the event "breadcrumbs.0.metaData.message" equals "Hello Breadcrumb!"
+    And the event "breadcrumbs.0.metaData.message" equals "Bugsnag loaded"

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
@@ -21,7 +21,8 @@ internal class BreadcrumbScenario(config: Configuration,
     override fun run() {
         super.run()
         Bugsnag.leaveBreadcrumb("Hello Breadcrumb!")
-        Bugsnag.leaveBreadcrumb("Another Breadcrumb", BreadcrumbType.USER, Collections.singletonMap("Foo", "Bar"))
+        val data = Collections.singletonMap("Foo", "Bar" as Any)
+        Bugsnag.leaveBreadcrumb("Another Breadcrumb", BreadcrumbType.USER, data)
         Bugsnag.notify(generateException())
     }
 

--- a/tests/features/breadcrumb.feature
+++ b/tests/features/breadcrumb.feature
@@ -7,13 +7,19 @@ Scenario: Manually added breadcrumbs are sent in report
     And the exception "message" equals "BreadcrumbScenario"
     And the event "breadcrumbs" is not null
 
+    And the event "breadcrumbs.2.timestamp" is not null
+    And the event "breadcrumbs.2.name" equals "Another Breadcrumb"
+    And the event "breadcrumbs.2.type" equals "user"
+    And the event "breadcrumbs.2.metaData.Foo" equals "Bar"
+
     And the event "breadcrumbs.1.timestamp" is not null
-    And the event "breadcrumbs.1.name" equals "Another Breadcrumb"
-    And the event "breadcrumbs.1.type" equals "user"
-    And the event "breadcrumbs.1.metaData.Foo" equals "Bar"
+    And the event "breadcrumbs.1.name" equals "manual"
+    And the event "breadcrumbs.1.type" equals "manual"
+    And the event "breadcrumbs.1.metaData" is not null
+    And the event "breadcrumbs.1.metaData.message" equals "Hello Breadcrumb!"
 
     And the event "breadcrumbs.0.timestamp" is not null
     And the event "breadcrumbs.0.name" equals "manual"
     And the event "breadcrumbs.0.type" equals "manual"
     And the event "breadcrumbs.0.metaData" is not null
-    And the event "breadcrumbs.0.metaData.message" equals "Hello Breadcrumb!"
+    And the event "breadcrumbs.0.metaData.message" equals "Bugsnag loaded


### PR DESCRIPTION
## Goal

Updates the breadcrumb functionality to better match the notifier spec.

## Changeset

- Renamed `breadcrumb.name` to `breadcrumb.message`
- Captured "Bugsnag loaded" breadcrumb when a `Client` is constructed
- Enforce 0-100 limit on valid values for `config.maxBreadcrumbs`
- Change default for `config.maxBreadcrumbs` from 32 to 25
- Removed 140 char limit from breadcrumb message length
- Altered `breadcrumb.metadata` to accept `Object` values rather than just `String`. (Note: this does not currently prevent nested values, which will be addressed in a separate PR that looks more fully at data redaction/serialization)

### New APIs

- Renamed `BeforeRecordBreadcrumb` to `OnBreadcrumb`
- Added `addOnBreadcrumb` and `removeOnBreadcrumb` to `Bugsnag` and `Client`
- Added `enabledBreadcrumbTypes to `Configuration`, which discards any breadcrumbs not of the type within this set

## Tests
- Added unit test to verify breadcrumbs with a type not contained in `enabledBreadcrumbTypes` are discarded
- Added unit test to verify that `enabledBreadcrumbTypes` can be configured and has a sensible default value
- Added unit test to verify that `OnBreadcrumb` callbacks can be removed