### PR TITLE
Update Metadata to use StateEvent observable message

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -169,7 +169,7 @@ public class ClientTest {
     public void testClientAddToTab() {
         client = generateClient();
         client.addMetadata("drink", "cola", "cherry");
-        assertNotNull(client.getMetadata("drink", null));
+        assertNotNull(client.getMetadata("drink"));
     }
 
     @Test
@@ -177,8 +177,8 @@ public class ClientTest {
         client = generateClient();
         client.addMetadata("drink", "cola", "cherry");
 
-        client.clearMetadata("drink", null);
-        assertNull(client.getMetadata("drink", null));
+        client.clearMetadata("drink");
+        assertNull(client.getMetadata("drink"));
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
@@ -27,7 +27,7 @@ public class NativeInterfaceTest {
     @Test
     public void getMetadata() {
         NativeInterface.setClient(client);
-        assertNotSame(client.clientState.getMetadata().toMap(), NativeInterface.getMetadata());
+        assertNotSame(client.metadataState.getMetadata().toMap(), NativeInterface.getMetadata());
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -50,59 +50,42 @@ public class ObserverInterfaceTest {
     @Test
     public void testAddMetadataToClientSendsMessage() {
         client.addMetadata("foo", "bar", "baz");
-        List<Object> metadataItem = (List<Object>)findMessageInQueue(
-                NativeInterface.MessageType.ADD_METADATA, List.class);
-        assertEquals(3, metadataItem.size());
-        assertEquals("foo", metadataItem.get(0));
-        assertEquals("bar", metadataItem.get(1));
-        assertEquals("baz", metadataItem.get(2));
+        StateEvent.AddMetadata msg = findMessageInQueue(StateEvent.AddMetadata.class);
+        assertEquals("foo", msg.getSection());
+        assertEquals("bar", msg.getKey());
+        assertEquals("baz", msg.getValue());
     }
 
     @Test
     public void testAddNullMetadataToClientSendsMessage() {
         client.addMetadata("foo", "bar", null);
-        List<Object> metadataItem = (List<Object>)findMessageInQueue(
-                NativeInterface.MessageType.REMOVE_METADATA, List.class);
-        assertEquals(2, metadataItem.size());
-        assertEquals("foo", metadataItem.get(0));
-        assertEquals("bar", metadataItem.get(1));
+        StateEvent.RemoveMetadata msg = findMessageInQueue(StateEvent.RemoveMetadata.class);
+        assertEquals("foo", msg.getSection());
+        assertEquals("bar", msg.getKey());
     }
 
     @Test
     public void testAddMetadataToMetadataSendsMessage() {
         client.addMetadata("foo", "bar", "baz");
-        List<Object> metadataItem = (List<Object>)findMessageInQueue(
-                NativeInterface.MessageType.ADD_METADATA, List.class);
-        assertEquals(3, metadataItem.size());
-        assertEquals("foo", metadataItem.get(0));
-        assertEquals("bar", metadataItem.get(1));
-        assertEquals("baz", metadataItem.get(2));
+        StateEvent.AddMetadata metadataItem = findMessageInQueue(StateEvent.AddMetadata.class);
+        assertEquals("foo", metadataItem.getSection());
+        assertEquals("bar", metadataItem.getKey());
+        assertEquals("baz", metadataItem.getValue());
     }
 
     @Test
     public void testClearTabFromClientSendsMessage() {
-        client.clearMetadata("axis", null);
-        Object value = findMessageInQueue(
-                NativeInterface.MessageType.CLEAR_METADATA_TAB, String.class);
-        assertEquals("axis", value);
-    }
-
-    @Test
-    public void testClearTabFromMetadataSendsMessage() {
-        client.clearMetadata("axis", null);
-        Object value =  findMessageInQueue(
-                NativeInterface.MessageType.CLEAR_METADATA_TAB, String.class);
-        assertEquals("axis", value);
+        client.clearMetadata("axis");
+        StateEvent.ClearMetadataTab value = findMessageInQueue(StateEvent.ClearMetadataTab.class);
+        assertEquals("axis", value.getSection());
     }
 
     @Test
     public void testAddNullMetadataToMetadataSendsMessage() {
         client.addMetadata("foo", "bar", null);
-        List<Object> metadataItem = (List<Object>)findMessageInQueue(
-                NativeInterface.MessageType.REMOVE_METADATA, List.class);
-        assertEquals(2, metadataItem.size());
-        assertEquals("foo", metadataItem.get(0));
-        assertEquals("bar", metadataItem.get(1));
+        StateEvent.RemoveMetadata msg = findMessageInQueue(StateEvent.RemoveMetadata.class);
+        assertEquals("foo", msg.getSection());
+        assertEquals("bar", msg.getKey());
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -2,8 +2,6 @@ package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
@@ -15,7 +13,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
 
@@ -48,7 +45,7 @@ public class ObserverInterfaceTest {
     }
 
     @Test
-    public void testAddMetadataToClientSendsMessage() {
+    public void testAddMetadataSendsMessage() {
         client.addMetadata("foo", "bar", "baz");
         StateEvent.AddMetadata msg = findMessageInQueue(StateEvent.AddMetadata.class);
         assertEquals("foo", msg.getSection());
@@ -57,7 +54,8 @@ public class ObserverInterfaceTest {
     }
 
     @Test
-    public void testAddNullMetadataToClientSendsMessage() {
+    public void testAddNullMetadataSendsMessage() {
+        client.addMetadata("foo", "bar", "baz");
         client.addMetadata("foo", "bar", null);
         StateEvent.RemoveMetadata msg = findMessageInQueue(StateEvent.RemoveMetadata.class);
         assertEquals("foo", msg.getSection());
@@ -65,27 +63,18 @@ public class ObserverInterfaceTest {
     }
 
     @Test
-    public void testAddMetadataToMetadataSendsMessage() {
-        client.addMetadata("foo", "bar", "baz");
-        StateEvent.AddMetadata metadataItem = findMessageInQueue(StateEvent.AddMetadata.class);
-        assertEquals("foo", metadataItem.getSection());
-        assertEquals("bar", metadataItem.getKey());
-        assertEquals("baz", metadataItem.getValue());
-    }
-
-    @Test
-    public void testClearTabFromClientSendsMessage() {
+    public void testClearTopLevelTabSendsMessage() {
         client.clearMetadata("axis");
         StateEvent.ClearMetadataTab value = findMessageInQueue(StateEvent.ClearMetadataTab.class);
         assertEquals("axis", value.getSection());
     }
 
     @Test
-    public void testAddNullMetadataToMetadataSendsMessage() {
-        client.addMetadata("foo", "bar", null);
-        StateEvent.RemoveMetadata msg = findMessageInQueue(StateEvent.RemoveMetadata.class);
-        assertEquals("foo", msg.getSection());
-        assertEquals("bar", msg.getKey());
+    public void testClearTabSendsMessage() {
+        client.clearMetadata("axis", "foo");
+        StateEvent.RemoveMetadata value = findMessageInQueue(StateEvent.RemoveMetadata.class);
+        assertEquals("axis", value.getSection());
+        assertEquals("foo", value.getKey());
     }
 
     @Test
@@ -183,27 +172,6 @@ public class ObserverInterfaceTest {
             }
         }
         throw new RuntimeException("Failed to find StateEvent message " + argClass.getSimpleName());
-    }
-
-    private Object findMessageInQueue(NativeInterface.MessageType type, Class<?> argClass) {
-        for (Object item : observer.observed) {
-            if (item instanceof  NativeInterface.Message) {
-                NativeInterface.Message message = (NativeInterface.Message)item;
-                if (message.type != type) {
-                    continue;
-                }
-                if (argClass == null) {
-                    if (((NativeInterface.Message)item).value == null) {
-                        return null;
-                    }
-                } else if (argClass.isInstance(message.value)) {
-                    return message.value;
-                }
-            }
-        }
-        assertTrue("Failed to find message matching " + type, false);
-
-        return null;
     }
 
     static class BugsnagTestObserver implements Observer {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -267,7 +267,7 @@ public final class Bugsnag {
         getClient().addMetadata(section, value);
     }
 
-    public static void addMetadata(@NonNull String section, @Nullable String key,
+    public static void addMetadata(@NonNull String section, @NonNull String key,
                                    @Nullable Object value) {
         getClient().addMetadata(section, key, value);
     }
@@ -276,17 +276,17 @@ public final class Bugsnag {
         getClient().clearMetadata(section);
     }
 
-    public static void clearMetadata(@NonNull String section, @Nullable String key) {
+    public static void clearMetadata(@NonNull String section, @NonNull String key) {
         getClient().clearMetadata(section, key);
     }
 
     @Nullable
-    public static Object getMetadata(@NonNull String section) {
+    public static Map<String, Object> getMetadata(@NonNull String section) {
         return getClient().getMetadata(section);
     }
 
     @Nullable
-    public static Object getMetadata(@NonNull String section, @Nullable String key) {
+    public static Object getMetadata(@NonNull String section, @NonNull String key) {
         return getClient().getMetadata(section, key);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -19,7 +19,8 @@ class Configuration(
     @JvmField
     internal val callbackState: CallbackState
 
-    var metadata = Metadata()
+    @JvmField
+    internal val metadataState: MetadataState
 
     /**
      * Set the buildUUID to your own value. This is used to identify proguard
@@ -178,8 +179,8 @@ class Configuration(
      * client.setRedactedKeys("password", "credit_card");
      */
     var redactedKeys: Set<String>
-        get() = Collections.unmodifiableSet(metadata.redactedKeys)
-        set(redactedKeys) = metadata.setRedactedKeys(redactedKeys)
+        get() = Collections.unmodifiableSet(metadataState.metadata.redactedKeys)
+        set(redactedKeys) = metadataState.metadata.setRedactedKeys(redactedKeys)
 
 
     var loggingEnabled: Boolean
@@ -187,6 +188,7 @@ class Configuration(
     init {
         require(!TextUtils.isEmpty(apiKey)) { "You must provide a Bugsnag API key" }
         this.callbackState = CallbackState()
+        this.metadataState = MetadataState()
 
         autoDetectNdkCrashes = try {
             // check if AUTO_DETECT_NDK_CRASHES has been set in bugsnag-android
@@ -291,16 +293,15 @@ class Configuration(
     override fun removeOnSession(onSession: OnSession) = callbackState.removeOnSession(onSession)
 
     override fun addMetadata(section: String, value: Map<String, Any?>) =
-        metadata.addMetadata(section, value)
-    override fun addMetadata(section: String, key: String?, value: Any?) =
-        metadata.addMetadata(section, key, value)
+        metadataState.addMetadata(section, value)
+    override fun addMetadata(section: String, key: String, value: Any?) =
+        metadataState.addMetadata(section, key, value)
 
-    override fun clearMetadata(section: String) = metadata.clearMetadata(section)
-    override fun clearMetadata(section: String, key: String?) =
-        metadata.clearMetadata(section, key)
+    override fun clearMetadata(section: String) = metadataState.clearMetadata(section)
+    override fun clearMetadata(section: String, key: String) = metadataState.clearMetadata(section, key)
 
-    override fun getMetadata(section: String) = metadata.getMetadata(section)
-    override fun getMetadata(section: String, key: String?) =metadata.getMetadata(section, key)
+    override fun getMetadata(section: String) = metadataState.getMetadata(section)
+    override fun getMetadata(section: String, key: String) = metadataState.getMetadata(section, key)
 
     companion object {
         private const val DEFAULT_MAX_SIZE = 25

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -153,12 +153,12 @@ class Event @JvmOverloads internal constructor(
     fun setUserName(name: String?) = setUser(_user.id, _user.email, name)
 
     override fun addMetadata(section: String, value: Map<String, Any?>) = metadata.addMetadata(section, value)
-    override fun addMetadata(section: String, key: String?, value: Any?) =
+    override fun addMetadata(section: String, key: String, value: Any?) =
         metadata.addMetadata(section, key, value)
 
     override fun clearMetadata(section: String) = metadata.clearMetadata(section)
-    override fun clearMetadata(section: String, key: String?) = metadata.clearMetadata(section, key)
+    override fun clearMetadata(section: String, key: String) = metadata.clearMetadata(section, key)
 
     override fun getMetadata(section: String) = metadata.getMetadata(section)
-    override fun getMetadata(section: String, key: String?) = metadata.getMetadata(section, key)
+    override fun getMetadata(section: String, key: String) = metadata.getMetadata(section, key)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
@@ -3,21 +3,18 @@
 package com.bugsnag.android
 
 import java.io.IOException
-import java.util.Arrays
 import java.util.HashMap
 import java.util.HashSet
-import java.util.Observable
 import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A container for additional diagnostic information you'd like to send with
  * every error report.
  *
- *
  * Diagnostic information is presented on your Bugsnag dashboard in tabs.
  */
 class Metadata @JvmOverloads constructor(map: Map<String, Any> = ConcurrentHashMap()) :
-    Observable(), JsonStream.Streamable, MetadataAware {
+    JsonStream.Streamable, MetadataAware {
 
     private val store: MutableMap<String, Any> = ConcurrentHashMap(map)
     internal val jsonStreamer = ObjectJsonStreamer()
@@ -33,79 +30,60 @@ class Metadata @JvmOverloads constructor(map: Map<String, Any> = ConcurrentHashM
             addMetadata(section, it.key, it.value)
         }
     }
-    override fun clearMetadata(section: String) = clearMetadata(section, null)
-    override fun getMetadata(section: String) = getMetadata(section, null)
 
-    override fun addMetadata(section: String, key: String?, value: Any?) {
+    override fun addMetadata(section: String, key: String, value: Any?) {
         if (value == null) {
             clearMetadata(section, key)
         } else {
-            val tab = getOrAddSection(section)
-
-            if (key == null) {
-                store[section] = value
-            } else {
-                tab[key] = value
+            var tab = store[section]
+            if (tab !is MutableMap<*, *>) {
+                tab = ConcurrentHashMap<Any, Any>()
+                store[section] = tab
             }
-
-            setChanged()
-            notifyObservers(
-                NativeInterface.Message(
-                    NativeInterface.MessageType.ADD_METADATA,
-                    Arrays.asList<Any>(section, key, value)
-                )
-            )
+            insertValue(tab as MutableMap<String, Any>, key, value)
         }
     }
 
-    override fun clearMetadata(section: String, key: String?) {
-        setChanged()
+    private fun insertValue(map: MutableMap<String, Any>, key: String, value: Any) {
+        var obj = value
 
-        if (key == null) {
-            store.remove(section)
-            notifyObservers(
-                NativeInterface.Message(NativeInterface.MessageType.CLEAR_METADATA_TAB, section)
-            )
-        } else {
-            val tab = store[section]
-
-            if (tab is MutableMap<*, *>) {
-                tab.remove(key)
-            }
-            notifyObservers(
-                NativeInterface.Message(
-                    NativeInterface.MessageType.REMOVE_METADATA, listOf(section, key)
-                )
-            )
+        if (obj is MutableMap<*, *> && map.isNotEmpty()) {
+            obj = mergeMaps(listOf(map as Map<String, Any>, value as Map<String, Any>))
         }
+        map[key] = obj
     }
 
-    override fun getMetadata(section: String, key: String?): Any? {
+    override fun clearMetadata(section: String) {
+        store.remove(section)
+    }
+
+    override fun clearMetadata(section: String, key: String) {
         val tab = store[section]
 
-        return when {
-            tab is Map<*, *> && key != null -> {
-                (tab as Map<String, Any>?)!![key]
+        if (tab is MutableMap<*, *>) {
+            tab.remove(key)
+
+            if (tab.isEmpty()) {
+                store.remove(section)
             }
+        }
+    }
+
+    override fun getMetadata(section: String): Map<String, Any>? {
+        return store[section] as (Map<String, Any>?)
+    }
+
+    override fun getMetadata(section: String, key: String): Any? {
+        return when (val tab = store[section]) {
+            is Map<*, *> -> (tab as Map<String, Any>?)!![key]
             else -> tab
         }
     }
 
-    private fun getOrAddSection(section: String): MutableMap<String, Any> {
-        var tab = store[section]
-
-        if (tab !is MutableMap<*, *>) {
-            tab = ConcurrentHashMap<Any, Any>()
-            store[section] = tab
-        }
-
-        return (tab as MutableMap<String, Any>?)!!
-    }
-
     fun toMap(): Map<String, Any> = HashMap(store)
 
-    fun setRedactedKeys(redactedKeys: Collection<String>) {
-        val data = HashSet(redactedKeys)
+    fun setRedactedKeys(redactKeys: Collection<String>) {
+        val data = HashSet(redactKeys)
         jsonStreamer.redactedKeys.clear()
         jsonStreamer.redactedKeys.addAll(data)
     }
@@ -113,13 +91,13 @@ class Metadata @JvmOverloads constructor(map: Map<String, Any> = ConcurrentHashM
     companion object {
         fun merge(vararg data: Metadata): Metadata {
             val stores = data.map { it.toMap() }
-            val filters = data.flatMap { it.jsonStreamer.redactedKeys }
+            val redactKeys = data.flatMap { it.jsonStreamer.redactedKeys }
             val newMeta = Metadata(mergeMaps(stores))
-            newMeta.setRedactedKeys(filters.toSet())
+            newMeta.setRedactedKeys(redactKeys.toSet())
             return newMeta
         }
 
-        private fun mergeMaps(data: List<Map<String, Any>>): Map<String, Any> {
+        internal fun mergeMaps(data: List<Map<String, Any>>): Map<String, Any> {
             val keys = data.flatMap { it.keys }.toSet()
             val result = ConcurrentHashMap<String, Any>()
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataAware.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataAware.kt
@@ -2,11 +2,11 @@ package com.bugsnag.android
 
 internal interface MetadataAware {
     fun addMetadata(section: String, value: Map<String, Any?>)
-    fun addMetadata(section: String, key: String?, value: Any?)
+    fun addMetadata(section: String, key: String, value: Any?)
 
     fun clearMetadata(section: String)
-    fun clearMetadata(section: String, key: String?)
+    fun clearMetadata(section: String, key: String)
 
-    fun getMetadata(section: String): Any?
-    fun getMetadata(section: String, key: String?): Any?
+    fun getMetadata(section: String): Map<String, Any>?
+    fun getMetadata(section: String, key: String): Any?
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -1,0 +1,35 @@
+package com.bugsnag.android
+
+internal data class MetadataState(val metadata: Metadata = Metadata()) : BaseObservable(),
+    MetadataAware {
+
+    override fun addMetadata(section: String, value: Map<String, Any?>) = metadata.addMetadata(section, value)
+    override fun addMetadata(section: String, key: String, value: Any?) {
+        metadata.addMetadata(section, key, value)
+
+        when (value) {
+            null -> notifyClear(section, key)
+            else -> notifyObservers(StateEvent.AddMetadata(section, key, metadata.getMetadata(section, key)))
+        }
+    }
+
+    override fun clearMetadata(section: String) {
+        metadata.clearMetadata(section)
+        notifyClear(section, null)
+        notifyObservers(StateEvent.ClearMetadataTab(section))
+    }
+    override fun clearMetadata(section: String, key: String) {
+        metadata.clearMetadata(section, key)
+        notifyClear(section, key)
+    }
+
+    private fun notifyClear(section: String, key: String?) {
+        when (key) {
+            null -> notifyObservers(StateEvent.ClearMetadataTab(section))
+            else -> notifyObservers(StateEvent.RemoveMetadata(section, key))
+        }
+    }
+
+    override fun getMetadata(section: String) = metadata.getMetadata(section)
+    override fun getMetadata(section: String, key: String) = metadata.getMetadata(section, key)
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -16,7 +16,6 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) : BaseObs
     override fun clearMetadata(section: String) {
         metadata.clearMetadata(section)
         notifyClear(section, null)
-        notifyObservers(StateEvent.ClearMetadataTab(section))
     }
     override fun clearMetadata(section: String, key: String) {
         metadata.clearMetadata(section, key)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -162,7 +162,7 @@ public class NativeInterface {
      */
     @NonNull
     public static Map<String, Object> getMetadata() {
-        return new HashMap<>(getClient().clientState.getMetadata().toMap());
+        return new HashMap<>(getClient().metadataState.getMetadata().toMap());
     }
 
     /**
@@ -214,7 +214,11 @@ public class NativeInterface {
      * Remove metadata from subsequent exception reports
      */
     public static void clearMetadata(@NonNull String section, @Nullable String key) {
-        getClient().clearMetadata(section, key);
+        if (key == null) {
+            getClient().clearMetadata(section);
+        } else {
+            getClient().clearMetadata(section, key);
+        }
     }
 
     /**

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
@@ -84,11 +84,11 @@ public class EventTest {
     @Test
     public void testErrorMetadata() {
         event.addMetadata("rocks", "geode", "a shiny mineral");
-        Map<String, Object> rocks = (Map<String, Object>) event.getMetadata("rocks", null);
+        Map<String, Object> rocks = event.getMetadata("rocks");
         assertNotNull(rocks);
 
-        event.clearMetadata("rocks", null);
+        event.clearMetadata("rocks");
         assertFalse(rocks.isEmpty());
-        assertNull(event.getMetadata("rocks", null));
+        assertNull(event.getMetadata("rocks"));
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataRedactionTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataRedactionTest.java
@@ -47,7 +47,7 @@ public class MetadataRedactionTest {
     public void testClearTab() throws IOException {
         Metadata metadata = new Metadata();
         metadata.addMetadata("example", "string", "value");
-        metadata.clearMetadata("example", null);
+        metadata.clearMetadata("example");
         verifyJsonRedacted(metadata, "metadata_redaction_3.json");
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataSerializationTest.kt
@@ -64,7 +64,7 @@ internal class MetadataSerializationTest {
         private fun clearedTab(): Metadata {
             val metadata = Metadata()
             metadata.addMetadata("example", "string", "value")
-            metadata.clearMetadata("example", null)
+            metadata.clearMetadata("example", "string")
             return metadata
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
@@ -1,0 +1,47 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class MetadataStateTest {
+
+    lateinit var state: MetadataState
+
+    @Before
+    fun setUp() {
+        state = MetadataState()
+    }
+
+    @Test
+    fun addTopLevel() {
+        state.addMetadata("foo", mapOf(Pair("wham", "bar")))
+        val tab = state.getMetadata("foo")
+        assertEquals(mapOf(Pair("wham", "bar")), tab)
+    }
+
+    @Test
+    fun addWithKey() {
+        state.addMetadata("foo", "wham", "baz")
+        val topLevel = state.getMetadata("foo") as Map<*, *>
+        val tab = state.getMetadata("foo", "wham")
+        assertEquals("baz", topLevel["wham"])
+        assertEquals("baz", tab)
+    }
+
+    @Test
+    fun clearTopLevel() {
+        state.addMetadata("foo", mapOf(Pair("wham", "bar")))
+        state.clearMetadata("foo")
+        assertNull(state.getMetadata("foo"))
+    }
+
+    @Test
+    fun clearWithKey() {
+        state.addMetadata("foo", "wham", "baz")
+        state.clearMetadata("foo", "wham")
+        assertNull(state.getMetadata("foo"))
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataTest.java
@@ -21,7 +21,7 @@ public class MetadataTest {
         base.addMetadata("example", "awesome", true);
 
         Metadata merged = Metadata.Companion.merge(base, overrides);
-        Map<String, Object> tab = (Map<String, Object>) merged.getMetadata("example", null);
+        Map<String, Object> tab = merged.getMetadata("example");
         assertEquals("bob", tab.get("name"));
         assertEquals(30, tab.get("age"));
         assertEquals(true, tab.get("awesome"));
@@ -40,7 +40,7 @@ public class MetadataTest {
         overrides.addMetadata("example", "map", overridesMap);
 
         Metadata merged = Metadata.Companion.merge(base, overrides);
-        Map<String, Object> tab = (Map<String, Object>) merged.getMetadata("example", null);
+        Map<String, Object> tab = merged.getMetadata("example");
 
         @SuppressWarnings("unchecked")
         Map<String, String> mergedMap = (Map<String, String>) tab.get("map");

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
@@ -52,7 +52,7 @@ public class NullMetadataTest {
     }
 
     private void validateDefaultMetadata(MetadataAware error) {
-        assertNull(error.getMetadata(TAB_KEY, null));
+        assertNull(error.getMetadata(TAB_KEY));
         error.addMetadata(TAB_KEY, "test", "data");
         assertEquals("data", error.getMetadata(TAB_KEY, "test"));
     }

--- a/bugsnag-android-core/src/test/resources/meta_data_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/meta_data_serialization_1.json
@@ -13,6 +13,18 @@
       "World"
     ],
     "map": {
+      "boolean": true,
+      "string": "value",
+      "array": [
+        "a",
+        "b"
+      ],
+      "double": 123.45,
+      "integer": 123,
+      "collection": [
+        "Hello",
+        "World"
+      ],
       "key": "value"
     }
   }


### PR DESCRIPTION
## Goal

Ensures that `Metadata` changes are synced to the NDK layer by using the `StateEvent` message rather than the obsolete `NativeInterface.Message` object.

## Changeset

- Added `MetadataState` which now sends `Observable` messages when the `Metadata` changes
- Updated `addMetadata()` so that the `key` is not null when it is an explicit parameter
- Changed return type of one `getMetadata()` to a more specific `Map` type
- Held `metadata` in a `MetadataState` field within `Client` that is copied from `Configuration`

## Tests
- Updated existing test code to use new `addMetadata()` and `getMetadata()` signatures
- Updated existing test code to check for presence of `StateEvent`
- Added unit test for `MetadataState`
- Updated `MetadataSerializationTest` test fixture to fix incorrect assertion
