### PR TITLE
Alter bugsnag loaded breadcrumb type

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -20,9 +20,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @SuppressWarnings("unchecked")
 @SmallTest
@@ -144,11 +148,12 @@ public class ClientTest {
         assertFalse(sharedPref.contains("user.name"));
     }
 
-    @SuppressWarnings("deprecation") // test backwards compatibility of client.setMaxBreadcrumbs
     @Test
     public void testMaxBreadcrumbs() {
         Configuration config = generateConfiguration();
-        config.setEnabledBreadcrumbTypes(Collections.singleton(BreadcrumbType.MANUAL));
+        List<BreadcrumbType> breadcrumbTypes
+                = Arrays.asList(BreadcrumbType.MANUAL, BreadcrumbType.NAVIGATION);
+        config.setEnabledBreadcrumbTypes(new HashSet<>(breadcrumbTypes));
         config.setMaxBreadcrumbs(2);
         client = generateClient(config);
         assertEquals(1, client.breadcrumbState.getStore().size());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -152,7 +152,7 @@ public class ClientTest {
     public void testMaxBreadcrumbs() {
         Configuration config = generateConfiguration();
         List<BreadcrumbType> breadcrumbTypes
-                = Arrays.asList(BreadcrumbType.MANUAL, BreadcrumbType.NAVIGATION);
+                = Arrays.asList(BreadcrumbType.MANUAL, BreadcrumbType.STATE);
         config.setEnabledBreadcrumbTypes(new HashSet<>(breadcrumbTypes));
         config.setMaxBreadcrumbs(2);
         client = generateClient(config);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -225,7 +225,8 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         // Flush any on-disk errors
         eventStore.flushOnLaunch();
         loadPlugins();
-        leaveBreadcrumb("Bugsnag loaded");
+        Map<String, Object> data = Collections.emptyMap();
+        leaveBreadcrumb("Bugsnag loaded", BreadcrumbType.NAVIGATION, data);
     }
 
     private OrientationEventListener registerOrientationChangeListener() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -226,7 +226,7 @@ public class Client extends Observable implements Observer, MetadataAware, Callb
         eventStore.flushOnLaunch();
         loadPlugins();
         Map<String, Object> data = Collections.emptyMap();
-        leaveBreadcrumb("Bugsnag loaded", BreadcrumbType.NAVIGATION, data);
+        leaveBreadcrumb("Bugsnag loaded", BreadcrumbType.STATE, data);
     }
 
     private OrientationEventListener registerOrientationChangeListener() {

--- a/features/breadcrumb.feature
+++ b/features/breadcrumb.feature
@@ -19,7 +19,6 @@ Scenario: Manually added breadcrumbs are sent in report
     And the event "breadcrumbs.1.metaData.message" equals "Hello Breadcrumb!"
 
     And the event "breadcrumbs.0.timestamp" is not null
-    And the event "breadcrumbs.0.name" equals "manual"
-    And the event "breadcrumbs.0.type" equals "manual"
+    And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
+    And the event "breadcrumbs.0.type" equals "state"
     And the event "breadcrumbs.0.metaData" is not null
-    And the event "breadcrumbs.0.metaData.message" equals "Bugsnag loaded"

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
@@ -15,7 +15,7 @@ internal class BreadcrumbScenario(config: Configuration,
                                   context: Context) : Scenario(config, context) {
     init {
         config.autoTrackSessions = false
-        config.enabledBreadcrumbTypes = setOf(BreadcrumbType.MANUAL, BreadcrumbType.USER)
+        config.enabledBreadcrumbTypes = setOf(BreadcrumbType.MANUAL, BreadcrumbType.USER, BreadcrumbType.STATE)
     }
 
     override fun run() {

--- a/tests/features/breadcrumb.feature
+++ b/tests/features/breadcrumb.feature
@@ -19,7 +19,6 @@ Scenario: Manually added breadcrumbs are sent in report
     And the event "breadcrumbs.1.metaData.message" equals "Hello Breadcrumb!"
 
     And the event "breadcrumbs.0.timestamp" is not null
-    And the event "breadcrumbs.0.name" equals "manual"
-    And the event "breadcrumbs.0.type" equals "manual"
+    And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
+    And the event "breadcrumbs.0.type" equals "state"
     And the event "breadcrumbs.0.metaData" is not null
-    And the event "breadcrumbs.0.metaData.message" equals "Bugsnag loaded


### PR DESCRIPTION
The "Bugsnag Loaded" breadcrumb should be of type Navigation according to the spec. This changeset updates the type to match the spec, and test assertions to pass the change.