### PR TITLE
Make native interface use immutable configuration

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -915,17 +915,17 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         }
     }
 
-    /**
-     * Returns the configuration used to initialise the client
-     * @return the config
-     */
-    @NonNull
-    Configuration getConfiguration() {
-        return clientState;
-    }
-
     ImmutableConfig getConfig() {
         return immutableConfig;
+    }
+
+    MetadataState getMetadataState() {
+        return metadataState;
+    }
+
+    @NonNull
+    BreadcrumbState getBreadcrumbState() {
+        return breadcrumbState;
     }
 
     void setBinaryArch(String binaryArch) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -787,7 +787,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
     }
 
     @NonNull
-    Collection<Breadcrumb> getBreadcrumbs() {
+    List<Breadcrumb> getBreadcrumbs() {
         return new ArrayList<>(breadcrumbState.getStore());
     }
 
@@ -831,6 +831,11 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
     @Nullable
     public Object getMetadata(@NonNull String section, @NonNull String key) {
         return metadataState.getMetadata(section, key);
+    }
+
+    @NonNull
+    Map<String, Object> getMetadata() {
+        return metadataState.getMetadata().toMap();
     }
 
     /**
@@ -917,15 +922,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
 
     ImmutableConfig getConfig() {
         return immutableConfig;
-    }
-
-    MetadataState getMetadataState() {
-        return metadataState;
-    }
-
-    @NonNull
-    BreadcrumbState getBreadcrumbState() {
-        return breadcrumbState;
     }
 
     void setBinaryArch(String binaryArch) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -18,59 +18,6 @@ import java.util.Queue;
  */
 public class NativeInterface {
 
-    public enum MessageType {
-        /**
-         * Add a new metadata value. The Message object should be an array
-         * containing [tab, key, value]
-         */
-        ADD_METADATA,
-        /**
-         * Clear all metadata on a tab. The Message object should be the tab
-         * name
-         */
-        CLEAR_METADATA_TAB,
-        /**
-         * Remove a metadata value. The Message object should be a string array
-         * containing [tab, key]
-         */
-        REMOVE_METADATA,
-        /**
-         * A new session was started. The Message object should be a string
-         * array
-         * containing [id, startDateIsoString]
-         */
-        START_SESSION,
-
-        /**
-         * A session was paused.
-         */
-        PAUSE_SESSION,
-
-        /**
-         * Set a new value for `app.inForeground`. The message object should be a
-         * List containing the values [inForeground (Boolean),
-         * foregroundActivityName (String)]
-         */
-        UPDATE_IN_FOREGROUND,
-    }
-
-    /**
-     * Wrapper for messages sent to native observers
-     */
-    public static class Message {
-
-        @NonNull
-        public final MessageType type;
-
-        @Nullable
-        public final Object value;
-
-        public Message(@NonNull MessageType type, @Nullable Object value) {
-            this.type = type;
-            this.value = value;
-        }
-    }
-
     /**
      * Static reference used if not using Bugsnag.init()
      */
@@ -99,13 +46,8 @@ public class NativeInterface {
     }
 
     @NonNull
-    public static Logger getLogger() {
-        return getClient().immutableConfig.getLogger();
-    }
-
-    @NonNull
     public static String getNativeReportPath() {
-        return getClient().appContext.getCacheDir().getAbsolutePath() + "/bugsnag-native/";
+        return getClient().getAppContext().getCacheDir().getAbsolutePath() + "/bugsnag-native/";
     }
 
     /**
@@ -113,13 +55,12 @@ public class NativeInterface {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public static Map<String,String> getUserData() {
+    public static Map<String,String> getUser() {
         HashMap<String, String> userData = new HashMap<>();
         User user = getClient().getUser();
         userData.put("id", user.getId());
         userData.put("name", user.getName());
         userData.put("email", user.getEmail());
-
         return userData;
     }
 
@@ -128,7 +69,7 @@ public class NativeInterface {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public static Map<String,Object> getAppData() {
+    public static Map<String,Object> getApp() {
         HashMap<String,Object> data = new HashMap<>();
         AppData source = getClient().getAppData();
         data.putAll(source.getAppData());
@@ -141,7 +82,7 @@ public class NativeInterface {
      */
     @NonNull
     @SuppressWarnings("unused")
-    public static Map<String,Object> getDeviceData() {
+    public static Map<String,Object> getDevice() {
         HashMap<String,Object> deviceData = new HashMap<>();
         DeviceData source = getClient().getDeviceData();
         deviceData.putAll(source.getDeviceMetadata());
@@ -154,7 +95,7 @@ public class NativeInterface {
      */
     @NonNull
     public static String[] getCpuAbi() {
-        return getClient().deviceData.cpuAbi;
+        return getClient().getDeviceData().getCpuAbi();
     }
 
     /**
@@ -162,15 +103,15 @@ public class NativeInterface {
      */
     @NonNull
     public static Map<String, Object> getMetadata() {
-        return new HashMap<>(getClient().metadataState.getMetadata().toMap());
+        return new HashMap<>(getClient().getMetadataState().getMetadata().toMap());
     }
 
     /**
-     * Retrieves breadcrumbs from the static Client instance as a Map
+     * Retrieves breadcrumbState from the static Client instance as a Map
      */
     @NonNull
     public static List<Breadcrumb> getBreadcrumbs() {
-        Queue<Breadcrumb> store = getClient().breadcrumbState.getStore();
+        Queue<Breadcrumb> store = getClient().getBreadcrumbState().getStore();
         return new ArrayList<>(store);
     }
 
@@ -225,8 +166,8 @@ public class NativeInterface {
      * Add metadata to subsequent exception reports
      */
     public static void addMetadata(@NonNull final String tab,
-                                  @Nullable final String key,
-                                  @Nullable final Object value) {
+                                   @Nullable final String key,
+                                   @Nullable final Object value) {
         getClient().addMetadata(tab, key, value);
     }
 
@@ -293,7 +234,7 @@ public class NativeInterface {
         User user = client.getUser();
         Date startDate = startedAt > 0 ? new Date(startedAt) : null;
         client.getSessionTracker().registerExistingSession(startDate, sessionId, user,
-                                                           unhandledCount, handledCount);
+                unhandledCount, handledCount);
     }
 
     /**
@@ -307,8 +248,8 @@ public class NativeInterface {
     public static void deliverReport(@Nullable String releaseStage, @NonNull String payload) {
         Client client = getClient();
         if (releaseStage == null
-            || releaseStage.length() == 0
-            || client.getConfig().shouldNotifyForReleaseStage()) {
+                || releaseStage.length() == 0
+                || client.getConfig().shouldNotifyForReleaseStage()) {
             client.getEventStore().enqueueContentForDelivery(payload);
             client.getEventStore().flushAsync();
         }
@@ -338,5 +279,10 @@ public class NativeInterface {
                 return true;
             }
         });
+    }
+
+    @NonNull
+    public static Logger getLogger() {
+        return getClient().getConfig().getLogger();
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -103,7 +103,7 @@ public class NativeInterface {
      */
     @NonNull
     public static Map<String, Object> getMetadata() {
-        return new HashMap<>(getClient().getMetadataState().getMetadata().toMap());
+        return getClient().getMetadata();
     }
 
     /**
@@ -111,8 +111,7 @@ public class NativeInterface {
      */
     @NonNull
     public static List<Breadcrumb> getBreadcrumbs() {
-        Queue<Breadcrumb> store = getClient().getBreadcrumbState().getStore();
-        return new ArrayList<>(store);
+        return getClient().getBreadcrumbs();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -107,7 +107,7 @@ public class NativeInterface {
     }
 
     /**
-     * Retrieves breadcrumbState from the static Client instance as a Map
+     * Retrieves a list of stored breadcrumbs from the static Client instance
      */
     @NonNull
     public static List<Breadcrumb> getBreadcrumbs() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -1,0 +1,229 @@
+package com.bugsnag.android
+
+import android.content.Context
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
+
+/**
+ * Verifies that method calls are forwarded onto the appropriate method on Client,
+ * and that adequate sanitisation takes place.
+ */
+@RunWith(MockitoJUnitRunner::class)
+internal class NativeInterfaceApiTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Mock
+    lateinit var immutableConfig: ImmutableConfig
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var appData: AppData
+
+    @Mock
+    lateinit var deviceData: DeviceData
+
+    @Mock
+    lateinit var sessionTracker: SessionTracker
+
+    @Mock
+    lateinit var eventStore: EventStore
+
+    @Before
+    fun setUp() {
+        NativeInterface.setClient(client)
+        `when`(client.config).thenReturn(immutableConfig)
+        `when`(client.getSessionTracker()).thenReturn(sessionTracker)
+        `when`(client.getEventStore()).thenReturn(eventStore)
+        `when`(immutableConfig.endpoints).thenReturn(
+            Endpoints(
+                "http://notify.bugsnag.com",
+                "http://sessions.bugsnag.com"
+            )
+        )
+
+        `when`(client.getAppData()).thenReturn(appData)
+        `when`(client.getDeviceData()).thenReturn(deviceData)
+        `when`(client.getUser()).thenReturn(User("123", "tod@example.com", "Tod"))
+
+    }
+
+    @Test
+    fun getContext() {
+        `when`(client.context).thenReturn("Foo")
+        assertEquals("Foo", NativeInterface.getContext())
+    }
+
+    @Test
+    fun getNativeReportPath() {
+        `when`(client.getAppContext()).thenReturn(context)
+        `when`(context.cacheDir).thenReturn(File("f"))
+        assertTrue(NativeInterface.getNativeReportPath().endsWith("/bugsnag-native/"))
+    }
+
+    @Test
+    fun getUserData() {
+        val data = mapOf(Pair("id", "123"), Pair("email", "tod@example.com"), Pair("name", "Tod"))
+        assertEquals(data, NativeInterface.getUser())
+    }
+
+    @Test
+    fun getAppData() {
+        `when`(appData.appData).thenReturn(mapOf(Pair("og", true)))
+        `when`(appData.appDataMetadata).thenReturn(mapOf(Pair("metadata", true)))
+        val expected = mapOf(Pair("og", true), Pair("metadata", true))
+        assertEquals(expected, NativeInterface.getApp())
+    }
+
+    @Test
+    fun getDeviceData() {
+        `when`(deviceData.deviceData).thenReturn(mapOf(Pair("og", true)))
+        `when`(deviceData.deviceMetadata).thenReturn(mapOf(Pair("metadata", true)))
+        val expected = mapOf(Pair("og", true), Pair("metadata", true))
+        assertEquals(expected, NativeInterface.getDevice())
+    }
+
+    @Test
+    fun getCpuAbi() {
+        `when`(deviceData.getCpuAbi()).thenReturn(arrayOf("x86"))
+        assertArrayEquals(arrayOf("x86"), NativeInterface.getCpuAbi())
+    }
+
+    @Test
+    fun getMetadata() {
+        val state = MetadataState()
+        state.addMetadata("Foo", mapOf(Pair("wham", "bar")))
+        `when`(client.getMetadataState()).thenReturn(state)
+        assertEquals(mapOf(Pair("Foo", mapOf(Pair("wham", "bar")))), NativeInterface.getMetadata())
+    }
+
+    @Test
+    fun getBreadcrumbs() {
+        val breadcrumbState = BreadcrumbState(50, NoopLogger)
+        `when`(client.getBreadcrumbState()).thenReturn(breadcrumbState)
+        val breadcrumb = Breadcrumb("Whoops")
+        breadcrumbState.add(breadcrumb)
+        assertEquals(listOf(breadcrumb), NativeInterface.getBreadcrumbs())
+    }
+
+    @Test
+    fun getReleaseStage() {
+        `when`(immutableConfig.releaseStage).thenReturn("dev")
+        assertEquals("dev", NativeInterface.getReleaseStage())
+    }
+
+    @Test
+    fun getSessionEndpoint() {
+        assertEquals("http://sessions.bugsnag.com", NativeInterface.getSessionEndpoint())
+    }
+
+    @Test
+    fun getEndpoint() {
+        assertEquals("http://notify.bugsnag.com", NativeInterface.getEndpoint())
+    }
+
+    @Test
+    fun getAppVersion() {
+        `when`(immutableConfig.appVersion).thenReturn("1.2.3")
+        assertEquals("1.2.3", NativeInterface.getAppVersion())
+    }
+
+    @Test
+    fun getEnabledReleaseStages() {
+        `when`(immutableConfig.enabledReleaseStages).thenReturn(setOf("prod"))
+        assertEquals(setOf("prod"), NativeInterface.getEnabledReleaseStages())
+    }
+
+    @Test
+    fun getLogger() {
+        `when`(immutableConfig.logger).thenReturn(NoopLogger)
+        assertEquals(NoopLogger, NativeInterface.getLogger())
+    }
+
+    @Test
+    fun setUser() {
+        NativeInterface.setUser("9", "bob@example.com", "Bob")
+        verify(client, times(1)).setUserId("9")
+        verify(client, times(1)).setUserEmail("bob@example.com")
+        verify(client, times(1)).setUserName("Bob")
+    }
+
+    @Test
+    fun leaveBreadcrumb() {
+        NativeInterface.leaveBreadcrumb("wow", BreadcrumbType.LOG)
+        verify(client, times(1)).leaveBreadcrumb("wow", BreadcrumbType.LOG, emptyMap())
+    }
+
+    @Test
+    fun leaveBreadcrumbMetadata() {
+        NativeInterface.leaveBreadcrumb("wow", "log", mapOf(Pair("foo", "bar")))
+        verify(client, times(1)).leaveBreadcrumb(
+            "wow",
+            BreadcrumbType.LOG,
+            mapOf(Pair("foo", "bar"))
+        )
+    }
+
+    @Test
+    fun clearMetadata() {
+        NativeInterface.clearMetadata("Foo", "Bar")
+        verify(client, times(1)).clearMetadata("Foo", "Bar")
+    }
+
+    @Test
+    fun addMetadata() {
+        NativeInterface.addMetadata("Foo", "Bar", "Baz")
+        verify(client, times(1)).addMetadata("Foo", "Bar", "Baz")
+    }
+
+    @Test
+    fun setContext() {
+        NativeInterface.setContext("Foo")
+        verify(client, times(1)).context = "Foo"
+    }
+
+    @Test
+    fun setBinaryArch() {
+        NativeInterface.setBinaryArch("x86")
+        verify(client, times(1)).setBinaryArch("x86")
+    }
+
+    @Test
+    fun registerSession() {
+        NativeInterface.registerSession(1, "55", 0, 1)
+        verify(sessionTracker, times(1)).registerExistingSession(
+            any(),
+            eq("55"),
+            any(),
+            eq(0),
+            eq(1)
+        )
+    }
+
+    @Test
+    fun deliverReport() {
+        NativeInterface.deliverReport(null, "{}")
+        verify(eventStore, times(1)).enqueueContentForDelivery("{}")
+    }
+
+    @Test
+    fun notifyCall() {
+        NativeInterface.notify("SIGPIPE", "SIGSEGV 11", Severity.ERROR, arrayOf())
+        verify(client, times(1)).notify(eq("SIGPIPE"), eq("SIGSEGV 11"), eq(arrayOf()), any())
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -106,19 +106,16 @@ internal class NativeInterfaceApiTest {
 
     @Test
     fun getMetadata() {
-        val state = MetadataState()
-        state.addMetadata("Foo", mapOf(Pair("wham", "bar")))
-        `when`(client.getMetadataState()).thenReturn(state)
-        assertEquals(mapOf(Pair("Foo", mapOf(Pair("wham", "bar")))), NativeInterface.getMetadata())
+        val map = mapOf(Pair("Foo", mapOf(Pair("wham", "bar"))))
+        `when`(client.metadata).thenReturn(map)
+        assertEquals(map, NativeInterface.getMetadata())
     }
 
     @Test
     fun getBreadcrumbs() {
-        val breadcrumbState = BreadcrumbState(50, NoopLogger)
-        `when`(client.getBreadcrumbState()).thenReturn(breadcrumbState)
-        val breadcrumb = Breadcrumb("Whoops")
-        breadcrumbState.add(breadcrumb)
-        assertEquals(listOf(breadcrumb), NativeInterface.getBreadcrumbs())
+        val breadcrumbs = listOf(Breadcrumb("Whoops"))
+        `when`(client.breadcrumbs).thenReturn(breadcrumbs)
+        assertEquals(breadcrumbs[0], NativeInterface.getBreadcrumbs()[0])
     }
 
     @Test

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -77,11 +77,11 @@ bsg_jni_cache *bsg_populate_jni_cache(JNIEnv *env) {
   jni_cache->native_interface =
       (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
   jni_cache->get_app_data = (*env)->GetStaticMethodID(
-      env, jni_cache->native_interface, "getAppData", "()Ljava/util/Map;");
+      env, jni_cache->native_interface, "getApp", "()Ljava/util/Map;");
   jni_cache->get_device_data = (*env)->GetStaticMethodID(
-      env, jni_cache->native_interface, "getDeviceData", "()Ljava/util/Map;");
+      env, jni_cache->native_interface, "getDevice", "()Ljava/util/Map;");
   jni_cache->get_user_data = (*env)->GetStaticMethodID(
-      env, jni_cache->native_interface, "getUserData", "()Ljava/util/Map;");
+      env, jni_cache->native_interface, "getUser", "()Ljava/util/Map;");
   jni_cache->get_metadata = (*env)->GetStaticMethodID(
       env, jni_cache->native_interface, "getMetadata", "()Ljava/util/Map;");
   jni_cache->get_context = (*env)->GetStaticMethodID(


### PR DESCRIPTION
## Goal

Updates `NativeInterface` to use the `ImmutableConfiguration` object rather than `Configuration` to prevent the user from mutating fields by holding onto a reference. This also renames methods for consistency with the Client's terminology.

## Changeset

- Removed non-public getter for `Configuration` on `Client`
- Added non-public getters/setters for `Client` fields as needed
- Removed `Message/MessageType` from `NativeInterface` as these are no longer used
- Renamed methods on `NativeInterface` to match terminology in rest of codebase
- Updated `NativeInterface` to use getters on `Client` rather than direct field access
- Updated JNI calls to use new method names
- Added a unit test to verify that `NativeInterface` calls the appropriate method on `Client`