### PR TITLE
Add Error interface

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
@@ -13,8 +13,8 @@ class Error @JvmOverloads internal constructor(
 
             var currentEx: Throwable? = exc
             while (currentEx != null) {
-                val trace = Stacktrace(exc.stackTrace, projectPackages)
-                errors.add(Error(exc.javaClass.name, exc.localizedMessage, trace.trace))
+                val trace = Stacktrace(currentEx.stackTrace, projectPackages)
+                errors.add(Error(currentEx.javaClass.name, currentEx.localizedMessage, trace.trace))
                 currentEx = currentEx.cause
             }
             return errors

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
@@ -1,0 +1,32 @@
+package com.bugsnag.android
+
+class Error @JvmOverloads internal constructor(
+    var errorClass: String,
+    var errorMessage: String?,
+    var stacktrace: List<Stackframe>,
+    var type: String = "android"
+): JsonStream.Streamable {
+
+    companion object {
+        fun createError(exc: Throwable, projectPackages: Collection<String>): List<Error> {
+            val errors = mutableListOf<Error>()
+
+            var currentEx: Throwable? = exc
+            while (currentEx != null) {
+                val trace = Stacktrace(exc.stackTrace, projectPackages)
+                errors.add(Error(exc.javaClass.name, exc.localizedMessage, trace.trace))
+                currentEx = currentEx.cause
+            }
+            return errors
+        }
+    }
+
+    override fun toStream(writer: JsonStream) {
+        writer.beginObject()
+        writer.name("errorClass").value(errorClass)
+        writer.name("message").value(errorMessage)
+        writer.name("type").value(type)
+        writer.name("stacktrace").value(stacktrace)
+        writer.endObject()
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+internal class ErrorSerializationTest {
+
+    companion object {
+        @JvmStatic
+        @Parameters
+        fun testCases() = generateSerializationTestCases(
+            "error",
+            Error("foo", "bar", listOf())
+        )
+    }
+
+    @Parameter
+    lateinit var testCase: Pair<Error, String>
+
+    @Test
+    fun testJsonSerialisation() = verifyJsonMatches(testCase.first, testCase.second)
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorTest.kt
@@ -1,0 +1,27 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ErrorTest {
+
+    @Test
+    fun createError() {
+        val err = Error.createError(RuntimeException("Whoops"), setOf())
+        assertEquals(1, err.size)
+        assertEquals("Whoops", err[0].errorMessage)
+        assertFalse(err[0].stacktrace.isEmpty())
+    }
+
+    @Test
+    fun createNestedError() {
+        val err = Error.createError(IllegalStateException("Some err", RuntimeException("Whoops")), setOf())
+        assertEquals(2, err.size)
+        assertEquals("Some err", err[0].errorMessage)
+        assertFalse(err[0].stacktrace.isEmpty())
+
+        assertEquals("Whoops", err[1].errorMessage)
+        assertFalse(err[1].stacktrace.isEmpty())
+    }
+}

--- a/bugsnag-android-core/src/test/resources/error_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/error_serialization_0.json
@@ -1,0 +1,6 @@
+{
+  "errorClass": "foo",
+  "message": "bar",
+  "type": "android",
+  "stacktrace": []
+}


### PR DESCRIPTION
## Goal

Adds the `Error` interface to conform to the Notifier spec. Note that this PR only adds the interface, and this is not used by the `Event` yet.

## Tests

Added a JVM serialization test to verify that JSON is constructed correctly.
