### PR TITLE
Add serialization test for Thread class

### DIFF
--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
@@ -1,0 +1,40 @@
+package com.bugsnag.android
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+internal class ThreadSerializationTest {
+
+    companion object {
+        @JvmStatic
+        @Parameters
+        fun testCases(): Collection<Pair<JsonStream.Streamable, String>> {
+            val stacktrace = arrayOf(
+                StackTraceElement("", "run_func", "librunner.so", 5038),
+                StackTraceElement("Runner", "runFunc", "Runner.java", 14),
+                StackTraceElement("App", "launch", "App.java", 70)
+            )
+
+            val thread = Thread(24, "main-one", "ando", true, Stacktrace(stacktrace, emptySet()))
+
+            val stacktrace1 = arrayOf(
+                StackTraceElement("", "run_func", "librunner.so", 5038),
+                StackTraceElement("Runner", "runFunc", "Runner.java", 14),
+                StackTraceElement("App", "launch", "App.java", 70)
+            )
+
+            val thread1 = Thread(24, "main-one", "ando", false, Stacktrace(stacktrace1, emptySet()))
+            return generateSerializationTestCases("thread", thread, thread1)
+        }
+    }
+
+    @Parameter
+    lateinit var testCase: Pair<Thread, String>
+
+    @Test
+    fun testJsonSerialisation() = verifyJsonMatches(testCase.first, testCase.second)
+}

--- a/bugsnag-android-core/src/test/resources/thread_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_0.json
@@ -1,0 +1,23 @@
+{
+  "id": 24,
+  "name": "main-one",
+  "type": "ando",
+  "stacktrace": [
+    {
+      "method": "run_func",
+      "file": "librunner.so",
+      "lineNumber": 5038
+    },
+    {
+      "method": "Runner.runFunc",
+      "file": "Runner.java",
+      "lineNumber": 14
+    },
+    {
+      "method": "App.launch",
+      "file": "App.java",
+      "lineNumber": 70
+    }
+  ],
+  "errorReportingThread": true
+}

--- a/bugsnag-android-core/src/test/resources/thread_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_1.json
@@ -1,0 +1,22 @@
+{
+  "id": 24,
+  "name": "main-one",
+  "type": "ando",
+  "stacktrace": [
+    {
+      "method": "run_func",
+      "file": "librunner.so",
+      "lineNumber": 5038
+    },
+    {
+      "method": "Runner.runFunc",
+      "file": "Runner.java",
+      "lineNumber": 14
+    },
+    {
+      "method": "App.launch",
+      "file": "App.java",
+      "lineNumber": 70
+    }
+  ]
+}


### PR DESCRIPTION
## Goal

Adds a parameterised JVM serialization test to verify JSON is constructed correctly for the `Thread` interface. This was originally added in the main integration branch.