### PR TITLE
Remove data class modifier from DeliveryParams/Endpoints

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryParams.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryParams.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-data class DeliveryParams(
+class DeliveryParams(
     val endpoint: String,
     val headers: Map<String, String>
 )

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Endpoints.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Endpoints.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-data class Endpoints(
+class Endpoints(
     val notify: String = "https://notify.bugsnag.com",
     val sessions: String = "https://sessions.bugsnag.com"
 )

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -89,7 +89,8 @@ internal class ImmutableConfigTest {
         seed.codeBundleId = "codebundle123"
         seed.appType = "custom"
 
-        seed.endpoints = Endpoints("http://example.com:1234", "http://example.com:1235")
+        val endpoints = Endpoints("http://example.com:1234", "http://example.com:1235")
+        seed.endpoints = endpoints
         seed.launchCrashThresholdMs = 7000
         seed.maxBreadcrumbs = 37
         seed.persistUserBetweenSessions = true
@@ -119,10 +120,8 @@ internal class ImmutableConfigTest {
             assertEquals("custom", seed.appType)
 
             // network config
-            assertEquals(
-                seed.endpoints,
-                Endpoints("http://example.com:1234", "http://example.com:1235")
-            )
+            assertEquals(seed.endpoints.notify, endpoints.notify)
+            assertEquals(seed.endpoints.sessions, endpoints.sessions)
 
             // behaviour
             assertEquals(7000, seed.launchCrashThresholdMs)


### PR DESCRIPTION
## Goal

A [data class](https://kotlinlang.org/docs/reference/data-classes.html) in Kotlin automatically generates methods such as `copy()`, `equals()`, and `componentN()`.

These features are not used within `DeliveryParams/Endpoints` and makes it hard to add new properties to these classes in future without causing a [breaking change](https://jakewharton.com/public-api-challenges-in-kotlin/). The modifier has therefore been removed.
