### PR TITLE
Fix test fixture ordering

### DIFF
--- a/bugsnag-android-core/src/test/resources/event_redaction.json
+++ b/bugsnag-android-core/src/test/resources/event_redaction.json
@@ -3,10 +3,10 @@
     "app": {
       "password": "[REDACTED]"
     },
-    "baz": {
+    "device": {
       "password": "[REDACTED]"
     },
-    "device": {
+    "baz": {
       "password": "[REDACTED]"
     }
   },

--- a/bugsnag-android-core/src/test/resources/event_serialization_6.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_6.json
@@ -3,11 +3,11 @@
     "app": {
       "foo": 55
     },
-    "wham": {
-      "some_key": "Avalue"
-    },
     "device": {
       "bar": true
+    },
+    "wham": {
+      "some_key": "Avalue"
     }
   },
   "severity": "warning",


### PR DESCRIPTION
Fixes the ordering of a JSON test fixture to pass the `EventRedactionTest` and `EventSerializationTest`, which were failing. Currently these tests serialize JSON to a string which is then compared for equality against a JSON fixture, so the ordering of elements in the file matters. The failure seems to have been introduced in a merge conflict.