### PR TITLE
Make AddBreadcrumb use StateEvent observable message

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -165,8 +165,7 @@ public class ObserverInterfaceTest {
     @Test
     public void testLeaveStringBreadcrumbSendsMessage() {
         client.leaveBreadcrumb("Drift 4 units left");
-        Breadcrumb crumb = (Breadcrumb)findMessageInQueue(
-                NativeInterface.MessageType.ADD_BREADCRUMB, Breadcrumb.class);
+        StateEvent.AddBreadcrumb crumb = findMessageInQueue(StateEvent.AddBreadcrumb.class);
         assertEquals(BreadcrumbType.MANUAL, crumb.getType());
         assertEquals("manual", crumb.getMessage());
         assertEquals(1, crumb.getMetadata().size());
@@ -176,8 +175,7 @@ public class ObserverInterfaceTest {
     @Test
     public void testLeaveStringBreadcrumbDirectlySendsMessage() {
         client.breadcrumbState.add(new Breadcrumb("Drift 4 units left"));
-        Breadcrumb crumb = (Breadcrumb)findMessageInQueue(
-                NativeInterface.MessageType.ADD_BREADCRUMB, Breadcrumb.class);
+        StateEvent.AddBreadcrumb crumb = findMessageInQueue(StateEvent.AddBreadcrumb.class);
         assertEquals(BreadcrumbType.MANUAL, crumb.getType());
         assertEquals("manual", crumb.getMessage());
         assertEquals(1, crumb.getMetadata().size());
@@ -187,8 +185,7 @@ public class ObserverInterfaceTest {
     @Test
     public void testLeaveBreadcrumbSendsMessage() {
         client.leaveBreadcrumb("Rollback", BreadcrumbType.LOG, new HashMap<String, Object>());
-        Breadcrumb crumb = (Breadcrumb)findMessageInQueue(
-                NativeInterface.MessageType.ADD_BREADCRUMB, Breadcrumb.class);
+        StateEvent.AddBreadcrumb crumb = findMessageInQueue(StateEvent.AddBreadcrumb.class);
         assertEquals(BreadcrumbType.LOG, crumb.getType());
         assertEquals("Rollback", crumb.getMessage());
         assertEquals(0, crumb.getMetadata().size());

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -6,7 +6,7 @@ import java.util.Observable
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 
-internal class BreadcrumbState(maxBreadcrumbs: Int, val logger: Logger) : Observable(),
+internal class BreadcrumbState(maxBreadcrumbs: Int, val logger: Logger) : BaseObservable(),
     JsonStream.Streamable {
     val store: Queue<Breadcrumb> = ConcurrentLinkedQueue()
 
@@ -39,10 +39,12 @@ internal class BreadcrumbState(maxBreadcrumbs: Int, val logger: Logger) : Observ
 
         store.add(breadcrumb)
         pruneBreadcrumbs()
-        setChanged()
         notifyObservers(
-            NativeInterface.Message(
-                NativeInterface.MessageType.ADD_BREADCRUMB, breadcrumb
+            StateEvent.AddBreadcrumb(
+                breadcrumb.message,
+                breadcrumb.type,
+                DateUtils.toIso8601(breadcrumb.timestamp),
+                breadcrumb.metadata
             )
         )
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -20,10 +20,6 @@ public class NativeInterface {
 
     public enum MessageType {
         /**
-         * Add a breadcrumb. The Message object should be the breadcrumb
-         */
-        ADD_BREADCRUMB,
-        /**
          * Add a new metadata value. The Message object should be an array
          * containing [tab, key, value]
          */


### PR DESCRIPTION
## Goal

Updates the `BreadcrumbState` class to use `StateEvent` observable messages rather than `NativeInterface`. This is required to pass the failing breadcrumb scenarios in the `native_api` mazerunner feature.