### PR TITLE
log exception as cause when loading manifest

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -53,8 +53,8 @@ internal class ManifestConfigLoader {
             val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
             val data = ai.metaData
             return load(data, userSuppliedApiKey)
-        } catch (ignore: Exception) {
-            throw IllegalStateException("Bugsnag is unable to read config from manifest.")
+        } catch (exc: Exception) {
+            throw IllegalStateException("Bugsnag is unable to read config from manifest.", exc)
         }
     }
 


### PR DESCRIPTION
Improves the stacktrace logged when something goes wrong reading the manifest, by setting a cause on the throwable.