### PR TITLE
Rename persistUserBetweenSessions to persistUser

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -96,7 +96,7 @@ public class ClientTest {
     public void testRestoreUserFromPrefs() {
         setUserPrefs();
 
-        config.setPersistUserBetweenSessions(true);
+        config.setPersistUser(true);
         config.setDelivery(BugsnagTestUtils.generateDelivery());
         client = new Client(context, config);
 
@@ -119,7 +119,7 @@ public class ClientTest {
 
     @Test
     public void testStoreUserInPrefs() {
-        config.setPersistUserBetweenSessions(true);
+        config.setPersistUser(true);
         client = new Client(context, config);
         client.setUser(USER_ID, USER_EMAIL, USER_NAME);
 
@@ -132,7 +132,7 @@ public class ClientTest {
 
     @Test
     public void testStoreUserInPrefsDisabled() {
-        config.setPersistUserBetweenSessions(false);
+        config.setPersistUser(false);
         client = new Client(context, config);
         client.setUser(USER_ID, USER_EMAIL, USER_NAME);
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -32,7 +32,7 @@ class ManifestConfigLoaderTest {
             assertFalse(autoDetectNdkCrashes)
             assertTrue(autoTrackSessions)
             assertTrue(sendThreads)
-            assertFalse(persistUserBetweenSessions)
+            assertFalse(persistUser)
 
             // endpoints
             assertEquals(endpoints.notify, "https://notify.bugsnag.com")
@@ -66,7 +66,7 @@ class ManifestConfigLoaderTest {
             putBoolean("com.bugsnag.android.AUTO_CAPTURE_SESSIONS", false)
             putBoolean("com.bugsnag.android.AUTO_CAPTURE_BREADCRUMBS", false)
             putBoolean("com.bugsnag.android.SEND_THREADS", false)
-            putBoolean("com.bugsnag.android.PERSIST_USER_BETWEEN_SESSIONS", true)
+            putBoolean("com.bugsnag.android.PERSIST_USER", true)
 
             // endpoints
             putString("com.bugsnag.android.ENDPOINT", "http://localhost:1234")
@@ -98,7 +98,7 @@ class ManifestConfigLoaderTest {
             assertTrue(autoDetectNdkCrashes)
             assertFalse(autoTrackSessions)
             assertFalse(sendThreads)
-            assertTrue(persistUserBetweenSessions)
+            assertTrue(persistUser)
 
             // endpoints
             assertEquals(endpoints.notify, "http://localhost:1234")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -158,7 +158,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
                 immutableConfig, sessionTracker, am, logger);
 
         UserRepository userRepository = new UserRepository(sharedPrefs,
-                immutableConfig.getPersistUserBetweenSessions());
+                immutableConfig.getPersistUser());
         userState = new UserState(userRepository);
 
         String id = userState.getUser().getId();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -59,7 +59,7 @@ class Configuration(
      * Set whether or not Bugsnag should persist user information between application settings
      * if set then any user information set will be re-used until
      */
-    var persistUserBetweenSessions: Boolean = false
+    var persistUser: Boolean = false
 
     /**
      * Sets the threshold in ms for an uncaught error to be considered as a crash on launch.

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -24,7 +24,7 @@ internal data class ImmutableConfig(
     val appType: String,
     val delivery: Delivery,
     val endpoints: Endpoints,
-    val persistUserBetweenSessions: Boolean,
+    val persistUser: Boolean,
     val launchCrashThresholdMs: Long,
     val logger: Logger,
     val maxBreadcrumbs: Int
@@ -99,7 +99,7 @@ internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
         appType = config.appType,
         delivery = config.delivery!!,
         endpoints = config.endpoints,
-        persistUserBetweenSessions = config.persistUserBetweenSessions,
+        persistUser = config.persistUser,
         launchCrashThresholdMs = config.launchCrashThresholdMs,
         logger = config.logger!!,
         maxBreadcrumbs = config.maxBreadcrumbs,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -20,7 +20,7 @@ internal class ManifestConfigLoader {
         private const val AUTO_DETECT_NDK_CRASHES = "$BUGSNAG_NS.AUTO_DETECT_NDK_CRASHES"
         private const val AUTO_CAPTURE_SESSIONS = "$BUGSNAG_NS.AUTO_CAPTURE_SESSIONS"
         private const val SEND_THREADS = "$BUGSNAG_NS.SEND_THREADS"
-        private const val PERSIST_USER = "$BUGSNAG_NS.PERSIST_USER_BETWEEN_SESSIONS"
+        private const val PERSIST_USER = "$BUGSNAG_NS.PERSIST_USER"
 
         // endpoints
         private const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT"
@@ -88,7 +88,7 @@ internal class ManifestConfigLoader {
             autoDetectNdkCrashes = data.getBoolean(AUTO_DETECT_NDK_CRASHES, autoDetectNdkCrashes)
             autoTrackSessions = data.getBoolean(AUTO_CAPTURE_SESSIONS, autoTrackSessions)
             sendThreads = data.getBoolean(SEND_THREADS, sendThreads)
-            persistUserBetweenSessions = data.getBoolean(PERSIST_USER, persistUserBetweenSessions)
+            persistUser = data.getBoolean(PERSIST_USER, persistUser)
         }
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -66,7 +66,7 @@ internal class ImmutableConfigTest {
             assertEquals(seed.launchCrashThresholdMs, launchCrashThresholdMs)
             assertEquals(NoopLogger, seed.logger)
             assertEquals(seed.maxBreadcrumbs, maxBreadcrumbs)
-            assertEquals(seed.persistUserBetweenSessions, persistUserBetweenSessions)
+            assertEquals(seed.persistUser, persistUser)
             assertEquals(seed.enabledBreadcrumbTypes, BreadcrumbType.values().toSet())
         }
     }
@@ -93,7 +93,7 @@ internal class ImmutableConfigTest {
         seed.endpoints = endpoints
         seed.launchCrashThresholdMs = 7000
         seed.maxBreadcrumbs = 37
-        seed.persistUserBetweenSessions = true
+        seed.persistUser = true
         seed.enabledBreadcrumbTypes = emptySet()
 
         // verify overrides are copied across
@@ -127,7 +127,7 @@ internal class ImmutableConfigTest {
             assertEquals(7000, seed.launchCrashThresholdMs)
             assertEquals(NoopLogger, seed.logger)
             assertEquals(37, seed.maxBreadcrumbs)
-            assertTrue(seed.persistUserBetweenSessions)
+            assertTrue(seed.persistUser)
             assertTrue(seed.enabledBreadcrumbTypes.isEmpty())
         }
     }


### PR DESCRIPTION
Renames `persistUserBetweenSessions` to `persistUser`. This achieves consistency with the latest version of the notifier spec.