### PR TITLE
refactor(DeliveryDelegate): encapsulate event caching code only

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -40,13 +40,9 @@ class DeliveryDelegate extends BaseObservable {
                 notifyObservers(StateEvent.NotifyHandled.INSTANCE);
             }
         }
-        cacheEvent(event, report, event.isUnhandled());
-    }
 
-    private void cacheEvent(@NonNull Event event, Report report, boolean persistImmediately) {
-        if (persistImmediately) {
-            eventStore.write(event);
-            eventStore.flushAsync();
+        if (event.isUnhandled()) {
+            cacheEvent(event, true);
         } else {
             deliverReportAsync(event, report);
         }
@@ -65,7 +61,7 @@ class DeliveryDelegate extends BaseObservable {
                 }
             });
         } catch (RejectedExecutionException exception) {
-            eventStore.write(event);
+            cacheEvent(event, false);
             logger.w("Exceeded max queue count, saving to disk to send later");
         }
     }
@@ -84,7 +80,7 @@ class DeliveryDelegate extends BaseObservable {
             case UNDELIVERED:
                 logger.w("Could not send event(s) to Bugsnag,"
                         + " saving to disk to send later");
-                eventStore.write(event);
+                cacheEvent(event, false);
                 leaveErrorBreadcrumb(event);
                 break;
             case FAILURE:
@@ -94,6 +90,13 @@ class DeliveryDelegate extends BaseObservable {
                 break;
         }
         return deliveryStatus;
+    }
+
+    private void cacheEvent(@NonNull Event event, boolean attemptSend) {
+        eventStore.write(event);
+        if (attemptSend) {
+            eventStore.flushAsync();
+        }
     }
 
     private void leaveErrorBreadcrumb(@NonNull Event event) {


### PR DESCRIPTION
## Goal

The change suggested in https://github.com/bugsnag/bugsnag-android/pull/700#discussion_r356149561
was suggesting just abstracting the code for caching to file and reusing it everywhere the class
deals with caching to file. I think it still makes sense for `deliver` to determine whether to
deliver or cache.