### PR TITLE
Refactor filestore to remove unnecessary generic type arg

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/FileStoreTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/FileStoreTest.kt
@@ -12,8 +12,7 @@ import java.lang.RuntimeException
 import java.util.Comparator
 
 class FileStoreTest {
-    val appContext = ApplicationProvider.getApplicationContext<Context>()
-    val config = Configuration("api-key")
+    private val appContext: Context = ApplicationProvider.getApplicationContext<Context>()
 
     @Test
     fun sendsInternalErrorReport() {
@@ -58,16 +57,16 @@ class CustomDelegate: FileStore.Delegate {
     }
 }
 
-class CustomStreamable(val exc: Throwable) : JsonStream.Streamable {
+class CustomStreamable(private val exc: Throwable) : JsonStream.Streamable {
     override fun toStream(stream: JsonStream) = throw exc
 }
 
 internal class CustomFileStore(
     appContext: Context,
-    val folder: String?,
+    private val folder: String?,
     maxStoreCount: Int,
     comparator: Comparator<File>?,
     delegate: Delegate?
-) : FileStore<CustomStreamable>(appContext, folder, maxStoreCount, comparator, NoopLogger, delegate) {
+) : FileStore(appContext, folder, maxStoreCount, comparator, NoopLogger, delegate) {
     override fun getFilename(`object`: Any?) = "$folder/foo.json"
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -218,7 +218,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
                 Client.this.reportInternalBugsnagError(err);
             }
         };
-        eventStore = new EventStore(immutableConfig, clientState, appContext, logger, delegate);
+        eventStore = new EventStore(immutableConfig, appContext, logger, delegate);
 
         // Install a default exception handler with this client
         if (immutableConfig.getAutoDetectErrors()) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 
 import java.io.File;
@@ -20,7 +21,7 @@ import java.util.concurrent.Semaphore;
  * Store and flush Event reports which couldn't be sent immediately due to
  * lack of network connectivity.
  */
-class EventStore extends FileStore<Event> {
+class EventStore extends FileStore {
 
     private static final String STARTUP_CRASH = "_startupcrash";
     private static final long LAUNCH_CRASH_TIMEOUT_MS = 2000;
@@ -29,7 +30,7 @@ class EventStore extends FileStore<Event> {
     volatile boolean flushOnLaunchCompleted = false;
     private final Semaphore semaphore = new Semaphore(1);
     private final ImmutableConfig config;
-    private final Configuration clientState;
+    private final Logger logger;
     private final Delegate delegate;
 
     static final Comparator<File> EVENT_COMPARATOR = new Comparator<File>() {
@@ -50,11 +51,11 @@ class EventStore extends FileStore<Event> {
         }
     };
 
-    EventStore(@NonNull ImmutableConfig config, @NonNull Configuration clientState,
-               @NonNull Context appContext, Logger logger, Delegate delegate) {
+    EventStore(@NonNull ImmutableConfig config,
+               @NonNull Context appContext, @NonNull Logger logger, Delegate delegate) {
         super(appContext, "/bugsnag-errors/", 128, EVENT_COMPARATOR, logger, delegate);
         this.config = config;
-        this.clientState = clientState;
+        this.logger = logger;
         this.delegate = delegate;
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -21,9 +21,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-abstract class FileStore<T extends JsonStream.Streamable> {
-
-    protected final Logger logger;
+abstract class FileStore {
 
     interface Delegate {
 
@@ -44,6 +42,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
 
     final Lock lock = new ReentrantLock();
     final Collection<File> queuedFiles = new ConcurrentSkipListSet<>();
+    private final Logger logger;
     protected final EventStore.Delegate delegate;
 
 
@@ -120,7 +119,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             Writer out = new BufferedWriter(new OutputStreamWriter(fos, "UTF-8"));
             stream = new JsonStream(out);
             stream.value(streamable);
-            logger.w(String.format("Saved unsent payload to disk (%s) ", filename));
+            logger.i(String.format("Saved unsent payload to disk (%s) ", filename));
             return filename;
         } catch (FileNotFoundException exc) {
             logger.w("Ignoring FileNotFoundException - unable to create file", exc);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -13,7 +14,7 @@ import java.util.UUID;
  * Store and flush Sessions which couldn't be sent immediately due to
  * lack of network connectivity.
  */
-class SessionStore extends FileStore<Session> {
+class SessionStore extends FileStore {
 
     static final Comparator<File> SESSION_COMPARATOR = new Comparator<File>() {
         @Override

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
@@ -31,7 +31,6 @@ class EventFilenameTest {
     fun setUp() {
         eventStore = EventStore(
             config,
-            BugsnagTestUtils.generateConfiguration(),
             context,
             NoopLogger,
             null


### PR DESCRIPTION
## Goal

Removes an unused generic type argument on `FileStore`, along with an unused `Configuration` constructor parameter. Test code has been updated to match these changes.
