### PR TITLE
Add test coverage for handled state JSON serialization

### DIFF
--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/HandledStateSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/HandledStateSerializationTest.kt
@@ -1,0 +1,33 @@
+package com.bugsnag.android
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+import org.junit.runners.Parameterized.Parameters
+
+@RunWith(Parameterized::class)
+internal class HandledStateSerializationTest {
+
+    companion object {
+        @JvmStatic
+        @Parameters
+        fun testCases() = generateSerializationTestCases(
+            "handled_state",
+            HandledState.newInstance(HandledState.REASON_UNHANDLED_EXCEPTION),
+            HandledState.newInstance(HandledState.REASON_STRICT_MODE, Severity.ERROR, "diskRead"),
+            HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION),
+            HandledState.newInstance(HandledState.REASON_USER_SPECIFIED),
+            HandledState.newInstance(HandledState.REASON_CALLBACK_SPECIFIED, Severity.INFO, null),
+            HandledState.newInstance(HandledState.REASON_PROMISE_REJECTION),
+            HandledState.newInstance(HandledState.REASON_LOG, Severity.WARNING, "warning"),
+            HandledState.newInstance(HandledState.REASON_ANR)
+        )
+    }
+
+    @Parameter
+    lateinit var testCase: Pair<HandledState, String>
+
+    @Test
+    fun testJsonSerialisation() = verifyJsonMatches(testCase.first, testCase.second)
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/HandledStateTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/HandledStateTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 public class HandledStateTest {
 
     @Test
-    public void testHandled() throws Exception {
+    public void testHandled() {
         HandledState handled = HandledState.newInstance(
             HandledState.REASON_HANDLED_EXCEPTION);
         assertNotNull(handled);
@@ -19,7 +19,7 @@ public class HandledStateTest {
     }
 
     @Test
-    public void testUnhandled() throws Exception {
+    public void testUnhandled() {
         HandledState unhandled = HandledState.newInstance(
             HandledState.REASON_UNHANDLED_EXCEPTION);
         assertNotNull(unhandled);
@@ -28,7 +28,7 @@ public class HandledStateTest {
     }
 
     @Test
-    public void testUserSpecified() throws Exception {
+    public void testUserSpecified() {
         HandledState userSpecified = HandledState.newInstance(
             HandledState.REASON_USER_SPECIFIED, Severity.INFO, null);
         assertNotNull(userSpecified);
@@ -37,7 +37,7 @@ public class HandledStateTest {
     }
 
     @Test
-    public void testStrictMode() throws Exception {
+    public void testStrictMode() {
         HandledState strictMode = HandledState.newInstance(
             HandledState.REASON_STRICT_MODE, null, "Test");
         assertNotNull(strictMode);
@@ -47,7 +47,7 @@ public class HandledStateTest {
     }
 
     @Test
-    public void testPromiseRejection() throws Exception { // invoked via react native
+    public void testPromiseRejection() { // invoked via react native
         HandledState unhandled = HandledState.newInstance(
             HandledState.REASON_PROMISE_REJECTION);
         assertNotNull(unhandled);
@@ -56,7 +56,7 @@ public class HandledStateTest {
     }
 
     @Test
-    public void testLog() throws Exception { // invoked via Unity
+    public void testLog() { // invoked via Unity
         HandledState unhandled = HandledState.newInstance(
             HandledState.REASON_LOG, Severity.WARNING, null);
         assertNotNull(unhandled);
@@ -65,7 +65,7 @@ public class HandledStateTest {
     }
 
     @Test
-    public void testCallbackSpecified() throws Exception {
+    public void testCallbackSpecified() {
         HandledState handled = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION);
         assertEquals(HandledState.REASON_HANDLED_EXCEPTION,
             handled.calculateSeverityReasonType());
@@ -76,7 +76,7 @@ public class HandledStateTest {
     }
 
     @Test
-    public void testInvalidUserSpecified() throws Exception {
+    public void testInvalidUserSpecified() {
         HandledState handled = HandledState.newInstance(HandledState.REASON_CALLBACK_SPECIFIED);
         assertEquals(HandledState.REASON_CALLBACK_SPECIFIED,
             handled.calculateSeverityReasonType());
@@ -87,8 +87,13 @@ public class HandledStateTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testInvalidStrictmodeVal() throws Exception {
+    public void testInvalidStrictmodeVal() {
         HandledState.newInstance(HandledState.REASON_STRICT_MODE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidHandledVal() {
+        HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION, Severity.ERROR, "Whoops");
     }
 
 }

--- a/bugsnag-android-core/src/test/resources/handled_state_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/handled_state_serialization_0.json
@@ -1,0 +1,3 @@
+{
+  "type": "unhandledException"
+}

--- a/bugsnag-android-core/src/test/resources/handled_state_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/handled_state_serialization_1.json
@@ -1,0 +1,6 @@
+{
+  "type": "strictMode",
+  "attributes": {
+    "violationType": "diskRead"
+  }
+}

--- a/bugsnag-android-core/src/test/resources/handled_state_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/handled_state_serialization_2.json
@@ -1,0 +1,3 @@
+{
+  "type": "handledException"
+}

--- a/bugsnag-android-core/src/test/resources/handled_state_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/handled_state_serialization_3.json
@@ -1,0 +1,3 @@
+{
+  "type": "userSpecifiedSeverity"
+}

--- a/bugsnag-android-core/src/test/resources/handled_state_serialization_4.json
+++ b/bugsnag-android-core/src/test/resources/handled_state_serialization_4.json
@@ -1,0 +1,3 @@
+{
+  "type": "userCallbackSetSeverity"
+}

--- a/bugsnag-android-core/src/test/resources/handled_state_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/handled_state_serialization_5.json
@@ -1,0 +1,3 @@
+{
+  "type": "unhandledPromiseRejection"
+}

--- a/bugsnag-android-core/src/test/resources/handled_state_serialization_6.json
+++ b/bugsnag-android-core/src/test/resources/handled_state_serialization_6.json
@@ -1,0 +1,6 @@
+{
+  "type": "log",
+  "attributes": {
+    "level": "warning"
+  }
+}

--- a/bugsnag-android-core/src/test/resources/handled_state_serialization_7.json
+++ b/bugsnag-android-core/src/test/resources/handled_state_serialization_7.json
@@ -1,0 +1,3 @@
+{
+  "type": "anrError"
+}


### PR DESCRIPTION
## Goal

Adds missing test coverage to verify that `HandledState` constructs JSON correctly.

## Changeset

Added a test case for each severity reason with a JSON fixture. Additionally a redundant throws clause has been removed from the test cases in `HandledStateTest`.