### PR TITLE
Remove setUser() overloads

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -114,23 +114,15 @@ public class ObserverInterfaceTest {
 
     @Test
     public void testClientSetUserId() {
-        client.setUserId("personX");
-        StateEvent.UpdateUserId msg = findMessageInQueue(StateEvent.UpdateUserId.class);
-        assertEquals("personX", msg.getId());
-    }
+        client.setUser("personX", "bip@example.com", "Loblaw");
+        StateEvent.UpdateUserId idMsg = findMessageInQueue(StateEvent.UpdateUserId.class);
+        assertEquals("personX", idMsg.getId());
 
-    @Test
-    public void testClientSetUserEmail() {
-        client.setUserEmail("bip@example.com");
-        StateEvent.UpdateUserEmail msg = findMessageInQueue(StateEvent.UpdateUserEmail.class);
-        assertEquals("bip@example.com", msg.getEmail());
-    }
+        StateEvent.UpdateUserEmail emailMsg = findMessageInQueue(StateEvent.UpdateUserEmail.class);
+        assertEquals("bip@example.com", emailMsg.getEmail());
 
-    @Test
-    public void testClientSetUserName() {
-        client.setUserName("Loblaw");
-        StateEvent.UpdateUserName msg = findMessageInQueue(StateEvent.UpdateUserName.class);
-        assertEquals("Loblaw", msg.getName());
+        StateEvent.UpdateUserName nameMsg = findMessageInQueue(StateEvent.UpdateUserName.class);
+        assertEquals("Loblaw", nameMsg.getName());
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -117,37 +117,6 @@ public final class Bugsnag {
     }
 
     /**
-     * Set a unique identifier for the user currently using your application.
-     * By default, this will be an automatically generated unique id
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param id a unique identifier of the current user
-     */
-    public static void setUserId(@Nullable final String id) {
-        getClient().setUserId(id);
-    }
-
-    /**
-     * Set the email address of the current user.
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param email the email address of the current user
-     */
-    public static void setUserEmail(@Nullable final String email) {
-        getClient().setUserEmail(email);
-    }
-
-    /**
-     * Set the name of the current user.
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param name the name of the current user
-     */
-    public static void setUserName(@Nullable final String name) {
-        getClient().setUserName(name);
-    }
-
-    /**
      * Add a "on error" callback, to execute code at the point where an error report is
      * captured in Bugsnag.
      * <p>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -385,9 +385,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
      */
     @Override
     public void setUser(@Nullable String id, @Nullable String email, @Nullable String name) {
-        setUserId(id);
-        setUserEmail(email);
-        setUserName(name);
+        userState.setUser(id, email, name);
     }
 
     /**
@@ -401,41 +399,6 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
     public User getUser() {
         return userState.getUser();
     }
-
-    /**
-     * Set a unique identifier for the user currently using your application.
-     * By default, this will be an automatically generated unique id
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param id a unique identifier of the current user
-     */
-    @Override
-    public void setUserId(@Nullable String id) {
-        userState.setUserId(id);
-    }
-
-    /**
-     * Set the email address of the current user.
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param email the email address of the current user
-     */
-    @Override
-    public void setUserEmail(@Nullable String email) {
-        userState.setUserEmail(email);
-    }
-
-    /**
-     * Set the name of the current user.
-     * You can search for this information in your Bugsnag dashboard.
-     *
-     * @param name the name of the current user
-     */
-    @Override
-    public void setUserName(@Nullable String name) {
-        userState.setUserName(name);
-    }
-
 
     /**
      * Add a "on error" callback, to execute code at the point where an error report is

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -148,9 +148,6 @@ class Event @JvmOverloads internal constructor(
     }
 
     override fun getUser() = _user
-    override fun setUserId(id: String?) = setUser(id, _user.email, _user.name)
-    override fun setUserEmail(email: String?) = setUser(_user.id, email, _user.name)
-    override fun setUserName(name: String?) = setUser(_user.id, _user.email, name)
 
     override fun addMetadata(section: String, value: Map<String, Any?>) = metadata.addMetadata(section, value)
     override fun addMetadata(section: String, key: String, value: Any?) =

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -124,9 +124,7 @@ public class NativeInterface {
                                @Nullable final String email,
                                @Nullable final String name) {
         Client client = getClient();
-        client.setUserId(id);
-        client.setUserEmail(email);
-        client.setUserName(name);
+        client.setUser(id, email, name);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserAware.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserAware.kt
@@ -3,7 +3,4 @@ package com.bugsnag.android
 internal interface UserAware {
     fun getUser(): User
     fun setUser(id: String?, email: String?, name: String?)
-    fun setUserId(id: String?)
-    fun setUserEmail(email: String?)
-    fun setUserName(name: String?)
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -50,24 +50,6 @@ class BugsnagApiTest {
     }
 
     @Test
-    fun setUserId() {
-        Bugsnag.setUserId("123")
-        verify(client, times(1)).setUserId("123")
-    }
-
-    @Test
-    fun setUserEmail() {
-        Bugsnag.setUserEmail("foo@example.com")
-        verify(client, times(1)).setUserEmail("foo@example.com")
-    }
-
-    @Test
-    fun setUserName() {
-        Bugsnag.setUserName("Bob")
-        verify(client, times(1)).setUserName("Bob")
-    }
-
-    @Test
     fun addOnError() {
         Bugsnag.addOnError { true }
         Bugsnag.addOnError(OnError { true })

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
@@ -39,24 +39,6 @@ internal class EventApiTest {
     }
 
     @Test
-    fun setUserId() {
-        event.setUserId("99")
-        assertEquals(User("99", "fred@example.com", "Fred"), event._user)
-    }
-
-    @Test
-    fun setUserEmail() {
-        event.setUserEmail("joe@test.com")
-        assertEquals(User("1", "joe@test.com", "Fred"), event._user)
-    }
-
-    @Test
-    fun setUserName() {
-        event.setUserName("Jacinta Barltrop")
-        assertEquals(User("1", "fred@example.com", "Jacinta Barltrop"), event._user)
-    }
-
-    @Test
     fun addMetadataTopLevel() {
         event.addMetadata("foo", mapOf(Pair("wham", "bar")))
         assertEquals(mapOf(Pair("wham", "bar")), event.metadata.getMetadata("foo"))

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -44,7 +44,7 @@ internal class EventSerializationTest {
                     it.app["foo"] = 55
                     it.device["bar"] = true
                     it.addMetadata("wham", "some_key", "A value")
-                    it.setUserName("Jamie")
+                    it.setUser(null, null, "Jamie")
 
                     val crumb = Breadcrumb("hello world", BreadcrumbType.MANUAL, mutableMapOf(), Date(0))
                     it.breadcrumbs = listOf(crumb)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -155,9 +155,7 @@ internal class NativeInterfaceApiTest {
     @Test
     fun setUser() {
         NativeInterface.setUser("9", "bob@example.com", "Bob")
-        verify(client, times(1)).setUserId("9")
-        verify(client, times(1)).setUserEmail("bob@example.com")
-        verify(client, times(1)).setUserName("Bob")
+        verify(client, times(1)).setUser("9", "bob@example.com", "Bob")
     }
 
     @Test


### PR DESCRIPTION
The notifier specification states that `setUser()` should not have overloads for individual methods and `null` should be passed instead. This changeset updates the implementation to match the spec.