### PR TITLE
Run OnBreadcrumb callback in BreadcrumbState

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -18,7 +18,7 @@ class BreadcrumbStateTest {
 
     @Before
     fun setUp() {
-        breadcrumbState = BreadcrumbState(20, NoopLogger)
+        breadcrumbState = BreadcrumbState(20, CallbackState(), NoopLogger)
         client = generateClient()
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -166,7 +166,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 Environment.getDataDirectory(), logger);
 
         // Set up breadcrumbs
-        breadcrumbState = new BreadcrumbState(immutableConfig.getMaxBreadcrumbs(), logger);
+        int maxBreadcrumbs = immutableConfig.getMaxBreadcrumbs();
+        breadcrumbState = new BreadcrumbState(maxBreadcrumbs, callbackState, logger);
 
         if (appContext instanceof Application) {
             Application application = (Application) appContext;
@@ -650,7 +651,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * @param message the log message to leave (max 140 chars)
      */
     public void leaveBreadcrumb(@NonNull String message) {
-        leaveBreadcrumbInternal(new Breadcrumb(message));
+        breadcrumbState.add(new Breadcrumb(message));
     }
 
     /**
@@ -660,13 +661,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     public void leaveBreadcrumb(@NonNull String message,
                                 @NonNull BreadcrumbType type,
                                 @NonNull Map<String, Object> metadata) {
-        leaveBreadcrumbInternal(new Breadcrumb(message, type, metadata, new Date()));
-    }
-
-    private void leaveBreadcrumbInternal(Breadcrumb crumb) {
-        if (callbackState.runOnBreadcrumbTasks(crumb, logger)) {
-            breadcrumbState.add(crumb);
-        }
+        breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date()));
     }
 
     SessionTracker getSessionTracker() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateSerializationTest.kt
@@ -14,7 +14,7 @@ internal class BreadcrumbStateSerializationTest {
         @JvmStatic
         @Parameters
         fun testCases(): Collection<Pair<JsonStream.Streamable, String>> {
-            val breadcrumbs = BreadcrumbState(50, NoopLogger)
+            val breadcrumbs = BreadcrumbState(50, CallbackState(), NoopLogger)
             val metadata = mutableMapOf<String, Any?>(Pair("direction", "left"))
             breadcrumbs.add(Breadcrumb("hello world", BreadcrumbType.MANUAL, metadata, Date(0)))
             return generateSerializationTestCases("breadcrumb_state", breadcrumbs)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -17,7 +17,7 @@ class BreadcrumbStateTest {
 
     @Before
     fun setUp() {
-        breadcrumbState = BreadcrumbState(20, NoopLogger)
+        breadcrumbState = BreadcrumbState(20, CallbackState(), NoopLogger)
     }
 
     /**
@@ -43,7 +43,7 @@ class BreadcrumbStateTest {
      */
     @Test
     fun testSizeLimitBeforeAdding() {
-        breadcrumbState = BreadcrumbState(5, NoopLogger)
+        breadcrumbState = BreadcrumbState(5, CallbackState(), NoopLogger)
 
         for (k in 1..6) {
             breadcrumbState.add(Breadcrumb("$k"))
@@ -59,7 +59,7 @@ class BreadcrumbStateTest {
      */
     @Test
     fun testSetSizeEmpty() {
-        breadcrumbState = BreadcrumbState(0, NoopLogger)
+        breadcrumbState = BreadcrumbState(0, CallbackState(), NoopLogger)
         breadcrumbState.add(Breadcrumb("1"))
         breadcrumbState.add(Breadcrumb("2"))
         assertTrue(breadcrumbState.store.isEmpty())
@@ -70,7 +70,7 @@ class BreadcrumbStateTest {
      */
     @Test
     fun testSetSizeNegative() {
-        breadcrumbState = BreadcrumbState(-1, NoopLogger)
+        breadcrumbState = BreadcrumbState(-1, CallbackState(), NoopLogger)
         breadcrumbState.add(Breadcrumb("1"))
         assertEquals(0, breadcrumbState.store.size)
     }
@@ -113,5 +113,15 @@ class BreadcrumbStateTest {
 
         config.maxBreadcrumbs = -5
         assertEquals(0, config.maxBreadcrumbs)
+    }
+
+    /**
+     * Verifies that an [OnBreadcrumb] callback is run when specified in [BreadcrumbState]
+     */
+    @Test
+    fun testOnBreadcrumbCallback() {
+        breadcrumbState.callbackState.addOnBreadcrumb(OnBreadcrumb { false })
+        breadcrumbState.add(Breadcrumb("Whoops"))
+        assertTrue(breadcrumbState.store.isEmpty())
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -18,7 +18,7 @@ internal class DeliveryDelegateTest {
     lateinit var eventStore: EventStore
 
     val config = generateImmutableConfig()
-    val breadcrumbState = BreadcrumbState(50, NoopLogger)
+    val breadcrumbState = BreadcrumbState(50, CallbackState(), NoopLogger)
     private val logger = InterceptingLogger()
     lateinit var deliveryDelegate: DeliveryDelegate
     val handledState = HandledState.newInstance(HandledState.REASON_UNHANDLED_EXCEPTION)


### PR DESCRIPTION
## Goal

Runs the `OnBreadcrumb` callback in `BreadcrumbState` rather than in `Client`. This means callers of `BreadcrumbState#add()` don't need to know that a callback must be run before adding a breadcrumb.

```
// old internal API
callbackState.runOnBreadcrumbTasks(crumb)
breadcrumbstate.add(crumb)

// new internal API
breadcrumbstate.add(crumb)
```

This fixes one bug where a callback wasn't run in the `leaveErrorBreadcrumb()` method of `DeliveryDelegate`.

## Changeset

Updated `BreadcrumbState` to run `OnBreadcrumb` tasks before adding a breadcrumb, and removed this functionality from `Client`. A unit test has been added to verify this and existing tests updated.