### PR TITLE
Prevent complex types from being serialized in breadcrumb metadata

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
@@ -19,12 +19,16 @@ class Breadcrumb internal constructor(
 
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {
+        val data = metadata.filter {
+            it.value is String || it.value is Boolean || it.value is Number
+        }
+
         writer.beginObject()
         writer.name("timestamp").value(DateUtils.toIso8601(timestamp))
         writer.name("name").value(message)
         writer.name("type").value(type.toString())
         writer.name("metaData")
-        writer.value(metadata, true)
+        writer.value(data, true)
         writer.endObject()
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbMetadataTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbMetadataTest.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android
+
+import org.junit.Test
+import java.math.BigInteger
+import java.util.Date
+
+class BreadcrumbMetadataTest {
+
+    @Test
+    fun checkComplexTypesRemoved() {
+        val crumb = Breadcrumb("hello world", BreadcrumbType.MANUAL, mutableMapOf(), Date(0))
+        crumb.metadata["bool"] = true
+        crumb.metadata["string"] = "Some data"
+        crumb.metadata["int"] = 55
+        crumb.metadata["double"] = 3950.20
+        crumb.metadata["long"] = 39501098235092342
+        crumb.metadata["obj"] = Endpoints()
+        crumb.metadata["map"] = mapOf(Pair("foo", "bar"))
+        verifyJsonMatches(crumb, "breadcrumb_metadata.json")
+    }
+}

--- a/bugsnag-android-core/src/test/resources/breadcrumb_metadata.json
+++ b/bugsnag-android-core/src/test/resources/breadcrumb_metadata.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "1970-01-01T00:00:00Z",
+  "name": "helloworld",
+  "type": "manual",
+  "metaData": {
+    "bool": true,
+    "string": "Somedata",
+    "int": 55,
+    "double": 3950.2,
+    "long": 39501098235092342
+  }
+}


### PR DESCRIPTION
## Goal

Prevents complex types from being serialized in breadcrumb metadata. This brings the implementation in line with the spec, which states that only strings, booleans, and numbers should be serialized as JSON.

## Changeset

Filtered the `metadata` added to the `Breadcrumb` during serialization to remove any complex objects, and added a unit test to verify that only primitive objects are serialized.