### PR TITLE
Synchronize Client with Bugsnag facade

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -92,6 +92,11 @@ public final class Bugsnag {
         getClient().setContext(context);
     }
 
+    @NonNull
+    public User getUser() {
+        return getClient().getUser();
+    }
+
     /**
      * Set details of the user currently using your application.
      * You can search for this information in your Bugsnag dashboard.
@@ -175,6 +180,10 @@ public final class Bugsnag {
         getClient().addOnError(onError);
     }
 
+    public static void removeOnError(@NonNull OnError onError) {
+        getClient().removeOnError(onError);
+    }
+
     /**
      * Add a "before breadcrumb" callback, to execute code before every
      * breadcrumb captured by Bugsnag.
@@ -199,6 +208,14 @@ public final class Bugsnag {
 
     public static void removeOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
         getClient().removeOnBreadcrumb(onBreadcrumb);
+    }
+
+    public static void addOnSession(@NonNull OnSession onSession) {
+        getClient().addOnSession(onSession);
+    }
+
+    public static void removeOnSession(@NonNull OnSession onSession) {
+        getClient().removeOnSession(onSession);
     }
 
     /**
@@ -252,13 +269,26 @@ public final class Bugsnag {
         getClient().notify(name, message, stacktrace, onError);
     }
 
+    public static void addMetadata(@NonNull String section, @Nullable Object value) {
+        getClient().addMetadata(section, value);
+    }
+
     public static void addMetadata(@NonNull String section, @Nullable String key,
                                    @Nullable Object value) {
         getClient().addMetadata(section, key, value);
     }
 
+    public static void clearMetadata(@NonNull String section) {
+        getClient().clearMetadata(section);
+    }
+
     public static void clearMetadata(@NonNull String section, @Nullable String key) {
         getClient().clearMetadata(section, key);
+    }
+
+    @Nullable
+    public static Object getMetadata(@NonNull String section) {
+        return getClient().getMetadata(section);
     }
 
     @Nullable

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -418,16 +418,6 @@ public class Client extends Observable implements Observer, MetaDataAware {
     }
 
     /**
-     * Starts tracking a new session only if no sessions have yet been tracked
-     *
-     * This is an integration point for custom libraries implementing automatic session capture
-     * which differs from the default activity-based initialization.
-     */
-    public void startFirstSession(@NonNull Activity activity) {
-        sessionTracker.startFirstSession(activity);
-    }
-
-    /**
      * Gets the context to be sent to Bugsnag.
      *
      * @return Context
@@ -477,17 +467,17 @@ public class Client extends Observable implements Observer, MetaDataAware {
     }
 
     @NonNull
-    public Collection<Breadcrumb> getBreadcrumbs() {
+    Collection<Breadcrumb> getBreadcrumbs() {
         return new ArrayList<>(breadcrumbState.getStore());
     }
 
     @NonNull
-    public AppData getAppData() {
+    AppData getAppData() {
         return appData;
     }
 
     @NonNull
-    public DeviceData getDeviceData() {
+    DeviceData getDeviceData() {
         return deviceData;
     }
 
@@ -1014,7 +1004,7 @@ public class Client extends Observable implements Observer, MetaDataAware {
      * @return the config
      */
     @NonNull
-    public BugsnagConfiguration getConfiguration() {
+    BugsnagConfiguration getConfiguration() {
         return clientState;
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -373,22 +373,6 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     }
 
     /**
-     * Tracks a session if a session has not yet been captured,
-     * recording the session as auto-captured. Requires the current activity.
-     *
-     * @param activity the current activity
-     */
-    void startFirstSession(Activity activity) {
-        Session session = currentSession.get();
-        if (session == null) {
-            long nowMs = System.currentTimeMillis();
-            lastEnteredForegroundMs.set(nowMs);
-            startNewSession(new Date(nowMs), client.getUser(), true);
-            foregroundActivities.add(getActivityName(activity));
-        }
-    }
-
-    /**
      * Tracks whether an activity is in the foreground or not.
      * <p>
      * If an activity leaves the foreground, a timeout should be recorded (e.g. 30s), during which

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagClientMirrorInterfaceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagClientMirrorInterfaceTest.kt
@@ -1,0 +1,49 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Method
+
+
+/**
+ * Uses reflection to check that the [Bugsnag] and [Client] classes share the same method
+ * signatures, and fails if the two are out of sync.
+ *
+ * This is intended to catch the case where a new API is added to one class but not the other.
+ * If a method genuinely only needs to be present on one of the classes, it can be added to a
+ * blacklist via [bugsnagBlacklist] or [clientBlacklist].
+ */
+class BugsnagClientMirrorInterfaceTest {
+
+    private val bugsnagBlacklist = setOf("init", "getClient")
+    private val clientBlacklist = setOf(
+        "update",
+        "notifyObservers",
+        "addObserver",
+        "deleteObserver",
+        "deleteObservers",
+        "hasChanged",
+        "countObservers"
+    )
+
+    data class MethodInfo(val name: String, val returnType: Class<*>, val params: List<Class<*>>) {
+        constructor(m: Method) : this(m.name, m.returnType, m.parameterTypes.toList())
+    }
+
+    private val bugsnagMethods = Bugsnag::class.java.methods.map(::MethodInfo)
+    private val clientMethods = Client::class.java.methods.map(::MethodInfo)
+
+    @Test
+    fun bugsnagHasSameMethodsAsClient() {
+        val methods = clientMethods.subtract(bugsnagMethods)
+            .filter { !clientBlacklist.contains(it.name) }
+        assertTrue("Bugsnag is missing the following methods: $methods", methods.isEmpty())
+    }
+
+    @Test
+    fun clientHasSameMethodsAsBugsnag() {
+        val methods = bugsnagMethods.subtract(clientMethods)
+            .filter { !bugsnagBlacklist.contains(it.name) }
+        assertTrue("Client is missing the following methods: $methods", methods.isEmpty())
+    }
+}


### PR DESCRIPTION
## Goal

The `Bugsnag` class provides a facade through which any method on the `Client` can be invoked. Historically the two classes have become out of sync.

This changeset synchronises the two classes to share similar method signatures, and adds a test that will fail if the two classes do fall out of sync again.

## Changeset

- Added missing public methods onto `Bugsnag` that were only present on `Client`
- Removed `startFirstSession` from `Client` as this is no longer used by Unity or React Native and is therefore dead code
- Made app/device/breadcrumb/configuration accessors on `Client` package-private, as these should not be part of our public API but are still required by the `NativeInterface` class

## Tests

Added a unit test to verify that the two classes share the same methods. This works by reflexively getting a Set of all methods on `Bugsnag` and `Client`, then subtracting to find all distinct methods. If the resulting Set is non-empty, this indicates that an extra method is present on either `Bugsnag` or the `Client`, and the test fails.
