### PR TITLE
Update warning message for multi init

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -68,9 +68,7 @@ public final class Bugsnag {
     }
 
     private static void logClientInitWarning() {
-        getClient().logger.w("It appears that Bugsnag.init() was called more than once. "
-            + "Subsequent calls have no effect, but may indicate that Bugsnag is not integrated in"
-            + " an Application subclass, which can lead to undesired behaviour.");
+        getClient().logger.w("Multiple Bugsnag.init calls detected. Ignoring.");
     }
 
     /**


### PR DESCRIPTION
Updates the warning message for calling `Bugsnag.init` multiple times to the message written in the spec.