### PR TITLE
Merge strictmode metadata with global Metadata

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -628,7 +628,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
                 = HandledState.newInstance(severityReason, Severity.ERROR, attributeValue);
         ThreadState threadState = new ThreadState(immutableConfig, exc, thread);
         Event event = new Event(exc, immutableConfig, handledState,
-                metadataState.getMetadata());
+                Metadata.Companion.merge(metadataState.getMetadata(), metadata));
         notifyInternal(event, DeliveryStyle.ASYNC_WITH_CACHE, null);
     }
 


### PR DESCRIPTION
## Goal

When a [StrictMode](https://developer.android.com/reference/android/os/StrictMode) exception is captured by our `UncaughtExceptionHandler` we attempt to extract additional information about the reason for the strictmode violation from the throwable object. This information is attached to the `Event` via a `Metadata` object passed to a notify call.

The implementation of `Client` did not merge this metadata object with the global metadata store, so the strictmode information was not included in events. This change fixes the `strict_mode.feature` scenarios which are only triggered on a full test run.
