### PR TITLE
Update DeviceData and add serialization test case

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -272,7 +272,7 @@ public class ClientTest {
     @Test
     public void testPopulateDeviceMetadata() {
         client = generateClient();
-        Map<String, Object> metaData = client.getDeviceData().getDeviceMetaData();
+        Map<String, Object> metaData = client.getDeviceData().getDeviceMetadata();
 
         assertEquals(9, metaData.size());
         assertNotNull(metaData.get("batteryLevel"));

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceDataSummaryTest.java
@@ -1,18 +1,12 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.BugsnagTestUtils.mapToJson;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.res.Resources;
 
 import androidx.test.core.app.ApplicationProvider;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -26,12 +20,12 @@ public class DeviceDataSummaryTest {
      * Generates a device data object
      */
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         Connectivity connectivity = BugsnagTestUtils.generateConnectivity();
         Context context = ApplicationProvider.getApplicationContext();
         Resources resources = context.getResources();
-        SharedPreferences prefs = context.getSharedPreferences("", Context.MODE_PRIVATE);
-        DeviceData deviceData = new DeviceData(connectivity, context, resources, "123");
+        DeviceData deviceData = new DeviceData(connectivity, context, resources,
+                "123", DeviceBuildInfo.Companion.defaultInfo());
         this.deviceData = deviceData.getDeviceDataSummary();
     }
 
@@ -41,21 +35,6 @@ public class DeviceDataSummaryTest {
         assertNotNull(deviceData.get("model"));
         assertNotNull(deviceData.get("osName"));
         assertNotNull(deviceData.get("osVersion"));
-    }
-
-    @Test
-    public void testJsonSerialisation() throws JSONException {
-        JSONObject deviceDataJson = mapToJson(deviceData);
-
-        assertEquals("android", deviceDataJson.getString("osName"));
-        assertNotNull(deviceDataJson.getString("osVersion"));
-        assertNotNull(deviceDataJson.getString("manufacturer"));
-        assertNotNull(deviceDataJson.getString("model"));
-        assertNotNull(deviceDataJson.get("cpuAbi"));
-        assertTrue(deviceDataJson.has("jailbroken"));
-
-        JSONObject versions = deviceDataJson.getJSONObject("runtimeVersions");
-        assertTrue((Integer) versions.get("androidApiLevel") >= 14);
     }
 
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceDataTest.java
@@ -1,21 +1,16 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.BugsnagTestUtils.mapToJson;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.res.Resources;
+
 import androidx.test.core.app.ApplicationProvider;
 
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.Arrays;
 import java.util.Map;
 
 public class DeviceDataTest {
@@ -26,12 +21,12 @@ public class DeviceDataTest {
      * Generates a device data object
      */
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         Connectivity connectivity = BugsnagTestUtils.generateConnectivity();
         Context context = ApplicationProvider.getApplicationContext();
         Resources resources = context.getResources();
-        SharedPreferences prefs = context.getSharedPreferences("", Context.MODE_PRIVATE);
-        DeviceData deviceData = new DeviceData(connectivity, context, resources, "123");
+        DeviceData deviceData = new DeviceData(connectivity, context, resources,
+                "123", DeviceBuildInfo.Companion.defaultInfo());
         this.deviceData = deviceData.getDeviceData();
     }
 
@@ -41,25 +36,6 @@ public class DeviceDataTest {
         assertNotNull(deviceData.get("orientation"));
         assertTrue((Long) deviceData.get("freeMemory") > 0);
         assertTrue((Long) deviceData.get("totalMemory") > 0);
-    }
-
-    @Test
-    public void testJsonSerialisation() throws IOException, JSONException {
-        JSONObject deviceDataJson = mapToJson(deviceData);
-
-        // serialises inherited fields correctly
-        for (String key : Arrays.asList("osName",
-            "osVersion", "manufacturer", "model", "jailbroken")) {
-            assertTrue(deviceDataJson.has(key));
-        }
-
-        assertNotNull(deviceDataJson.getString("id"));
-        assertTrue(deviceDataJson.getLong("freeMemory") > 0);
-        assertTrue(deviceDataJson.getLong("totalMemory") > 0);
-        assertTrue(deviceDataJson.has("freeDisk"));
-        assertNotNull(deviceDataJson.getString("orientation"));
-        assertNotNull(deviceDataJson.getString("time"));
-        assertNotNull(deviceDataJson.get("locale"));
     }
 
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventSerializationTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventSerializationTest.java
@@ -284,7 +284,8 @@ public class EventSerializationTest {
         Context context = ApplicationProvider.getApplicationContext();
         Resources resources = context.getResources();
         SharedPreferences prefs = context.getSharedPreferences("", Context.MODE_PRIVATE);
-        DeviceData data = new DeviceData(connectivity, context, resources, "123");
+        DeviceBuildInfo info = DeviceBuildInfo.Companion.defaultInfo();
+        DeviceData data = new DeviceData(connectivity, context, resources, "123", info);
 
         Map<String, Object> deviceData = data.getDeviceData();
         event.setDeviceData(deviceData);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -146,7 +146,8 @@ public class Client extends Observable implements Observer, MetaDataAware {
                 immutableConfig.getPersistUserBetweenSessions());
         setUserInternal(userRepository.load());
 
-        deviceData = new DeviceData(connectivity, appContext, resources, user.installId);
+        DeviceBuildInfo info = DeviceBuildInfo.Companion.defaultInfo();
+        deviceData = new DeviceData(connectivity, appContext, resources, user.installId, info);
 
         // Set up breadcrumbs
         breadcrumbs = new Breadcrumbs(immutableConfig.getMaxBreadcrumbs());
@@ -694,7 +695,7 @@ public class Client extends Observable implements Observer, MetaDataAware {
         // Capture the state of the app and device and attach diagnostics to the event
         Map<String, Object> errorDeviceData = deviceData.getDeviceData();
         event.setDeviceData(errorDeviceData);
-        event.addMetadata("device", null, deviceData.getDeviceMetaData());
+        event.addMetadata("device", null, deviceData.getDeviceMetadata());
 
 
         // add additional info that belongs in metadata

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceBuildInfo.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceBuildInfo.kt
@@ -10,6 +10,7 @@ internal class DeviceBuildInfo(
     val osBuild: String,
     val fingerprint: String,
     val tags: String,
+    val brand: String,
     val cpuAbis: Array<String>
 ) {
     companion object {
@@ -27,6 +28,7 @@ internal class DeviceBuildInfo(
                 Build.DISPLAY,
                 Build.FINGERPRINT,
                 Build.TAGS,
+                Build.BRAND,
                 cpuABis
             )
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceBuildInfo.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceBuildInfo.kt
@@ -1,0 +1,34 @@
+package com.bugsnag.android
+
+import android.os.Build
+
+internal class DeviceBuildInfo(
+    val manufacturer: String,
+    val model: String,
+    val osVersion: String,
+    val apiLevel: Int,
+    val osBuild: String,
+    val fingerprint: String,
+    val tags: String,
+    val cpuAbis: Array<String>
+) {
+    companion object {
+        fun defaultInfo(): DeviceBuildInfo {
+            @Suppress("DEPRECATION") val cpuABis = when {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP -> Build.SUPPORTED_ABIS
+                else -> arrayOf(Build.CPU_ABI, Build.CPU_ABI2)
+            }
+
+            return DeviceBuildInfo(
+                Build.MANUFACTURER,
+                Build.MODEL,
+                Build.VERSION.RELEASE,
+                Build.VERSION.SDK_INT,
+                Build.DISPLAY,
+                Build.FINGERPRINT,
+                Build.TAGS,
+                cpuABis
+            )
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -5,24 +5,21 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.BatteryManager;
 import android.os.Build;
 import android.os.Environment;
-import android.os.StatFs;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 
 import java.io.File;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.UUID;
 
 class DeviceData {
 
@@ -47,6 +44,7 @@ class DeviceData {
     private final Connectivity connectivity;
     private final Resources resources;
     private final String installId;
+    private final DeviceBuildInfo buildInfo;
     private final DisplayMetrics displayMetrics;
     private final boolean rooted;
 
@@ -66,11 +64,12 @@ class DeviceData {
     final String[] cpuAbi;
 
     DeviceData(Connectivity connectivity, Context appContext, Resources resources,
-               String installId) {
+               String installId, DeviceBuildInfo buildInfo) {
         this.connectivity = connectivity;
         this.appContext = appContext;
         this.resources = resources;
         this.installId = installId;
+        this.buildInfo = buildInfo;
 
         if (resources != null) {
             displayMetrics = resources.getDisplayMetrics();
@@ -81,7 +80,7 @@ class DeviceData {
         screenDensity = getScreenDensity();
         dpi = getScreenDensityDpi();
         screenResolution = getScreenResolution();
-        locale = getLocale();
+        locale = Locale.getDefault().toString();
         cpuAbi = getCpuAbi();
         emulator = isEmulator();
         rooted = isRooted();
@@ -89,16 +88,16 @@ class DeviceData {
 
     Map<String, Object> getDeviceDataSummary() {
         Map<String, Object> map = new HashMap<>();
-        map.put("manufacturer", Build.MANUFACTURER);
-        map.put("model", Build.MODEL);
+        map.put("manufacturer", buildInfo.getManufacturer());
+        map.put("model", buildInfo.getModel());
         map.put("jailbroken", rooted);
         map.put("osName", "android");
-        map.put("osVersion", Build.VERSION.RELEASE);
+        map.put("osVersion", buildInfo.getOsVersion());
         map.put("cpuAbi", cpuAbi);
 
         Map<String, Object> versions = new HashMap<>();
-        versions.put("androidApiLevel", Build.VERSION.SDK_INT);
-        versions.put("osBuild", Build.DISPLAY);
+        versions.put("androidApiLevel", buildInfo.getApiLevel());
+        versions.put("osBuild", buildInfo.getOsBuild());
         map.put("runtimeVersions", versions);
         return map;
     }
@@ -115,7 +114,7 @@ class DeviceData {
         return map;
     }
 
-    Map<String, Object> getDeviceMetaData() {
+    Map<String, Object> getDeviceMetadata() {
         Map<String, Object> map = new HashMap<>();
         map.put("batteryLevel", getBatteryLevel());
         map.put("charging", isCharging());
@@ -129,15 +128,11 @@ class DeviceData {
         return map;
     }
 
-    String getId() {
-        return installId;
-    }
-
     /**
      * Check if the current Android device is rooted
      */
     private boolean isRooted() {
-        if (android.os.Build.TAGS != null && android.os.Build.TAGS.contains("test-keys")) {
+        if (buildInfo.getTags().contains("test-keys")) {
             return true;
         }
 
@@ -159,7 +154,7 @@ class DeviceData {
      * @return true if the current device is an emulator
      */
     private boolean isEmulator() {
-        String fingerprint = Build.FINGERPRINT;
+        String fingerprint = buildInfo.getFingerprint();
         return fingerprint.startsWith("unknown")
             || fingerprint.contains("generic")
             || fingerprint.contains("vbox"); // genymotion
@@ -216,22 +211,11 @@ class DeviceData {
     }
 
     /**
-     * Get the locale of the current Android device, eg en_US
-     */
-    @NonNull
-    private String getLocale() {
-        return Locale.getDefault().toString();
-    }
-
-    /**
      * Gets information about the CPU / API
      */
     @NonNull
-    private String[] getCpuAbi() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            return SupportedAbiWrapper.getSupportedAbis();
-        }
-        return Abi2Wrapper.getAbi1andAbi2();
+    String[] getCpuAbi() {
+        return buildInfo.getCpuAbis();
     }
 
     /**
@@ -351,24 +335,4 @@ class DeviceData {
         return DateUtils.toIso8601(new Date());
     }
 
-    /**
-     * Wrapper class to allow the test framework to use the correct version of the CPU / ABI
-     */
-    static class SupportedAbiWrapper {
-        @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-        static String[] getSupportedAbis() {
-            return Build.SUPPORTED_ABIS;
-        }
-    }
-
-    /**
-     * Wrapper class to allow the test framework to use the correct version of the CPU / ABI
-     */
-    static class Abi2Wrapper {
-        @NonNull
-        @SuppressWarnings("deprecation") // new API already used elsewhere
-        static String[] getAbi1andAbi2() {
-            return new String[]{Build.CPU_ABI, Build.CPU_ABI2};
-        }
-    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Resources;
 import android.os.BatteryManager;
-import android.os.Build;
 import android.os.Environment;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
@@ -120,7 +119,7 @@ class DeviceData {
         map.put("charging", isCharging());
         map.put("locationStatus", getLocationStatus());
         map.put("networkAccess", getNetworkAccess());
-        map.put("brand", Build.BRAND);
+        map.put("brand", buildInfo.getBrand());
         map.put("screenDensity", screenDensity);
         map.put("dpi", dpi);
         map.put("emulator", emulator);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -208,7 +208,7 @@ public class NativeInterface {
     public static Map<String,Object> getDeviceData() {
         HashMap<String,Object> deviceData = new HashMap<>();
         DeviceData source = getClient().getDeviceData();
-        deviceData.putAll(source.getDeviceMetaData());
+        deviceData.putAll(source.getDeviceMetadata());
         deviceData.putAll(source.getDeviceData()); // wat
         return deviceData;
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataSerializationTest.kt
@@ -1,0 +1,41 @@
+package com.bugsnag.android
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.Resources
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+import org.junit.runners.Parameterized.Parameters
+import org.mockito.Mockito
+
+@RunWith(Parameterized::class)
+internal class DeviceDataSerializationTest {
+
+    companion object {
+        @JvmStatic
+        @Parameters
+        fun testCases(): Collection<Pair<Map<String, Any>, String>> {
+            val context = Mockito.mock(Context::class.java)
+            val res = Mockito.mock(Resources::class.java)
+            val prefs = Mockito.mock(SharedPreferences::class.java)
+            val editor = Mockito.mock(SharedPreferences.Editor::class.java)
+            Mockito.`when`(prefs.edit()).thenReturn(editor)
+            Mockito.`when`(editor.putString(Mockito.anyString(), Mockito.anyString())).thenReturn(editor)
+
+            val buildInfo = DeviceBuildInfo(
+                "samsung", "s7", "7.1", 24, "bulldog",
+                "foo-google", "prod,build", arrayOf("armeabi-v7a")
+            )
+            val deviceData = DeviceData(null, context, res, "123", buildInfo)
+            return generateSerializationTestCases("device_data", deviceData.deviceDataSummary)
+        }
+    }
+
+    @Parameter
+    lateinit var testCase: Pair<Map<String, Any>, String>
+
+    @Test
+    fun testJsonSerialisation() = verifyJsonMatches(testCase.first, testCase.second)
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataSerializationTest.kt
@@ -26,7 +26,7 @@ internal class DeviceDataSerializationTest {
 
             val buildInfo = DeviceBuildInfo(
                 "samsung", "s7", "7.1", 24, "bulldog",
-                "foo-google", "prod,build", arrayOf("armeabi-v7a")
+                "foo-google", "prod,build", "google", arrayOf("armeabi-v7a")
             )
             val deviceData = DeviceData(null, context, res, "123", buildInfo)
             return generateSerializationTestCases("device_data", deviceData.deviceDataSummary)

--- a/bugsnag-android-core/src/test/resources/device_data_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/device_data_serialization_0.json
@@ -1,0 +1,14 @@
+{
+  "cpuAbi": [
+    "armeabi-v7a"
+  ],
+  "osVersion": "7.1",
+  "jailbroken": false,
+  "model": "s7",
+  "runtimeVersions": {
+    "osBuild": "bulldog",
+    "androidApiLevel": 24
+  },
+  "osName": "android",
+  "manufacturer": "samsung"
+}


### PR DESCRIPTION
## Goal

Ports changes to `DeviceData` made in this PR to the notifier spec update branch, and adds JVM serialization tests: https://github.com/bugsnag/bugsnag-android/pull/606#discussion_r331988213

## Changeset

- Renames `getDeviceMetadata()` for consistency with `Metadata` capitalization
- Convert `DeviceData` instrumentation tests to single JVM serialization test that verifies JSON structure
- Adds `DeviceBuildInfo`, which holds static `Build` fields directly so that their values can be faked under test
- Updated `DeviceData` to take `DeviceBuildInfo` as a field