### PR TITLE
Extract sanitisation of Configuration to ImmutableConfig.kt

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -2,7 +2,16 @@
 <SmellBaseline>
   <Blacklist></Blacklist>
   <Whitelist>
-    <ID>MaxLineLength:EventFilenameTest.kt$ErrorFilenameTest$arrayOf("1504255147933_e-u-java.lang.RuntimeException_30b7e350-dcd1-4032-969e-98d30be62bbc_startupcrash.json")</ID>
+    <ID>ComplexMethod:ImmutableConfig.kt$internal fun sanitiseConfiguration( appContext: Context, configuration: Configuration, connectivity: Connectivity ): ImmutableConfig</ID>
+    <ID>ComplexMethod:ObjectJsonStreamer.kt$ObjectJsonStreamer$// Write complex/nested values to a JsonStreamer @Throws(IOException::class) fun objectToStream(obj: Any?, writer: JsonStream, shouldRedactKeys: Boolean = false)</ID>
+    <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$299</ID>
+    <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$429</ID>
+    <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>
+    <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String&gt; ): DeliveryStatus</ID>
     <ID>TooGenericExceptionCaught:BugsnagPluginInterface.kt$BugsnagPluginInterface$exc: Exception</ID>
+    <ID>TooGenericExceptionCaught:Configuration.kt$Configuration$exc: Throwable</ID>
+    <ID>TooGenericExceptionCaught:DefaultDelivery.kt$DefaultDelivery$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:Stacktrace.kt$Stacktrace$lineEx: Exception</ID>
+    <ID>TooManyFunctions:Configuration.kt$Configuration : CallbackAwareMetadataAware</ID>
   </Whitelist>
 </SmellBaseline>

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -8,15 +9,22 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
-class ImmutableConfigTest {
+internal class ImmutableConfigTest {
 
     private val seed = Configuration("api-key")
 
     @Mock
     lateinit var delivery: Delivery
+
+    @Mock
+    lateinit var connectivity: Connectivity
+
+    @Mock
+    lateinit var context: Context
 
     @Before
     fun setUp() {
@@ -141,5 +149,15 @@ class ImmutableConfigTest {
         assertEquals(config.apiKey, headers["Bugsnag-Api-Key"])
         assertNotNull(headers["Bugsnag-Sent-At"])
         assertNotNull(headers["Bugsnag-Payload-Version"])
+    }
+
+    @Test
+    fun configSanitisation() {
+        Mockito.`when`(context.packageName).thenReturn("com.example.foo")
+        val seed = Configuration("api-key")
+        val config = sanitiseConfiguration(context, seed, connectivity)
+        assertEquals(setOf("com.example.foo"), config.projectPackages)
+
+        assertNotNull(config.delivery)
     }
 }

--- a/bugsnag-plugin-android-anr/detekt-baseline.xml
+++ b/bugsnag-plugin-android-anr/detekt-baseline.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <Blacklist></Blacklist>
-  <Whitelist></Whitelist>
+  <Whitelist>
+    <ID>TooGenericExceptionCaught:AnrDetailsCollector.kt$AnrDetailsCollector$exc: RuntimeException</ID>
+  </Whitelist>
 </SmellBaseline>

--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <Blacklist></Blacklist>
-  <Whitelist></Whitelist>
+  <Whitelist>
+    <ID>NewLineAtEndOfFile:VerifyUtils.kt$com.bugsnag.android.ndk.VerifyUtils.kt</ID>
+  </Whitelist>
 </SmellBaseline>

--- a/mazerunner-scenarios/detekt-baseline.xml
+++ b/mazerunner-scenarios/detekt-baseline.xml
@@ -3,13 +3,18 @@
   <Blacklist></Blacklist>
   <Whitelist>
     <ID>EmptyFunctionBlock:Scenario.kt$Scenario${}</ID>
+    <ID>MagicNumber:AppNotRespondingDisabledNdkScenario.kt$AppNotRespondingDisabledNdkScenario$50000</ID>
+    <ID>MagicNumber:AppNotRespondingDisabledScenario.kt$AppNotRespondingDisabledScenario$50000</ID>
+    <ID>MagicNumber:AppNotRespondingScenario.kt$AppNotRespondingScenario$50000</ID>
     <ID>MagicNumber:BugsnagInitScenario.kt$BugsnagInitScenario$25</ID>
     <ID>MagicNumber:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$6000</ID>
     <ID>MagicNumber:TestHarnessHooks.kt$&lt;no name provided&gt;$500</ID>
     <ID>MagicNumber:TrimmedStacktraceScenario.kt$TrimmedStacktraceScenario$100000</ID>
+    <ID>MatchingDeclarationName:ArrayNotifyReleaseStageScenario.kt$com.bugsnag.android.mazerunner.scenarios.ArrayNotifyReleaseStageScenario.kt</ID>
+    <ID>MatchingDeclarationName:HandledExceptionWithoutMessage.kt$com.bugsnag.android.mazerunner.scenarios.HandledExceptionWithoutMessage.kt</ID>
     <ID>TooGenericExceptionThrown:CrashHandlerScenario.kt$CrashHandlerScenario$throw RuntimeException("CrashHandlerScenario")</ID>
     <ID>TooGenericExceptionThrown:CustomClientErrorFlushScenario.kt$CustomClientErrorFlushScenario$throw RuntimeException("ReportCacheScenario")</ID>
-    <ID>TooGenericExceptionThrown:DisableAutoDetectErrorsScenario.kt$DisableAutoNotifyScenario$throw RuntimeException("Should never appear")</ID>
+    <ID>TooGenericExceptionThrown:DisableAutoDetectErrorsScenario.kt$DisableAutoDetectErrorsScenario$throw RuntimeException("Should never appear")</ID>
     <ID>TooGenericExceptionThrown:IgnoredExceptionScenario.kt$IgnoredExceptionScenario$throw RuntimeException("Should never appear")</ID>
     <ID>TooGenericExceptionThrown:ReportCacheScenario.kt$ReportCacheScenario$throw RuntimeException("ReportCacheScenario")</ID>
     <ID>TooGenericExceptionThrown:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$throw RuntimeException("Regular crash")</ID>


### PR DESCRIPTION
## Goal

Extracts sanitisation code from `Client` to `ImmutableConfig`, which makes the deep-copy of the user-supplied `Configuration` more testable and reduces the responsibilities of `Client`.

## Changeset

- Extracted `sanitiseConfiguration()` to `ImmutableConfig` 
- Added a test to verify that the projectPackages are set to an appropriate default