### PR TITLE
Delete NDK report file if signal handler returns without terminating process

### DIFF
--- a/sdk/src/main/jni/utils/serializer.c
+++ b/sdk/src/main/jni/utils/serializer.c
@@ -32,6 +32,10 @@ bool bsg_serialize_report_to_file(bsg_environment *env) {
   return bsg_report_write(&env->report_header, &env->next_report, fd);
 }
 
+bool bsg_delete_report_file(const char *report_path) {
+  return unlink(report_path) == 0;
+}
+
 bugsnag_report *bsg_deserialize_report_from_file(char *filepath) {
   int fd = open(filepath, O_RDONLY);
   if (fd == -1) {

--- a/sdk/src/main/jni/utils/serializer.h
+++ b/sdk/src/main/jni/utils/serializer.h
@@ -15,6 +15,8 @@ char *bsg_serialize_report_to_json_string(bugsnag_report *report);
 
 bool bsg_serialize_report_to_file(bsg_environment *env) __asyncsafe;
 
+bool bsg_delete_report_file(const char *report_path) __asyncsafe;
+
 bugsnag_report *bsg_deserialize_report_from_file(char *filepath);
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Goal

If the previous signal handler returns without crashing the app, this indicates that the signal may
be a false positive. On Unity this can be triggered by loading an invalid asset then force-closing
the app, which triggers a bug in Unity that causes a SIGSEGV, and the previous handler does not terminate the process.

We do not wish to report these types of errors if the process has not been terminated, so should
delete the file in this scenario.

## Changeset

Delete report file if the handler does not terminate the process.

## Tests

Manually verified that a SIGSEGV was reported before the change, and not reported after the change.
