### PR TITLE
Client should not extend Observable

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -34,7 +34,7 @@ public class ObserverInterfaceTest {
         config.setAutoDetectErrors(false);
         client = new Client(ApplicationProvider.getApplicationContext(), config);
         observer = new BugsnagTestObserver();
-        client.addObserver(observer);
+        client.registerObserver(observer);
     }
 
     @After

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Observable;
 import java.util.Observer;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -38,8 +37,7 @@ import java.util.concurrent.RejectedExecutionException;
  * @see Bugsnag
  */
 @SuppressWarnings("checkstyle:JavadocTagContinuationIndentation")
-public class Client extends Observable implements Observer, MetadataAware, CallbackAware,
-        UserAware {
+public class Client implements MetadataAware, CallbackAware, UserAware {
 
     private static final String SHARED_PREF_KEY = "com.bugsnag.android";
 
@@ -205,13 +203,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         }
         connectivity.registerForNetworkChanges();
 
-        metadataState.addObserver(this);
-        breadcrumbState.addObserver(this);
-        sessionTracker.addObserver(this);
-        clientObservable.addObserver(this);
-        userState.addObserver(this);
-        contextState.addObserver(this);
-        deliveryDelegate.addObserver(this);
         orientationListener = registerOrientationChangeListener();
 
         // filter out any disabled breadcrumb types
@@ -280,10 +271,14 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         }
     }
 
-    @Override
-    public void update(@NonNull Observable observable, @NonNull Object arg) {
-        setChanged();
-        super.notifyObservers(arg);
+    void registerObserver(Observer observer) {
+        metadataState.addObserver(observer);
+        breadcrumbState.addObserver(observer);
+        sessionTracker.addObserver(observer);
+        clientObservable.addObserver(observer);
+        userState.addObserver(observer);
+        contextState.addObserver(observer);
+        deliveryDelegate.addObserver(observer);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -30,8 +30,6 @@ class DeliveryDelegate extends BaseObservable {
         Session session = event.getSession();
 
         if (session != null) {
-            setChanged();
-
             if (event.isUnhandled()) {
                 event.setSession(session.incrementUnhandledAndCopy());
                 notifyObservers(StateEvent.NotifyUnhandled.INSTANCE);

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -7,7 +7,7 @@ internal class NdkPlugin : BugsnagPlugin {
     override fun initialisePlugin(client: Client) {
         System.loadLibrary("bugsnag-ndk")
         val nativeBridge = NativeBridge()
-        client.addObserver(nativeBridge)
+        client.registerObserver(nativeBridge)
         client.sendNativeSetupNotification()
         NativeInterface.getLogger().i("Initialised NDK Plugin")
     }


### PR DESCRIPTION
`Client` is a public type and should therefore use composition rather than inheritance to emit observable events. This gives us a free hand to change the implementation of observable messaging in the future, whereas otherwise we would remain constrained to inheriting from `Observable` unless we wished to introduce a breaking change.

This changeset makes `Client` use composition by providing a method to register an `Observer` on all its `Observable` fields. Additionally, it removes an obsolete call to `setChanged()` that was present in `DeliveryDelegate`.