### PR TITLE
Refactor ThreadState implementation

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
@@ -15,7 +15,7 @@ import java.lang.Thread
 class ThreadStateTest {
 
     private val configuration = generateImmutableConfig()
-    private val trace = arrayOf(StackTraceElement("Foo", "Bar", "foobar", 5))
+    private val trace: Throwable? = null
 
     private val threadState = ThreadState(configuration, trace)
     private val json = streamableToJsonArray(threadState)
@@ -106,7 +106,7 @@ class ThreadStateTest {
         val exc: Throwable = RuntimeException("Whoops")
         val expectedTrace = exc.stackTrace
 
-        val state = ThreadState(configuration, exc.stackTrace, currentThread, allStackTraces)
+        val state = ThreadState(configuration, exc, currentThread, allStackTraces)
         val json = streamableToJsonArray(state)
 
         verifyCurrentThreadStructure(json, currentThread.id) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -419,13 +419,7 @@ public class Event implements JsonStream.Streamable, MetadataAware {
                 boolean unhandled,
                 Metadata globalMetadata) {
             Throwable exc = unhandled ? exception : null;
-            StackTraceElement[] stackTrace;
-            if (exc != null) {
-                stackTrace = exc.getStackTrace();
-            } else {
-                stackTrace = thread.getStackTrace();
-            }
-            this.threadState = new ThreadState(config, stackTrace, thread);
+            this.threadState = new ThreadState(config, exc, thread);
             this.config = config;
             this.exception = exception;
             this.severityReasonType = HandledState.REASON_USER_SPECIFIED; // default

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -419,7 +419,13 @@ public class Event implements JsonStream.Streamable, MetadataAware {
                 boolean unhandled,
                 Metadata globalMetadata) {
             Throwable exc = unhandled ? exception : null;
-            this.threadState = new ThreadState(config, thread, Thread.getAllStackTraces(), exc);
+            StackTraceElement[] stackTrace;
+            if (exc != null) {
+                stackTrace = exc.getStackTrace();
+            } else {
+                stackTrace = thread.getStackTrace();
+            }
+            this.threadState = new ThreadState(config, stackTrace, thread);
             this.config = config;
             this.exception = exception;
             this.severityReasonType = HandledState.REASON_USER_SPECIFIED; // default

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -5,37 +5,29 @@ import java.io.IOException
 /**
  * Capture and serialize the state of all threads at the time of an exception.
  */
-internal class ThreadState : JsonStream.Streamable {
+internal class ThreadState @JvmOverloads constructor
+    (
+    config: ImmutableConfig,
+    excStacktrace: Array<StackTraceElement>,
+    currentThread: java.lang.Thread = java.lang.Thread.currentThread(),
+    stackTraces: MutableMap<java.lang.Thread, Array<StackTraceElement>> = java.lang.Thread.getAllStackTraces()
+) : JsonStream.Streamable {
 
-    private val threads: List<Thread>
+    internal val threads: MutableList<Thread>
 
-    constructor(threads: List<Thread>) {
-        this.threads = threads
-    }
-
-    constructor(
-        config: ImmutableConfig,
-        currentThread: java.lang.Thread,
-        stackTraces: MutableMap<java.lang.Thread, Array<StackTraceElement>>,
-        exc: Throwable?
-    ) {
+    init {
+        // unhandled errors use the exception trace
         // API 24/25 don't record the currentThread, add it in manually
         // https://issuetracker.google.com/issues/64122757
-        if (!stackTraces.containsKey(currentThread)) {
-            stackTraces[currentThread] = currentThread.stackTrace
-        }
-        if (exc != null) { // unhandled errors use the exception trace
-            stackTraces[currentThread] = exc.stackTrace
-        }
+        stackTraces[currentThread] = excStacktrace
 
         val currentThreadId = currentThread.id
-
         threads = stackTraces.keys
             .sortedBy { it.id }
             .map {
                 val stacktrace = Stacktrace(stackTraces[it]!!, config.projectPackages)
                 Thread(it.id, it.name, "android", it.id == currentThreadId, stacktrace)
-            }
+            }.toMutableList()
     }
 
     @Throws(IOException::class)


### PR DESCRIPTION
## Goal

Refactors the `ThreadState` implementation to reduce the knowledge required to create an object.

This is not a public interface so does not result in any publicly facing change, but is designed to make the construction of an `Event` easier (and forms the groundwork of a future PR to alter the `Event` interface).

## Changeset

- Removed obsolete constructor which takes a list of Threads, as this was only required when deserializing JSON which we no longer do
- Made `threads` mutable to allow users to alter the value on `Event`
- Alter the constructor so that only a configuration and `Array<StacktraceElement>` are required parameters, and a sensible default is chosen for the current thread/thread trace
- Remove `testSerialization()` test case as this is covered by `ThreadSerializationTest` 