### PR TITLE
Add test coverage for redaction on event fields

### DIFF
--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventRedactionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventRedactionTest.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import org.junit.Test
+import java.io.StringWriter
+import java.util.Date
+
+internal class EventRedactionTest {
+
+    @Test
+    fun testEventRedaction() {
+        val event = Event(
+            null,
+            generateImmutableConfig(),
+            HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
+        )
+
+        event.app["password"] = "foo"
+        event.device["password"] = "bar"
+        event.metadata.addMetadata("baz", "password", "hunter2")
+        val metadata = mutableMapOf<String, Any?>(Pair("password", "whoops"))
+        event.breadcrumbs = listOf(Breadcrumb("Whoops", BreadcrumbType.LOG, metadata, Date(0)))
+        event.threads = emptyList()
+
+
+        val writer = StringWriter()
+        val stream = JsonStream(writer)
+        event.toStream(stream)
+        validateJson("event_redaction.json", writer.toString())
+    }
+}

--- a/bugsnag-android-core/src/test/resources/event_redaction.json
+++ b/bugsnag-android-core/src/test/resources/event_redaction.json
@@ -1,0 +1,31 @@
+{
+  "metaData": {
+    "baz": {
+      "password": "[REDACTED]"
+    }
+  },
+  "severity": "warning",
+  "severityReason": {
+    "type": "handledException"
+  },
+  "unhandled": false,
+  "exceptions": [],
+  "user": {},
+  "app": {
+    "password": "foo"
+  },
+  "device": {
+    "password": "bar"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "1970-01-01T00:00:00Z",
+      "name": "Whoops",
+      "type": "log",
+      "metaData": {
+        "password": "[REDACTED]"
+      }
+    }
+  ],
+  "threads": []
+}


### PR DESCRIPTION
## Goal

Adds a test to verify that values are redacted from `Event` fields.

Note that `MetadataRedactionTest` already contains more in-depth coverage to verify how metadata is sanitised - this test case is intended to verify that the functionality is not broken on `Event`.