### PR TITLE
Increase session tracking test coverage

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -1001,6 +1001,10 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         getAppData().setBinaryArch(binaryArch);
     }
 
+    Context getAppContext() {
+        return appContext;
+    }
+
     void close() {
         orientationListener.disable();
         connectivity.unregisterForNetworkChanges();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -64,7 +64,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
         this.client = client;
         this.timeoutMs = timeoutMs;
         this.sessionStore = sessionStore;
-        this.foregroundDetector = new ForegroundDetector(client.appContext);
+        this.foregroundDetector = new ForegroundDetector(client.getAppContext());
         this.logger = logger;
         notifyNdkInForeground();
     }
@@ -179,8 +179,8 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
 
                         SessionPayload payload =
                             new SessionPayload(session, null,
-                                client.appData.getAppDataSummary(),
-                                    client.deviceData.getDeviceDataSummary());
+                                client.getAppData().getAppDataSummary(),
+                                    client.getDeviceData().getDeviceDataSummary());
 
                         try {
                             for (OnSession mutator : clientState.getSessionCallbacks()) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerBreadcrumbTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerBreadcrumbTest.kt
@@ -1,0 +1,105 @@
+package com.bugsnag.android
+
+import android.app.Activity
+import android.app.ActivityManager
+import android.content.Context
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+internal class SessionTrackerBreadcrumbTest {
+
+    private lateinit var tracker: SessionTracker
+
+    @Mock
+    lateinit var client: Client
+
+    @Mock
+    internal var appData: AppData? = null
+
+    @Mock
+    internal var deviceData: DeviceData? = null
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var activity: Activity
+
+    @Mock
+    lateinit var activityManager: ActivityManager
+
+    @Mock
+    lateinit var sessionStore: SessionStore
+
+    @Before
+    fun setUp() {
+        `when`(client.getAppContext()).thenReturn(context)
+        `when`(client.getAppData()).thenReturn(appData)
+        `when`(client.getDeviceData()).thenReturn(deviceData)
+        `when`(context.getSystemService("activity")).thenReturn(activityManager)
+        tracker = SessionTracker(
+            BugsnagTestUtils.generateImmutableConfig(),
+            BugsnagTestUtils.generateConfiguration(),
+            client,
+            sessionStore,
+            NoopLogger
+        )
+    }
+
+    @Test
+    fun onCreateBreadcrumb() {
+        tracker.onActivityCreated(activity, null)
+        verifyLifecycleBreadcrumb("onCreate()")
+    }
+
+    @Test
+    fun onStartBreadcrumb() {
+        tracker.onActivityStarted(activity)
+        verifyLifecycleBreadcrumb("onStart()")
+    }
+
+    @Test
+    fun onResumeBreadcrumb() {
+        tracker.onActivityResumed(activity)
+        verifyLifecycleBreadcrumb("onResume()")
+    }
+
+    @Test
+    fun onPauseBreadcrumb() {
+        tracker.onActivityPaused(activity)
+        verifyLifecycleBreadcrumb("onPause()")
+    }
+
+    @Test
+    fun onStopBreadcrumb() {
+        tracker.onActivityStopped(activity)
+        verifyLifecycleBreadcrumb("onStop()")
+    }
+
+    @Test
+    fun onSaveInstanceState() {
+        tracker.onActivitySaveInstanceState(activity, null)
+        verifyLifecycleBreadcrumb("onSaveInstanceState()")
+    }
+
+    @Test
+    fun onDestroyBreadcrumb() {
+        tracker.onActivityDestroyed(activity)
+        verifyLifecycleBreadcrumb("onDestroy()")
+    }
+
+    private fun verifyLifecycleBreadcrumb(method: String) {
+        verify(client, times(1)).leaveBreadcrumb(
+            "Activity",
+            BreadcrumbType.NAVIGATION,
+            mapOf(Pair("ActivityLifecycle", method))
+        )
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
@@ -1,9 +1,8 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.BugsnagTestUtils.generateClient
+import android.app.ActivityManager
+import android.content.Context
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
-import com.bugsnag.android.BugsnagTestUtils.generateSessionStore
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -12,29 +11,47 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
 
-class SessionTrackerPauseResumeTest {
+@RunWith(MockitoJUnitRunner::class)
+internal class SessionTrackerPauseResumeTest {
 
     private val configuration = generateConfiguration().also {
         it.autoTrackSessions = false
     }
-    private val sessionStore = generateSessionStore()
     private lateinit var tracker: SessionTracker
 
-    private var client: Client? = null
+    @Mock
+    lateinit var client: Client
+
+    @Mock
+    internal var appData: AppData? = null
+
+    @Mock
+    internal var deviceData: DeviceData? = null
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var activityManager: ActivityManager
+
+    @Mock
+    lateinit var sessionStore: SessionStore
 
     @Before
     fun setUp() {
-        client = generateClient()
+        `when`(client.getAppContext()).thenReturn(context)
+        `when`(client.getAppData()).thenReturn(appData)
+        `when`(client.getDeviceData()).thenReturn(deviceData)
+        `when`(context.getSystemService("activity")).thenReturn(activityManager)
         tracker = SessionTracker(
             BugsnagTestUtils.generateImmutableConfig(),
             configuration, client, sessionStore, NoopLogger
         )
-    }
-
-    @After
-    fun tearDown() {
-        client?.close()
     }
 
     /**


### PR DESCRIPTION
## Goal

Adds unit test coverage for the `SessionTracker` class. This was added as part of a general drive to increase test coverage on the original integration branch for the notifier spec updates.

## Changeset

- Converted existing instrumentation tests to run on the JVM
- Added a test to verify automatic breadcrumbs left by the session tracker contain the correct data
- Updated the `SessionTracker` to use getters where necessary as these methods are mockable for tests, whereas fields are not
- Removed redundant check for whether breadcrumbs are enabled
- Enabled [mock-maker-inline](https://stackoverflow.com/questions/14292863/how-to-mock-a-final-class-with-mockito) which is required to appropriately mock the `Activity` class.