### PR TITLE
Rename Callback interfaces

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -100,9 +100,9 @@ public class ClientTest {
         config.setDelivery(BugsnagTestUtils.generateDelivery());
         client = new Client(context, config);
 
-        client.addOnError(new OnError() {
+        client.addOnError(new OnErrorCallback() {
             @Override
-            public boolean run(@NonNull Event event) {
+            public boolean onError(@NonNull Event event) {
                 // Pull out the user information
                 ClientTest.this.user = event.getUser();
                 return true;

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbCallbackStateTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbCallbackStateTest.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 
 @SmallTest
-public class OnBreadcrumbStateTest {
+public class OnBreadcrumbCallbackStateTest {
 
     private Client client;
 
@@ -45,9 +45,9 @@ public class OnBreadcrumbStateTest {
 
     @Test
     public void falseCallback() {
-        client.addOnBreadcrumb(new OnBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 return false;
             }
         });
@@ -57,9 +57,9 @@ public class OnBreadcrumbStateTest {
 
     @Test
     public void trueCallback() {
-        client.addOnBreadcrumb(new OnBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 return true;
             }
         });
@@ -69,15 +69,15 @@ public class OnBreadcrumbStateTest {
 
     @Test
     public void multipleCallbacks() {
-        client.addOnBreadcrumb(new OnBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 return true;
             }
         });
-        client.addOnBreadcrumb(new OnBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 return false;
             }
         });
@@ -88,16 +88,16 @@ public class OnBreadcrumbStateTest {
     @Test
     public void ensureBothCalled() {
         final int[] count = {1};
-        client.addOnBreadcrumb(new OnBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
                 return true;
             }
         });
-        client.addOnBreadcrumb(new OnBreadcrumb() {
+        client.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
                 return true;
             }
@@ -112,9 +112,9 @@ public class OnBreadcrumbStateTest {
     public void ensureCalledTwice() {
         final int[] count = {1};
 
-        OnBreadcrumb onBreadcrumb = new OnBreadcrumb() {
+        OnBreadcrumbCallback onBreadcrumb = new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
                 return true;
             }
@@ -129,9 +129,9 @@ public class OnBreadcrumbStateTest {
     public void checkBreadcrumbFields() {
         final int[] count = {1};
 
-        OnBreadcrumb onBreadcrumb = new OnBreadcrumb() {
+        OnBreadcrumbCallback onBreadcrumb = new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 count[0] += 1;
                 assertEquals("Hello", breadcrumb.getMessage());
                 assertEquals(BreadcrumbType.MANUAL, breadcrumb.getType());
@@ -146,9 +146,9 @@ public class OnBreadcrumbStateTest {
 
     @Test
     public void removedCallback() {
-        OnBreadcrumb cb = new OnBreadcrumb() {
+        OnBreadcrumbCallback cb = new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 return false;
             }
         };

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/UniqueOnErrorCallbackTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/UniqueOnErrorCallbackTest.java
@@ -10,22 +10,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Ensures that OnError is only called once,
+ * Ensures that OnErrorCallback is only called once,
  * and that the callbacks are called in insertion order.
  */
 @SmallTest
-public class UniqueOnErrorTest {
+public class UniqueOnErrorCallbackTest {
 
-    private final OnError firstCb = new OnError() {
+    private final OnErrorCallback firstCb = new OnErrorCallback() {
         @Override
-        public boolean run(@NonNull Event event) {
+        public boolean onError(@NonNull Event event) {
             return handleCallback();
         }
     };
 
-    private final OnError secondCb = new OnError() {
+    private final OnErrorCallback secondCb = new OnErrorCallback() {
         @Override
-        public boolean run(@NonNull Event event) {
+        public boolean onError(@NonNull Event event) {
             return handleCallback();
         }
     };
@@ -68,17 +68,17 @@ public class UniqueOnErrorTest {
 
     @Test
     public void testCallbackOrder() {
-        client.addOnError(new OnError() {
+        client.addOnError(new OnErrorCallback() {
             @Override
-            public boolean run(@NonNull Event event) {
+            public boolean onError(@NonNull Event event) {
                 assertEquals(0, callbackCount);
                 callbackCount++;
                 return false;
             }
         });
-        client.addOnError(new OnError() {
+        client.addOnError(new OnErrorCallback() {
             @Override
-            public boolean run(@NonNull Event event) {
+            public boolean onError(@NonNull Event event) {
                 assertEquals(1, callbackCount);
                 return false;
             }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -171,11 +171,11 @@ public final class Bugsnag {
         getClient().removeOnBreadcrumb(onBreadcrumb);
     }
 
-    public static void addOnSession(@NonNull OnSession onSession) {
+    public static void addOnSession(@NonNull OnSessionCallback onSession) {
         getClient().addOnSession(onSession);
     }
 
-    public static void removeOnSession(@NonNull OnSession onSession) {
+    public static void removeOnSession(@NonNull OnSessionCallback onSession) {
         getClient().removeOnSession(onSession);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -126,7 +126,7 @@ public final class Bugsnag {
      * <p>
      * For example:
      * <p>
-     * Bugsnag.addOnError(new OnError() {
+     * Bugsnag.addOnError(new OnErrorCallback() {
      * public boolean run(Event event) {
      * event.setSeverity(Severity.INFO);
      * return true;
@@ -135,13 +135,13 @@ public final class Bugsnag {
      *
      * @param onError a callback to run before sending errors to Bugsnag
      * <p/>
-     * @see OnError
+     * @see OnErrorCallback
      */
-    public static void addOnError(@NonNull OnError onError) {
+    public static void addOnError(@NonNull OnErrorCallback onError) {
         getClient().addOnError(onError);
     }
 
-    public static void removeOnError(@NonNull OnError onError) {
+    public static void removeOnError(@NonNull OnErrorCallback onError) {
         getClient().removeOnError(onError);
     }
 
@@ -196,7 +196,7 @@ public final class Bugsnag {
      *                  additional modification
      */
     public static void notify(@NonNull final Throwable exception,
-                              @Nullable final OnError onError) {
+                              @Nullable final OnErrorCallback onError) {
         getClient().notify(exception, onError);
     }
 
@@ -226,7 +226,7 @@ public final class Bugsnag {
     public static void notify(@NonNull String name,
                               @NonNull String message,
                               @NonNull StackTraceElement[] stacktrace,
-                              @Nullable OnError onError) {
+                              @Nullable OnErrorCallback onError) {
         getClient().notify(name, message, stacktrace, onError);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -154,20 +154,20 @@ public final class Bugsnag {
      * <p>
      * For example:
      * <p>
-     * Bugsnag.onBreadcrumb(new OnBreadcrumb() {
+     * Bugsnag.onBreadcrumb(new OnBreadcrumbCallback() {
      * public boolean run(Breadcrumb breadcrumb) {
      * return false; // ignore the breadcrumb
      * }
      * })
      *
      * @param onBreadcrumb a callback to run before a breadcrumb is captured
-     * @see OnBreadcrumb
+     * @see OnBreadcrumbCallback
      */
-    public static void addOnBreadcrumb(@NonNull final OnBreadcrumb onBreadcrumb) {
+    public static void addOnBreadcrumb(@NonNull final OnBreadcrumbCallback onBreadcrumb) {
         getClient().addOnBreadcrumb(onBreadcrumb);
     }
 
-    public static void removeOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
+    public static void removeOnBreadcrumb(@NonNull OnBreadcrumbCallback onBreadcrumb) {
         getClient().removeOnBreadcrumb(onBreadcrumb);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackAware.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackAware.kt
@@ -5,6 +5,6 @@ internal interface CallbackAware {
     fun removeOnError(onError: OnErrorCallback)
     fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback)
     fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback)
-    fun addOnSession(onSession: OnSession)
-    fun removeOnSession(onSession: OnSession)
+    fun addOnSession(onSession: OnSessionCallback)
+    fun removeOnSession(onSession: OnSessionCallback)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackAware.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackAware.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android
 
 internal interface CallbackAware {
-    fun addOnError(onError: OnError)
-    fun removeOnError(onError: OnError)
+    fun addOnError(onError: OnErrorCallback)
+    fun removeOnError(onError: OnErrorCallback)
     fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback)
     fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback)
     fun addOnSession(onSession: OnSession)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackAware.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackAware.kt
@@ -3,8 +3,8 @@ package com.bugsnag.android
 internal interface CallbackAware {
     fun addOnError(onError: OnError)
     fun removeOnError(onError: OnError)
-    fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumb)
-    fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumb)
+    fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback)
+    fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback)
     fun addOnSession(onSession: OnSession)
     fun removeOnSession(onSession: OnSession)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 internal data class CallbackState(
     val onErrorTasks: MutableCollection<OnErrorCallback> = ConcurrentLinkedQueue<OnErrorCallback>(),
     val onBreadcrumbTasks: MutableCollection<OnBreadcrumbCallback> = ConcurrentLinkedQueue<OnBreadcrumbCallback>(),
-    val onSessionTasks: MutableCollection<OnSession> = ConcurrentLinkedQueue()
+    val onSessionTasks: MutableCollection<OnSessionCallback> = ConcurrentLinkedQueue()
 ): CallbackAware {
 
     override fun addOnError(onError: OnErrorCallback) {
@@ -24,11 +24,11 @@ internal data class CallbackState(
         onBreadcrumbTasks.remove(onBreadcrumb)
     }
 
-    override fun addOnSession(onSession: OnSession) {
+    override fun addOnSession(onSession: OnSessionCallback) {
         onSessionTasks.add(onSession)
     }
 
-    override fun removeOnSession(onSession: OnSession) {
+    override fun removeOnSession(onSession: OnSessionCallback) {
         onSessionTasks.remove(onSession)
     }
 
@@ -62,11 +62,11 @@ internal data class CallbackState(
     fun runOnSessionTasks(sessionPayload: SessionPayload, logger: Logger): Boolean {
         onSessionTasks.forEach {
             try {
-                if (!it.run(sessionPayload)) {
+                if (!it.onSession(sessionPayload)) {
                     return false
                 }
             } catch (ex: Throwable) {
-                logger.w("OnSession threw an Exception", ex)
+                logger.w("OnSessionCallback threw an Exception", ex)
             }
         }
         return true

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
@@ -4,7 +4,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 internal data class CallbackState(
     val onErrorTasks: MutableCollection<OnError> = ConcurrentLinkedQueue<OnError>(),
-    val onBreadcrumbTasks: MutableCollection<OnBreadcrumb> = ConcurrentLinkedQueue<OnBreadcrumb>(),
+    val onBreadcrumbTasks: MutableCollection<OnBreadcrumbCallback> = ConcurrentLinkedQueue<OnBreadcrumbCallback>(),
     val onSessionTasks: MutableCollection<OnSession> = ConcurrentLinkedQueue()
 ): CallbackAware {
 
@@ -16,11 +16,11 @@ internal data class CallbackState(
         onErrorTasks.remove(onError)
     }
 
-    override fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumb) {
+    override fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback) {
         onBreadcrumbTasks.add(onBreadcrumb)
     }
 
-    override fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumb) {
+    override fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback) {
         onBreadcrumbTasks.remove(onBreadcrumb)
     }
 
@@ -40,7 +40,7 @@ internal data class CallbackState(
                     return false
                 }
             } catch (ex: Throwable) {
-                logger.w("OnBreadcrumb threw an Exception", ex)
+                logger.w("OnBreadcrumbCallback threw an Exception", ex)
             }
         }
         return true
@@ -49,11 +49,11 @@ internal data class CallbackState(
     fun runOnBreadcrumbTasks(breadcrumb: Breadcrumb, logger: Logger): Boolean {
         onBreadcrumbTasks.forEach {
             try {
-                if (!it.run(breadcrumb)) {
+                if (!it.onBreadcrumb(breadcrumb)) {
                     return false
                 }
             } catch (ex: Throwable) {
-                logger.w("OnBreadcrumb threw an Exception", ex)
+                logger.w("OnBreadcrumbCallback threw an Exception", ex)
             }
         }
         return true

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
@@ -3,16 +3,16 @@ package com.bugsnag.android
 import java.util.concurrent.ConcurrentLinkedQueue
 
 internal data class CallbackState(
-    val onErrorTasks: MutableCollection<OnError> = ConcurrentLinkedQueue<OnError>(),
+    val onErrorTasks: MutableCollection<OnErrorCallback> = ConcurrentLinkedQueue<OnErrorCallback>(),
     val onBreadcrumbTasks: MutableCollection<OnBreadcrumbCallback> = ConcurrentLinkedQueue<OnBreadcrumbCallback>(),
     val onSessionTasks: MutableCollection<OnSession> = ConcurrentLinkedQueue()
 ): CallbackAware {
 
-    override fun addOnError(onError: OnError) {
+    override fun addOnError(onError: OnErrorCallback) {
         onErrorTasks.add(onError)
     }
 
-    override fun removeOnError(onError: OnError) {
+    override fun removeOnError(onError: OnErrorCallback) {
         onErrorTasks.remove(onError)
     }
 
@@ -36,7 +36,7 @@ internal data class CallbackState(
     fun runOnErrorTasks(event: Event, logger: Logger): Boolean {
         onErrorTasks.forEach {
             try {
-                if (!it.run(event)) {
+                if (!it.onError(event)) {
                     return false
                 }
             } catch (ex: Throwable) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -207,9 +207,9 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         orientationListener = registerOrientationChangeListener();
 
         // filter out any disabled breadcrumb types
-        addOnBreadcrumb(new OnBreadcrumb() {
+        addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 return immutableConfig.getEnabledBreadcrumbTypes().contains(breadcrumb.getType());
             }
         });
@@ -437,22 +437,22 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * <p>
      * For example:
      * <p>
-     * Bugsnag.onBreadcrumb(new OnBreadcrumb() {
+     * Bugsnag.onBreadcrumb(new OnBreadcrumbCallback() {
      * public boolean run(Breadcrumb breadcrumb) {
      * return false; // ignore the breadcrumb
      * }
      * })
      *
      * @param onBreadcrumb a callback to run before a breadcrumb is captured
-     * @see OnBreadcrumb
+     * @see OnBreadcrumbCallback
      */
     @Override
-    public void addOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
+    public void addOnBreadcrumb(@NonNull OnBreadcrumbCallback onBreadcrumb) {
         callbackState.addOnBreadcrumb(onBreadcrumb);
     }
 
     @Override
-    public void removeOnBreadcrumb(@NonNull OnBreadcrumb onBreadcrumb) {
+    public void removeOnBreadcrumb(@NonNull OnBreadcrumbCallback onBreadcrumb) {
         callbackState.removeOnBreadcrumb(onBreadcrumb);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -408,7 +408,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * <p>
      * For example:
      * <p>
-     * Bugsnag.addOnError(new OnError() {
+     * Bugsnag.addOnError(new OnErrorCallback() {
      * public boolean run(Event event) {
      * event.setSeverity(Severity.INFO);
      * return true;
@@ -416,15 +416,15 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * })
      *
      * @param onError a callback to run before sending errors to Bugsnag
-     * @see OnError
+     * @see OnErrorCallback
      */
     @Override
-    public void addOnError(@NonNull OnError onError) {
+    public void addOnError(@NonNull OnErrorCallback onError) {
         callbackState.addOnError(onError);
     }
 
     @Override
-    public void removeOnError(@NonNull OnError onError) {
+    public void removeOnError(@NonNull OnErrorCallback onError) {
         callbackState.removeOnError(onError);
     }
 
@@ -482,7 +482,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * @param onError  callback invoked on the generated error report for
      *                  additional modification
      */
-    public void notify(@NonNull Throwable exc, @Nullable OnError onError) {
+    public void notify(@NonNull Throwable exc, @Nullable OnErrorCallback onError) {
         HandledState handledState = HandledState.newInstance(REASON_HANDLED_EXCEPTION);
         Event event = new Event(exc, immutableConfig, handledState, metadataState.getMetadata());
         notifyInternal(event, onError);
@@ -513,7 +513,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     public void notify(@NonNull String name,
                        @NonNull String message,
                        @NonNull StackTraceElement[] stacktrace,
-                       @Nullable OnError onError) {
+                       @Nullable OnErrorCallback onError) {
         HandledState handledState = HandledState.newInstance(REASON_HANDLED_EXCEPTION);
         Stacktrace trace = new Stacktrace(stacktrace, immutableConfig.getProjectPackages(),
                 immutableConfig.getLogger());
@@ -540,7 +540,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     }
 
     void notifyInternal(@NonNull Event event,
-                        @Nullable OnError onError) {
+                        @Nullable OnErrorCallback onError) {
         // Don't notify if this event class should be ignored
         if (event.shouldIgnoreClass()) {
             return;
@@ -584,7 +584,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
         // Run on error tasks, don't notify if any return false
         if (!callbackState.runOnErrorTasks(event, logger)
-                || (onError != null && !onError.run(event))) {
+                || (onError != null && !onError.onError(event))) {
             logger.i("Skipping notification - onError task returned false");
             return;
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -457,12 +457,12 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     }
 
     @Override
-    public void addOnSession(@NonNull OnSession onSession) {
+    public void addOnSession(@NonNull OnSessionCallback onSession) {
         callbackState.addOnSession(onSession);
     }
 
     @Override
-    public void removeOnSession(@NonNull OnSession onSession) {
+    public void removeOnSession(@NonNull OnSessionCallback onSession) {
         callbackState.removeOnSession(onSession);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -276,14 +276,14 @@ class Configuration(
      *
      * @param onSession the on session callback
      */
-    override fun addOnSession(onSession: OnSession) = callbackState.addOnSession(onSession)
+    override fun addOnSession(onSession: OnSessionCallback) = callbackState.addOnSession(onSession)
 
     /**
      * Removes an on session callback
      *
      * @param onSession the on session callback
      */
-    override fun removeOnSession(onSession: OnSession) = callbackState.removeOnSession(onSession)
+    override fun removeOnSession(onSession: OnSessionCallback) = callbackState.removeOnSession(onSession)
 
     override fun addMetadata(section: String, value: Map<String, Any?>) =
         metadataState.addMetadata(section, value)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -260,7 +260,7 @@ class Configuration(
      *
      * @param onBreadcrumb the on breadcrumb callback
      */
-    override fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumb) =
+    override fun addOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback) =
         callbackState.addOnBreadcrumb(onBreadcrumb)
 
     /**
@@ -268,7 +268,7 @@ class Configuration(
      *
      * @param onBreadcrumb the on breadcrumb callback
      */
-    override fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumb) =
+    override fun removeOnBreadcrumb(onBreadcrumb: OnBreadcrumbCallback) =
         callbackState.removeOnBreadcrumb(onBreadcrumb)
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -241,7 +241,7 @@ class Configuration(
      *
      * For example:
      *
-     * Bugsnag.addOnError(new OnError() {
+     * Bugsnag.addOnError(new OnErrorCallback() {
      * public boolean run(Event event) {
      * event.setSeverity(Severity.INFO);
      * return true;
@@ -249,11 +249,11 @@ class Configuration(
      * })
      *
      * @param onError a callback to run before sending errors to Bugsnag
-     * @see OnError
+     * @see OnErrorCallback
      */
-    override fun addOnError(onError: OnError) = callbackState.addOnError(onError)
+    override fun addOnError(onError: OnErrorCallback) = callbackState.addOnError(onError)
 
-    override fun removeOnError(onError: OnError) = callbackState.removeOnError(onError)
+    override fun removeOnError(onError: OnErrorCallback) = callbackState.removeOnError(onError)
 
     /**
      * Adds an on breadcrumb callback

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -7,10 +7,10 @@ import java.util.HashMap
  * Information and associated diagnostics relating to a handled or unhandled
  * Exception.
  *
- * This object is made available in OnError callbacks, so you can
+ * This object is made available in OnErrorCallback callbacks, so you can
  * inspect and modify it before it is delivered to Bugsnag.
  *
- * @see OnError
+ * @see OnErrorCallback
  */
 class Event @JvmOverloads internal constructor(
     val originalError: Throwable? = null,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -262,9 +262,9 @@ public class NativeInterface {
                               @NonNull final Severity severity,
                               @NonNull final StackTraceElement[] stacktrace) {
 
-        getClient().notify(name, message, stacktrace, new OnError() {
+        getClient().notify(name, message, stacktrace, new OnErrorCallback() {
             @Override
-            public boolean run(@NonNull Event event) {
+            public boolean onError(@NonNull Event event) {
                 event.updateSeverityInternal(severity);
 
                 for (Error error : event.getErrors()) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/OnBreadcrumbCallback.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/OnBreadcrumbCallback.java
@@ -17,16 +17,16 @@ import androidx.annotation.NonNull;
  * }
  * })
  */
-public interface OnBreadcrumb {
+public interface OnBreadcrumbCallback {
 
     /**
      * Runs the "on breadcrumb" callback. If the callback returns
-     * <code>false</code> any further OnBreadcrumb callbacks will not be called
+     * <code>false</code> any further OnBreadcrumbCallback callbacks will not be called
      * and the breadcrumb will not be captured by Bugsnag.
      *
      * @param breadcrumb the breadcrumb to be captured by Bugsnag
      * @see Breadcrumb
      */
-    boolean run(@NonNull Breadcrumb breadcrumb);
+    boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb);
 
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/OnErrorCallback.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/OnErrorCallback.java
@@ -10,15 +10,15 @@ import androidx.annotation.NonNull;
  * <code>false</code> from any callback to halt execution.
  * <p>"on error" callbacks added via the JVM API do not run when a fatal C/C++ crash occurs.
  */
-public interface OnError {
+public interface OnErrorCallback {
 
     /**
      * Runs the "on error" callback. If the callback returns
-     * <code>false</code> any further OnError callbacks will not be called
+     * <code>false</code> any further OnErrorCallback callbacks will not be called
      * and the event will not be sent to Bugsnag.
      *
      * @param event the event to be sent to Bugsnag
      * @see Event
      */
-    boolean run(@NonNull Event event);
+    boolean onError(@NonNull Event event);
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/OnSession.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/OnSession.java
@@ -1,7 +1,0 @@
-package com.bugsnag.android;
-
-import androidx.annotation.NonNull;
-
-public interface OnSession {
-    boolean run(@NonNull SessionPayload payload);
-}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/OnSessionCallback.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/OnSessionCallback.java
@@ -1,0 +1,7 @@
+package com.bugsnag.android;
+
+import androidx.annotation.NonNull;
+
+public interface OnSessionCallback {
+    boolean onSession(@NonNull SessionPayload payload);
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -117,11 +117,11 @@ class BreadcrumbStateTest {
     }
 
     /**
-     * Verifies that an [OnBreadcrumb] callback is run when specified in [BreadcrumbState]
+     * Verifies that an [OnBreadcrumbCallback] callback is run when specified in [BreadcrumbState]
      */
     @Test
     fun testOnBreadcrumbCallback() {
-        breadcrumbState.callbackState.addOnBreadcrumb(OnBreadcrumb { false })
+        breadcrumbState.callbackState.addOnBreadcrumb(OnBreadcrumbCallback { false })
         breadcrumbState.add(Breadcrumb("Whoops"))
         assertTrue(breadcrumbState.store.isEmpty())
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -80,14 +80,14 @@ class BugsnagApiTest {
     @Test
     fun addOnSession() {
         Bugsnag.addOnSession { true }
-        Bugsnag.addOnSession(OnSession { true })
+        Bugsnag.addOnSession(OnSessionCallback { true })
         verify(client, times(2)).addOnSession(ArgumentMatchers.any())
     }
 
     @Test
     fun removeOnSession() {
         Bugsnag.removeOnSession { true }
-        Bugsnag.removeOnSession(OnSession { true })
+        Bugsnag.removeOnSession(OnSessionCallback { true })
         verify(client, times(2)).removeOnSession(ArgumentMatchers.any())
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -66,14 +66,14 @@ class BugsnagApiTest {
     @Test
     fun addOnBreadcrumb() {
         Bugsnag.addOnBreadcrumb { true }
-        Bugsnag.addOnBreadcrumb(OnBreadcrumb { true })
+        Bugsnag.addOnBreadcrumb(OnBreadcrumbCallback { true })
         verify(client, times(2)).addOnBreadcrumb(ArgumentMatchers.any())
     }
 
     @Test
     fun removeOnBreadcrumb() {
         Bugsnag.removeOnBreadcrumb { true }
-        Bugsnag.removeOnBreadcrumb(OnBreadcrumb { true })
+        Bugsnag.removeOnBreadcrumb(OnBreadcrumbCallback { true })
         verify(client, times(2)).removeOnBreadcrumb(ArgumentMatchers.any())
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -52,14 +52,14 @@ class BugsnagApiTest {
     @Test
     fun addOnError() {
         Bugsnag.addOnError { true }
-        Bugsnag.addOnError(OnError { true })
+        Bugsnag.addOnError(OnErrorCallback { true })
         verify(client, times(2)).addOnError(ArgumentMatchers.any())
     }
 
     @Test
     fun removeOnError() {
         Bugsnag.removeOnError { true }
-        Bugsnag.removeOnError(OnError { true })
+        Bugsnag.removeOnError(OnErrorCallback { true })
         verify(client, times(2)).removeOnError(ArgumentMatchers.any())
     }
 
@@ -101,7 +101,7 @@ class BugsnagApiTest {
     @Test
     fun notify2() {
         val exc = RuntimeException()
-        val onError = OnError { true }
+        val onError = OnErrorCallback { true }
         Bugsnag.notify(exc, onError)
         verify(client, times(1)).notify(exc, onError)
     }
@@ -114,7 +114,7 @@ class BugsnagApiTest {
 
     @Test
     fun notify4() {
-        val onError = OnError { true }
+        val onError = OnErrorCallback { true }
         Bugsnag.notify("LeakException", "whoops", arrayOf(), onError)
         verify(client, times(1)).notify("LeakException", "whoops", arrayOf(), onError)
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
@@ -20,7 +20,7 @@ class CallbackStateTest {
     @Test
     fun testCopy() {
         val state = CallbackState()
-        state.addOnError(OnError { true })
+        state.addOnError(OnErrorCallback { true })
         state.addOnBreadcrumb(OnBreadcrumbCallback { true })
         state.addOnSession(OnSession { true })
 
@@ -33,8 +33,8 @@ class CallbackStateTest {
     @Test
     fun onErrorExcThrown() {
         val state = CallbackState()
-        state.addOnError(OnError { true })
-        state.addOnError(OnError { throw RuntimeException() })
+        state.addOnError(OnErrorCallback { true })
+        state.addOnError(OnErrorCallback { throw RuntimeException() })
 
         val logger = InterceptingLogger()
         assertNull(logger.msg)
@@ -46,8 +46,8 @@ class CallbackStateTest {
     fun onErrorFalseReturned() {
         val state = CallbackState()
         var count = 0
-        state.addOnError(OnError { false })
-        state.addOnError(OnError {
+        state.addOnError(OnErrorCallback { false })
+        state.addOnError(OnErrorCallback {
             count = 1
             true
         })

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
@@ -21,7 +21,7 @@ class CallbackStateTest {
     fun testCopy() {
         val state = CallbackState()
         state.addOnError(OnError { true })
-        state.addOnBreadcrumb(OnBreadcrumb { true })
+        state.addOnBreadcrumb(OnBreadcrumbCallback { true })
         state.addOnSession(OnSession { true })
 
         val copy = state.copy()
@@ -83,8 +83,8 @@ class CallbackStateTest {
     @Test
     fun onBreadcrumbExcThrown() {
         val state = CallbackState()
-        state.addOnBreadcrumb(OnBreadcrumb { true })
-        state.addOnBreadcrumb(OnBreadcrumb { throw RuntimeException() })
+        state.addOnBreadcrumb(OnBreadcrumbCallback { true })
+        state.addOnBreadcrumb(OnBreadcrumbCallback { throw RuntimeException() })
 
         val logger = InterceptingLogger()
         assertNull(logger.msg)
@@ -96,8 +96,8 @@ class CallbackStateTest {
     fun onBreadcrumbFalseReturned() {
         val state = CallbackState()
         var count = 0
-        state.addOnBreadcrumb(OnBreadcrumb { false })
-        state.addOnBreadcrumb(OnBreadcrumb {
+        state.addOnBreadcrumb(OnBreadcrumbCallback { false })
+        state.addOnBreadcrumb(OnBreadcrumbCallback {
             count = 1
             true
         })

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
@@ -22,7 +22,7 @@ class CallbackStateTest {
         val state = CallbackState()
         state.addOnError(OnErrorCallback { true })
         state.addOnBreadcrumb(OnBreadcrumbCallback { true })
-        state.addOnSession(OnSession { true })
+        state.addOnSession(OnSessionCallback { true })
 
         val copy = state.copy()
         assertEquals(1, copy.onErrorTasks.size)
@@ -58,8 +58,8 @@ class CallbackStateTest {
     @Test
     fun onSessionExcThrown() {
         val state = CallbackState()
-        state.addOnSession(OnSession { true })
-        state.addOnSession(OnSession { throw RuntimeException() })
+        state.addOnSession(OnSessionCallback { true })
+        state.addOnSession(OnSessionCallback { throw RuntimeException() })
 
         val logger = InterceptingLogger()
         assertNull(logger.msg)
@@ -71,8 +71,8 @@ class CallbackStateTest {
     fun onSessionFalseReturned() {
         val state = CallbackState()
         var count = 0
-        state.addOnSession(OnSession { false })
-        state.addOnSession(OnSession {
+        state.addOnSession(OnSessionCallback { false })
+        state.addOnSession(OnSessionCallback {
             count = 1
             true
         })

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -59,16 +59,16 @@ public class ConcurrentCallbackTest {
     @Test
     public void testOnSessionConcurrentModification() {
         CallbackState config = new CallbackState();
-        final Collection<OnSession> tasks = config.getOnSessionTasks();
-        config.addOnSession(new OnSession() {
+        final Collection<OnSessionCallback> tasks = config.getOnSessionTasks();
+        config.addOnSession(new OnSessionCallback() {
             @Override
-            public boolean run(@NonNull SessionPayload event) {
-                tasks.add(new OnSessionSkeleton());
+            public boolean onSession(@NonNull SessionPayload event) {
+                tasks.add(new OnSessionCallbackSkeleton());
                 // modify the Set, when iterating to the next callback this should not crash
                 return true;
             }
         });
-        config.addOnSession(new OnSessionSkeleton());
+        config.addOnSession(new OnSessionCallbackSkeleton());
         config.runOnSessionTasks(sessionPayload, NoopLogger.INSTANCE);
     }
 
@@ -86,9 +86,9 @@ public class ConcurrentCallbackTest {
         }
     }
 
-    static class OnSessionSkeleton implements OnSession {
+    static class OnSessionCallbackSkeleton implements OnSessionCallback {
         @Override
-        public boolean run(@NonNull SessionPayload sessionPayload) {
+        public boolean onSession(@NonNull SessionPayload sessionPayload) {
             return true;
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -27,16 +27,16 @@ public class ConcurrentCallbackTest {
     @Test
     public void testOnErrorConcurrentModification() {
         CallbackState config = new CallbackState();
-        final Collection<OnError> tasks = config.getOnErrorTasks();
-        config.addOnError(new OnError() {
+        final Collection<OnErrorCallback> tasks = config.getOnErrorTasks();
+        config.addOnError(new OnErrorCallback() {
             @Override
-            public boolean run(@NonNull Event event) {
-                tasks.add(new OnErrorSkeleton());
+            public boolean onError(@NonNull Event event) {
+                tasks.add(new OnErrorCallbackSkeleton());
                 // modify the Set, when iterating to the next callback this should not crash
                 return true;
             }
         });
-        config.addOnError(new OnErrorSkeleton());
+        config.addOnError(new OnErrorCallbackSkeleton());
         config.runOnErrorTasks(event, NoopLogger.INSTANCE);
     }
 
@@ -72,9 +72,9 @@ public class ConcurrentCallbackTest {
         config.runOnSessionTasks(sessionPayload, NoopLogger.INSTANCE);
     }
 
-    static class OnErrorSkeleton implements OnError {
+    static class OnErrorCallbackSkeleton implements OnErrorCallback {
         @Override
-        public boolean run(@NonNull Event event) {
+        public boolean onError(@NonNull Event event) {
             return true;
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -43,16 +43,16 @@ public class ConcurrentCallbackTest {
     @Test
     public void testOnBreadcrumbConcurrentModification() {
         CallbackState config = new CallbackState();
-        final Collection<OnBreadcrumb> tasks = config.getOnBreadcrumbTasks();
-        config.addOnBreadcrumb(new OnBreadcrumb() {
+        final Collection<OnBreadcrumbCallback> tasks = config.getOnBreadcrumbTasks();
+        config.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
-            public boolean run(@NonNull Breadcrumb breadcrumb) {
-                tasks.add(new OnBreadcrumbSkeleton());
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
+                tasks.add(new OnBreadcrumbCallbackSkeleton());
                 // modify the Set, when iterating to the next callback this should not crash
                 return true;
             }
         });
-        config.addOnBreadcrumb(new OnBreadcrumbSkeleton());
+        config.addOnBreadcrumb(new OnBreadcrumbCallbackSkeleton());
         config.runOnBreadcrumbTasks(new Breadcrumb("Foo"), NoopLogger.INSTANCE);
     }
 
@@ -79,9 +79,9 @@ public class ConcurrentCallbackTest {
         }
     }
 
-    static class OnBreadcrumbSkeleton implements OnBreadcrumb {
+    static class OnBreadcrumbCallbackSkeleton implements OnBreadcrumbCallback {
         @Override
-        public boolean run(@NonNull Breadcrumb breadcrumb) {
+        public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
             return true;
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
@@ -60,14 +60,14 @@ internal class ConfigApiTest {
 
     @Test
     fun addOnSession() {
-        val onSession = OnSession { true }
+        val onSession = OnSessionCallback { true }
         config.addOnSession(onSession)
         assertTrue(callbackState.onSessionTasks.contains(onSession))
     }
 
     @Test
     fun removeOnSession() {
-        val onSession = OnSession { true }
+        val onSession = OnSessionCallback { true }
         config.addOnSession(onSession)
         config.removeOnSession(onSession)
         assertFalse(callbackState.onSessionTasks.contains(onSession))

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
@@ -45,14 +45,14 @@ internal class ConfigApiTest {
 
     @Test
     fun addOnBreadcrumb() {
-        val onBreadcrumb = OnBreadcrumb { true }
+        val onBreadcrumb = OnBreadcrumbCallback { true }
         config.addOnBreadcrumb(onBreadcrumb)
         assertTrue(callbackState.onBreadcrumbTasks.contains(onBreadcrumb))
     }
 
     @Test
     fun removeOnBreadcrumb() {
-        val onBreadcrumb = OnBreadcrumb { true }
+        val onBreadcrumb = OnBreadcrumbCallback { true }
         config.addOnBreadcrumb(onBreadcrumb)
         config.removeOnBreadcrumb(onBreadcrumb)
         assertFalse(callbackState.onBreadcrumbTasks.contains(onBreadcrumb))

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
@@ -30,14 +30,14 @@ internal class ConfigApiTest {
 
     @Test
     fun addOnError() {
-        val onError = OnError { true }
+        val onError = OnErrorCallback { true }
         config.addOnError(onError)
         assertTrue(callbackState.onErrorTasks.contains(onError))
     }
 
     @Test
     fun removeOnError() {
-        val onError = OnError { true }
+        val onError = OnErrorCallback { true }
         config.addOnError(onError)
         config.removeOnError(onError)
         assertFalse(callbackState.onErrorTasks.contains(onError))

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/OnErrorCallbackTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/OnErrorCallbackTest.kt
@@ -6,7 +6,7 @@ import org.junit.Assert.assertEquals
 
 import org.junit.Test
 
-class OnErrorTest {
+class OnErrorCallbackTest {
 
     private val config = generateImmutableConfig()
 
@@ -14,14 +14,14 @@ class OnErrorTest {
     fun testRunModifiesError() {
         val context = "new-context"
 
-        val onError = OnError {
+        val onError = OnErrorCallback {
             it.context = context
             false
         }
 
         val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
         val error = Event(RuntimeException("Test"), config, handledState)
-        onError.run(error)
+        onError.onError(error)
         assertEquals(context, error.context)
     }
 }


### PR DESCRIPTION
## Goal

Renames the `OnError/OnBreadcrumb/OnSession` callbacks to have a "Callback" suffix as their type. The actual usage in fields and methods should remain as `OnError` without the suffix.

The method name has also been updated from `run()` to `onX()`, as this will be more descriptive for Java consumers of our library.
