### PR TITLE
Remove unused sanitisation code from Client

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -139,7 +139,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         // set sensible defaults for delivery/project packages etc if not set
         warnIfNotAppContext(androidContext);
         appContext = androidContext.getApplicationContext();
-        sanitiseConfiguration(configuration);
 
         storageManager = (StorageManager) appContext.getSystemService(Context.STORAGE_SERVICE);
 
@@ -152,6 +151,8 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
                 return null;
             }
         });
+        ImmutableConfigKt.sanitiseConfiguration(appContext, configuration, connectivity);
+
 
         clientState = configuration;
         immutableConfig = ImmutableConfigKt.convertToImmutableConfig(configuration);
@@ -289,47 +290,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
                 event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "cacheGroup", group);
             } catch (IOException exc) {
                 logger.w("Failed to record cache behaviour, skipping diagnostics", exc);
-            }
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    private void sanitiseConfiguration(@NonNull Configuration configuration) {
-        if (configuration.getDelivery() == null) {
-            configuration.setDelivery(new DefaultDelivery(connectivity, logger));
-        }
-
-        String packageName = appContext.getPackageName();
-
-        if (configuration.getVersionCode() == null || configuration.getVersionCode() == 0) {
-            try {
-                PackageManager packageManager = appContext.getPackageManager();
-                PackageInfo packageInfo = packageManager.getPackageInfo(packageName, 0);
-                configuration.setVersionCode(packageInfo.versionCode);
-            } catch (Exception ignore) {
-                logger.w("Bugsnag is unable to read version code from manifest.");
-            }
-        }
-
-        // Set sensible defaults if project packages not already set
-        if (configuration.getProjectPackages().isEmpty()) {
-            configuration.setProjectPackages(Collections.singleton(packageName));
-        }
-
-        // populate from manifest (in the case where the constructor was called directly by the
-        // User or no UUID was supplied)
-        if (configuration.getBuildUuid() == null) {
-            String buildUuid = null;
-            try {
-                PackageManager packageManager = appContext.getPackageManager();
-                ApplicationInfo ai = packageManager.getApplicationInfo(
-                        packageName, PackageManager.GET_META_DATA);
-                buildUuid = ai.metaData.getString(BUILD_UUID);
-            } catch (Exception ignore) {
-                logger.w("Bugsnag is unable to read build UUID from manifest.");
-            }
-            if (buildUuid != null) {
-                configuration.setBuildUuid(buildUuid);
             }
         }
     }


### PR DESCRIPTION
## Goal

Updates the sanitisation of the `Configuration` object to happen in `ImmutableConfig` rather than the method defined in `Client`.

This was originally added in #682 but seems to have been lost in a merge conflict somewhere along the way.
