### PR TITLE
Fix: address CVE-2019-10101 by increasing Kotlin version to 1.3.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Fix: address CVE-2019-10101 by increasing Kotlin version to 1.3.61
+  [#739](https://github.com/bugsnag/bugsnag-android/pull/739)
+
 * Catch throwables when invoking methods on system services
   [#623](https://github.com/bugsnag/bugsnag-android/pull/623)
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
         jcenter()
     }
-    ext.kotlin_version = "1.3.21"
+    ext.kotlin_version = "1.3.61"
     ext.agpVersion = "3.4.2"
 
     dependencies {

--- a/features/fixtures/mazerunner/build.gradle
+++ b/features/fixtures/mazerunner/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
         jcenter()
     }
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.61'
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'

--- a/tests/features/fixtures/mazerunner/build.gradle
+++ b/tests/features/fixtures/mazerunner/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         mavenCentral()
         jcenter()
     }
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.61'
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'

--- a/tests/features/fixtures/minimalapp/build.gradle
+++ b/tests/features/fixtures/minimalapp/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
bugsnag-android used [version 1.3.21](https://github.com/bugsnag/bugsnag-android/blob/master/build.gradle#L10) of Kotlin, which has a security vulnerability [CVE-2019-10101](https://nvd.nist.gov/vuln/detail/CVE-2019-10101).

Updating to a newer version of Kotlin prevents the possibility of a MITM attack when downloading the Kotlin library dependency.

Fixes #738 