### PR TITLE
Rename Endpoints -> EndpointConfiguration

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -142,7 +142,7 @@ class Configuration(
      * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
      * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoints.
      */
-    var endpoints: Endpoints = Endpoints()
+    var endpoints: EndpointConfiguration = EndpointConfiguration()
 
     /**
      * Set the maximum number of breadcrumbState to keep and sent to Bugsnag.

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-class Endpoints(
+class EndpointConfiguration(
     val notify: String = "https://notify.bugsnag.com",
     val sessions: String = "https://sessions.bugsnag.com"
 )

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -23,7 +23,7 @@ internal data class ImmutableConfig(
     val codeBundleId: String?,
     val appType: String,
     val delivery: Delivery,
-    val endpoints: Endpoints,
+    val endpoints: EndpointConfiguration,
     val persistUser: Boolean,
     val launchCrashThresholdMs: Long,
     val logger: Logger,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -100,7 +100,7 @@ internal class ManifestConfigLoader {
         if (data.containsKey(ENDPOINT_NOTIFY)) {
             val endpoint = data.getString(ENDPOINT_NOTIFY, config.endpoints.notify)
             val sessionEndpoint = data.getString(ENDPOINT_SESSIONS, config.endpoints.sessions)
-            config.endpoints = Endpoints(endpoint, sessionEndpoint)
+            config.endpoints = EndpointConfiguration(endpoint, sessionEndpoint)
         }
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -26,7 +26,7 @@ public class ConfigurationTest {
     public void testEndpoints() {
         String notify = "https://notify.myexample.com";
         String sessions = "https://sessions.myexample.com";
-        config.setEndpoints(new Endpoints(notify, sessions));
+        config.setEndpoints(new EndpointConfiguration(notify, sessions));
 
         assertEquals(notify, config.getEndpoints().getNotify());
         assertEquals(sessions, config.getEndpoints().getSessions());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -90,7 +90,7 @@ internal class ImmutableConfigTest {
         seed.codeBundleId = "codebundle123"
         seed.appType = "custom"
 
-        val endpoints = Endpoints("http://example.com:1234", "http://example.com:1235")
+        val endpoints = EndpointConfiguration("http://example.com:1234", "http://example.com:1235")
         seed.endpoints = endpoints
         seed.launchCrashThresholdMs = 7000
         seed.maxBreadcrumbs = 37

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -51,7 +51,7 @@ internal class NativeInterfaceApiTest {
         `when`(client.getSessionTracker()).thenReturn(sessionTracker)
         `when`(client.getEventStore()).thenReturn(eventStore)
         `when`(immutableConfig.endpoints).thenReturn(
-            Endpoints(
+            EndpointConfiguration(
                 "http://notify.bugsnag.com",
                 "http://sessions.bugsnag.com"
             )

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import android.util.Log
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.Endpoints
+import com.bugsnag.android.EndpointConfiguration
 import com.bugsnag.android.mazerunner.scenarios.Scenario
 
 class MainActivity : Activity() {
@@ -45,7 +45,7 @@ class MainActivity : Activity() {
         val eventType = intent.getStringExtra("EVENT_TYPE")
         val config = Configuration(intent.getStringExtra("BUGSNAG_API_KEY"))
         val port = intent.getStringExtra("BUGSNAG_PORT")
-        config.endpoints = Endpoints("${findHostname()}:$port", "${findHostname()}:$port")
+        config.endpoints = EndpointConfiguration("${findHostname()}:$port", "${findHostname()}:$port")
         config.autoDetectNdkCrashes = true
         config.autoDetectAnrs = true
         return config

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -8,7 +8,7 @@ import android.widget.Button
 import android.widget.EditText
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.Endpoints
+import com.bugsnag.android.EndpointConfiguration
 import com.bugsnag.android.mazerunner.scenarios.Scenario
 
 class MainActivity : Activity() {
@@ -74,7 +74,7 @@ class MainActivity : Activity() {
 
     private fun prepareConfig(): Configuration {
         val config = Configuration("a35a2a72bd230ac0aa0f52715bbdc6aa")
-        config.endpoints = Endpoints("http://bs-local.com:9339", "http://bs-local.com:9339")
+        config.endpoints = EndpointConfiguration("http://bs-local.com:9339", "http://bs-local.com:9339")
         config.autoDetectNdkCrashes = true
         config.autoDetectAnrs = true
         return config


### PR DESCRIPTION
Renames `Endpoints` to `EndpointConfiguration` to match the notifier spec. Note that the field name should rename the same and only the type should change.