### PR TITLE
Remove notify method variant

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -200,36 +200,6 @@ public final class Bugsnag {
         getClient().notify(exception, onError);
     }
 
-    /**
-     * Notify Bugsnag of an error
-     *
-     * @param name       the error name or class
-     * @param message    the error message
-     * @param stacktrace the stackframes associated with the error
-     *
-     */
-    public static void notify(@NonNull String name,
-                              @NonNull String message,
-                              @NonNull StackTraceElement[] stacktrace) {
-        getClient().notify(name, message, stacktrace);
-    }
-
-    /**
-     * Notify Bugsnag of an error
-     *
-     * @param name       the error name or class
-     * @param message    the error message
-     * @param stacktrace the stackframes associated with the error
-     * @param onError   callback invoked on the generated error report for
-     *                   additional modification
-     */
-    public static void notify(@NonNull String name,
-                              @NonNull String message,
-                              @NonNull StackTraceElement[] stacktrace,
-                              @Nullable OnErrorCallback onError) {
-        getClient().notify(name, message, stacktrace, onError);
-    }
-
     public static void addMetadata(@NonNull String section, @NonNull Map<String, ?> value) {
         getClient().addMetadata(section, value);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -490,42 +490,6 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     }
 
     /**
-     * Notify Bugsnag of an error
-     *
-     * @param name       the error name or class
-     * @param message    the error message
-     * @param stacktrace the stackframes associated with the error
-     */
-    public void notify(@NonNull String name,
-                       @NonNull String message,
-                       @NonNull StackTraceElement[] stacktrace) {
-        notify(name, message, stacktrace, null);
-    }
-
-    /**
-     * Notify Bugsnag of an error
-     *
-     * @param name       the error name or class
-     * @param message    the error message
-     * @param stacktrace the stackframes associated with the error
-     * @param onError   callback invoked on the generated error report for
-     *                   additional modification
-     */
-    public void notify(@NonNull String name,
-                       @NonNull String message,
-                       @NonNull StackTraceElement[] stacktrace,
-                       @Nullable OnErrorCallback onError) {
-        HandledState handledState = HandledState.newInstance(REASON_HANDLED_EXCEPTION);
-        Stacktrace trace = new Stacktrace(stacktrace, immutableConfig.getProjectPackages(),
-                immutableConfig.getLogger());
-        Error err = new Error(name, message, trace.getTrace());
-        Metadata metadata = metadataState.getMetadata();
-        Event event = new Event(null, immutableConfig, handledState, metadata);
-        event.setErrors(Collections.singletonList(err));
-        notifyInternal(event, onError);
-    }
-
-    /**
      * Caches an error then attempts to notify.
      *
      * Should only ever be called from the {@link ExceptionHandler}.

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -261,14 +261,22 @@ public class NativeInterface {
                               @NonNull final String message,
                               @NonNull final Severity severity,
                               @NonNull final StackTraceElement[] stacktrace) {
+        Throwable exc = new RuntimeException();
+        exc.setStackTrace(stacktrace);
 
-        getClient().notify(name, message, stacktrace, new OnErrorCallback() {
+        getClient().notify(exc, new OnErrorCallback() {
             @Override
             public boolean onError(@NonNull Event event) {
                 event.updateSeverityInternal(severity);
+                List<Error> errors = event.getErrors();
 
-                for (Error error : event.getErrors()) {
-                    error.setType(Error.Type.C);
+                if (!errors.isEmpty()) {
+                    errors.get(0).setErrorClass(name);
+                    errors.get(0).setErrorMessage(message);
+
+                    for (Error error : errors) {
+                        error.setType(Error.Type.C);
+                    }
                 }
                 return true;
             }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -107,19 +107,6 @@ class BugsnagApiTest {
     }
 
     @Test
-    fun notify3() {
-        Bugsnag.notify("LeakException", "whoops", arrayOf())
-        verify(client, times(1)).notify("LeakException", "whoops", arrayOf())
-    }
-
-    @Test
-    fun notify4() {
-        val onError = OnErrorCallback { true }
-        Bugsnag.notify("LeakException", "whoops", arrayOf(), onError)
-        verify(client, times(1)).notify("LeakException", "whoops", arrayOf(), onError)
-    }
-
-    @Test
     fun addMetadataTopLevel() {
         val map = mutableMapOf(Pair("bar", "wham"))
         Bugsnag.addMetadata("foo", map)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -219,6 +219,6 @@ internal class NativeInterfaceApiTest {
     @Test
     fun notifyCall() {
         NativeInterface.notify("SIGPIPE", "SIGSEGV 11", Severity.ERROR, arrayOf())
-        verify(client, times(1)).notify(eq("SIGPIPE"), eq("SIGSEGV 11"), eq(arrayOf()), any())
+        verify(client, times(1)).notify(any(), any())
     }
 }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TrimmedStacktraceScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TrimmedStacktraceScenario.kt
@@ -22,8 +22,14 @@ internal class TrimmedStacktraceScenario(config: Configuration,
             stacktrace.add(StackTraceElement("SomeClass",
                 "someRecursiveMethod", "Foo.kt", lineNumber))
         }
+        val exc = RuntimeException()
+        exc.stackTrace = stacktrace.toTypedArray()
 
-        Bugsnag.notify("CustomException", "foo", stacktrace.toTypedArray(), null)
+        Bugsnag.notify(exc){
+            it.errors[0].errorClass = "CustomException"
+            it.errors[0].errorMessage = "foo"
+            true
+        }
     }
 
 }


### PR DESCRIPTION
## Goal

Removes a `notify()` method variant that accepts a name, message, and stacktrace. It is possible to achieve this by using a `Throwable` with a custom stacktrace set on it and altering the name/message in a callback. This variant should therefore be removed.