### PR TITLE
Extract InternalReportDelegate class from Client

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -1,16 +1,13 @@
 package com.bugsnag.android;
 
 import static com.bugsnag.android.HandledState.REASON_HANDLED_EXCEPTION;
-import static com.bugsnag.android.HandledState.REASON_UNHANDLED_EXCEPTION;
 
-import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.app.Application;
 import android.content.Context;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.os.Build;
 import android.os.Environment;
 import android.os.storage.StorageManager;
 import android.view.OrientationEventListener;
@@ -47,8 +44,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         UserAware {
 
     private static final String SHARED_PREF_KEY = "com.bugsnag.android";
-
-    static final String INTERNAL_DIAGNOSTICS_TAB = "BugsnagDiagnostics";
 
     final ImmutableConfig immutableConfig;
 
@@ -185,28 +180,8 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
                 + "breadcrumbs on API Levels below 14.");
         }
 
-        // Create the error store that is used in the exception handler
-        FileStore.Delegate delegate = new EventStore.Delegate() {
-            @Override
-            public void onErrorIOFailure(Exception exc, File errorFile, String context) {
-                // send an internal error to bugsnag with no cache
-                HandledState handledState = HandledState.newInstance(REASON_UNHANDLED_EXCEPTION);
-                Event err = new Event(exc, immutableConfig, handledState);
-                err.setContext(context);
-
-                err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "canRead", errorFile.canRead());
-                err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "canWrite", errorFile.canWrite());
-                err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "exists", errorFile.exists());
-
-                @SuppressLint("UsableSpace") // storagemanager alternative API requires API 26
-                long usableSpace = appContext.getCacheDir().getUsableSpace();
-                err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "usableSpace", usableSpace);
-                err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "filename", errorFile.getName());
-                err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "fileLength", errorFile.length());
-                recordStorageCacheBehavior(err);
-                Client.this.reportInternalBugsnagError(err);
-            }
-        };
+        InternalReportDelegate delegate = new InternalReportDelegate(appContext,
+                logger, immutableConfig, storageManager, appData, deviceData, sessionTracker);
         eventStore = new EventStore(immutableConfig, appContext, logger, delegate);
 
         // Install a default exception handler with this client
@@ -264,22 +239,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
             logger.w("Failed to set up orientation tracking: " + ex);
         }
         return orientationListener;
-    }
-
-    void recordStorageCacheBehavior(Event event) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            File cacheDir = appContext.getCacheDir();
-            File errDir = new File(cacheDir, "bugsnag-errors");
-
-            try {
-                boolean tombstone = storageManager.isCacheBehaviorTombstone(errDir);
-                boolean group = storageManager.isCacheBehaviorGroup(errDir);
-                event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "cacheTombstone", tombstone);
-                event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "cacheGroup", group);
-            } catch (IOException exc) {
-                logger.w("Failed to record cache behaviour, skipping diagnostics", exc);
-            }
-        }
     }
 
     private void loadPlugins() {
@@ -695,58 +654,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
                 break;
             default:
                 break;
-        }
-    }
-
-    /**
-     * Reports an event that occurred within the notifier to bugsnag. A lean event report will be
-     * generated and sent asynchronously with no callbacks, retry attempts, or writing to disk.
-     * This is intended for internal use only, and reports will not be visible to end-users.
-     */
-    void reportInternalBugsnagError(@NonNull Event event) {
-        Map<String, Object> app = appData.getAppDataSummary();
-        app.put("duration", AppData.getDurationMs());
-        app.put("durationInForeground", appData.calculateDurationInForeground());
-        app.put("inForeground", sessionTracker.isInForeground());
-        event.setApp(app);
-
-        Map<String, Object> device = deviceData.getDeviceDataSummary();
-        device.put("freeDisk", deviceData.calculateFreeDisk());
-        event.setDevice(device);
-
-        Notifier notifier = Notifier.INSTANCE;
-        event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "notifierName", notifier.getName());
-        event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "notifierVersion", notifier.getVersion());
-        event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "apiKey", immutableConfig.getApiKey());
-
-        Object packageName = appData.getAppData().get("packageName");
-        event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "packageName", packageName);
-
-        final Report report = new Report(null, event);
-        try {
-            Async.run(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        Delivery delivery = immutableConfig.getDelivery();
-                        DeliveryParams params = immutableConfig.errorApiDeliveryParams();
-
-                        // can only modify headers if DefaultDelivery is in use
-                        if (delivery instanceof DefaultDelivery) {
-                            Map<String, String> headers = params.getHeaders();
-                            headers.put("Bugsnag-Internal-Error", "true");
-                            headers.remove("Bugsnag-Api-Key");
-                            DefaultDelivery defaultDelivery = (DefaultDelivery) delivery;
-                            defaultDelivery.deliver(params.getEndpoint(), report, headers);
-                        }
-
-                    } catch (Exception exception) {
-                        logger.w("Failed to report internal event to Bugsnag", exception);
-                    }
-                }
-            });
-        } catch (RejectedExecutionException ignored) {
-            // drop internal report
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -32,7 +32,8 @@ internal data class ImmutableConfig(
 
     companion object {
         private const val HEADER_API_PAYLOAD_VERSION = "Bugsnag-Payload-Version"
-        private const val HEADER_API_KEY = "Bugsnag-Api-Key"
+        internal const val HEADER_API_KEY = "Bugsnag-Api-Key"
+        internal const val HEADER_INTERNAL_ERROR = "Bugsnag-Internal-Error"
         private const val HEADER_BUGSNAG_SENT_AT = "Bugsnag-Sent-At"
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -1,0 +1,135 @@
+package com.bugsnag.android;
+
+import static com.bugsnag.android.HandledState.REASON_UNHANDLED_EXCEPTION;
+import static com.bugsnag.android.ImmutableConfig.HEADER_API_KEY;
+import static com.bugsnag.android.ImmutableConfig.HEADER_INTERNAL_ERROR;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.Build;
+import android.os.storage.StorageManager;
+
+import androidx.annotation.NonNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
+
+class InternalReportDelegate implements EventStore.Delegate {
+
+    static final String INTERNAL_DIAGNOSTICS_TAB = "BugsnagDiagnostics";
+
+    final Logger logger;
+    final ImmutableConfig immutableConfig;
+    final StorageManager storageManager;
+
+    final AppData appData;
+    final DeviceData deviceData;
+    final Context appContext;
+    final SessionTracker sessionTracker;
+
+    InternalReportDelegate(Context context,
+                           Logger logger,
+                           ImmutableConfig immutableConfig,
+                           StorageManager storageManager,
+                           AppData appData,
+                           DeviceData deviceData,
+                           SessionTracker sessionTracker) {
+        this.logger = logger;
+        this.immutableConfig = immutableConfig;
+        this.storageManager = storageManager;
+        this.appData = appData;
+        this.deviceData = deviceData;
+        this.appContext = context;
+        this.sessionTracker = sessionTracker;
+    }
+
+    @Override
+    public void onErrorIOFailure(Exception exc, File errorFile, String context) {
+        // send an internal error to bugsnag with no cache
+        HandledState handledState = HandledState.newInstance(REASON_UNHANDLED_EXCEPTION);
+        Event err = new Event(exc, immutableConfig, handledState);
+        err.setContext(context);
+
+        err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "canRead", errorFile.canRead());
+        err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "canWrite", errorFile.canWrite());
+        err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "exists", errorFile.exists());
+
+        @SuppressLint("UsableSpace") // storagemanager alternative API requires API 26
+        long usableSpace = appContext.getCacheDir().getUsableSpace();
+        err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "usableSpace", usableSpace);
+        err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "filename", errorFile.getName());
+        err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "fileLength", errorFile.length());
+        recordStorageCacheBehavior(err);
+        reportInternalBugsnagError(err);
+    }
+
+    void recordStorageCacheBehavior(Event event) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            File cacheDir = appContext.getCacheDir();
+            File errDir = new File(cacheDir, "bugsnag-errors");
+
+            try {
+                boolean tombstone = storageManager.isCacheBehaviorTombstone(errDir);
+                boolean group = storageManager.isCacheBehaviorGroup(errDir);
+                event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "cacheTombstone", tombstone);
+                event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "cacheGroup", group);
+            } catch (IOException exc) {
+                logger.w("Failed to record cache behaviour, skipping diagnostics", exc);
+            }
+        }
+    }
+
+    /**
+     * Reports an event that occurred within the notifier to bugsnag. A lean event report will be
+     * generated and sent asynchronously with no callbacks, retry attempts, or writing to disk.
+     * This is intended for internal use only, and reports will not be visible to end-users.
+     */
+    void reportInternalBugsnagError(@NonNull Event event) {
+        Map<String, Object> app = appData.getAppDataSummary();
+        app.put("duration", AppData.getDurationMs());
+        app.put("durationInForeground", appData.calculateDurationInForeground());
+        app.put("inForeground", sessionTracker.isInForeground());
+        event.setApp(app);
+
+        Map<String, Object> device = deviceData.getDeviceDataSummary();
+        device.put("freeDisk", deviceData.calculateFreeDisk());
+        event.setDevice(device);
+
+        Notifier notifier = Notifier.INSTANCE;
+        event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "notifierName", notifier.getName());
+        event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "notifierVersion", notifier.getVersion());
+        event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "apiKey", immutableConfig.getApiKey());
+
+        Object packageName = appData.getAppData().get("packageName");
+        event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "packageName", packageName);
+
+        final Report report = new Report(null, event);
+        try {
+            Async.run(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Delivery delivery = immutableConfig.getDelivery();
+                        DeliveryParams params = immutableConfig.errorApiDeliveryParams();
+
+                        // can only modify headers if DefaultDelivery is in use
+                        if (delivery instanceof DefaultDelivery) {
+                            Map<String, String> headers = params.getHeaders();
+                            headers.put(HEADER_INTERNAL_ERROR, "true");
+                            headers.remove(HEADER_API_KEY);
+                            DefaultDelivery defaultDelivery = (DefaultDelivery) delivery;
+                            defaultDelivery.deliver(params.getEndpoint(), report, headers);
+                        }
+
+                    } catch (Exception exception) {
+                        logger.w("Failed to report internal event to Bugsnag", exception);
+                    }
+                }
+            });
+        } catch (RejectedExecutionException ignored) {
+            // drop internal report
+        }
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalReportDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalReportDelegateTest.kt
@@ -1,0 +1,76 @@
+package com.bugsnag.android
+
+import android.content.Context
+import android.os.storage.StorageManager
+import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+internal class InternalReportDelegateTest {
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var appData: AppData
+
+    @Mock
+    lateinit var deviceData: DeviceData
+
+    @Mock
+    lateinit var sessionTracker: SessionTracker
+
+    @Mock
+    lateinit var storageManager: StorageManager
+
+    @Test
+    fun onErrorIOFailure() {
+        val app = HashMap<String, Any>()
+        app["foo"] = 2
+        `when`(this.appData.appDataSummary).thenReturn(app)
+        `when`(this.appData.appData).thenReturn(mapOf(Pair("packageName", "com.example")))
+        `when`(this.appData.calculateDurationInForeground()).thenReturn(500)
+        `when`(sessionTracker.isInForeground).thenReturn(true)
+
+        val device = HashMap<String, Any>()
+        device["id"] = "234"
+
+        `when`(deviceData.deviceDataSummary).thenReturn(device)
+        `when`(deviceData.calculateFreeDisk()).thenReturn(10592342221)
+
+        val config = generateImmutableConfig()
+        val delegate = InternalReportDelegate(
+            context,
+            NoopLogger,
+            config,
+            storageManager,
+            appData,
+            deviceData,
+            sessionTracker
+        )
+
+        val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
+        val event = Event(RuntimeException(), config, handledState)
+        delegate.reportInternalBugsnagError(event)
+
+        // app
+        assertEquals(2, event.app["foo"])
+        assertEquals(500L, event.app["durationInForeground"])
+        assertEquals(true, event.app["inForeground"])
+
+        // device
+        assertEquals("234", event.device["id"])
+        assertEquals(10592342221, event.device["freeDisk"])
+
+        // metadata
+        assertNotNull(event.getMetadata("BugsnagDiagnostics", "notifierName"))
+        assertNotNull(event.getMetadata("BugsnagDiagnostics", "notifierVersion"))
+        assertEquals("test", event.getMetadata("BugsnagDiagnostics", "apiKey"))
+        assertEquals("com.example", event.getMetadata("BugsnagDiagnostics", "packageName"))
+    }
+}


### PR DESCRIPTION
## Goal

Extracts the logic for sending an internal bugsnag report from the `Client` to its own class.

There should be no functional change here, but this enables the addition of a unit test to verify the behaviour of internal reporting on top of existing E2E tests. It also reduces the responsibilities of the large `Client` class.
