### PR TITLE
build(core): Prevent obfuscation of classes for native access

### DIFF
--- a/bugsnag-android-core/proguard-rules.pro
+++ b/bugsnag-android-core/proguard-rules.pro
@@ -1,6 +1,9 @@
 -keepattributes LineNumberTable,SourceFile
 -keep class com.bugsnag.android.NativeInterface { *; }
+-keep class com.bugsnag.android.Bugsnag { *; }
+-keep class com.bugsnag.android.Client { *; }
 -keep class com.bugsnag.android.Breadcrumb { *; }
 -keep class com.bugsnag.android.Breadcrumbs { *; }
 -keep class com.bugsnag.android.BreadcrumbType { *; }
+-keep class com.bugsnag.android.JsonStream { *; }
 -keep class com.bugsnag.android.Severity { *; }


### PR DESCRIPTION
Fixes app compilation warnings and potential crash when calling the `Bugsnag` class via JNI.

Compiling against latest bugsnag-android showed warnings for keeping
`NativeInterface` while `Client` was obfuscated and a part of its public 
API, and similarly for `JsonStream` and `Breadcrumb`.

Additionally added the `Bugsnag` class to make it available via the JNI 
when obfuscation is in effect (as classes are loaded via the JNI by
name).