### PR TITLE
Explicitly specify types on public interfaces

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagPluginInterface.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagPluginInterface.kt
@@ -32,6 +32,6 @@ object BugsnagPluginInterface {
      * Constructs an event from an exception, by accessing the internally visible constructor
      * and returning the created object. This API is intended for internal use only.
      */
-    fun createEvent(exc: Throwable, client: Client, severityReason: String) =
+    fun createEvent(exc: Throwable, client: Client, severityReason: String): Event =
         Event(exc, client.config, HandledState.newInstance(severityReason))
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -53,13 +53,13 @@ class Configuration(
      * Set whether to send thread-state with report.
      * By default, this will be true.
      */
-    var sendThreads = true
+    var sendThreads: Boolean = true
 
     /**
      * Set whether or not Bugsnag should persist user information between application settings
      * if set then any user information set will be re-used until
      */
-    var persistUserBetweenSessions = false
+    var persistUserBetweenSessions: Boolean = false
 
     /**
      * Sets the threshold in ms for an uncaught error to be considered as a crash on launch.
@@ -84,7 +84,7 @@ class Configuration(
      *
      * By default this behavior is enabled.
      */
-    var autoTrackSessions = true
+    var autoTrackSessions: Boolean = true
 
     /**
      * Sets whether [ANRs](https://developer.android.com/topic/performance/vitals/anr)
@@ -93,7 +93,7 @@ class Configuration(
      *
      * If you wish to enable ANR detection, you should set this property to true.
      */
-    var autoDetectAnrs = false
+    var autoDetectAnrs: Boolean = false
 
     /**
      * Determines whether NDK crashes such as signals and exceptions should be reported by bugsnag.
@@ -107,7 +107,7 @@ class Configuration(
      * Sets whether Bugsnag should automatically capture and report unhandled errors.
      * By default, this value is true.
      */
-    var autoDetectErrors = true
+    var autoDetectErrors: Boolean = true
 
     /**
      * Intended for internal use only - sets the code bundle id for React Native
@@ -117,7 +117,7 @@ class Configuration(
     /**
      * Sets the type of the notifier (e.g. Android, React Native)
      */
-    var appType = "android"
+    var appType: String = "android"
 
     /**
      * Sets the logger used for logging internal messages within the bugsnag SDK to a custom
@@ -142,14 +142,14 @@ class Configuration(
      * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
      * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoints.
      */
-    var endpoints = Endpoints()
+    var endpoints: Endpoints = Endpoints()
 
     /**
      * Set the maximum number of breadcrumbState to keep and sent to Bugsnag.
      * By default, we'll keep and send the 25 most recent breadcrumb log
      * messages.
      */
-    var maxBreadcrumbs = DEFAULT_MAX_SIZE
+    var maxBreadcrumbs: Int = DEFAULT_MAX_SIZE
         set(numBreadcrumbs) {
             field = when {
                 numBreadcrumbs <= MIN_BREADCRUMBS -> MIN_BREADCRUMBS
@@ -301,7 +301,7 @@ class Configuration(
     override fun getMetadata(section: String) = metadataState.getMetadata(section)
     override fun getMetadata(section: String, key: String) = metadataState.getMetadata(section, key)
 
-    companion object {
+    private companion object {
         private const val DEFAULT_MAX_SIZE = 25
         private const val DEFAULT_LAUNCH_CRASH_THRESHOLD_MS: Long = 5000
         private const val MIN_BREADCRUMBS = 0

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
@@ -7,7 +7,7 @@ class Error @JvmOverloads internal constructor(
     var type: String = "android"
 ): JsonStream.Streamable {
 
-    companion object {
+    internal companion object {
         fun createError(exc: Throwable, projectPackages: Collection<String>, logger: Logger): List<Error> {
             val errors = mutableListOf<Error>()
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -41,7 +41,7 @@ class Event @JvmOverloads internal constructor(
     var app: MutableMap<String, Any?> = HashMap()
     var device: MutableMap<String, Any?> = HashMap()
 
-    val isUnhandled = handledState.isUnhandled
+    val isUnhandled: Boolean = handledState.isUnhandled
 
     var breadcrumbs: List<Breadcrumb> = emptyList()
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Logger.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Logger.kt
@@ -1,12 +1,12 @@
 package com.bugsnag.android
 
 interface Logger {
-    fun e(msg: String) = Unit
-    fun e(msg: String, throwable: Throwable) = Unit
-    fun w(msg: String) = Unit
-    fun w(msg: String, throwable: Throwable) = Unit
-    fun i(msg: String) = Unit
-    fun i(msg: String, throwable: Throwable) = Unit
-    fun d(msg: String) = Unit
-    fun d(msg: String, throwable: Throwable) = Unit
+    fun e(msg: String): Unit = Unit
+    fun e(msg: String, throwable: Throwable): Unit = Unit
+    fun w(msg: String): Unit = Unit
+    fun w(msg: String, throwable: Throwable): Unit = Unit
+    fun i(msg: String): Unit = Unit
+    fun i(msg: String, throwable: Throwable): Unit = Unit
+    fun d(msg: String): Unit = Unit
+    fun d(msg: String, throwable: Throwable): Unit = Unit
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,9 +7,9 @@ import java.io.IOException
  */
 internal object Notifier : JsonStream.Streamable {
 
-    var name = "Android Bugsnag Notifier"
-    var version = "4.21.0"
-    var url = "https://bugsnag.com"
+    var name: String = "Android Bugsnag Notifier"
+    var version: String = "4.21.0"
+    var url: String = "https://bugsnag.com"
 
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {


### PR DESCRIPTION
## Goal

Explicitly lists the types on public interfaces where they were not already listed, to reduce the chance of type inference causing a breaking change if the implementation changes.

For example, if we expose an API like thus:

```
fun foo() = mutableListOf("bar")
fun foo2(): List<String> = mutableListOf("bar")
```

If we decide to change `foo2()` to return a `Set` instead, the build will only break if the type is explicitly listed:

```
fun foo() = mutableSetOf("bar") // does not break compilation
fun foo2(): List<String> = mutableSetOf("bar") // breaks compilation
```

Therefore we want to list types explicitly for all our public interface that is written in Kotlin. Further reading on this topic is available here: https://jakewharton.com/public-api-challenges-in-kotlin/

## Changeset

Specified return type explicitly for _public_ fields and methods only. The type has been left implicit for any non-public fields.

The `Configuration/Error` companion objects have also been made non-public, as we don't need to expose these types.