### PR TITLE
Make SessionTracker use StateEvent messages

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -113,23 +113,20 @@ public class ObserverInterfaceTest {
     }
 
     @Test
-    public void testStartSessionSendsMessage() throws InterruptedException {
+    public void testStartSessionSendsMessage() {
         client.startSession();
-        List<Object> sessionInfo = (List<Object>)findMessageInQueue(
-                NativeInterface.MessageType.START_SESSION, List.class);
-        assertEquals(4, sessionInfo.size());
-        assertTrue(sessionInfo.get(0) instanceof String);
-        assertTrue(sessionInfo.get(1) instanceof String);
-        assertTrue(sessionInfo.get(2) instanceof Integer);
-        assertTrue(sessionInfo.get(3) instanceof Integer);
+        StateEvent.StartSession sessionInfo = findMessageInQueue(StateEvent.StartSession.class);
+        assertNotNull(sessionInfo.getId());
+        assertNotNull(sessionInfo.getStartedAt());
+        assertEquals(0, sessionInfo.getHandledCount());
+        assertEquals(0, sessionInfo.getUnhandledCount());
     }
 
     @Test
-    public void testPauseSessionSendsmessage() {
+    public void testPauseSessionSendsMessage() {
         client.startSession();
         client.pauseSession();
-        Object msg = findMessageInQueue(NativeInterface.MessageType.PAUSE_SESSION, null);
-        assertNull(msg);
+        assertNotNull(findMessageInQueue(StateEvent.PauseSession.class));
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -130,6 +130,12 @@ public class ObserverInterfaceTest {
     }
 
     @Test
+    public void testRegisterSessionSendsMessage() {
+        client.sessionTracker.registerExistingSession(null, null, null, 0, 1);
+        assertNotNull(findMessageInQueue(StateEvent.PauseSession.class));
+    }
+
+    @Test
     public void testClientSetContextSendsMessage() {
         client.setContext("Pod Bay");
         StateEvent.UpdateContext msg = findMessageInQueue(StateEvent.UpdateContext.class);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -10,13 +10,11 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Observable;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-class SessionTracker extends Observable implements Application.ActivityLifecycleCallbacks {
+class SessionTracker extends BaseObservable implements Application.ActivityLifecycleCallbacks {
 
     private static final String HEADER_API_PAYLOAD_VERSION = "Bugsnag-Payload-Version";
     private static final String HEADER_API_KEY = "Bugsnag-Api-Key";
@@ -97,9 +97,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
 
         if (session != null) {
             session.isPaused.set(true);
-            setChanged();
-            notifyObservers(new NativeInterface.Message(
-                NativeInterface.MessageType.PAUSE_SESSION, null));
+            notifyObservers(StateEvent.PauseSession.INSTANCE);
         }
     }
 
@@ -121,12 +119,9 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     }
 
     private void notifySessionStartObserver(Session session) {
-        setChanged();
         String startedAt = DateUtils.toIso8601(session.getStartedAt());
-        notifyObservers(new NativeInterface.Message(
-            NativeInterface.MessageType.START_SESSION,
-            Arrays.asList(session.getId(), startedAt,
-                session.getHandledCount(), session.getUnhandledCount())));
+        notifyObservers(new StateEvent.StartSession(session.getId(), startedAt,
+                session.getHandledCount(), session.getUnhandledCount()));
     }
 
     /**
@@ -148,9 +143,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
             session = new Session(sessionId, date, user, unhandledCount, handledCount);
             notifySessionStartObserver(session);
         } else {
-            setChanged();
-            notifyObservers(new NativeInterface.Message(
-                NativeInterface.MessageType.PAUSE_SESSION, null));
+            notifyObservers(StateEvent.PauseSession.INSTANCE);
         }
         currentSession.set(session);
         return session;
@@ -411,9 +404,7 @@ class SessionTracker extends Observable implements Application.ActivityLifecycle
     }
 
     private void notifyNdkInForeground() {
-        notifyObservers(new NativeInterface.Message(
-            NativeInterface.MessageType.UPDATE_IN_FOREGROUND,
-            Arrays.asList(isInForeground(), getContextActivity())));
+        notifyObservers(new StateEvent.UpdateInForeground(isInForeground(), getContextActivity()));
     }
 
     boolean isInForeground() {


### PR DESCRIPTION
## Goal

Updates the `SessionTracker` class to use `StateEvent` observable messages rather than `NativeInterface`. This is required to pass failing scenarios in the `native_session_tracking` mazerunner feature.

## Testing

The remaining scenarios are failing due to the integration branch not fully merging all the PRs which update the NDK messaging to use StateEvent.