### PR TITLE
Create ContextState class to encapsulate context

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import android.content.Context;
 
@@ -38,7 +39,7 @@ public class ClientConfigTest {
     public void testSetContext() throws Exception {
         client.setContext("JunitTest");
         assertEquals("JunitTest", client.getContext());
-        assertEquals("JunitTest", config.getContext());
+        assertNull(config.getContext());
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -136,9 +136,8 @@ public class ObserverInterfaceTest {
     @Test
     public void testClientSetContextSendsMessage() {
         client.setContext("Pod Bay");
-        String context = (String)findMessageInQueue(
-                NativeInterface.MessageType.UPDATE_CONTEXT, String.class);
-        assertEquals("Pod Bay", context);
+        StateEvent.UpdateContext msg = findMessageInQueue(StateEvent.UpdateContext.class);
+        assertEquals("Pod Bay", msg.getContext());
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -60,6 +60,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
     final Configuration clientState;
     final ImmutableConfig immutableConfig;
 
+    final ContextState contextState;
     final UserState userState;
 
     final Context appContext;
@@ -148,6 +149,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
         clientState = configuration;
         immutableConfig = ImmutableConfigKt.convertToImmutableConfig(configuration);
+        contextState = configuration.contextState.copy();
 
         sessionStore = new SessionStore(appContext, logger, null);
         sessionTracker = new SessionTracker(immutableConfig, clientState, this, sessionStore,
@@ -229,6 +231,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         sessionTracker.addObserver(this);
         clientObservable.addObserver(this);
         userState.addObserver(this);
+        contextState.addObserver(this);
         orientationListener = registerOrientationChangeListener();
 
         // filter out any disabled breadcrumb types
@@ -431,7 +434,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      * @return Context
      */
     @Nullable public String getContext() {
-        return clientState.getContext();
+        return contextState.getContext();
     }
 
     /**
@@ -442,10 +445,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      * @param context set what was happening at the time of a crash
      */
     public void setContext(@Nullable String context) {
-        clientState.setContext(context);
-        setChanged();
-        notifyObservers(new NativeInterface.Message(
-                NativeInterface.MessageType.UPDATE_CONTEXT, context));
+        contextState.setContext(context);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -149,7 +149,8 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
         clientState = configuration;
         immutableConfig = ImmutableConfigKt.convertToImmutableConfig(configuration);
-        contextState = configuration.contextState.copy();
+        contextState = new ContextState();
+        contextState.setContext(configuration.getContext());
 
         sessionStore = new SessionStore(appContext, logger, null);
         sessionTracker = new SessionTracker(immutableConfig, clientState, this, sessionStore,
@@ -698,7 +699,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
         // Attach default context from active activity
         if (Intrinsics.isEmpty(event.getContext())) {
-            String context = clientState.getContext();
+            String context = contextState.getContext();
             event.setContext(context != null ? context : appData.getActiveScreenClass());
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -18,9 +18,6 @@ class Configuration(
 
     var metadata = Metadata()
 
-    @JvmField
-    internal val contextState: ContextState
-
     protected val onErrorTasks = ConcurrentLinkedQueue<OnError>()
     protected val breadcrumbCallbacks = ConcurrentLinkedQueue<OnBreadcrumb>()
     protected val sessionCallbacks = ConcurrentLinkedQueue<OnSession>()
@@ -168,11 +165,7 @@ class Configuration(
      * name of the top-most activity at the time of a report, and use this
      * as the context, but sometime this is not possible.
      */
-    var context: String?
-        get() = contextState.context
-        set(context) {
-            contextState.context = context
-        }
+    var context: String? = null
 
     /**
      * Set which keys should be redacted when sending metadata to Bugsnag.
@@ -194,7 +187,6 @@ class Configuration(
 
     init {
         require(!TextUtils.isEmpty(apiKey)) { "You must provide a Bugsnag API key" }
-        this.contextState = ContextState()
 
         autoDetectNdkCrashes = try {
             // check if AUTO_DETECT_NDK_CRASHES has been set in bugsnag-android

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -17,6 +17,10 @@ class Configuration(
 ) : CallbackAware, MetadataAware {
 
     var metadata = Metadata()
+
+    @JvmField
+    internal val contextState: ContextState
+
     protected val onErrorTasks = ConcurrentLinkedQueue<OnError>()
     protected val breadcrumbCallbacks = ConcurrentLinkedQueue<OnBreadcrumb>()
     protected val sessionCallbacks = ConcurrentLinkedQueue<OnSession>()
@@ -164,7 +168,11 @@ class Configuration(
      * name of the top-most activity at the time of a report, and use this
      * as the context, but sometime this is not possible.
      */
-    var context: String? = null
+    var context: String?
+        get() = contextState.context
+        set(context) {
+            contextState.context = context
+        }
 
     /**
      * Set which keys should be redacted when sending metadata to Bugsnag.
@@ -186,6 +194,8 @@ class Configuration(
 
     init {
         require(!TextUtils.isEmpty(apiKey)) { "You must provide a Bugsnag API key" }
+        this.contextState = ContextState()
+
         autoDetectNdkCrashes = try {
             // check if AUTO_DETECT_NDK_CRASHES has been set in bugsnag-android
             // or bugsnag-android-ndk

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ContextState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ContextState.kt
@@ -1,0 +1,11 @@
+package com.bugsnag.android
+
+internal class ContextState(context: String? = null) : BaseObservable() {
+    var context = context
+        set(value) {
+            field = value
+            notifyObservers(StateEvent.UpdateContext(context))
+        }
+
+    fun copy() = ContextState(context)
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -59,10 +59,6 @@ public class NativeInterface {
         PAUSE_SESSION,
 
         /**
-         * Set a new context. The message object should be the new context
-         */
-        UPDATE_CONTEXT,
-        /**
          * Set a new value for `app.inForeground`. The message object should be a
          * List containing the values [inForeground (Boolean),
          * foregroundActivityName (String)]


### PR DESCRIPTION
## Goal

Creates a class named `ContextState` which holds the current context and notifies observers. This passes a failing mazerunner scenario that checks the NDK is informed of any update to context.

## Changeset

- Created `ContextState` class
- Updated change in context to emit a `StateEvent` object as an observable, which passes the 
 failing `CXXUpdateContextCrashScenario`
- Deep copy context from `Configuration` to `Client`
- Removed obsolete `UPDATE_CONTEXT` from `NativeInterface`