### PR TITLE
Change [FILTERED] to [REDACTED] for metadata mazerunner scenarios

### DIFF
--- a/features/filtering_metadata.feature
+++ b/features/filtering_metadata.feature
@@ -7,8 +7,8 @@ Scenario: Using the default metadata filter
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the exception "message" equals "AutoRedactKeysScenario"
     And the event "metaData.custom.foo" equals "hunter2"
-    And the event "metaData.custom.password" equals "[FILTERED]"
-    And the event "metaData.user.password" equals "[FILTERED]"
+    And the event "metaData.custom.password" equals "[REDACTED]"
+    And the event "metaData.user.password" equals "[REDACTED]"
 
 Scenario: Adding a custom metadata filter
     When I run "ManualRedactKeysScenario"
@@ -16,6 +16,6 @@ Scenario: Adding a custom metadata filter
     And the request is a valid for the error reporting API
     And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And the exception "message" equals "ManualRedactKeysScenario"
-    And the event "metaData.custom.foo" equals "[FILTERED]"
-    And the event "metaData.user.foo" equals "[FILTERED]"
+    And the event "metaData.custom.foo" equals "[REDACTED]"
+    And the event "metaData.user.foo" equals "[REDACTED]"
     And the event "metaData.custom.bar" equals "hunter2"

--- a/tests/features/filtering_metadata.feature
+++ b/tests/features/filtering_metadata.feature
@@ -6,14 +6,14 @@ Scenario: Using the default metadata filter
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "message" equals "AutoRedactKeysScenario"
     And the event "metaData.custom.foo" equals "hunter2"
-    And the event "metaData.custom.password" equals "[FILTERED]"
-    And the event "metaData.user.password" equals "[FILTERED]"
+    And the event "metaData.custom.password" equals "[REDACTED]"
+    And the event "metaData.user.password" equals "[REDACTED]"
 
 Scenario: Adding a custom metadata filter
     When I run "ManualRedactKeysScenario"
     Then I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "message" equals "ManualRedactKeysScenario"
-    And the event "metaData.custom.foo" equals "[FILTERED]"
-    And the event "metaData.user.foo" equals "[FILTERED]"
+    And the event "metaData.custom.foo" equals "[REDACTED]"
+    And the event "metaData.user.foo" equals "[REDACTED]"
     And the event "metaData.custom.bar" equals "hunter2"


### PR DESCRIPTION
## Goal

The mazerunner scenarios are still asserting that the value should be `[FILTERED]` rather than `[REDACTED]`, which fails CI.
