### PR TITLE
Add Stackframe serialization test

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JsonStream.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JsonStream.java
@@ -44,7 +44,7 @@ public class JsonStream extends JsonWriter {
      * Serialises an arbitrary object as JSON, handling primitive types as well as
      * Collections, Maps, and arrays.
      */
-    public void value(@NonNull Object object) throws IOException {
+    public void value(@Nullable Object object) throws IOException {
         if (object instanceof Streamable) {
             ((Streamable) object).toStream(this);
         } else {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
@@ -7,7 +7,7 @@ class Stackframe internal constructor(
     var file: String?,
     var lineNumber: Number?,
     var inProject: Boolean?,
-    private var customFields: Map<String, Any>
+    private var customFields: Map<String, Any?>
 ): JsonStream.Streamable {
 
     @Throws(IOException::class)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StackframeSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StackframeSerializationTest.kt
@@ -1,0 +1,27 @@
+package com.bugsnag.android
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+internal class StackframeSerializationTest {
+
+    companion object {
+        @JvmStatic
+        @Parameters
+        fun testCases() =
+            generateSerializationTestCases(
+                "stackframe",
+                Stackframe("foo", "Bar", 55, true, mapOf(Pair("loadAddress", "0x520923409")))
+            )
+    }
+
+    @Parameter
+    lateinit var testCase: Pair<Stackframe, String>
+
+    @Test
+    fun testJsonSerialisation() = verifyJsonMatches(testCase.first, testCase.second)
+}

--- a/bugsnag-android-core/src/test/resources/stackframe_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/stackframe_serialization_0.json
@@ -1,0 +1,7 @@
+{
+  "method": "foo",
+  "file": "Bar",
+  "lineNumber": 55,
+  "inProject": true,
+  "loadAddress": "0x520923409"
+}


### PR DESCRIPTION
## Goal

Adds a JVM serialization test to verify the constructed JSON for the `Stackframe` object.

Additionally, the `customFields` field has been updated to allow nullable values in its map, and the serializer has been updated to allow nullable objects (which are not omitted from serialization by default)