### PR TITLE
Use consistent case for enums

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadTest.java
@@ -29,7 +29,7 @@ public class ThreadTest {
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
         Stacktrace trace = new Stacktrace(stacktrace, Collections.<String>emptyList(),
                 NoopLogger.INSTANCE);
-        Thread thread = new Thread(24, "main-one", Thread.Type.Android, true, trace);
+        Thread thread = new Thread(24, "main-one", Thread.Type.ANDROID, true, trace);
         JSONObject result = streamableToJson(thread);
         assertEquals(24, result.getLong("id"));
         assertEquals("main-one", result.getString("name"));
@@ -60,7 +60,7 @@ public class ThreadTest {
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
         Stacktrace trace = new Stacktrace(stacktrace, Collections.<String>emptyList(),
                 NoopLogger.INSTANCE);
-        Thread thread = new Thread(24, "main-one", Thread.Type.Android,false, trace);
+        Thread thread = new Thread(24, "main-one", Thread.Type.ANDROID,false, trace);
         JSONObject result = streamableToJson(thread);
         assertEquals(24, result.getLong("id"));
         assertEquals("main-one", result.getString("name"));

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
@@ -4,12 +4,12 @@ class Error @JvmOverloads internal constructor(
     var errorClass: String,
     var errorMessage: String?,
     var stacktrace: List<Stackframe>,
-    var type: Type = Type.Android
+    var type: Type = Type.ANDROID
 ): JsonStream.Streamable {
 
     enum class Type(internal val desc: String) {
-        Android("android"),
-        BrowserJs("browserjs"),
+        ANDROID("android"),
+        BROWSER_JS("browserjs"),
         C("c")
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
@@ -14,8 +14,8 @@ class Thread internal constructor(
 ) : JsonStream.Streamable {
 
     enum class Type(internal val desc: String) {
-        Android("android"),
-        BrowserJs("browserjs")
+        ANDROID("android"),
+        BROWSER_JS("browserjs")
     }
 
     var stacktrace: MutableList<Stackframe> = stacktrace.trace.toMutableList()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -31,7 +31,7 @@ internal class ThreadState @JvmOverloads constructor
             .sortedBy { it.id }
             .map {
                 val stacktrace = Stacktrace(stackTraces[it]!!, config.projectPackages, logger)
-                Thread(it.id, it.name, Thread.Type.Android, it.id == currentThreadId, stacktrace)
+                Thread(it.id, it.name, Thread.Type.ANDROID, it.id == currentThreadId, stacktrace)
             }.toMutableList()
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -36,7 +36,7 @@ internal class EventSerializationTest {
                 // threads included
                 createEvent {
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
-                    it.threads = mutableListOf(Thread(5, "main", Thread.Type.Android, true, stacktrace))
+                    it.threads = mutableListOf(Thread(5, "main", Thread.Type.ANDROID, true, stacktrace))
                 },
 
                 // threads included

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
@@ -19,7 +19,7 @@ internal class ThreadSerializationTest {
                 StackTraceElement("App", "launch", "App.java", 70)
             )
 
-            val thread = Thread(24, "main-one", Thread.Type.Android, true, Stacktrace(
+            val thread = Thread(24, "main-one", Thread.Type.ANDROID, true, Stacktrace(
                 stacktrace,
                 emptySet(),
                 NoopLogger
@@ -31,7 +31,7 @@ internal class ThreadSerializationTest {
                 StackTraceElement("App", "launch", "App.java", 70)
             )
 
-            val thread1 = Thread(24, "main-one", Thread.Type.Android, false, Stacktrace(
+            val thread1 = Thread(24, "main-one", Thread.Type.ANDROID, false, Stacktrace(
                 stacktrace1,
                 emptySet(),
                 NoopLogger


### PR DESCRIPTION
## Goal

The casing we use for enums is inconsistent in the codebase. While [both are valid for Kotlin](https://kotlinlang.org/docs/reference/coding-conventions.html#property-names), we should try and pick one to ensure our API remains consistent.

## Changeset

Changed `Error.Type` and `Thread.Type` to use upper-case. Existing test code was also updated to use these new names.
