### PR TITLE
Use enums rather than strings for Error/Thread type

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadTest.java
@@ -29,11 +29,11 @@ public class ThreadTest {
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
         Stacktrace trace = new Stacktrace(stacktrace, Collections.<String>emptyList(),
                 NoopLogger.INSTANCE);
-        Thread thread = new Thread(24, "main-one", "ando", true, trace);
+        Thread thread = new Thread(24, "main-one", Thread.Type.Android, true, trace);
         JSONObject result = streamableToJson(thread);
         assertEquals(24, result.getLong("id"));
         assertEquals("main-one", result.getString("name"));
-        assertEquals("ando", result.getString("type"));
+        assertEquals("android", result.getString("type"));
         assertTrue(result.getBoolean("errorReportingThread"));
 
         JSONArray frames = result.getJSONArray("stacktrace");
@@ -60,11 +60,11 @@ public class ThreadTest {
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
         Stacktrace trace = new Stacktrace(stacktrace, Collections.<String>emptyList(),
                 NoopLogger.INSTANCE);
-        Thread thread = new Thread(24, "main-one", "ando",false, trace);
+        Thread thread = new Thread(24, "main-one", Thread.Type.Android,false, trace);
         JSONObject result = streamableToJson(thread);
         assertEquals(24, result.getLong("id"));
         assertEquals("main-one", result.getString("name"));
-        assertEquals("ando", result.getString("type"));
+        assertEquals("android", result.getString("type"));
         assertFalse("Error reporting thread should not be set when false",
                     result.has("errorReportingThread"));
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
@@ -4,8 +4,14 @@ class Error @JvmOverloads internal constructor(
     var errorClass: String,
     var errorMessage: String?,
     var stacktrace: List<Stackframe>,
-    var type: String = "android"
+    var type: Type = Type.Android
 ): JsonStream.Streamable {
+
+    enum class Type(internal val desc: String) {
+        Android("android"),
+        BrowserJs("browserjs"),
+        C("c")
+    }
 
     internal companion object {
         fun createError(exc: Throwable, projectPackages: Collection<String>, logger: Logger): List<Error> {
@@ -25,7 +31,7 @@ class Error @JvmOverloads internal constructor(
         writer.beginObject()
         writer.name("errorClass").value(errorClass)
         writer.name("message").value(errorMessage)
-        writer.name("type").value(type)
+        writer.name("type").value(type.desc)
         writer.name("stacktrace").value(stacktrace)
         writer.endObject()
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -268,7 +268,7 @@ public class NativeInterface {
                 event.updateSeverityInternal(severity);
 
                 for (Error error : event.getErrors()) {
-                    error.setType("c");
+                    error.setType(Error.Type.C);
                 }
                 return true;
             }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
@@ -8,10 +8,15 @@ import java.io.IOException
 class Thread internal constructor(
     val id: Long,
     val name: String,
-    val type: String,
+    val type: Type,
     val isErrorReportingThread: Boolean,
     stacktrace: Stacktrace
 ) : JsonStream.Streamable {
+
+    enum class Type(internal val desc: String) {
+        Android("android"),
+        BrowserJs("browserjs")
+    }
 
     var stacktrace: MutableList<Stackframe> = stacktrace.trace.toMutableList()
 
@@ -20,7 +25,7 @@ class Thread internal constructor(
         writer.beginObject()
         writer.name("id").value(id)
         writer.name("name").value(name)
-        writer.name("type").value(type)
+        writer.name("type").value(type.desc)
 
         writer.name("stacktrace")
         writer.beginArray()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -31,7 +31,7 @@ internal class ThreadState @JvmOverloads constructor
             .sortedBy { it.id }
             .map {
                 val stacktrace = Stacktrace(stackTraces[it]!!, config.projectPackages, logger)
-                Thread(it.id, it.name, "android", it.id == currentThreadId, stacktrace)
+                Thread(it.id, it.name, Thread.Type.Android, it.id == currentThreadId, stacktrace)
             }.toMutableList()
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -36,7 +36,7 @@ internal class EventSerializationTest {
                 // threads included
                 createEvent {
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
-                    it.threads = mutableListOf(Thread(5, "main", "android", true, stacktrace))
+                    it.threads = mutableListOf(Thread(5, "main", Thread.Type.Android, true, stacktrace))
                 },
 
                 // threads included

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
@@ -19,7 +19,7 @@ internal class ThreadSerializationTest {
                 StackTraceElement("App", "launch", "App.java", 70)
             )
 
-            val thread = Thread(24, "main-one", "ando", true, Stacktrace(
+            val thread = Thread(24, "main-one", Thread.Type.Android, true, Stacktrace(
                 stacktrace,
                 emptySet(),
                 NoopLogger
@@ -31,7 +31,7 @@ internal class ThreadSerializationTest {
                 StackTraceElement("App", "launch", "App.java", 70)
             )
 
-            val thread1 = Thread(24, "main-one", "ando", false, Stacktrace(
+            val thread1 = Thread(24, "main-one", Thread.Type.Android, false, Stacktrace(
                 stacktrace1,
                 emptySet(),
                 NoopLogger

--- a/bugsnag-android-core/src/test/resources/thread_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_0.json
@@ -1,7 +1,7 @@
 {
   "id": 24,
   "name": "main-one",
-  "type": "ando",
+  "type": "android",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-android-core/src/test/resources/thread_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_1.json
@@ -1,7 +1,7 @@
 {
   "id": 24,
   "name": "main-one",
-  "type": "ando",
+  "type": "android",
   "stacktrace": [
     {
       "method": "run_func",


### PR DESCRIPTION
## Goal

Uses enums rather than strings for `ErrorType/ThreadType`. This matches the notifier spec and also constrains the notifier to explicitly support android/browserjs/c thread traces. If we wish to support additional types of error/thread in future, we will have to explicitly add these in and perform any work required to parse stack frames differently, rather than blindly accepting any string value for `type`.

## Changeset

Added `ErrorType` and `ThreadType` and updated existing code and test coverage to use these rather than strings.