### PR TITLE
IgnoreClasses should apply to all errors in an event

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -79,7 +79,7 @@ class Event @JvmOverloads internal constructor(
     protected fun shouldIgnoreClass(): Boolean {
         return when {
             errors.isEmpty() -> true
-            else -> ignoreClasses.contains(errors[0].errorClass)
+            else -> errors.any { ignoreClasses.contains(it.errorClass) }
         }
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStateTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStateTest.java
@@ -38,10 +38,30 @@ public class EventStateTest {
     }
 
     @Test
+    public void shouldIgnoreMatchesMultiple() {
+        Configuration configuration = BugsnagTestUtils.generateConfiguration();
+        configuration.setIgnoreClasses(Collections.singleton("java.io.IOException"));
+
+        RuntimeException exc = new RuntimeException(new IOException());
+        event = new Event(exc, BugsnagTestUtils.convert(configuration), handledState);
+        assertTrue(event.shouldIgnoreClass());
+    }
+
+    @Test
     public void shouldIgnoreDoesNotMatch() {
         Configuration configuration = BugsnagTestUtils.generateConfiguration();
         configuration.setIgnoreClasses(Collections.<String>emptySet());
         event = new Event(new IOException(), BugsnagTestUtils.convert(configuration), handledState);
+        assertFalse(event.shouldIgnoreClass());
+    }
+
+    @Test
+    public void shouldIgnoreDoesNotMatchMultiple() {
+        Configuration configuration = BugsnagTestUtils.generateConfiguration();
+        configuration.setIgnoreClasses(Collections.<String>emptySet());
+        RuntimeException exc = new RuntimeException(new IllegalStateException());
+
+        event = new Event(exc, BugsnagTestUtils.convert(configuration), handledState);
         assertFalse(event.shouldIgnoreClass());
     }
 


### PR DESCRIPTION
According to the notifier spec `ignoreClasses` should apply to all errors in an event. This updates the implementation to consider all errors rather than just the first one, and adds test cases for this scenario.