### PR TITLE
Add ndk accessor methods for event.app

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
@@ -51,20 +51,6 @@ void bugsnag_add_on_error(bsg_on_error on_error);
  */
 void bugsnag_remove_on_error();
 
-/**
- * Retrieves the event context
- * @param event_ptr a pointer to the event supplied in an on_error callback
- * @return the event context, or NULL if this has not been set
- */
-char *bugsnag_event_get_context(void *event_ptr);
-
-/**
- * Sets the event context
- * @param event_ptr a pointer to the event supplied in an on_error callback
- * @param value the new event context value, which can be NULL
- */
-void bugsnag_event_set_context(void *event_ptr, char *value);
-
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -1,6 +1,9 @@
 #ifndef BUGSNAG_ANDROID_NDK_EVENT_API_H
 #define BUGSNAG_ANDROID_NDK_EVENT_API_H
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 typedef enum {
   /** An unhandled exception */
   BSG_SEVERITY_ERR,
@@ -46,5 +49,61 @@ typedef enum {
    */
   BSG_CRUMB_USER,
 } bsg_breadcrumb_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Retrieves the event context
+ * @param event_ptr a pointer to the event supplied in an on_error callback
+ * @return the event context, or NULL if this has not been set
+ */
+char *bugsnag_event_get_context(void *event_ptr);
+
+/**
+ * Sets the event context
+ * @param event_ptr a pointer to the event supplied in an on_error callback
+ * @param value the new event context value, which can be NULL
+ */
+void bugsnag_event_set_context(void *event_ptr, char *value);
+
+
+/* Accessors for event.app */
+
+
+char *bugsnag_app_get_binary_arch(void *event_ptr);
+void bugsnag_app_set_binary_arch(void *event_ptr, char *value);
+
+char *bugsnag_app_get_build_uuid(void *event_ptr);
+void bugsnag_app_set_build_uuid(void *event_ptr, char *value);
+
+char *bugsnag_app_get_id(void *event_ptr);
+void bugsnag_app_set_id(void *event_ptr, char *value);
+
+char *bugsnag_app_get_release_stage(void *event_ptr);
+void bugsnag_app_set_release_stage(void *event_ptr, char *value);
+
+char *bugsnag_app_get_type(void *event_ptr);
+void bugsnag_app_set_type(void *event_ptr, char *value);
+
+char *bugsnag_app_get_version(void *event_ptr);
+void bugsnag_app_set_version(void *event_ptr, char *value);
+
+int bugsnag_app_get_version_code(void *event_ptr);
+void bugsnag_app_set_version_code(void *event_ptr, int value);
+
+time_t bugsnag_app_get_duration(void *event_ptr);
+void bugsnag_app_set_duration(void *event_ptr, time_t value);
+
+time_t bugsnag_app_get_duration_in_foreground(void *event_ptr);
+void bugsnag_app_set_duration_in_foreground(void *event_ptr, time_t value);
+
+bool bugsnag_app_get_in_foreground(void *event_ptr);
+void bugsnag_app_set_in_foreground(void *event_ptr, bool value);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -228,11 +228,3 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
   (*env)->DeleteLocalRef(env, type_class);
   (*env)->DeleteLocalRef(env, interface_class);
 }
-
-void bugsnag_add_on_error(bsg_on_error on_error) {
-  bugsnag_add_on_error_env(bsg_global_jni_env, on_error);
-}
-
-void bugsnag_remove_on_error(bsg_on_error on_error) {
-  bugsnag_remove_on_error_env(bsg_global_jni_env, on_error);
-}

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -228,3 +228,11 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
   (*env)->DeleteLocalRef(env, type_class);
   (*env)->DeleteLocalRef(env, interface_class);
 }
+
+void bugsnag_add_on_error(bsg_on_error on_error) {
+  bugsnag_add_on_error_env(bsg_global_jni_env, on_error);
+}
+
+void bugsnag_remove_on_error(bsg_on_error on_error) {
+  bugsnag_remove_on_error_env(bsg_global_jni_env, on_error);
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -282,7 +282,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateAppVersion(JNIEnv *env,
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
   bsg_request_env_write_lock();
-  bugsnag_event_set_app_version(&bsg_global_env->next_event, value);
+  bugsnag_app_set_version(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
   (*env)->ReleaseStringUTFChars(env, new_value, value);
 }
@@ -297,7 +297,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateBuildUUID(JNIEnv *env,
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
   bsg_request_env_write_lock();
-  bugsnag_event_set_build_uuid(&bsg_global_env->next_event, value);
+  bugsnag_app_set_build_uuid(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
   (*env)->ReleaseStringUTFChars(env, new_value, value);
 }
@@ -376,7 +376,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateReleaseStage(
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
   bsg_request_env_write_lock();
-  bugsnag_event_set_release_stage(&bsg_global_env->next_event, value);
+  bugsnag_app_set_release_stage(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
     (*env)->ReleaseStringUTFChars(env, new_value, value);

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -121,16 +121,6 @@ void bugsnag_event_set_orientation(bugsnag_event *event, int value) {
                    sizeof(event->device.orientation));
 }
 
-void bugsnag_event_set_build_uuid(bugsnag_event *event, char *value) {
-  bsg_strncpy_safe(event->app.build_uuid, value,
-                   sizeof(event->app.build_uuid));
-}
-
-void bugsnag_event_set_release_stage(bugsnag_event *event, char *value) {
-  bsg_strncpy_safe(event->app.release_stage, value,
-                   sizeof(event->app.release_stage));
-}
-
 void bugsnag_event_set_user_email(bugsnag_event *event, char *value) {
   bsg_strncpy_safe(event->user.email, value, sizeof(event->user.email));
 }
@@ -141,10 +131,6 @@ void bugsnag_event_set_user_name(bugsnag_event *event, char *value) {
 
 void bugsnag_event_set_user_id(bugsnag_event *event, char *value) {
   bsg_strncpy_safe(event->user.id, value, sizeof(event->user.id));
-}
-
-void bugsnag_event_set_app_version(bugsnag_event *event, char *value) {
-  bsg_strncpy_safe(event->app.version, value, sizeof(event->app.version));
 }
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,
@@ -168,4 +154,108 @@ void bugsnag_event_clear_breadcrumbs(bugsnag_event *event) {
 
 bool bugsnag_event_has_session(bugsnag_event *event) {
     return strlen(event->session_id) > 0;
+}
+
+
+/* Accessors for event.app */
+
+
+char *bugsnag_app_get_binary_arch(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.binaryArch;
+}
+
+void bugsnag_app_set_binary_arch(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->app.binaryArch, value, sizeof(event->app.binaryArch));
+}
+
+char *bugsnag_app_get_build_uuid(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.build_uuid;
+}
+
+void bugsnag_app_set_build_uuid(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->app.build_uuid, value, sizeof(event->app.build_uuid));
+}
+
+char *bugsnag_app_get_id(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.id;
+}
+
+void bugsnag_app_set_id(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->app.id, value, sizeof(event->app.id));
+}
+
+char *bugsnag_app_get_release_stage(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.release_stage;
+}
+
+void bugsnag_app_set_release_stage(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->app.release_stage, value, sizeof(event->app.release_stage));
+}
+
+char *bugsnag_app_get_type(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.type;
+}
+
+void bugsnag_app_set_type(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->app.type, value, sizeof(event->app.type));
+}
+
+char *bugsnag_app_get_version(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.version;
+}
+
+void bugsnag_app_set_version(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->app.version, value, sizeof(event->app.version));
+}
+
+int bugsnag_app_get_version_code(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.version_code;
+}
+
+void bugsnag_app_set_version_code(void *event_ptr, int value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->app.version_code = value;
+}
+
+time_t bugsnag_app_get_duration(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.duration;
+}
+
+void bugsnag_app_set_duration(void *event_ptr, time_t value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->app.duration = value;
+}
+
+time_t bugsnag_app_get_duration_in_foreground(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.duration_in_foreground;
+}
+
+void bugsnag_app_set_duration_in_foreground(void *event_ptr, time_t value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->app.duration_in_foreground = value;
+}
+
+bool bugsnag_app_get_in_foreground(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->app.in_foreground;
+}
+
+void bugsnag_app_set_in_foreground(void *event_ptr, bool value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->app.in_foreground = value;
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -35,8 +35,6 @@
 #define BUGSNAG_EVENT_VERSION 3
 
 #define BUGSNAG_USER_INFO_LEN 64
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -261,9 +259,6 @@ void bugsnag_event_remove_metadata(bugsnag_event *event, char *section,
                                    char *name);
 void bugsnag_event_remove_metadata_tab(bugsnag_event *event, char *section);
 void bugsnag_event_set_orientation(bugsnag_event *event, int value);
-void bugsnag_event_set_app_version(bugsnag_event *event, char *value);
-void bugsnag_event_set_build_uuid(bugsnag_event *event, char *value);
-void bugsnag_event_set_release_stage(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_email(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_id(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_name(bugsnag_event *event, char *value);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -1,23 +1,135 @@
 #include <greatest/greatest.h>
 #include <event.h>
 #include <utils/string.h>
-#include "../../main/assets/include/bugsnag.h"
+#include <event.h>
 
 bugsnag_event *init_event() {
     bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
     bsg_strncpy_safe(event->context, "Foo", sizeof(event->context));
+
+    bsg_strncpy_safe(event->app.binaryArch, "x86", sizeof(event->app.binaryArch));
+    bsg_strncpy_safe(event->app.build_uuid, "123", sizeof(event->app.build_uuid));
+    bsg_strncpy_safe(event->app.id, "fa02", sizeof(event->app.id));
+    bsg_strncpy_safe(event->app.release_stage, "dev", sizeof(event->app.release_stage));
+    bsg_strncpy_safe(event->app.type, "C", sizeof(event->app.type));
+    bsg_strncpy_safe(event->app.version, "1.0", sizeof(event->app.version));
+    event->app.version_code = 55;
+    event->app.duration = 9019;
+    event->app.duration_in_foreground = 7017;
+    event->app.in_foreground = true;
     return event;
 }
 
 TEST test_event_context(void) {
     bugsnag_event *event = init_event();
-    ASSERT_STR_EQ("Foo", event->context);
+    ASSERT_STR_EQ("Foo", bugsnag_event_get_context(event));
     bugsnag_event_set_context(event, "SomeContext");
-    ASSERT_STR_EQ("SomeContext", event->context);
+    ASSERT_STR_EQ("SomeContext", bugsnag_event_get_context(event));
     free(event);
     PASS();
 }
 
+TEST test_event_binary_arch(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("x86", bugsnag_app_get_binary_arch(event));
+    bugsnag_app_set_binary_arch(event, "armeabi-v7a");
+    ASSERT_STR_EQ("armeabi-v7a", bugsnag_app_get_binary_arch(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_build_uuid(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("123", bugsnag_app_get_build_uuid(event));
+    bugsnag_app_set_build_uuid(event, "my-id-123");
+    ASSERT_STR_EQ("my-id-123", bugsnag_app_get_build_uuid(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_id(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("fa02", bugsnag_app_get_id(event));
+    bugsnag_app_set_id(event, "my-id-123");
+    ASSERT_STR_EQ("my-id-123", bugsnag_app_get_id(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_release_stage(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("dev", bugsnag_app_get_release_stage(event));
+    bugsnag_app_set_release_stage(event, "beta");
+    ASSERT_STR_EQ("beta", bugsnag_app_get_release_stage(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_type(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("C", bugsnag_app_get_type(event));
+    bugsnag_app_set_type(event, "C++");
+    ASSERT_STR_EQ("C++", bugsnag_app_get_type(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_version(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("1.0", bugsnag_app_get_version(event));
+    bugsnag_app_set_version(event, "2.2");
+    ASSERT_STR_EQ("2.2", bugsnag_app_get_version(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_version_code(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_EQ(55, bugsnag_app_get_version_code(event));
+    bugsnag_app_set_version_code(event, 99);
+    ASSERT_EQ(99, bugsnag_app_get_version_code(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_duration(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_EQ(9019, bugsnag_app_get_duration(event));
+    bugsnag_app_set_duration(event, 552);
+    ASSERT_EQ(552, bugsnag_app_get_duration(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_duration_in_foreground(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_EQ(7017, bugsnag_app_get_duration_in_foreground(event));
+    bugsnag_app_set_duration_in_foreground(event, 209);
+    ASSERT_EQ(209, bugsnag_app_get_duration_in_foreground(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_in_foreground(void) {
+    bugsnag_event *event = init_event();
+    ASSERT(bugsnag_app_get_in_foreground(event));
+    bugsnag_app_set_in_foreground(event, false);
+    ASSERT_FALSE(bugsnag_app_get_in_foreground(event));
+    free(event);
+    PASS();
+}
+
+
 SUITE(event_mutators) {
     RUN_TEST(test_event_context);
+    RUN_TEST(test_event_binary_arch);
+    RUN_TEST(test_event_build_uuid);
+    RUN_TEST(test_event_id);
+    RUN_TEST(test_event_release_stage);
+    RUN_TEST(test_event_type);
+    RUN_TEST(test_event_version);
+    RUN_TEST(test_event_version_code);
+    RUN_TEST(test_event_duration);
+    RUN_TEST(test_event_duration_in_foreground);
+    RUN_TEST(test_event_in_foreground);
 }


### PR DESCRIPTION
## Goal

Adds accessor methods for manipulating the fields on `event.app`. This is necessary now that the `bugsnag_event` pointer is exposed in an `on_error` callback, and allows users to mutate the generated report.

## Changeset

Added get/set methods for each field defined on `event.app` that is present in the notifier spec.

## Tests

Added unit tests for each new accessor method.
