### PR TITLE
Add unit test coverage for Connectivity implementations

### DIFF
--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityApi24Test.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityApi24Test.kt
@@ -1,0 +1,45 @@
+package com.bugsnag.android
+
+import android.net.ConnectivityManager
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ConnectivityApi24Test {
+
+    @Mock
+    lateinit var cm: ConnectivityManager
+
+    @Test
+    fun registerForNetworkChanges() {
+        val conn = ConnectivityApi24(cm) { }
+        conn.registerForNetworkChanges()
+        verify(cm, times(1)).registerDefaultNetworkCallback(any())
+    }
+
+    @Test
+    fun unregisterForNetworkChanges() {
+        val conn = ConnectivityApi24(cm) { }
+        conn.unregisterForNetworkChanges()
+        verify(cm, times(1)).unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>())
+    }
+
+    @Test
+    fun hasNetworkConnection() {
+        val conn = ConnectivityApi24(cm) { }
+        assertFalse(conn.hasNetworkConnection())
+    }
+
+    @Test
+    fun networkAccessState() {
+        val conn = ConnectivityApi24(cm) {}
+        assertEquals("none", conn.retrieveNetworkAccessState())
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
@@ -1,0 +1,50 @@
+package com.bugsnag.android
+
+import android.content.Context
+import android.net.ConnectivityManager
+import org.junit.Assert
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.junit.MockitoJUnitRunner
+
+@Suppress("DEPRECATION")
+@RunWith(MockitoJUnitRunner::class)
+class ConnectivityLegacyTest {
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var cm: ConnectivityManager
+
+    @Test
+    fun registerForNetworkChanges() {
+        val conn = ConnectivityLegacy(context, cm, null)
+        conn.registerForNetworkChanges()
+        Mockito.verify(context, times(1)).registerReceiver(any(), any())
+    }
+
+    @Test
+    fun unregisterForNetworkChanges() {
+        val conn = ConnectivityLegacy(context, cm, null)
+        conn.unregisterForNetworkChanges()
+        Mockito.verify(context, times(1)).unregisterReceiver(any())
+    }
+
+    @Test
+    fun hasNetworkConnection() {
+        val conn = ConnectivityLegacy(context, cm, null)
+        assertFalse(conn.hasNetworkConnection())
+    }
+
+    @Test
+    fun networkAccessState() {
+        val conn = ConnectivityLegacy(context, cm, null)
+        assertEquals("none", conn.retrieveNetworkAccessState())
+    }
+}


### PR DESCRIPTION
## Goal

Adds unit test coverage for the `Connectivity` class, which detects whether the device has a network connection. This was added as part of a general drive to increase test coverage on the original integration branch for the notifier spec updates.

## Changeset

Added tests for the two `Connectivity` implementations: `ConnectivityApi24`, and `ConnectivityLegacy`, which runs on pre-API 24 devices.

The tests verify that the appropriate callback is registered/unregistered to listen for network callbacks, and that the network state returns an appropriate value.