### PR TITLE
Update mazerunner scenarios to use new constructor

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -51,7 +51,7 @@ class Event @JvmOverloads internal constructor(
     }
 
     var threads: List<Thread> = when {
-        config.sendThreads -> ThreadState(config, originalError).threads
+        config.sendThreads -> ThreadState(config, if (isUnhandled) originalError else null).threads
         else -> emptyList()
     }
 

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -62,11 +62,6 @@ abstract class Scenario(
         }
     }
 
-    internal fun createDefaultDelivery(): Delivery { // use reflection as DefaultDelivery is internal
-        val clz = java.lang.Class.forName("com.bugsnag.android.DefaultDelivery")
-        return clz.constructors[0].newInstance(null) as Delivery
-    }
-
     /**
      * Returns a throwable with the message as the current classname
      */

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TestHarnessHooks.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TestHarnessHooks.kt
@@ -58,7 +58,16 @@ internal fun createCustomHeaderDelivery(): Delivery {
 
 internal fun createDefaultDelivery(): Delivery { // use reflection as DefaultDelivery is internal
     val clz = Class.forName("com.bugsnag.android.DefaultDelivery")
-    return clz.constructors[0].newInstance(null) as Delivery
+    return clz.constructors[0].newInstance(null, object: Logger {
+        override fun e(msg: String) = Unit
+        override fun e(msg: String, throwable: Throwable) = Unit
+        override fun w(msg: String) = Unit
+        override fun w(msg: String, throwable: Throwable) = Unit
+        override fun i(msg: String) = Unit
+        override fun i(msg: String, throwable: Throwable) = Unit
+        override fun d(msg: String) = Unit
+        override fun d(msg: String, throwable: Throwable) = Unit
+    }) as Delivery
 }
 
 internal fun writeErrorToStore(client: Client) {


### PR DESCRIPTION
## Goal

#672 added a `Logger` interface which is injected into `Delivery`, but some mazerunner scenario code was not updated to add the new constructor parameter. This led to a crash when creating `DefaultDelivery` via reflection, which has therefore been updated to pass in a no-op `Logger` implementation that passes the following scenarios:

- async_error_flush
- custom_client
- handled_exception
- unhandled_exception

The `ThreadState` refactor also broke one assertion in the error_reporting_thread feature - this has been addressed by only replacing the thread trace with an exception stacktrace when the exception is unhandled.

It's worth noting that the native_api feature is expected to fail its second scenario as this will rely on changes made in #680 being fully implemented across the codebase.

