### PR TITLE
Validate API key to be 16 hexadecimal characters long

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -51,7 +51,7 @@ final class BugsnagTestUtils {
     }
 
     static Client generateClient() {
-        return generateClient(new Configuration("api-key"));
+        return generateClient(new Configuration("5d1ec5bd39a74caa1267142706a7fb21"));
     }
 
     static Session generateSession() {
@@ -59,7 +59,7 @@ final class BugsnagTestUtils {
     }
 
     static Configuration generateConfiguration() {
-        Configuration configuration = new Configuration("test");
+        Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());
         configuration.setLogger(NoopLogger.INSTANCE);
         return configuration;

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -25,7 +26,7 @@ public class ClientConfigTest {
     @Before
     public void setUp() {
         Context context = ApplicationProvider.getApplicationContext();
-        config = new Configuration("api-key");
+        config = generateConfiguration();
         client = new Client(context, config);
     }
 
@@ -44,7 +45,7 @@ public class ClientConfigTest {
     @Test
     public void testCustomDeliveryOverride() {
         Context context = ApplicationProvider.getApplicationContext();
-        config = BugsnagTestUtils.generateConfiguration();
+        config = generateConfiguration();
         Delivery customDelivery = new Delivery() {
             @NotNull
             @Override

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -44,7 +44,7 @@ public class ClientTest {
     public void setUp() {
         context = ApplicationProvider.getApplicationContext();
         clearSharedPrefs();
-        config = new Configuration("api-key");
+        config = generateConfiguration();
     }
 
     /**
@@ -80,7 +80,7 @@ public class ClientTest {
         return sharedPref;
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testNullContext() {
         client = new Client(null, "api-key");
     }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -13,17 +13,17 @@ class ManifestConfigLoaderTest {
 
     @Test(expected = IllegalArgumentException::class)
     fun testMissingApiKey() {
-        configLoader.load(Bundle())
+        configLoader.load(Bundle(), null)
     }
 
     @Test
     fun testManifestLoadsDefaults() {
         val data = Bundle()
-        data.putString("com.bugsnag.android.API_KEY", "abc123")
-        val config = configLoader.load(data)
+        data.putString("com.bugsnag.android.API_KEY", "5d1ec5bd39a74caa1267142706a7fb21")
+        val config = configLoader.load(data, null)
 
         with(config) {
-            assertEquals(apiKey, "abc123")
+            assertEquals(apiKey, "5d1ec5bd39a74caa1267142706a7fb21")
             assertNull(buildUuid)
 
             // detection
@@ -58,7 +58,7 @@ class ManifestConfigLoaderTest {
     @Test
     fun testManifestOverridesDefaults() {
         val data = Bundle().apply {
-            putString("com.bugsnag.android.API_KEY", "abc123")
+            putString("com.bugsnag.android.API_KEY", "5d1ec5bd39a74caa1267142706a7fb21")
             putString("com.bugsnag.android.BUILD_UUID", "fgh123456")
 
             // detection
@@ -90,10 +90,10 @@ class ManifestConfigLoaderTest {
             putString("com.bugsnag.android.CODE_BUNDLE_ID", "123")
         }
 
-        val config = configLoader.load(data)
+        val config = configLoader.load(data, null)
 
         with(config) {
-            assertEquals("abc123", apiKey)
+            assertEquals("5d1ec5bd39a74caa1267142706a7fb21", apiKey)
             assertEquals("fgh123456", buildUuid)
 
             // detection
@@ -128,14 +128,14 @@ class ManifestConfigLoaderTest {
     @Test
     fun testManifestAliases() {
         val data = Bundle().apply {
-            putString("com.bugsnag.android.API_KEY", "abc123")
+            putString("com.bugsnag.android.API_KEY", "5d1ec5bd39a74caa1267142706a7fb21")
             putBoolean("com.bugsnag.android.ENABLE_EXCEPTION_HANDLER", false)
         }
 
-        val config = configLoader.load(data)
+        val config = configLoader.load(data, null)
 
         with(config) {
-            assertEquals("abc123", apiKey)
+            assertEquals("5d1ec5bd39a74caa1267142706a7fb21", apiKey)
             assertFalse(autoDetectErrors)
         }
     }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -29,7 +30,7 @@ public class ObserverInterfaceTest {
      */
     @Before
     public void setUp() {
-        Configuration config = new Configuration("some-api-key");
+        Configuration config = generateConfiguration();
         config.setDelivery(BugsnagTestUtils.generateDelivery());
         config.setAutoDetectErrors(false);
         client = new Client(ApplicationProvider.getApplicationContext(), config);

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbStateTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbStateTest.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import static com.bugsnag.android.BugsnagTestUtils.generateClient;
+import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -25,7 +26,7 @@ public class OnBreadcrumbStateTest {
      */
     @Before
     public void setUp() {
-        Configuration configuration = new Configuration("api-key");
+        Configuration configuration = generateConfiguration();
         configuration.setEnabledBreadcrumbTypes(Collections.<BreadcrumbType>emptySet());
         client = generateClient();
         assertEquals(1, client.breadcrumbState.getStore().size());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ProjectPackagesTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ProjectPackagesTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -10,7 +11,7 @@ class ProjectPackagesTest {
 
     @Test
     fun testDefaultProjectPackages() {
-        val configuration = Configuration("api-key")
+        val configuration = generateConfiguration()
         assertTrue(configuration.projectPackages.isEmpty())
 
         val client = Client(ApplicationProvider.getApplicationContext<Context>(), configuration)
@@ -20,7 +21,7 @@ class ProjectPackagesTest {
 
     @Test
     fun testProjectPackagesOverride() {
-        val configuration = Configuration("api-key")
+        val configuration = generateConfiguration()
         configuration.projectPackages = setOf("com.foo.example")
         val client = Client(ApplicationProvider.getApplicationContext<Context>(), configuration)
         assertEquals(setOf("com.foo.example"), client.config.projectPackages)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -46,7 +46,7 @@ public final class Bugsnag {
      */
     @NonNull
     public static Client init(@NonNull Context androidContext, @NonNull String apiKey) {
-        return init(androidContext, new Configuration(apiKey));
+        return init(androidContext, Configuration.load(androidContext, apiKey));
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -83,7 +83,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * @param androidContext an Android context, usually <code>this</code>
      */
     public Client(@NonNull Context androidContext) {
-        this(androidContext, new ManifestConfigLoader().load(androidContext));
+        this(androidContext, Configuration.load(androidContext));
     }
 
     /**
@@ -93,7 +93,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * @param apiKey         your Bugsnag API key from your Bugsnag dashboard
      */
     public Client(@NonNull Context androidContext, @NonNull String apiKey) {
-        this(androidContext, new Configuration(apiKey));
+        this(androidContext, Configuration.load(androidContext, apiKey));
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android
 
 import android.content.Context
-import android.text.TextUtils
 import java.util.Collections
 
 /**
@@ -182,7 +181,7 @@ class Configuration(
         set(redactedKeys) = metadataState.metadata.setRedactedKeys(redactedKeys)
 
     init {
-        require(!TextUtils.isEmpty(apiKey)) { "You must provide a Bugsnag API key" }
+        require(apiKey.matches(API_KEY_REGEX.toRegex())) { "You must provide a valid Bugsnag API key" }
         this.callbackState = CallbackState()
         this.metadataState = MetadataState()
 
@@ -303,8 +302,14 @@ class Configuration(
         private const val MIN_BREADCRUMBS = 0
         private const val MAX_BREADCRUMBS = 100
         private const val MIN_LAUNCH_CRASH_THRESHOLD_MS: Long = 0
+        private const val API_KEY_REGEX = "[A-Fa-f0-9]{32}"
 
         @JvmStatic
-        fun load(context: Context): Configuration = ManifestConfigLoader().load(context)
+        fun load(context: Context): Configuration = load(context, null)
+
+        @JvmStatic
+        protected fun load(context: Context, apiKey: String?): Configuration {
+            return ManifestConfigLoader().load(context, apiKey)
+        }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/AnrConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/AnrConfigTest.kt
@@ -1,11 +1,12 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class AnrConfigTest {
 
-    private val config = Configuration("api-key")
+    private val config = generateConfiguration()
 
     @Test
     fun testDetectAnrDefault() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyValidationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyValidationTest.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android
+
+import org.junit.Test
+
+class ApiKeyValidationTest {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testEmptyApiKey() {
+        Configuration("")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testWrongSizeApiKey() {
+        Configuration("abfe05f")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testNonHexApiKey() {
+        Configuration("yej0492j55z92z2p")
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.BreadcrumbType.MANUAL
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 
@@ -102,7 +103,7 @@ class BreadcrumbStateTest {
      */
     @Test
     fun testMaxBreadcrumbAccessors() {
-        val config = Configuration("api-key")
+        val config = generateConfiguration()
         assertEquals(25, config.maxBreadcrumbs)
 
         config.maxBreadcrumbs = 50

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -5,7 +5,7 @@ import org.jetbrains.annotations.NotNull;
 final class BugsnagTestUtils {
 
     static Configuration generateConfiguration() {
-        Configuration configuration = new Configuration("test");
+        Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());
         configuration.setLogger(NoopLogger.INSTANCE);
         return configuration;

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -22,7 +23,7 @@ internal class ConfigApiTest {
 
     @Before
     fun setUp() {
-        config = Configuration("api-key")
+        config = generateConfiguration()
         callbackState = config.callbackState
         metadataState = config.metadataState
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -18,7 +19,7 @@ public class ConfigurationTest {
 
     @Before
     public void setUp() {
-        config = BugsnagTestUtils.generateConfiguration();
+        config = generateConfiguration();
     }
 
     @Test
@@ -119,7 +120,7 @@ public class ConfigurationTest {
 
     @Test
     public void testSetDelivery() {
-        Configuration configuration = new Configuration("api-key");
+        Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
         assertNull(configuration.getDelivery());
         Delivery delivery = new Delivery() {
             @NotNull
@@ -144,7 +145,7 @@ public class ConfigurationTest {
 
     @Test
     public void testVersionCode() {
-        Configuration configuration = new Configuration("api-key");
+        Configuration configuration = generateConfiguration();
         assertEquals(0, (int) configuration.getVersionCode()); // populated in client ctor if null
         configuration.setVersionCode(577);
         assertEquals(577, (int) configuration.getVersionCode());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import android.content.Context
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -15,7 +16,7 @@ import org.mockito.junit.MockitoJUnitRunner
 @RunWith(MockitoJUnitRunner::class)
 internal class ImmutableConfigTest {
 
-    private val seed = Configuration("api-key")
+    private val seed = generateConfiguration()
 
     @Mock
     lateinit var delivery: Delivery
@@ -37,7 +38,7 @@ internal class ImmutableConfigTest {
     @Test
     fun defaultConversion() {
         with(convertToImmutableConfig(seed)) {
-            assertEquals("api-key", apiKey)
+            assertEquals("5d1ec5bd39a74caa1267142706a7fb21", apiKey)
 
             // detection
             assertTrue(autoTrackSessions)
@@ -98,7 +99,7 @@ internal class ImmutableConfigTest {
 
         // verify overrides are copied across
         with(convertToImmutableConfig(seed)) {
-            assertEquals("api-key", apiKey)
+            assertEquals("5d1ec5bd39a74caa1267142706a7fb21", apiKey)
 
             // detection
             assertFalse(autoTrackSessions)
@@ -153,7 +154,7 @@ internal class ImmutableConfigTest {
     @Test
     fun configSanitisation() {
         Mockito.`when`(context.packageName).thenReturn("com.example.foo")
-        val seed = Configuration("api-key")
+        val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
         seed.logger = NoopLogger
         val config = sanitiseConfiguration(context, seed, connectivity)
         assertEquals(setOf("com.example.foo"), config.projectPackages)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalReportDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalReportDelegateTest.kt
@@ -70,7 +70,7 @@ internal class InternalReportDelegateTest {
         // metadata
         assertNotNull(event.getMetadata("BugsnagDiagnostics", "notifierName"))
         assertNotNull(event.getMetadata("BugsnagDiagnostics", "notifierVersion"))
-        assertEquals("test", event.getMetadata("BugsnagDiagnostics", "apiKey"))
+        assertEquals("5d1ec5bd39a74caa1267142706a7fb21", event.getMetadata("BugsnagDiagnostics", "apiKey"))
         assertEquals("com.example", event.getMetadata("BugsnagDiagnostics", "packageName"))
     }
 }

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -8,7 +8,7 @@ final class BugsnagTestUtils {
     }
 
     static Configuration generateConfiguration() {
-        Configuration configuration = new Configuration("test");
+        Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());
         configuration.setLogger(NoopLogger.INSTANCE);
         return configuration;

--- a/examples/sdk-app-example/src/main/AndroidManifest.xml
+++ b/examples/sdk-app-example/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
 
     <meta-data
       android:name="com.bugsnag.android.API_KEY"
-      android:value="YOUR-API-KEY-HERE" />
+      android:value="5d1ec5bd39a74caa1267142706a7fb21" />
 
     <meta-data
       android:name="com.bugsnag.android.AUTO_DETECT_ANRS"

--- a/tests/features/fixtures/mazerunner/src/main/AndroidManifest.xml
+++ b/tests/features/fixtures/mazerunner/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
-        <meta-data android:name="com.bugsnag.android.API_KEY" android:value="ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"/>
+        <meta-data android:name="com.bugsnag.android.API_KEY" android:value="5d1ec5bd39a74caa1267142706a7fb21"/>
     </application>
 
 </manifest>

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -73,7 +73,7 @@ class MainActivity : Activity() {
     }
 
     private fun prepareConfig(): Configuration {
-        val config = Configuration("ABCDEFGHIJKLMNOPQRSTUVWXYZ012345")
+        val config = Configuration("a35a2a72bd230ac0aa0f52715bbdc6aa")
         config.endpoints = Endpoints("http://bs-local.com:9339", "http://bs-local.com:9339")
         config.autoDetectNdkCrashes = true
         config.autoDetectAnrs = true

--- a/tests/features/support/env.rb
+++ b/tests/features/support/env.rb
@@ -6,7 +6,7 @@ bs_device = ENV['DEVICE_TYPE']
 app_location = ENV['APP_LOCATION']
 
 # Set this explicitly
-$api_key = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+$api_key = "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
 After do |scenario|
   $driver.reset


### PR DESCRIPTION
## Goal

Validates the API key to be 16 hexadecimal characters long, as per the notifier spec.

## Changeset

- Made `Bugsnag.init(apiKey: String)` load `Configuration` with an `apiKey` override, rather than just use a `Configuration` object
- Validated that an API key supplied to `Configuration` must be 32 chars in length and only contains hexadecimal alphanumerics

## Tests

Added additional unit test coverage for `Configuration` API key validation, and updated existing test cases to pass in a valid API key.
