### PR TITLE
Alter observable events to use a sealed class hierarchy

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BaseObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BaseObservable.kt
@@ -1,0 +1,10 @@
+package com.bugsnag.android
+
+import java.util.Observable
+
+internal open class BaseObservable: Observable() {
+    fun notifyObservers(event: StateEvent) {
+        setChanged()
+        super.notifyObservers(event)
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
@@ -1,0 +1,43 @@
+package com.bugsnag.android
+
+sealed class StateEvent {
+    class Install(
+        val autoDetectNdkCrashes: Boolean,
+        val appVersion: String?,
+        val buildUuid: String?,
+        val releaseStage: String?
+    ) : StateEvent()
+
+    object DeliverPending : StateEvent()
+
+    class AddMetadata(val section: String, val key: String?, val value: Any?) : StateEvent()
+    object ClearBreadcrumbs : StateEvent()
+    class ClearMetadataTab(val section: String) : StateEvent()
+    class RemoveMetadata(val section: String, val key: String?) : StateEvent()
+
+    class AddBreadcrumb(
+        val message: String,
+        val type: BreadcrumbType,
+        val timestamp: String,
+        val metadata: MutableMap<String, Any?>
+    ) : StateEvent()
+
+    object NotifyHandled : StateEvent()
+    object NotifyUnhandled : StateEvent()
+
+    object PauseSession : StateEvent()
+    class StartSession(
+        val id: String,
+        val startedAt: String,
+        val handledCount: Int,
+        val unhandledCount: Int
+    ) : StateEvent()
+
+    class UpdateContext(val context: String?) : StateEvent()
+    class UpdateInForeground(val inForeground: Boolean, val contextActivity: String?) : StateEvent()
+    class UpdateOrientation(val orientation: Int) : StateEvent()
+
+    class UpdateUserEmail(val email: String?) : StateEvent()
+    class UpdateUserName(val name: String?) : StateEvent()
+    class UpdateUserId(val id: String?) : StateEvent()
+}


### PR DESCRIPTION
# Goal

This changeset aims to simplify the communication of state changes from the JVM to the NDK. It does so by focusing on two areas:

1. Reducing the amount of code required to emit an Observable event and ensuring that `setChanged()` is always called
2. Altering the message sent to a sealed class, to improve the type safety and reduce validation on the `Observer`

## Background
For context, when the user leaves a breadcrumb, the Notifier sends an `ADD_BREADCRUMB` message to the NDK `Observer` with details of the new breadcrumb. This allows the NDK to keep a copy of the current breadcrumb collection, and serialize it into a report if a fatal native crash occurs.

This is done because it's not possible to make JNI calls after a C signal has been raised, as this would terminate the process, so we need to keep a copy of state like breadcrumbs/metadata/context etc in the NDK layer.

## Emitting Observable events

We relay messages using the [Observer Pattern](https://en.wikipedia.org/wiki/Observer_pattern), by using [Java's `Observable`](https://docs.oracle.com/javase/7/docs/api/java/util/Observable.html) implementation. This requires calling `setChanged()` then `notifyObservers(msg)`, where the message is any `Object`.

For our use-case we can simplify this API by creating a `BaseObservable` class that extends `Observable`. We can always call `setChanged()` to avoid the case where a developer forgets to invoke this method, and additionally can enforce that the message is of a type our `Observer` can handle, rather than just an `Object`.

```
fun notifyObservers(event: StateEvent) {
    setChanged()
    super.notifyObservers(event)
}
```

The old and new way of emitting an event are presented here:
```
// new way of emitting events
notifyObservers(StateEvent.AddBreadcrumb(breadcrumb))

// old way of emitting events
setChanged();
notifyObservers(new NativeInterface.Message(NativeInterface.MessageType.ADD_BREADCRUMB, breadcrumb));

```

## Sealed class type safety

A [sealed class](https://kotlinlang.org/docs/reference/sealed-classes.html) is a concept in Kotlin which allows for the creation of a restricted type hierarchy. This gives superior type safety to the current implementation and avoids the laborious and error-prone type-checking we [currently perform in the NDK observer](https://github.com/bugsnag/bugsnag-android/blob/master/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java#L231).

### Old implementation
The current Java implementation uses an enum and `Message` class, which from start to finish looks like this when emitting an event:

```
// old message 
public static class Message {
    public final MessageType type;
    public final Object value;
}

// event emitted
setChanged();
notifyObservers(new NativeInterface.Message(NativeInterface.MessageType.UPDATE_CONTEXT, context));

// handle event in NDK observer
NativeInterface.Message message = parseMessage(rawMessage);
Object arg = (Object) message.value;

if (arg.type instanceof UPDATE_CONTEXT) {
    if (arg.value instanceof String) {
        // update the NDK context
    }
}
```

This can get very complex when checking a complicated message, such as [`INSTALL`](https://github.com/bugsnag/bugsnag-android/blob/master/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java#L231).

### Sealed class implementation

A sealed class on the other hand allows us to represent each message as its own subclass of `StateEvent`. From start to finish emitting an event will look like this:

```
// new message
sealed class StateEvent {
    class UpdateContext(val context: String?) : StateEvent()
}

// event emitted
notifyObservers(StateEvent.UpdateContext(context))

// handle event in NDK observer
StateEvent event = parseMessage(rawMessage);
when (event) {
    is UpdateContext -> println("Update the NDK context here: $event.context")
}
```

Note that due to Kotlin's type inference, we did not need to cast the `event` explicitly to `UpdateContext`, yet were still able to access fields specific to `UpdateContext` without compilation errors. This has greatly reduced the size and complexity of the `NativeBridge` NDK observer in the prototype integration branch.

## Use across codebbase

Once approved, the observable event implementation will be updated on a piecemeal basis in small PRs. After this has been done, the NDK `NativeBridge` observer will also be updated separately.