### PR TITLE
Allow disabling previous signal handler invocation for Unity ANRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TBD
 
+* Allow disabling previous signal handler invocation for Unity ANRs
+  [#743](https://github.com/bugsnag/bugsnag-android/pull/743)
+
 * Avoid polling when detecting ANRs by invoking JNI from SIGQUIT handler
   [#741](https://github.com/bugsnag/bugsnag-android/pull/741)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientConfigObserver.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientConfigObserver.kt
@@ -22,8 +22,12 @@ internal class ClientConfigObserver(
 
     private fun handleNotifyReleaseStages() {
         if (config.shouldNotifyForReleaseStage(config.releaseStage)) {
-            client.enableAnrReporting()
-            client.enableNdkCrashReporting()
+            if (config.detectAnrs) {
+                client.enableAnrReporting()
+            }
+            if (config.detectNdkCrashes) {
+                client.enableNdkCrashReporting()
+            }
         } else {
             client.disableAnrReporting()
             client.disableNdkCrashReporting()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -1,7 +1,7 @@
 package com.bugsnag.android;
 
 import android.content.Context;
-import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -49,6 +49,7 @@ public class Configuration extends Observable implements Observer {
     private boolean autoCaptureSessions = true;
     private boolean automaticallyCollectBreadcrumbs = true;
 
+    private boolean callPreviousSigquitHandler = true;
     private boolean detectAnrs = false;
     private boolean detectNdkCrashes;
     private long anrThresholdMs = 5000;
@@ -703,6 +704,14 @@ public class Configuration extends Observable implements Observer {
      */
     public void setDetectAnrs(boolean detectAnrs) {
         this.detectAnrs = detectAnrs;
+    }
+
+    boolean getCallPreviousSigquitHandler() {
+        return callPreviousSigquitHandler;
+    }
+
+    void setCallPreviousSigquitHandler(boolean callPreviousSigquitHandler) {
+        this.callPreviousSigquitHandler = callPreviousSigquitHandler;
     }
 
     /**

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_handler.h
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_handler.h
@@ -26,8 +26,9 @@ extern "C" {
  * Monitor for ANRs, writing to a byte buffer when detected
  * @param env the JNIEnv used to notify when an ANR occurs
  * @param plugin the AnrPlugin object that shouild be used to notify bugsnag
+ * @param callPreviousSigquitHandler whether the previous SIGQUIT handler should be invoked
  */
-bool bsg_handler_install_anr(JNIEnv *env, jobject plugin);
+bool bsg_handler_install_anr(JNIEnv *env, jobject plugin, jboolean callPreviousSigquitHandler);
 
 void bsg_handler_uninstall_anr(void);
 

--- a/bugsnag-plugin-android-anr/src/main/jni/bugsnag_anr.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/bugsnag_anr.c
@@ -8,8 +8,8 @@ extern "C" {
 #endif
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_AnrPlugin_enableAnrReporting(
-        JNIEnv *env, jobject _this) {
-    bsg_handler_install_anr(env, _this);
+        JNIEnv *env, jobject _this, jboolean callPreviousSigquitHandler) {
+    bsg_handler_install_anr(env, _this, callPreviousSigquitHandler);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_AnrPlugin_disableAnrReporting(


### PR DESCRIPTION
Currently the previously installed signal handler is always invoked for SIGQUIT. In Unity apps invoking the previous handler triggers a SIGSEGV in the Unity signal handler, which is an apparent bug in the implementation. As the handler only appears to print a dump of the threads to the console, we should therefore avoid calling it as doing so will allow us to detect ANRs on Unity.

This is controlled by adding a non-public `unityApp` flag to `Configuration`, which is set by Unity during initialisation, then passed onto the `AnrPlugin` and ultimately the native layer.

Methods which enable/disable native error capture such as `enableAnrReporting/disableAnrReporting` have also been tweaked so that they do not flip the configuration option when invoked. This is because when the releaseStage was changed from the native layer, it would automatically enable/disable ANRs via `ClientConfigObserver` without respecting the current `detectAnrs` flag value.

Tested by verifying that an Android + Unity example app can both send ANRs without crashing.