### PR TITLE
Remove non-compliant methods from Bugsnag/Client interface

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -146,23 +146,6 @@ public class ClientTest {
         assertFalse(sharedPref.contains("user.name"));
     }
 
-    @Test
-    public void testClearUser() {
-        // Set a user in prefs
-        setUserPrefs();
-
-        // Clear the user using the command
-        client = new Client(context, "api-key");
-        client.setUser(null, null, null);
-
-        // Check that there is no user information in the prefs anymore
-        SharedPreferences sharedPref = getSharedPrefs(context);
-        assertNotNull(sharedPref.getString("install.iud", null));
-        assertFalse(sharedPref.contains("user.id"));
-        assertFalse(sharedPref.contains("user.email"));
-        assertFalse(sharedPref.contains("user.name"));
-    }
-
     @SuppressWarnings("deprecation") // test backwards compatibility of client.setMaxBreadcrumbs
     @Test
     public void testMaxBreadcrumbs() {
@@ -180,20 +163,6 @@ public class ClientTest {
         assertEquals(BreadcrumbType.MANUAL, poll.getType());
         assertEquals("manual", poll.getMessage());
         assertEquals("test", poll.getMetadata().get("message"));
-    }
-
-    @Test
-    public void testClearBreadcrumbs() {
-        Configuration config = generateConfiguration();
-        config.setEnabledBreadcrumbTypes(Collections.singleton(BreadcrumbType.MANUAL));
-        client = generateClient(config);
-        assertEquals(1, client.breadcrumbState.getStore().size());
-
-        client.leaveBreadcrumb("test");
-        assertEquals(2, client.breadcrumbState.getStore().size());
-
-        client.clearBreadcrumbs();
-        assertEquals(0, client.breadcrumbState.getStore().size());
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -163,13 +163,6 @@ public class ObserverInterfaceTest {
     }
 
     @Test
-    public void testClientClearUserSendsMessage() {
-        client.setUser(null, null, null); // resets to device ID
-        StateEvent.UpdateUserId msg = findMessageInQueue(StateEvent.UpdateUserId.class);
-        assertNull(msg.getId());
-    }
-
-    @Test
     public void testLeaveStringBreadcrumbSendsMessage() {
         client.leaveBreadcrumb("Drift 4 units left");
         Breadcrumb crumb = (Breadcrumb)findMessageInQueue(
@@ -189,18 +182,6 @@ public class ObserverInterfaceTest {
         assertEquals("manual", crumb.getMessage());
         assertEquals(1, crumb.getMetadata().size());
         assertEquals("Drift 4 units left", crumb.getMetadata().get("message"));
-    }
-
-    @Test
-    public void testClearBreadcrumbsSendsMessage() {
-        client.clearBreadcrumbs();
-        findMessageInQueue(NativeInterface.MessageType.CLEAR_BREADCRUMBS, null);
-    }
-
-    @Test
-    public void testClearBreadcrumbsDirectlySendsMessage() {
-        client.breadcrumbState.clear();
-        findMessageInQueue(NativeInterface.MessageType.CLEAR_BREADCRUMBS, null);
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -47,16 +47,6 @@ internal class BreadcrumbState(maxBreadcrumbs: Int) : Observable(),
         )
     }
 
-    fun clear() {
-        store.clear()
-        setChanged()
-        notifyObservers(
-            NativeInterface.Message(
-                NativeInterface.MessageType.CLEAR_BREADCRUMBS, null
-            )
-        )
-    }
-
     private fun pruneBreadcrumbs() {
         // Remove oldest breadcrumbState until new max size reached
         while (store.size > maxBreadcrumbs) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -92,11 +93,6 @@ public final class Bugsnag {
         getClient().setContext(context);
     }
 
-    @NonNull
-    public User getUser() {
-        return getClient().getUser();
-    }
-
     /**
      * Set details of the user currently using your application.
      * You can search for this information in your Bugsnag dashboard.
@@ -115,11 +111,9 @@ public final class Bugsnag {
         getClient().setUser(id, email, name);
     }
 
-    /**
-     * Removes the current user data and sets it back to defaults
-     */
-    public static void clearUser() {
-        getClient().clearUser();
+    @NonNull
+    public static User getUser() {
+        return getClient().getUser();
     }
 
     /**
@@ -250,7 +244,7 @@ public final class Bugsnag {
     public static void notify(@NonNull String name,
                               @NonNull String message,
                               @NonNull StackTraceElement[] stacktrace) {
-        getClient().notify(name, message, stacktrace, null);
+        getClient().notify(name, message, stacktrace);
     }
 
     /**
@@ -321,15 +315,8 @@ public final class Bugsnag {
     }
 
     /**
-     * Clear any breadcrumbs that have been left so far.
-     */
-    public static void clearBreadcrumbs() {
-        getClient().clearBreadcrumbs();
-    }
-
-    /**
      * Starts tracking a new session. You should disable automatic session tracking via
-     * {@link #setAutoTrackSessions(boolean)} if you call this method.
+     * {@link Configuration#setAutoTrackSessions(boolean)} if you call this method.
      * <p/>
      * You should call this at the appropriate time in your application when you wish to start a
      * session. Any subsequent errors which occur in your application will still be reported to
@@ -351,7 +338,7 @@ public final class Bugsnag {
      * Resumes a session which has previously been paused, or starts a new session if none exists.
      * If a session has already been resumed or started and has not been paused, calling this
      * method will have no effect. You should disable automatic session tracking via
-     * {@link #setAutoTrackSessions(boolean)} if you call this method.
+     * {@link Configuration#setAutoTrackSessions(boolean)} if you call this method.
      * <p/>
      * It's important to note that sessions are stored in memory for the lifetime of the
      * application process and are not persisted on disk. Therefore calling this method on app
@@ -375,7 +362,7 @@ public final class Bugsnag {
 
     /**
      * Pauses tracking of a session. You should disable automatic session tracking via
-     * {@link #setAutoTrackSessions(boolean)} if you call this method.
+     * {@link Configuration#setAutoTrackSessions(boolean)} if you call this method.
      * <p/>
      * You should call this at the appropriate time in your application when you wish to pause a
      * session. Any subsequent errors which occur in your application will still be reported to

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -468,7 +468,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      * Add a "on error" callback, to execute code at the point where an error report is
      * captured in Bugsnag.
      * <p>
-     * You can use this to add or modify information attached to an error
+     * You can use this to add or modify information attached to an Event
      * before it is sent to your dashboard. You can also return
      * <code>false</code> from any callback to prevent delivery. "on error"
      * callbacks do not run before reports generated in the event

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -141,7 +141,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
         appData = new AppData(appContext, appContext.getPackageManager(),
                 immutableConfig, sessionTracker);
-        Resources resources = appContext.getResources();
 
         userRepository = new UserRepository(sharedPrefs,
                 immutableConfig.getPersistUserBetweenSessions());
@@ -149,7 +148,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
         String id = userState.getUser().getId();
         DeviceBuildInfo info = DeviceBuildInfo.Companion.defaultInfo();
-        deviceData = new DeviceData(connectivity, appContext, resources, id, info);
+        deviceData = new DeviceData(connectivity, appContext, appContext.getResources(), id, info);
 
         // Set up breadcrumbs
         breadcrumbState = new BreadcrumbState(immutableConfig.getMaxBreadcrumbs());
@@ -313,7 +312,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
     /**
      * Starts tracking a new session. You should disable automatic session tracking via
-     * {@link #setAutoTrackSessions(boolean)} if you call this method.
+     * {@link Configuration#setAutoTrackSessions(boolean)} if you call this method.
      * <p/>
      * You should call this at the appropriate time in your application when you wish to start a
      * session. Any subsequent errors which occur in your application will still be reported to
@@ -333,7 +332,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
     /**
      * Pauses tracking of a session. You should disable automatic session tracking via
-     * {@link #setAutoTrackSessions(boolean)} if you call this method.
+     * {@link Configuration#setAutoTrackSessions(boolean)} if you call this method.
      * <p/>
      * You should call this at the appropriate time in your application when you wish to pause a
      * session. Any subsequent errors which occur in your application will still be reported to
@@ -346,7 +345,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      * @see #resumeSession()
      * @see Configuration#setAutoTrackSessions(boolean)
      */
-    public final void pauseSession() {
+    public void pauseSession() {
         sessionTracker.pauseSession();
     }
 
@@ -354,7 +353,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      * Resumes a session which has previously been paused, or starts a new session if none exists.
      * If a session has already been resumed or started and has not been paused, calling this
      * method will have no effect. You should disable automatic session tracking via
-     * {@link #setAutoTrackSessions(boolean)} if you call this method.
+     * {@link Configuration#setAutoTrackSessions(boolean)} if you call this method.
      * <p/>
      * It's important to note that sessions are stored in memory for the lifetime of the
      * application process and are not persisted on disk. Therefore calling this method on app
@@ -372,7 +371,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      *
      * @return true if a previous session was resumed, false if a new session was started.
      */
-    public final boolean resumeSession() {
+    public boolean resumeSession() {
         return sessionTracker.resumeSession();
     }
 
@@ -430,30 +429,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         return userState.getUser();
     }
 
-    @NonNull
-    Collection<Breadcrumb> getBreadcrumbs() {
-        return new ArrayList<>(breadcrumbState.getStore());
-    }
-
-    @NonNull
-    AppData getAppData() {
-        return appData;
-    }
-
-    @NonNull
-    DeviceData getDeviceData() {
-        return deviceData;
-    }
-
-    private void setUserInternal(User user) {
-    }
-
-    /**
-     * Removes the current user data and sets it back to defaults
-     */
-    public void clearUser() {
-    }
-
     /**
      * Set a unique identifier for the user currently using your application.
      * By default, this will be an automatically generated unique id
@@ -488,11 +463,12 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         userState.setUserName(name);
     }
 
+
     /**
      * Add a "on error" callback, to execute code at the point where an error report is
      * captured in Bugsnag.
      * <p>
-     * You can use this to add or modify information attached to an Event
+     * You can use this to add or modify information attached to an error
      * before it is sent to your dashboard. You can also return
      * <code>false</code> from any callback to prevent delivery. "on error"
      * callbacks do not run before reports generated in the event
@@ -783,16 +759,18 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
     }
 
     @NonNull
-    private String getKeyFromClientData(Map<String, Object> clientData,
-                                        String key,
-                                        boolean required) {
-        Object value = clientData.get(key);
-        if (value instanceof String) {
-            return (String) value;
-        } else if (required) {
-            throw new IllegalStateException("Failed to set " + key + " in client data!");
-        }
-        return null;
+    Collection<Breadcrumb> getBreadcrumbs() {
+        return new ArrayList<>(breadcrumbState.getStore());
+    }
+
+    @NonNull
+    AppData getAppData() {
+        return appData;
+    }
+
+    @NonNull
+    DeviceData getDeviceData() {
+        return deviceData;
     }
 
     @Override
@@ -853,13 +831,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         }
     }
 
-    /**
-     * Clear any breadcrumbs that have been left so far.
-     */
-    public void clearBreadcrumbs() {
-        breadcrumbState.clear();
-    }
-
     void deliver(@NonNull Report report, @NonNull Event event) {
         DeliveryParams deliveryParams = immutableConfig.errorApiDeliveryParams();
         Delivery delivery = immutableConfig.getDelivery();
@@ -882,10 +853,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
             default:
                 break;
         }
-    }
-
-    OrientationEventListener getOrientationListener() {
-        return orientationListener; // this only exists for tests
     }
 
     SessionTracker getSessionTracker() {
@@ -919,18 +886,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
             }
         }
         return true;
-    }
-
-    /**
-     * Stores the given key value pair into shared preferences
-     *
-     * @param key   The key to store
-     * @param value The value to store
-     */
-    private void storeInSharedPrefs(String key, String value) {
-        SharedPreferences sharedPref =
-            appContext.getSharedPreferences(SHARED_PREF_KEY, Context.MODE_PRIVATE);
-        sharedPref.edit().putString(key, value).apply();
     }
 
     EventStore getEventStore() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -29,10 +29,6 @@ public class NativeInterface {
          */
         ADD_METADATA,
         /**
-         * Clear all breadcrumbs
-         */
-        CLEAR_BREADCRUMBS,
-        /**
          * Clear all metadata on a tab. The Message object should be the tab
          * name
          */

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -75,16 +75,6 @@ class BreadcrumbStateTest {
     }
 
     /**
-     * Verifies that clearing removes all the breadcrumbs
-     */
-    @Test
-    fun testClear() {
-        breadcrumbState.add(Breadcrumb("1"))
-        breadcrumbState.clear()
-        assertTrue(breadcrumbState.store.isEmpty())
-    }
-
-    /**
      * Verifies that the type of a breadcrumb is manual by default
      */
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -1,0 +1,212 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * Verifies that method calls are forwarded onto the appropriate method on Client.
+ */
+@RunWith(MockitoJUnitRunner::class)
+class BugsnagApiTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Before
+    fun setUp() {
+        Bugsnag.client = client
+    }
+
+    @Test
+    fun getContext() {
+        `when`(client.context).thenReturn("foo")
+        assertEquals("foo", Bugsnag.getContext())
+    }
+
+    @Test
+    fun setContext() {
+        Bugsnag.setContext("Bar")
+        verify(client, times(1)).context = "Bar"
+    }
+
+    @Test
+    fun getUser() {
+        Bugsnag.getUser()
+        verify(client, times(1)).getUser()
+    }
+
+    @Test
+    fun setUser() {
+        Bugsnag.setUser("123", "Jane@example.com", "Jig")
+        verify(client, times(1)).setUser("123", "Jane@example.com", "Jig")
+    }
+
+    @Test
+    fun setUserId() {
+        Bugsnag.setUserId("123")
+        verify(client, times(1)).setUserId("123")
+    }
+
+    @Test
+    fun setUserEmail() {
+        Bugsnag.setUserEmail("foo@example.com")
+        verify(client, times(1)).setUserEmail("foo@example.com")
+    }
+
+    @Test
+    fun setUserName() {
+        Bugsnag.setUserName("Bob")
+        verify(client, times(1)).setUserName("Bob")
+    }
+
+    @Test
+    fun addOnError() {
+        Bugsnag.addOnError { true }
+        Bugsnag.addOnError(OnError { true })
+        verify(client, times(2)).addOnError(ArgumentMatchers.any())
+    }
+
+    @Test
+    fun removeOnError() {
+        Bugsnag.removeOnError { true }
+        Bugsnag.removeOnError(OnError { true })
+        verify(client, times(2)).removeOnError(ArgumentMatchers.any())
+    }
+
+    @Test
+    fun addOnBreadcrumb() {
+        Bugsnag.addOnBreadcrumb { true }
+        Bugsnag.addOnBreadcrumb(OnBreadcrumb { true })
+        verify(client, times(2)).addOnBreadcrumb(ArgumentMatchers.any())
+    }
+
+    @Test
+    fun removeOnBreadcrumb() {
+        Bugsnag.removeOnBreadcrumb { true }
+        Bugsnag.removeOnBreadcrumb(OnBreadcrumb { true })
+        verify(client, times(2)).removeOnBreadcrumb(ArgumentMatchers.any())
+    }
+
+    @Test
+    fun addOnSession() {
+        Bugsnag.addOnSession { true }
+        Bugsnag.addOnSession(OnSession { true })
+        verify(client, times(2)).addOnSession(ArgumentMatchers.any())
+    }
+
+    @Test
+    fun removeOnSession() {
+        Bugsnag.removeOnSession { true }
+        Bugsnag.removeOnSession(OnSession { true })
+        verify(client, times(2)).removeOnSession(ArgumentMatchers.any())
+    }
+
+    @Test
+    fun notify1() {
+        val exc = RuntimeException()
+        Bugsnag.notify(exc)
+        verify(client, times(1)).notify(exc)
+    }
+
+    @Test
+    fun notify2() {
+        val exc = RuntimeException()
+        val onError = OnError { true }
+        Bugsnag.notify(exc, onError)
+        verify(client, times(1)).notify(exc, onError)
+    }
+
+    @Test
+    fun notify3() {
+        Bugsnag.notify("LeakException", "whoops", arrayOf())
+        verify(client, times(1)).notify("LeakException", "whoops", arrayOf())
+    }
+
+    @Test
+    fun notify4() {
+        val onError = OnError { true }
+        Bugsnag.notify("LeakException", "whoops", arrayOf(), onError)
+        verify(client, times(1)).notify("LeakException", "whoops", arrayOf(), onError)
+    }
+
+    @Test
+    fun addMetadataTopLevel() {
+        val map = mutableMapOf(Pair("bar", "wham"))
+        Bugsnag.addMetadata("foo", map)
+        verify(client, times(1)).addMetadata("foo", map)
+    }
+
+    @Test
+    fun addMetadata() {
+        Bugsnag.addMetadata("foo", "bar", "wham")
+        verify(client, times(1)).addMetadata("foo", "bar", "wham")
+    }
+
+    @Test
+    fun clearMetadataTopLevel() {
+        Bugsnag.clearMetadata("foo")
+        verify(client, times(1)).clearMetadata("foo")
+    }
+
+    @Test
+    fun clearMetadata() {
+        Bugsnag.clearMetadata("foo", "bar")
+        verify(client, times(1)).clearMetadata("foo", "bar")
+    }
+
+    @Test
+    fun getMetadataTopLevel() {
+        Bugsnag.getMetadata("foo")
+        verify(client, times(1)).getMetadata("foo")
+    }
+
+    @Test
+    fun getMetadata() {
+        Bugsnag.getMetadata("foo", "bar")
+        verify(client, times(1)).getMetadata("foo", "bar")
+    }
+
+    @Test
+    fun leaveBreadcrumb() {
+        Bugsnag.leaveBreadcrumb("whoops")
+        verify(client, times(1)).leaveBreadcrumb("whoops")
+    }
+
+    @Test
+    fun leaveBreadcrumb1() {
+        Bugsnag.leaveBreadcrumb("whoops", BreadcrumbType.LOG, mapOf())
+        verify(client, times(1)).leaveBreadcrumb("whoops", BreadcrumbType.LOG, mapOf())
+    }
+
+    @Test
+    fun startSession() {
+        Bugsnag.startSession()
+        verify(client, times(1)).startSession()
+    }
+
+    @Test
+    fun resumeSession() {
+        Bugsnag.resumeSession()
+        verify(client, times(1)).resumeSession()
+    }
+
+    @Test
+    fun pauseSession() {
+        Bugsnag.pauseSession()
+        verify(client, times(1)).pauseSession()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun nullClient() {
+        Bugsnag.client = null
+        Bugsnag.getClient()
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -57,8 +57,6 @@ public class NativeBridge implements Observer {
 
     public static native void addUnhandledEvent();
 
-    public static native void clearBreadcrumbs();
-
     public static native void clearMetadataTab(@NonNull String tab);
 
     public static native void removeMetadata(@NonNull String tab,@NonNull  String key);

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -129,9 +129,6 @@ public class NativeBridge implements Observer {
             case ADD_METADATA:
                 handleAddMetadata(arg);
                 break;
-            case CLEAR_BREADCRUMBS:
-                clearBreadcrumbs();
-                break;
             case CLEAR_METADATA_TAB:
                 handleClearMetadataTab(arg);
                 break;

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -173,16 +173,6 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_pausedSession(
     bsg_release_env_write_lock();
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_clearBreadcrumbs(JNIEnv *env,
-                                                           jobject _this) {
-  if (bsg_global_env == NULL)
-    return;
-  bsg_request_env_write_lock();
-  bugsnag_report_clear_breadcrumbs(&bsg_global_env->next_report);
-  bsg_release_env_write_lock();
-}
-
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
     JNIEnv *env, jobject _this, jstring name_, jstring crumb_type,
     jstring timestamp_, jobject metadata) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/report.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/report.c
@@ -155,11 +155,6 @@ void bugsnag_report_add_breadcrumb(bugsnag_report *report,
   memcpy(&report->breadcrumbs[crumb_index], crumb, sizeof(bugsnag_breadcrumb));
 }
 
-void bugsnag_report_clear_breadcrumbs(bugsnag_report *report) {
-  report->crumb_count = 0;
-  report->crumb_first_index = 0;
-}
-
 bool bugsnag_report_has_session(bugsnag_report *report) {
     return strlen(report->session_id) > 0;
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/report.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/report.h
@@ -303,7 +303,6 @@ void bugsnag_report_add_metadata_bool(bugsnag_report *report, char *section,
                                       char *name, bool value);
 void bugsnag_report_add_breadcrumb(bugsnag_report *report,
                                    bugsnag_breadcrumb *crumb);
-void bugsnag_report_clear_breadcrumbs(bugsnag_report *report);
 void bugsnag_report_remove_metadata(bugsnag_report *report, char *section,
                                     char *name);
 void bugsnag_report_remove_metadata_tab(bugsnag_report *report, char *section);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
@@ -65,33 +65,7 @@ TEST test_add_breadcrumbs_over_max(void) {
   PASS();
 }
 
-TEST test_clear_empty_breadcrumbs(void) {
-  bugsnag_report *report = calloc(1, sizeof(bugsnag_report));
-  bugsnag_report_clear_breadcrumbs(report);
-  ASSERT_EQ(0, report->crumb_count);
-  ASSERT_EQ(0, report->crumb_first_index);
-  PASS();
-}
-
-TEST test_clear_breadcrumbs(void) {
-  bugsnag_report *report = calloc(1, sizeof(bugsnag_report));
-  bugsnag_breadcrumb *crumb1 = init_breadcrumb("running!", "this is a drill.", BSG_CRUMB_USER);
-  bugsnag_report_add_breadcrumb(report, crumb1);
-  free(crumb1);
-  bugsnag_breadcrumb *crumb2 = init_breadcrumb("walking...", "this is not a drill.", BSG_CRUMB_USER);
-  bugsnag_report_add_breadcrumb(report, crumb2);
-  bugsnag_report_clear_breadcrumbs(report);
-  ASSERT_EQ(0, report->crumb_count);
-  ASSERT_EQ(0, report->crumb_first_index);
-
-  free(report);
-  free(crumb2);
-  PASS();
-}
-
 SUITE(breadcrumbs) {
   RUN_TEST(test_add_breadcrumb);
   RUN_TEST(test_add_breadcrumbs_over_max);
-  RUN_TEST(test_clear_empty_breadcrumbs);
-  RUN_TEST(test_clear_breadcrumbs);
 }


### PR DESCRIPTION
## Goal

Removes obsolete and methods which do not comply with the notifier spec from the Bugsnag/Client interfaces.

## Changeset

- Removed ability to clear breadcrumbs and associated test code, as this should now be done with an `OnBreadcrumb` callback
- Removed `clearUser()` in favour of `setUser(null, null, null)`
- Removed `final` from `pauseSession/resumeSession` to allow mocking of `Client` methods
- Removed unused private implementation methods in `Client`
- Added `BugsnagApiTest`, which verifies that the `Bugsnag` facade invokes the appropriate method on `Client`

