### PR TITLE
Update error breadcrumb metadata

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
@@ -99,10 +100,15 @@ class DeliveryDelegate extends BaseObservable {
         List<Error> errors = event.getErrors();
 
         if (errors.size() > 0) {
-            String name = errors.get(0).getErrorClass();
-            String msg = errors.get(0).getErrorMessage();
-            Map<String, Object> message = Collections.<String, Object>singletonMap("message", msg);
-            breadcrumbState.add(new Breadcrumb(name, BreadcrumbType.ERROR, message, new Date()));
+            String errorClass = errors.get(0).getErrorClass();
+            String message = errors.get(0).getErrorMessage();
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("errorClass", errorClass);
+            data.put("message", message);
+            data.put("unhandled", String.valueOf(event.isUnhandled()));
+            data.put("severity", event.getSeverity().toString());
+            breadcrumbState.add(new Breadcrumb(errorClass, BreadcrumbType.ERROR, data, new Date()));
         }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -4,6 +4,7 @@ import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -92,7 +93,10 @@ internal class DeliveryDelegateTest {
         val breadcrumb = breadcrumbState.store.peek()
         assertEquals(BreadcrumbType.ERROR, breadcrumb.type)
         assertEquals("java.lang.RuntimeException", breadcrumb.message)
+        assertEquals("java.lang.RuntimeException", breadcrumb.metadata["errorClass"])
         assertEquals("Whoops!", breadcrumb.metadata["message"])
+        assertEquals("true", breadcrumb.metadata["unhandled"])
+        assertEquals("ERROR", breadcrumb.metadata["severity"])
     }
 
     private class InterceptingLogger : Logger {


### PR DESCRIPTION
Updates the error breadcrumb metadata to include fields defined in the notifier spec, and updates test coverage to verify this.