### PR TITLE
feat: (internal) Support initializing custom plugins before init

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagPluginInterface.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagPluginInterface.kt
@@ -15,7 +15,8 @@ object BugsnagPluginInterface {
         registeredPluginClasses.add(clz)
     }
 
-    fun loadRegisteredPlugins(client: Client) {
+    @JvmName("loadRegisteredPlugins")
+    internal fun loadRegisteredPlugins(client: Client) {
         registeredPluginClasses.forEach { loadPlugin(client, it) }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagPluginInterface.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagPluginInterface.kt
@@ -9,6 +9,15 @@ interface BugsnagPlugin {
 object BugsnagPluginInterface {
 
     private var plugins = mutableMapOf<Class<*>, BugsnagPlugin>()
+    private var registeredPluginClasses = mutableSetOf<Class<*>>()
+
+    fun registerPlugin(clz: Class<*>) {
+        registeredPluginClasses.add(clz)
+    }
+
+    fun loadRegisteredPlugins(client: Client) {
+        registeredPluginClasses.forEach { loadPlugin(client, it) }
+    }
 
     @JvmName("loadPlugin")
     internal fun loadPlugin(client: Client, clz: Class<*>) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -318,6 +318,7 @@ public class Client extends Observable implements Observer {
         NativeInterface.setClient(this);
         enableOrDisableNdkReporting();
         enableOrDisableAnrReporting();
+        BugsnagPluginInterface.INSTANCE.loadRegisteredPlugins(this);
     }
 
     void enableOrDisableNdkReporting() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagPluginInterfaceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagPluginInterfaceTest.kt
@@ -26,6 +26,15 @@ class BugsnagPluginInterfaceTest {
         BugsnagPluginInterface.loadPlugin(client, String::class.java)
         BugsnagPluginInterface.unloadPlugin(String::class.java)
     }
+
+    @Test
+    fun registerPluginClass() {
+        BugsnagPluginInterface.registerPlugin(FakePlugin::class.java)
+        BugsnagPluginInterface.loadRegisteredPlugins(client)
+        assertTrue(FakePlugin.active)
+        BugsnagPluginInterface.unloadPlugin(FakePlugin::class.java)
+        assertFalse(FakePlugin.active)
+    }
 }
 
 internal class FakePlugin : BugsnagPlugin {

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/CustomPluginExample.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/CustomPluginExample.kt
@@ -1,0 +1,29 @@
+package com.bugsnag.android
+
+// In the main package as a part of an internal interface
+
+class CustomPluginExample : BugsnagPlugin {
+
+    override var loaded = false
+
+
+    companion object {
+        @JvmStatic
+        fun register() {
+            BugsnagPluginInterface.registerPlugin(CustomPluginExample::class.java)
+        }
+    }
+
+    override fun loadPlugin(client: Client) {
+        client.config.beforeSend { report ->
+            report.notifier.name = "Foo Handler Library"
+            report.notifier.version = "2.1.0"
+            report.notifier.setURL("https://example.com")
+
+            true
+        }
+    }
+
+    override fun unloadPlugin() {
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomPluginNotifierDescriptionScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomPluginNotifierDescriptionScenario.kt
@@ -1,0 +1,25 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Client
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.CustomPluginExample
+import java.lang.RuntimeException
+
+
+internal class CustomPluginNotifierDescriptionScenario(
+    config: Configuration,
+    context: Context
+) : Scenario(config, context) {
+
+    init {
+        CustomPluginExample.register()
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.notify(RuntimeException())
+    }
+}

--- a/features/plugin_interface.feature
+++ b/features/plugin_interface.feature
@@ -1,0 +1,16 @@
+Feature: Add custom behavior through a plugin interface
+
+    Some internal libraries may build on top of the Bugsnag Android library and
+    require custom behavior prior to the library being fully initialized. This
+    interface allows for installing that behavior before calling the regular
+    initialization process.
+
+    Scenario: Changing payload notifier description
+        When I run "CustomPluginNotifierDescriptionScenario"
+        Then I should receive a request
+        Then the payload field "notifier.name" equals "Foo Handler Library"
+        And the payload field "notifier.version" equals "2.1.0"
+        And the payload field "notifier.url" equals "https://example.com"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "java.lang.RuntimeException"
+

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/CustomPluginExample.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/CustomPluginExample.kt
@@ -1,0 +1,29 @@
+package com.bugsnag.android
+
+// In the main package as a part of an internal interface
+
+class CustomPluginExample : BugsnagPlugin {
+
+    override var loaded = false
+
+
+    companion object {
+        @JvmStatic
+        fun register() {
+            BugsnagPluginInterface.registerPlugin(CustomPluginExample::class.java)
+        }
+    }
+
+    override fun loadPlugin(client: Client) {
+        client.config.beforeSend { report ->
+            report.notifier.name = "Foo Handler Library"
+            report.notifier.version = "2.1.0"
+            report.notifier.setURL("https://example.com")
+
+            true
+        }
+    }
+
+    override fun unloadPlugin() {
+    }
+}

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomPluginNotifierDescriptionScenario.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomPluginNotifierDescriptionScenario.kt
@@ -1,0 +1,25 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Client
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.CustomPluginExample
+import java.lang.RuntimeException
+
+
+internal class CustomPluginNotifierDescriptionScenario(
+    config: Configuration,
+    context: Context
+) : Scenario(config, context) {
+
+    init {
+        CustomPluginExample.register()
+        config.setAutoCaptureSessions(false)
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.notify(RuntimeException())
+    }
+}

--- a/tests/features/plugin_interface.feature
+++ b/tests/features/plugin_interface.feature
@@ -1,0 +1,16 @@
+Feature: Add custom behavior through a plugin interface
+
+    Some internal libraries may build on top of the Bugsnag Android library and
+    require custom behavior prior to the library being fully initialized. This
+    interface allows for installing that behavior before calling the regular
+    initialization process.
+
+    Scenario: Changing payload notifier description
+        When I run "CustomPluginNotifierDescriptionScenario"
+        Then I should receive a request
+        Then the payload field "notifier.name" equals "Foo Handler Library"
+        And the payload field "notifier.version" equals "2.1.0"
+        And the payload field "notifier.url" equals "https://example.com"
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "java.lang.RuntimeException"
+


### PR DESCRIPTION
Fixes an issue where a plugin cannot be configured until _after_ Bugsnag
is started, potentially sending reports prior to a plugin being able to
modify them.