### PR TITLE
Add CallbackAware interface

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagConfiguration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagConfiguration.kt
@@ -3,5 +3,4 @@ package com.bugsnag.android
 interface BugsnagConfiguration {
     fun setContext(context: String?)
     fun getContext(): String?
-    fun addOnError(onError: OnError)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackAware.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackAware.kt
@@ -1,0 +1,10 @@
+package com.bugsnag.android
+
+internal interface CallbackAware {
+    fun addOnError(onError: OnError)
+    fun removeOnError(onError: OnError)
+    fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumb)
+    fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumb)
+    fun addOnSession(onSession: OnSession)
+    fun removeOnSession(onSession: OnSession)
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -49,7 +49,7 @@ import java.util.concurrent.RejectedExecutionException;
  * @see Bugsnag
  */
 @SuppressWarnings("checkstyle:JavadocTagContinuationIndentation")
-public class Client extends Observable implements Observer, MetadataAware {
+public class Client extends Observable implements Observer, MetadataAware, CallbackAware {
 
     private static final boolean BLOCKING = true;
     private static final String SHARED_PREF_KEY = "com.bugsnag.android";
@@ -553,10 +553,12 @@ public class Client extends Observable implements Observer, MetadataAware {
      * @param onError a callback to run before sending errors to Bugsnag
      * @see OnError
      */
+    @Override
     public void addOnError(@NonNull OnError onError) {
         clientState.addOnError(onError);
     }
 
+    @Override
     public void removeOnError(@NonNull OnError onError) {
         clientState.removeOnError(onError);
     }
@@ -579,18 +581,22 @@ public class Client extends Observable implements Observer, MetadataAware {
      * @param onBreadcrumb a callback to run before a breadcrumb is captured
      * @see OnBreadcrumb
      */
+    @Override
     public void addOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
         clientState.addOnBreadcrumb(onBreadcrumb);
     }
 
+    @Override
     public void removeOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
         clientState.removeOnBreadcrumb(onBreadcrumb);
     }
 
+    @Override
     public void addOnSession(@NonNull OnSession onSession) {
         clientState.addOnSession(onSession);
     }
 
+    @Override
     public void removeOnSession(@NonNull OnSession onSession) {
         clientState.removeOnSession(onSession);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -19,7 +19,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * User-specified configuration storage object, contains information
  * specified at the client level, api-key and endpoint configuration.
  */
-public class Configuration extends Observable implements Observer, BugsnagConfiguration {
+public class Configuration extends Observable implements Observer, BugsnagConfiguration,
+        CallbackAware {
 
     private static final String HEADER_API_PAYLOAD_VERSION = "Bugsnag-Payload-Version";
     static final String HEADER_API_KEY = "Bugsnag-Api-Key";
@@ -710,7 +711,8 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
         }
     }
 
-    void removeOnError(@NonNull OnError onError) {
+    @Override
+    public void removeOnError(@NonNull OnError onError) {
         onErrorTasks.remove(onError);
     }
 
@@ -739,6 +741,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
      *
      * @param onBreadcrumb the on breadcrumb callback
      */
+    @Override
     public void addOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
         if (!breadcrumbCallbacks.contains(onBreadcrumb)) {
             breadcrumbCallbacks.add(onBreadcrumb);
@@ -750,6 +753,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
      *
      * @param onBreadcrumb the on breadcrumb callback
      */
+    @Override
     public void removeOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
         breadcrumbCallbacks.remove(onBreadcrumb);
     }
@@ -769,6 +773,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
      *
      * @param onSession the on session callback
      */
+    @Override
     public void addOnSession(@NonNull OnSession onSession) {
         if (!sessionCallbacks.contains(onSession)) {
             sessionCallbacks.add(onSession);
@@ -780,6 +785,7 @@ public class Configuration extends Observable implements Observer, BugsnagConfig
      *
      * @param onSession the on session callback
      */
+    @Override
     public void removeOnSession(@NonNull OnSession onSession) {
         sessionCallbacks.remove(onSession);
     }


### PR DESCRIPTION
## Goal

Adds a non-public interface which contains the methods for adding/removing callbacks.

According to the notifier spec these methods share the same signatures on both `Client` and `Configuration`, therefore we should ensure they retain consistency by implementing the same interface.
