### PR TITLE
Remove unused imports

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ReportTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ReportTest.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.lang.Thread;
 
 @SmallTest
 public class ReportTest {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android
 
 import java.io.IOException
 import java.io.StringWriter
-import java.util.Observable
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -2,20 +2,13 @@ package com.bugsnag.android;
 
 import static com.bugsnag.android.HandledState.REASON_HANDLED_EXCEPTION;
 import static com.bugsnag.android.HandledState.REASON_UNHANDLED_EXCEPTION;
-import static com.bugsnag.android.ManifestConfigLoader.BUILD_UUID;
-
-import com.bugsnag.android.NativeInterface.Message;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.Application;
 import android.content.Context;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Build;
 import android.os.Environment;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android
 import android.content.Context
 import android.text.TextUtils
 import java.util.Collections
-import java.util.concurrent.ConcurrentLinkedQueue
 
 /**
  * User-specified configuration storage object, contains information

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Resources;
 import android.os.BatteryManager;
-import android.os.Environment;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/User.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/User.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android
 
 import java.io.IOException
-import java.util.Observable
 
 /**
  * Information about the current user of your application.

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
@@ -7,7 +7,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.File
 import java.util.ArrayList
 import java.util.HashMap
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
@@ -7,8 +7,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
 
 /**

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android
 
 import android.content.Context
 import android.net.ConnectivityManager
-import org.junit.Assert
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataSerializationTest.kt
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameter
 import org.junit.runners.Parameterized.Parameters
-import org.mockito.Mockito
 import org.mockito.Mockito.*
 import java.io.File
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
@@ -8,9 +8,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.ArgumentMatchers.matches
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
@@ -9,7 +9,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.Mockito.*
 import org.mockito.junit.MockitoJUnitRunner
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/UserRepositoryTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/UserRepositoryTest.kt
@@ -3,14 +3,11 @@ package com.bugsnag.android
 import android.content.SharedPreferences
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.Mockito.*
 import org.mockito.junit.MockitoJUnitRunner
 


### PR DESCRIPTION
## Goal

Removes unused imports revealed by the IntelliJ inspection tool. These are unnecessary and can therefore be removed from the codebase.
