### PR TITLE
Support loading all primitive values from manifest

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -50,6 +50,8 @@ class ManifestConfigLoaderTest {
             // misc
             assertEquals(maxBreadcrumbs, 25)
             assertEquals(launchCrashThresholdMs, 5000)
+            assertEquals("android", appType)
+            assertNull(codeBundleId)
         }
     }
 
@@ -63,7 +65,7 @@ class ManifestConfigLoaderTest {
             putBoolean("com.bugsnag.android.AUTO_DETECT_ERRORS", false)
             putBoolean("com.bugsnag.android.AUTO_DETECT_ANRS", true)
             putBoolean("com.bugsnag.android.AUTO_DETECT_NDK_CRASHES", true)
-            putBoolean("com.bugsnag.android.AUTO_CAPTURE_SESSIONS", false)
+            putBoolean("com.bugsnag.android.AUTO_TRACK_SESSIONS", false)
             putBoolean("com.bugsnag.android.AUTO_CAPTURE_BREADCRUMBS", false)
             putBoolean("com.bugsnag.android.SEND_THREADS", false)
             putBoolean("com.bugsnag.android.PERSIST_USER_BETWEEN_SESSIONS", true)
@@ -84,6 +86,8 @@ class ManifestConfigLoaderTest {
             // misc
             putInt("com.bugsnag.android.MAX_BREADCRUMBS", 50)
             putInt("com.bugsnag.android.LAUNCH_CRASH_THRESHOLD_MS", 7000)
+            putString("com.bugsnag.android.APP_TYPE", "react-native")
+            putString("com.bugsnag.android.CODE_BUNDLE_ID", "123")
         }
 
         val config = configLoader.load(data)
@@ -116,6 +120,8 @@ class ManifestConfigLoaderTest {
             // misc
             assertEquals(maxBreadcrumbs, 50)
             assertEquals(launchCrashThresholdMs, 7000)
+            assertEquals("react-native", appType)
+            assertEquals("123", codeBundleId)
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -35,7 +35,7 @@ public final class Bugsnag {
      */
     @NonNull
     public static Client init(@NonNull Context androidContext) {
-        return init(androidContext, new ManifestConfigLoader().load(androidContext));
+        return init(androidContext, Configuration.load(androidContext));
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import android.content.Context
 import android.text.TextUtils
 import java.util.Collections
 
@@ -180,9 +181,6 @@ class Configuration(
         get() = Collections.unmodifiableSet(metadataState.metadata.redactedKeys)
         set(redactedKeys) = metadataState.metadata.setRedactedKeys(redactedKeys)
 
-
-    var loggingEnabled: Boolean
-
     init {
         require(!TextUtils.isEmpty(apiKey)) { "You must provide a Bugsnag API key" }
         this.callbackState = CallbackState()
@@ -197,8 +195,6 @@ class Configuration(
         } catch (exc: Throwable) {
             false
         }
-
-        loggingEnabled = AppData.RELEASE_STAGE_PRODUCTION != releaseStage
     }
 
     /**
@@ -301,11 +297,14 @@ class Configuration(
     override fun getMetadata(section: String) = metadataState.getMetadata(section)
     override fun getMetadata(section: String, key: String) = metadataState.getMetadata(section, key)
 
-    private companion object {
+    companion object {
         private const val DEFAULT_MAX_SIZE = 25
         private const val DEFAULT_LAUNCH_CRASH_THRESHOLD_MS: Long = 5000
         private const val MIN_BREADCRUMBS = 0
         private const val MAX_BREADCRUMBS = 100
         private const val MIN_LAUNCH_CRASH_THRESHOLD_MS: Long = 0
+
+        @JvmStatic
+        fun load(context: Context): Configuration = ManifestConfigLoader().load(context)
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -18,7 +18,7 @@ internal class ManifestConfigLoader {
         private const val AUTO_DETECT_ERRORS = "$BUGSNAG_NS.AUTO_DETECT_ERRORS"
         private const val AUTO_DETECT_ANRS = "$BUGSNAG_NS.AUTO_DETECT_ANRS"
         private const val AUTO_DETECT_NDK_CRASHES = "$BUGSNAG_NS.AUTO_DETECT_NDK_CRASHES"
-        private const val AUTO_CAPTURE_SESSIONS = "$BUGSNAG_NS.AUTO_CAPTURE_SESSIONS"
+        private const val AUTO_TRACK_SESSIONS = "$BUGSNAG_NS.AUTO_TRACK_SESSIONS"
         private const val SEND_THREADS = "$BUGSNAG_NS.SEND_THREADS"
         private const val PERSIST_USER = "$BUGSNAG_NS.PERSIST_USER_BETWEEN_SESSIONS"
 
@@ -38,6 +38,8 @@ internal class ManifestConfigLoader {
         // misc
         private const val MAX_BREADCRUMBS = "$BUGSNAG_NS.MAX_BREADCRUMBS"
         private const val LAUNCH_CRASH_THRESHOLD_MS = "$BUGSNAG_NS.LAUNCH_CRASH_THRESHOLD_MS"
+        private const val CODE_BUNDLE_ID = "$BUGSNAG_NS.CODE_BUNDLE_ID"
+        private const val APP_TYPE = "$BUGSNAG_NS.APP_TYPE"
 
         // deprecated aliases
         private const val ENABLE_EXCEPTION_HANDLER = "$BUGSNAG_NS.ENABLE_EXCEPTION_HANDLER"
@@ -86,7 +88,7 @@ internal class ManifestConfigLoader {
             autoDetectErrors = data.getBoolean(AUTO_DETECT_ERRORS, autoDetectErrors)
             autoDetectAnrs = data.getBoolean(AUTO_DETECT_ANRS, autoDetectAnrs)
             autoDetectNdkCrashes = data.getBoolean(AUTO_DETECT_NDK_CRASHES, autoDetectNdkCrashes)
-            autoTrackSessions = data.getBoolean(AUTO_CAPTURE_SESSIONS, autoTrackSessions)
+            autoTrackSessions = data.getBoolean(AUTO_TRACK_SESSIONS, autoTrackSessions)
             sendThreads = data.getBoolean(SEND_THREADS, sendThreads)
             persistUserBetweenSessions = data.getBoolean(PERSIST_USER, persistUserBetweenSessions)
         }
@@ -104,6 +106,8 @@ internal class ManifestConfigLoader {
         with(config) {
             releaseStage = data.getString(RELEASE_STAGE, config.releaseStage)
             appVersion = data.getString(APP_VERSION, config.appVersion)
+            appType = data.getString(APP_TYPE, config.appType)
+            codeBundleId = data.getString(CODE_BUNDLE_ID, config.codeBundleId)
 
             if (data.containsKey(VERSION_CODE)) {
                 versionCode = data.getInt(VERSION_CODE)


### PR DESCRIPTION
Adds support for loading all primitive configuration values from the manifest. This changeset loads the fields which were missing from the previous implementation:

- appType
- codeBundleId
- autoTrackSessions

`loggingEnabled` has been removed as it is obsolete and replaced by `logger`. Additionally, a `Configuration.load()` method has been added to match the notifier spec implementation.