### PR TITLE
Migrate device payload fields

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -274,13 +274,12 @@ public class ClientTest {
         client = generateClient();
         Map<String, Object> metaData = client.getDeviceData().getDeviceMetaData();
 
-        assertEquals(10, metaData.size());
+        assertEquals(9, metaData.size());
         assertNotNull(metaData.get("batteryLevel"));
         assertNotNull(metaData.get("charging"));
         assertNotNull(metaData.get("locationStatus"));
         assertNotNull(metaData.get("networkAccess"));
         assertNotNull(metaData.get("brand"));
-        assertNotNull(metaData.get("locale"));
         assertNotNull(metaData.get("screenDensity"));
         assertNotNull(metaData.get("dpi"));
         assertNotNull(metaData.get("emulator"));

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -274,12 +274,11 @@ public class ClientTest {
         client = generateClient();
         Map<String, Object> metaData = client.getDeviceData().getDeviceMetaData();
 
-        assertEquals(11, metaData.size());
+        assertEquals(10, metaData.size());
         assertNotNull(metaData.get("batteryLevel"));
         assertNotNull(metaData.get("charging"));
         assertNotNull(metaData.get("locationStatus"));
         assertNotNull(metaData.get("networkAccess"));
-        assertNotNull(metaData.get("time"));
         assertNotNull(metaData.get("brand"));
         assertNotNull(metaData.get("locale"));
         assertNotNull(metaData.get("screenDensity"));

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -58,6 +58,7 @@ public class DeviceDataTest {
         assertTrue(deviceDataJson.getLong("totalMemory") > 0);
         assertTrue(deviceDataJson.has("freeDisk"));
         assertNotNull(deviceDataJson.getString("orientation"));
+        assertNotNull(deviceDataJson.getString("time"));
     }
 
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -59,6 +59,7 @@ public class DeviceDataTest {
         assertTrue(deviceDataJson.has("freeDisk"));
         assertNotNull(deviceDataJson.getString("orientation"));
         assertNotNull(deviceDataJson.getString("time"));
+        assertNotNull(deviceDataJson.get("locale"));
     }
 
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -111,6 +111,7 @@ class DeviceData {
         map.put("freeDisk", calculateFreeDisk());
         map.put("orientation", calculateOrientation());
         map.put("time", getTime());
+        map.put("locale", locale);
         return map;
     }
 
@@ -121,7 +122,6 @@ class DeviceData {
         map.put("locationStatus", getLocationStatus());
         map.put("networkAccess", getNetworkAccess());
         map.put("brand", Build.BRAND);
-        map.put("locale", locale);
         map.put("screenDensity", screenDensity);
         map.put("dpi", dpi);
         map.put("emulator", emulator);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -110,6 +110,7 @@ class DeviceData {
         map.put("totalMemory", calculateTotalMemory());
         map.put("freeDisk", calculateFreeDisk());
         map.put("orientation", calculateOrientation());
+        map.put("time", getTime());
         return map;
     }
 
@@ -119,7 +120,6 @@ class DeviceData {
         map.put("charging", isCharging());
         map.put("locationStatus", getLocationStatus());
         map.put("networkAccess", getNetworkAccess());
-        map.put("time", getTime());
         map.put("brand", Build.BRAND);
         map.put("locale", locale);
         map.put("screenDensity", screenDensity);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -213,6 +213,7 @@ void bsg_serialize_app_metadata(const bsg_app_info app, JSON_Object *event) {
 void bsg_serialize_device(const bsg_device_info device, JSON_Object *event) {
   json_object_dotset_string(event, "device.osName", "android");
   json_object_dotset_string(event, "device.id", device.id);
+  json_object_dotset_string(event, "device.locale", device.locale);
   json_object_dotset_string(event, "device.osVersion", device.os_version);
   json_object_dotset_string(event, "device.manufacturer", device.manufacturer);
   json_object_dotset_string(event, "device.model", device.model);
@@ -240,7 +241,6 @@ void bsg_serialize_device_metadata(const bsg_device_info device, JSON_Object *ev
   json_object_dotset_string(event, "metaData.device.brand", device.brand);
   json_object_dotset_boolean(event, "metaData.device.emulator", device.emulator);
   json_object_dotset_boolean(event, "metaData.device.jailbroken", device.jailbroken);
-  json_object_dotset_string(event, "metaData.device.locale", device.locale);
   json_object_dotset_string(event, "metaData.device.locationStatus", device.location_status);
   json_object_dotset_string(event, "metaData.device.networkAccess", device.network_access);
   json_object_dotset_number(event, "metaData.device.dpi", device.dpi);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -228,6 +228,12 @@ void bsg_serialize_device(const bsg_device_info device, JSON_Object *event) {
   }
 
   json_object_dotset_number(event, "device.totalMemory", device.total_memory);
+
+  char report_time[sizeof "2018-10-08T12:07:09Z"];
+  if (device.time > 0) {
+    strftime(report_time, sizeof report_time, "%FT%TZ", gmtime(&device.time));
+    json_object_dotset_string(event, "device.time", report_time);
+  }
 }
 
 void bsg_serialize_device_metadata(const bsg_device_info device, JSON_Object *event) {
@@ -240,12 +246,6 @@ void bsg_serialize_device_metadata(const bsg_device_info device, JSON_Object *ev
   json_object_dotset_number(event, "metaData.device.dpi", device.dpi);
   json_object_dotset_number(event, "metaData.device.screenDensity", device.screen_density);
   json_object_dotset_string(event, "metaData.device.screenResolution", device.screen_resolution);
-
-  char report_time[sizeof "2018-10-08T12:07:09Z"];
-  if (device.time > 0) {
-    strftime(report_time, sizeof report_time, "%FT%TZ", gmtime(&device.time));
-    json_object_dotset_string(event, "metaData.device.time", report_time);
-  }
 }
 
 void bsg_serialize_custom_metadata(const bugsnag_metadata metadata, JSON_Object *event) {

--- a/features/steps/build_steps.rb
+++ b/features/steps/build_steps.rb
@@ -127,6 +127,7 @@ Then("the report in request {int} contains the required fields") do |index|
     And the payload field "events.0.app.version" is not null for request #{index}
     And the payload field "events.0.app.versionCode" equals 34 for request #{index}
     And the payload field "events.0.device.id" is not null for request #{index}
+    And the payload field "events.0.device.locale" is not null for request #{index}
     And the payload field "events.0.device.manufacturer" is not null for request #{index}
     And the payload field "events.0.device.model" is not null for request #{index}
     And the payload field "events.0.device.orientation" is not null for request #{index}
@@ -140,7 +141,6 @@ Then("the report in request {int} contains the required fields") do |index|
     And the payload field "events.0.metaData.device.brand" is not null for request #{index}
     And the payload field "events.0.metaData.device.dpi" is not null for request #{index}
     And the payload field "events.0.metaData.device.emulator" is true for request #{index}
-    And the payload field "events.0.metaData.device.locale" is not null for request #{index}
     And the payload field "events.0.metaData.device.locationStatus" is not null for request #{index}
     And the payload field "events.0.metaData.device.networkAccess" is not null for request #{index}
     And the payload field "events.0.metaData.device.screenDensity" is not null for request #{index}

--- a/features/steps/build_steps.rb
+++ b/features/steps/build_steps.rb
@@ -131,6 +131,7 @@ Then("the report in request {int} contains the required fields") do |index|
     And the payload field "events.0.device.model" is not null for request #{index}
     And the payload field "events.0.device.orientation" is not null for request #{index}
     And the payload field "events.0.device.osName" equals "android" for request #{index}
+    And the payload field "events.0.device.time" is not null for request #{index}
     And the payload field "events.0.device.totalMemory" is not null for request #{index}
     And the payload field "events.0.device.runtimeVersions.osBuild" is not null for request #{index}
     And the payload field "events.0.metaData.app.name" equals "MazeRunner" for request #{index}
@@ -144,7 +145,6 @@ Then("the report in request {int} contains the required fields") do |index|
     And the payload field "events.0.metaData.device.networkAccess" is not null for request #{index}
     And the payload field "events.0.metaData.device.screenDensity" is not null for request #{index}
     And the payload field "events.0.metaData.device.screenResolution" is not null for request #{index}
-    And the payload field "events.0.metaData.device.time" is not null for request #{index}
     And the payload field "events.0.severity" is not null for request #{index}
     And the payload field "events.0.severityReason.type" is not null for request #{index}
     And the payload field "events.0.device.cpuAbi" is a non-empty array for request #{index}

--- a/tests/features/steps/android_steps.rb
+++ b/tests/features/steps/android_steps.rb
@@ -118,6 +118,7 @@ Then("the report contains the required fields") do
     And the payload field "events.0.app.version" is not null
     And the payload field "events.0.app.versionCode" equals 34
     And the payload field "events.0.device.id" is not null
+    And the payload field "events.0.device.locale" is not null
     And the payload field "events.0.device.manufacturer" is not null
     And the payload field "events.0.device.model" is not null
     And the payload field "events.0.device.orientation" is not null
@@ -130,7 +131,6 @@ Then("the report contains the required fields") do
     And the payload field "events.0.metaData.app.versionName" is not null
     And the payload field "events.0.metaData.device.brand" is not null
     And the payload field "events.0.metaData.device.dpi" is not null
-    And the payload field "events.0.metaData.device.locale" is not null
     And the payload field "events.0.metaData.device.locationStatus" is not null
     And the payload field "events.0.metaData.device.networkAccess" is not null
     And the payload field "events.0.metaData.device.screenDensity" is not null

--- a/tests/features/steps/android_steps.rb
+++ b/tests/features/steps/android_steps.rb
@@ -122,6 +122,7 @@ Then("the report contains the required fields") do
     And the payload field "events.0.device.model" is not null
     And the payload field "events.0.device.orientation" is not null
     And the payload field "events.0.device.osName" equals "android"
+    And the payload field "events.0.device.time" is not null
     And the payload field "events.0.device.totalMemory" is not null
     And the payload field "events.0.device.runtimeVersions.osBuild" is not null
     And the payload field "events.0.metaData.app.name" equals "MazeRunner"
@@ -134,7 +135,6 @@ Then("the report contains the required fields") do
     And the payload field "events.0.metaData.device.networkAccess" is not null
     And the payload field "events.0.metaData.device.screenDensity" is not null
     And the payload field "events.0.metaData.device.screenResolution" is not null
-    And the payload field "events.0.metaData.device.time" is not null
     And the payload field "events.0.severity" is not null
     And the payload field "events.0.severityReason.type" is not null
     And the payload field "events.0.device.cpuAbi" is a non-empty array


### PR DESCRIPTION
## Goal

Migrates the `time` and `locale` fields from `metaData.device` to `device`, to match the current error API payload structure.

Originally raised in #629 