### PR TITLE
Catch throwables when invoking methods on system services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Catch throwables when invoking methods on system services
+  [#623](https://github.com/bugsnag/bugsnag-android/pull/623)
+
 ## 4.21.1 (2019-10-15)
 
 * Fix a packaging issue on Maven Central in v4.21.0

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppData.java
@@ -111,7 +111,8 @@ class AppData {
      *
      * @return the duration in ms
      */
-    long calculateDurationInForeground() {
+    @Nullable
+    Long calculateDurationInForeground() {
         long nowMs = System.currentTimeMillis();
         return sessionTracker.getDurationInForegroundMs(nowMs);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
@@ -31,10 +31,23 @@ internal class ConnectivityCompat(
             else -> ConnectivityLegacy(context, cm, callback)
         }
 
-    override fun registerForNetworkChanges() = connectivity.registerForNetworkChanges()
-    override fun hasNetworkConnection() = connectivity.hasNetworkConnection()
-    override fun unregisterForNetworkChanges() = connectivity.unregisterForNetworkChanges()
-    override fun retrieveNetworkAccessState() = connectivity.retrieveNetworkAccessState()
+    override fun registerForNetworkChanges() {
+        runCatching { connectivity.registerForNetworkChanges() }
+    }
+
+    override fun hasNetworkConnection(): Boolean {
+        val result = runCatching { connectivity.hasNetworkConnection() }
+        return result.getOrElse { true } // allow network requests to be made if state unknown
+    }
+
+    override fun unregisterForNetworkChanges() {
+        runCatching { connectivity.unregisterForNetworkChanges() }
+    }
+
+    override fun retrieveNetworkAccessState(): String {
+        val result = runCatching { connectivity.retrieveNetworkAccessState() }
+        return result.getOrElse { "unknown" }
+    }
 }
 
 @Suppress("DEPRECATION")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ForegroundDetector.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ForegroundDetector.java
@@ -31,12 +31,16 @@ class ForegroundDetector {
      */
     @Nullable
     Boolean isInForeground() {
-        ActivityManager.RunningAppProcessInfo info = getProcessInfo();
+        try {
+            ActivityManager.RunningAppProcessInfo info = getProcessInfo();
 
-        if (info != null) {
-            return info.importance
-                <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
-        } else {
+            if (info != null) {
+                return info.importance
+                        <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+            } else {
+                return null;
+            }
+        } catch (RuntimeException exc) {
             return null;
         }
     }
@@ -54,13 +58,8 @@ class ForegroundDetector {
 
     @Nullable
     private ActivityManager.RunningAppProcessInfo getProcessInfoPreApi16() {
-        List<ActivityManager.RunningAppProcessInfo> appProcesses;
-
-        try {
-            appProcesses = activityManager.getRunningAppProcesses();
-        } catch (RuntimeException exc) {
-            return null;
-        }
+        List<ActivityManager.RunningAppProcessInfo> appProcesses
+                = activityManager.getRunningAppProcesses();
 
         if (appProcesses != null) {
             int pid = Process.myPid();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ForegroundDetector.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ForegroundDetector.java
@@ -22,10 +22,8 @@ class ForegroundDetector {
      * importance as a proxy.
      * <p/>
      * In the unlikely event that information about the process cannot be retrieved, this method
-     * will return true. This is deemed preferable as ANRs are only reported when the application
-     * is in the foreground, and we would rather deliver false-positives than miss true ANRs in
-     * this case. We also need to report 'inForeground' as a boolean value in API calls, and
-     * need to keep the definition of the value consistent throughout the application.
+     * will return null, and the 'inForeground' and 'durationInForeground' values will not be
+     * serialized in API calls.
      *
      * @return whether the application is in the foreground or not
      */

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ForegroundDetector.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ForegroundDetector.java
@@ -29,14 +29,15 @@ class ForegroundDetector {
      *
      * @return whether the application is in the foreground or not
      */
-    boolean isInForeground() {
+    @Nullable
+    Boolean isInForeground() {
         ActivityManager.RunningAppProcessInfo info = getProcessInfo();
 
         if (info != null) {
             return info.importance
                 <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
-        } else { // prefer a false negative if process info not available
-            return false;
+        } else {
+            return null;
         }
     }
 
@@ -57,7 +58,7 @@ class ForegroundDetector {
 
         try {
             appProcesses = activityManager.getRunningAppProcesses();
-        } catch (SecurityException exc) {
+        } catch (RuntimeException exc) {
             return null;
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -401,21 +401,32 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     }
 
     private void notifyNdkInForeground() {
-        notifyObservers(new NativeInterface.Message(
-            NativeInterface.MessageType.UPDATE_IN_FOREGROUND,
-            Arrays.asList(isInForeground(), getContextActivity())));
+        Boolean inForeground = isInForeground();
+
+        if (inForeground != null) {
+            notifyObservers(new NativeInterface.Message(
+                    NativeInterface.MessageType.UPDATE_IN_FOREGROUND,
+                    Arrays.asList(inForeground, getContextActivity())));
+        }
     }
 
-    boolean isInForeground() {
+    @Nullable
+    Boolean isInForeground() {
         return foregroundDetector.isInForeground();
     }
 
     //FUTURE:SM This shouldnt be here
-    long getDurationInForegroundMs(long nowMs) {
+    @Nullable
+    Long getDurationInForegroundMs(long nowMs) {
         long durationMs = 0;
         long sessionStartTimeMs = lastEnteredForegroundMs.get();
 
-        if (isInForeground() && sessionStartTimeMs != 0) {
+        Boolean inForeground = isInForeground();
+
+        if (inForeground == null) {
+            return null;
+        }
+        if (inForeground && sessionStartTimeMs != 0) {
             durationMs = nowMs - sessionStartTimeMs;
         }
         return durationMs > 0 ? durationMs : 0;

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityApi24Test.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityApi24Test.kt
@@ -1,0 +1,55 @@
+@file:Suppress("DEPRECATION")
+
+package com.bugsnag.android
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ConnectivityApi24Test {
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var cm: ConnectivityManager
+
+    @Mock
+    lateinit var info: Network
+
+    @Mock
+    lateinit var capabilities: NetworkCapabilities
+
+    @Test
+    fun connectivityLegacyHasConnection() {
+        val conn = ConnectivityApi24(cm, null)
+        assertFalse(conn.hasNetworkConnection())
+
+        conn.activeNetwork = info;
+        assertTrue(conn.hasNetworkConnection())
+    }
+
+    @Test
+    fun connectivityLegacyNetworkState() {
+        val conn = ConnectivityApi24(cm, null)
+        Mockito.`when`(cm.activeNetwork).thenReturn(info)
+        
+        Mockito.`when`(cm.getNetworkCapabilities(info)).thenReturn(null)
+        assertEquals("none", conn.retrieveNetworkAccessState())
+
+        Mockito.`when`(cm.getNetworkCapabilities(info)).thenReturn(capabilities)
+        Mockito.`when`(capabilities.hasTransport(0)).thenReturn(true)
+        assertEquals("cellular", conn.retrieveNetworkAccessState())
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
@@ -1,0 +1,50 @@
+@file:Suppress("DEPRECATION")
+
+package com.bugsnag.android
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ConnectivityLegacyTest {
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var cm: ConnectivityManager
+
+    @Mock
+    lateinit var info: NetworkInfo
+
+    @Test
+    fun connectivityLegacyHasConnection() {
+        val conn = ConnectivityLegacy(context, cm, null)
+        assertFalse(conn.hasNetworkConnection())
+
+        Mockito.`when`(cm.activeNetworkInfo).thenReturn(info)
+        Mockito.`when`(info.isConnectedOrConnecting).thenReturn(true)
+        assertTrue(conn.hasNetworkConnection())
+    }
+
+    @Test
+    fun connectivityLegacyNetworkState() {
+        val conn = ConnectivityLegacy(context, cm, null)
+
+        Mockito.`when`(cm.activeNetworkInfo).thenReturn(info)
+        Mockito.`when`(info.type).thenReturn(99)
+        assertEquals("cellular", conn.retrieveNetworkAccessState())
+
+        Mockito.`when`(info.type).thenReturn(1)
+        assertEquals("wifi", conn.retrieveNetworkAccessState())
+    }
+}


### PR DESCRIPTION
## Goal

System services can throw a `RuntimeException` if the [remote call failed](https://developer.android.com/reference/android/os/RemoteException). We should swallow these in
bugsnag-android and attempt a sensible default rather than terminating the process, such as returning null for serialized values such as `app.inForeground`.

## Changeset

Caught an exception whenever a method is invoked on a system service that can throw a `RuntimeException`. In some cases this handling was already in place, where it wasn't, the following changes were made:

- Catching exceptions from `ConnectivityManager` and returning a sensible default in `ConnectivityCompat`
- Caught `RuntimeException` in `ForegroundDetector` rather than more specific `SecurityException`
- Return nullable values for `app.inForeground` and `app.durationInForeground` if information couldn't be retrieved, and avoid serializing in the payload body

## Tests

Installed local artefact and verified that a report is still sent after regaining a network connection, and that the `inForeground` fields are correct in both JVM + NDK payloads.
