### PR TITLE
Remove payload size limit on breadcrumb metadata

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android
 
 import java.io.IOException
-import java.io.StringWriter
 import java.util.Queue
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -27,15 +26,6 @@ internal class BreadcrumbState(maxBreadcrumbs: Int, val logger: Logger) : BaseOb
     }
 
     fun add(breadcrumb: Breadcrumb) {
-        try {
-            if (breadcrumbPayloadSize(breadcrumb) > MAX_PAYLOAD_SIZE) {
-                logger.w("Dropping breadcrumb because payload exceeds 4KB limit")
-                return
-            }
-        } catch (ex: IOException) {
-            logger.w("Dropping breadcrumb because it could not be serialized", ex)
-        }
-
         store.add(breadcrumb)
         pruneBreadcrumbs()
         notifyObservers(
@@ -52,18 +42,6 @@ internal class BreadcrumbState(maxBreadcrumbs: Int, val logger: Logger) : BaseOb
         // Remove oldest breadcrumbState until new max size reached
         while (store.size > maxBreadcrumbs) {
             store.poll()
-        }
-    }
-
-    companion object {
-        private const val MAX_PAYLOAD_SIZE = 4096
-
-        @Throws(IOException::class)
-        internal fun breadcrumbPayloadSize(breadcrumb: Breadcrumb): Int {
-            val writer = StringWriter()
-            val jsonStream = JsonStream(writer)
-            breadcrumb.toStream(jsonStream)
-            return writer.toString().length
         }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BreadcrumbType.MANUAL
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -84,7 +85,7 @@ class BreadcrumbStateTest {
     }
 
     /**
-     * Ensures a breadcrumb is dropped if it exceeds the payload size limit
+     * Ensures a breadcrumb is not dropped if it contains a large amount of metadata
      */
     @Test
     fun testPayloadSizeLimit() {
@@ -93,7 +94,7 @@ class BreadcrumbStateTest {
             metadata[String.format(Locale.US, "%d", i)] = "!!"
         }
         breadcrumbState.add(Breadcrumb("Rotated Menu", BreadcrumbType.STATE, metadata))
-        assertTrue(breadcrumbState.store.isEmpty())
+        assertFalse(breadcrumbState.store.isEmpty())
     }
 
     /**


### PR DESCRIPTION
Removes the payload size limit on breadcrumb metadata, as this is no longer in the notifier specification.

We plan on adding a more holistic method of reducing overall payload size at a later date.