### PR TITLE
Add test coverage to Event class

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/User.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/User.kt
@@ -32,4 +32,24 @@ class User @JvmOverloads internal constructor(
         writer.endObject()
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as User
+
+        if (id != other.id) return false
+        if (email != other.email) return false
+        if (name != other.name) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id?.hashCode() ?: 0
+        result = 31 * result + (email?.hashCode() ?: 0)
+        result = 31 * result + (name?.hashCode() ?: 0)
+        return result
+    }
+
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
@@ -1,0 +1,84 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * Verifies that method calls are forwarded onto the appropriate method on Event fields,
+ * and that adequate sanitisation takes place.
+ */
+@RunWith(MockitoJUnitRunner::class)
+internal class EventApiTest {
+
+    lateinit var event: Event
+
+    @Before
+    fun setUp() {
+        event = Event(
+            RuntimeException(),
+            generateImmutableConfig(),
+            HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
+        )
+        event.setUser("1", "fred@example.com", "Fred")
+    }
+
+    @Test
+    fun getUser() {
+        assertEquals(event._user, event.getUser())
+    }
+
+    @Test
+    fun setUser() {
+        event.setUser("99", "boo@example.com", "Boo")
+        assertEquals(User("99", "boo@example.com", "Boo"), event._user)
+    }
+
+    @Test
+    fun setUserId() {
+        event.setUserId("99")
+        assertEquals(User("99", "fred@example.com", "Fred"), event._user)
+    }
+
+    @Test
+    fun setUserEmail() {
+        event.setUserEmail("joe@test.com")
+        assertEquals(User("1", "joe@test.com", "Fred"), event._user)
+    }
+
+    @Test
+    fun setUserName() {
+        event.setUserName("Jacinta Barltrop")
+        assertEquals(User("1", "fred@example.com", "Jacinta Barltrop"), event._user)
+    }
+
+    @Test
+    fun addMetadataTopLevel() {
+        event.addMetadata("foo", mapOf(Pair("wham", "bar")))
+        assertEquals(mapOf(Pair("wham", "bar")), event.metadata.getMetadata("foo"))
+    }
+
+    @Test
+    fun addMetadata() {
+        event.addMetadata("foo", "wham", "bar")
+        assertEquals("bar", event.metadata.getMetadata("foo", "wham"))
+    }
+
+    @Test
+    fun clearMetadataTopLevel() {
+        event.addMetadata("foo", mapOf(Pair("wham", "bar")))
+        event.clearMetadata("foo")
+        assertNull(event.metadata.getMetadata("foo"))
+    }
+
+    @Test
+    fun clearMetadata() {
+        event.addMetadata("foo", "wham", "bar")
+        event.clearMetadata("foo", "wham")
+        assertNull(event.metadata.getMetadata("foo", "wham"))
+    }
+}


### PR DESCRIPTION
## Goal

Increases test coverage by verifying that when the user/metadata is updated on the `Event` class, the appropriate backing field is altered.

Note that this adds an `equals()/hashcode()` implementation so that the `User` object can be compared by whether its fields match, rather than for referential equality.
