### PR TITLE
Add duplicate callbacks if already in collection

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbStateTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbStateTest.java
@@ -108,7 +108,7 @@ public class OnBreadcrumbStateTest {
     }
 
     @Test
-    public void ensureOnlyCalledOnce() {
+    public void ensureCalledTwice() {
         final int[] count = {1};
 
         OnBreadcrumb onBreadcrumb = new OnBreadcrumb() {
@@ -121,7 +121,7 @@ public class OnBreadcrumbStateTest {
         client.addOnBreadcrumb(onBreadcrumb);
         client.addOnBreadcrumb(onBreadcrumb);
         client.leaveBreadcrumb("Foo");
-        assertEquals(2, count[0]);
+        assertEquals(3, count[0]);
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/UniqueOnErrorTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/UniqueOnErrorTest.java
@@ -63,7 +63,7 @@ public class UniqueOnErrorTest {
         client.addOnError(secondCb);
         client.addOnError(secondCb);
         client.notify(new Throwable());
-        assertEquals(2, callbackCount);
+        assertEquals(4, callbackCount);
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
@@ -9,9 +9,7 @@ internal data class CallbackState(
 ): CallbackAware {
 
     override fun addOnError(onError: OnError) {
-        if (!onErrorTasks.contains(onError)) {
-            onErrorTasks.add(onError)
-        }
+        onErrorTasks.add(onError)
     }
 
     override fun removeOnError(onError: OnError) {
@@ -19,9 +17,7 @@ internal data class CallbackState(
     }
 
     override fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumb) {
-        if (!onBreadcrumbTasks.contains(onBreadcrumb)) {
-            onBreadcrumbTasks.add(onBreadcrumb)
-        }
+        onBreadcrumbTasks.add(onBreadcrumb)
     }
 
     override fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumb) {
@@ -29,9 +25,7 @@ internal data class CallbackState(
     }
 
     override fun addOnSession(onSession: OnSession) {
-        if (!onSessionTasks.contains(onSession)) {
-            onSessionTasks.add(onSession)
-        }
+        onSessionTasks.add(onSession)
     }
 
     override fun removeOnSession(onSession: OnSession) {


### PR DESCRIPTION
An `OnError/OnSession/OnBreadcrumb` callback should be added regardless of whether it is already in the collection. This changeset brings the implementation in line with the latest version of the notifier spec.