### PR TITLE
Clone metadata for configuration and event

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -13,5 +13,7 @@
     <ID>TooGenericExceptionCaught:DefaultDelivery.kt$DefaultDelivery$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:Stacktrace.kt$Stacktrace$lineEx: Exception</ID>
     <ID>TooManyFunctions:Configuration.kt$Configuration : CallbackAwareMetadataAware</ID>
-  </Whitelist>
+    <ID>TooManyFunctions:Event.kt$Event : StreamableMetadataAwareUserAware</ID>
+    <ID>TooManyFunctions:Metadata.kt$Metadata : StreamableMetadataAware</ID>
+    </Whitelist>
 </SmellBaseline>

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -6,6 +6,7 @@ import static com.bugsnag.android.BugsnagTestUtils.getSharedPrefs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -23,10 +24,10 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @SuppressWarnings("unchecked")
 @SmallTest
@@ -254,5 +255,32 @@ public class ClientTest {
         assertNotNull(metadata.get("dpi"));
         assertNotNull(metadata.get("emulator"));
         assertNotNull(metadata.get("screenResolution"));
+    }
+
+    @Test
+    public void testMetadataCloned() {
+        config.addMetadata("test_section", "foo", "bar");
+        client = new Client(context, config);
+        client.addMetadata("test_section", "second", "another value");
+
+        // metadata state should be deep copied
+        assertNotSame(config.metadataState, client.metadataState);
+
+        // metadata object should be deep copied
+        Metadata configData = config.metadataState.getMetadata();
+        Metadata clientData = client.metadataState.getMetadata();
+        assertNotSame(configData, clientData);
+
+        // metadata backing map should be deep copied
+
+        // validate configuration metadata
+        Map<String, Object> configExpected = Collections.<String, Object>singletonMap("foo", "bar");
+        assertEquals(configExpected, config.getMetadata("test_section"));
+
+        // validate client metadata
+        Map<String, Object> data = new HashMap<>();
+        data.put("foo", "bar");
+        data.put("second", "another value");
+        assertEquals(data, client.getMetadata("test_section"));
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -145,7 +145,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 logger);
         systemBroadcastReceiver = new SystemBroadcastReceiver(this, logger);
 
-        metadataState = configuration.metadataState.copy(configuration.metadataState.getMetadata());
+        // performs deep copy of metadata to preserve immutability of Configuration interface
+        Metadata orig = configuration.metadataState.getMetadata();
+        Metadata copy = orig.copy();
+        metadataState = configuration.metadataState.copy(copy);
+
         // Set up and collect constant app and device diagnostics
         sharedPrefs = appContext.getSharedPreferences(SHARED_PREF_KEY, Context.MODE_PRIVATE);
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -16,9 +16,10 @@ class Event @JvmOverloads internal constructor(
     val originalError: Throwable? = null,
     config: ImmutableConfig,
     private var handledState: HandledState,
-    internal val metadata: Metadata = Metadata()
+    data: Metadata = Metadata()
 ) : JsonStream.Streamable, MetadataAware, UserAware {
 
+    internal val metadata: Metadata = data.copy()
     private val ignoreClasses: Set<String> = config.ignoreClasses.toSet()
 
     var session: Session? = null

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventMetadataCloneTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventMetadataCloneTest.kt
@@ -1,0 +1,32 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+import java.util.Collections
+import java.util.HashMap
+
+class EventMetadataCloneTest {
+
+    @Test
+    fun testMetadataClone() {
+        val data = Metadata()
+        data.addMetadata("test_section", "foo", "bar")
+
+        val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
+        val config = BugsnagTestUtils.generateImmutableConfig()
+        val event = Event(RuntimeException(), config, handledState, data)
+        event.addMetadata("test_section", "second", "another value")
+
+        // metadata object should be deep copied
+        assertNotSame(data, event.metadata)
+
+        // validate event metadata
+        val origExpected = mapOf(Pair("foo", "bar"))
+        assertEquals(origExpected, data.getMetadata("test_section"))
+
+        // validate event metadata
+        val eventExpected = mapOf(Pair("foo", "bar"), Pair("second", "another value"))
+        assertEquals(eventExpected, event.metadata.getMetadata("test_section"))
+    }
+}


### PR DESCRIPTION
## Goal

Clones metadata when setting the initial Client value from Configuration, and setting metadata on an Event. This matches the notifier spec and avoids global state mutating event payloads in-flight.

## Changeset

Made `Metadata` a data class which allows for its values to be cloned via a `copy()` method when setting on the `Event`.

## Tests

Added unit tests to verify that metadata is deep-cloned when necessary.
