### PR TITLE
Update notify to send StateEvent message rather than NativeInterface

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -108,9 +109,7 @@ public class ObserverInterfaceTest {
     public void testNotifySendsMessage() {
         client.startSession();
         client.notify(new Exception("ruh roh"));
-        Object errorClass = findMessageInQueue(
-                NativeInterface.MessageType.NOTIFY_HANDLED, null);
-        assertNull(errorClass);
+        assertNotNull(findMessageInQueue(StateEvent.NotifyHandled.class));
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -716,12 +716,10 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
             if (event.isUnhandled()) {
                 event.setSession(currentSession.incrementUnhandledAndCopy());
-                notifyObservers(new Message(
-                    NativeInterface.MessageType.NOTIFY_UNHANDLED, null));
+                notifyObservers(StateEvent.NotifyUnhandled.INSTANCE);
             } else {
                 event.setSession(currentSession.incrementHandledAndCopy());
-                notifyObservers(new Message(
-                    NativeInterface.MessageType.NOTIFY_HANDLED,  null));
+                notifyObservers(StateEvent.NotifyHandled.INSTANCE);
             }
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -34,14 +34,6 @@ public class NativeInterface {
          */
         CLEAR_METADATA_TAB,
         /**
-         * Send a report for a handled Java exception
-         */
-        NOTIFY_HANDLED,
-        /**
-         * Send a report for an unhandled error in the Java layer
-         */
-        NOTIFY_UNHANDLED,
-        /**
          * Remove a metadata value. The Message object should be a string array
          * containing [tab, key]
          */


### PR DESCRIPTION
## Goal

Updates the `notify()` call to send a `StateEvent` message rather than `NativeInterface.Message`. This ensures that the NDK keeps session counts up to date and therefore passes the `CXXSessionInfoCrashScenario` mazerunner scenario (once #691 has been passed).

The remaining mazerunner scenarios are expected to fail as the NDK messaging has not yet been fully updated to use `StateEvent`.
