### PR TITLE
Add UserAware interface

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -49,7 +49,8 @@ import java.util.concurrent.RejectedExecutionException;
  * @see Bugsnag
  */
 @SuppressWarnings("checkstyle:JavadocTagContinuationIndentation")
-public class Client extends Observable implements Observer, MetadataAware, CallbackAware {
+public class Client extends Observable implements Observer, MetadataAware, CallbackAware,
+        UserAware {
 
     private static final boolean BLOCKING = true;
     private static final String SHARED_PREF_KEY = "com.bugsnag.android";
@@ -450,6 +451,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      * @param email the email address of the current user
      * @param name  the name of the current user
      */
+    @Override
     public void setUser(@Nullable String id, @Nullable String email, @Nullable String name) {
         setUserId(id);
         setUserEmail(email);
@@ -463,6 +465,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      * @return the current user
      */
     @NonNull
+    @Override
     public User getUser() {
         return user;
     }
@@ -504,6 +507,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      *
      * @param id a unique identifier of the current user
      */
+    @Override
     public void setUserId(@Nullable String id) {
         user.setId(id);
         userRepository.save(user);
@@ -515,6 +519,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      *
      * @param email the email address of the current user
      */
+    @Override
     public void setUserEmail(@Nullable String email) {
         user.setEmail(email);
         userRepository.save(user);
@@ -526,6 +531,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      *
      * @param name the name of the current user
      */
+    @Override
     public void setUserName(@Nullable String name) {
         user.setName(name);
         userRepository.save(user);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -20,7 +20,7 @@ import java.util.Map;
  *
  * @see OnError
  */
-public class Event implements JsonStream.Streamable, MetadataAware {
+public class Event implements JsonStream.Streamable, MetadataAware, UserAware {
 
     @NonNull
     private Map<String, Object> appData = new HashMap<>();
@@ -208,6 +208,7 @@ public class Event implements JsonStream.Streamable, MetadataAware {
      * @param email the email address of the user
      * @param name  the name of the user
      */
+    @Override
     public void setUser(@Nullable String id, @Nullable String email, @Nullable String name) {
         this.user = new User(id, email, name);
     }
@@ -220,6 +221,7 @@ public class Event implements JsonStream.Streamable, MetadataAware {
      * @return user information associated with this Event
      */
     @NonNull
+    @Override
     public User getUser() {
         return user;
     }
@@ -229,6 +231,7 @@ public class Event implements JsonStream.Streamable, MetadataAware {
      *
      * @param id the id of the user
      */
+    @Override
     public void setUserId(@Nullable String id) {
         this.user = new User(this.user);
         this.user.setId(id);
@@ -239,6 +242,7 @@ public class Event implements JsonStream.Streamable, MetadataAware {
      *
      * @param email the email address of the user
      */
+    @Override
     public void setUserEmail(@Nullable String email) {
         this.user = new User(this.user);
         this.user.setEmail(email);
@@ -249,6 +253,7 @@ public class Event implements JsonStream.Streamable, MetadataAware {
      *
      * @param name the name of the user
      */
+    @Override
     public void setUserName(@Nullable String name) {
         this.user = new User(this.user);
         this.user.setName(name);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserAware.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserAware.kt
@@ -1,0 +1,9 @@
+package com.bugsnag.android
+
+internal interface UserAware {
+    fun getUser(): User
+    fun setUser(id: String?, email: String?, name: String?)
+    fun setUserId(id: String?)
+    fun setUserEmail(email: String?)
+    fun setUserName(name: String?)
+}


### PR DESCRIPTION
## Goal

Adds a non-public interface which contains the methods for setting/getting a `User`.

According to the notifier spec these methods share the same signatures on both `Client` and `Event`, therefore we should ensure they retain consistency by implementing the same interface.
