### PR TITLE
Fix ignored reports mazerunner test

### DIFF
--- a/features/fixtures/mazerunner/src/main/cpp/entrypoint.cpp
+++ b/features/fixtures/mazerunner/src/main/cpp/entrypoint.cpp
@@ -219,6 +219,28 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXThrowSomethingScenario_crash(JN
 }
 
 JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXThrowSomethingReenabledScenario_crash(JNIEnv *env,
+                                                                                       jobject instance,
+                                                                                       jint num) {
+  printf("This one here: %ld\n", (long) throw_an_object((num - 10) > 0, num));
+  printf("This one here: %ld\n", (long) trigger_an_exception(num > 0));
+}
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXThrowSomethingOutsideReleaseStagesScenario_crash(JNIEnv *env,
+                                                                                                  jobject instance,
+                                                                                                  jint num) {
+  printf("This one here: %ld\n", (long) throw_an_object((num - 10) > 0, num));
+  printf("This one here: %ld\n", (long) trigger_an_exception(num > 0));
+}
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXTrapOutsideReleaseStagesScenario_crash(JNIEnv *env,
+                                                                                        jobject instance) {
+  printf("This one here: %ld\n", (long) crash_trap());
+}
+
+JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXStackoverflowScenario_crash(JNIEnv *env,
                                                                              jobject instance,
                                                                              jint counter,

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingReenabledScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingReenabledScenario.java
@@ -31,6 +31,7 @@ public class CXXThrowSomethingReenabledScenario extends Scenario {
         }
         Bugsnag.getClient().getConfig().setReleaseStage("production");
         Bugsnag.getClient().getConfig().setNotifyReleaseStages(new String[]{"fee-fi-fo-fum"});
+        Bugsnag.getClient().getConfig().setDetectNdkCrashes(true);
         Bugsnag.getClient().getConfig().setNotifyReleaseStages(new String[]{"production"});
         crash(23);
     }

--- a/tests/features/fixtures/mazerunner/src/main/cpp/entrypoint.cpp
+++ b/tests/features/fixtures/mazerunner/src/main/cpp/entrypoint.cpp
@@ -221,6 +221,29 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXThrowSomethingScenario_crash(JN
   printf("This one here: %ld\n", (long) trigger_an_exception(num > 0));
 }
 
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXThrowSomethingReenabledScenario_crash(JNIEnv *env,
+                                                                                       jobject instance,
+                                                                                       jint num) {
+  printf("This one here: %ld\n", (long) throw_an_object((num - 10) > 0, num));
+  printf("This one here: %ld\n", (long) trigger_an_exception(num > 0));
+}
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXThrowSomethingOutsideReleaseStagesScenario_crash(JNIEnv *env,
+                                                                                                  jobject instance,
+                                                                                                  jint num) {
+  printf("This one here: %ld\n", (long) throw_an_object((num - 10) > 0, num));
+  printf("This one here: %ld\n", (long) trigger_an_exception(num > 0));
+}
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXTrapOutsideReleaseStagesScenario_crash(JNIEnv *env,
+                                                                                        jobject instance) {
+  printf("This one here: %ld\n", (long) crash_trap());
+}
+
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXStackoverflowScenario_crash(JNIEnv *env,
                                                                              jobject instance,

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -65,10 +65,9 @@ class MainActivity : Activity() {
     private fun loadScenario(configuration: Configuration, eventType: String, eventMetaData: String): Scenario {
         Log.d("Bugsnag", "Received test case, executing " + eventType)
         Log.d("Bugsnag", "Received metadata: " + eventMetaData)
-
         this.intent.putExtra("eventMetaData", eventMetaData)
         val testCase = factory.testCaseForName(eventType, configuration, this)
-
+        testCase.eventMetaData = eventMetaData
         return testCase
     }
 

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingReenabledScenario.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingReenabledScenario.java
@@ -31,6 +31,7 @@ public class CXXThrowSomethingReenabledScenario extends Scenario {
         }
         Bugsnag.getClient().getConfig().setReleaseStage("production");
         Bugsnag.getClient().getConfig().setNotifyReleaseStages(new String[]{"fee-fi-fo-fum"});
+        Bugsnag.getClient().getConfig().setDetectNdkCrashes(true);
         Bugsnag.getClient().getConfig().setNotifyReleaseStages(new String[]{"production"});
         crash(23);
     }

--- a/tests/features/ignored_reports.feature
+++ b/tests/features/ignored_reports.feature
@@ -26,7 +26,7 @@ Scenario: Reenabling native crash reporting before a native C++ crash
     When I run "CXXThrowSomethingReenabledScenario" and relaunch the app
     And I configure the app to run in the "non-crashy" state
     And I run "CXXThrowSomethingReenabledScenario"
-    Then I should receive a request
+    Then I wait to receive a request
 
 Scenario: Changing release stage to exclude the current stage settings before a POSIX signal
     When I run "CXXTrapOutsideReleaseStagesScenario" and relaunch the app


### PR DESCRIPTION
## Goal

Fixes `ignored_report.feature` which was failing on Android 6 browserstack devices, but passing locally.

## Changeset

This fix comes in 4 parts:

1. Add missing C++ methods that are called by the JNI. As these weren't present the scenario would always crash prior to execution
2. Set `setDetectNdkCrashes` to `true` after altering the release stages, required since #736 
3. Set the `eventMetaData` variable for scenarios in the fixture app. The `eventMetaData` variable was not set by default in the browserstack fixture but was set in the local fixture, which led to the scenario failing _only_ when run on browserstack under a specific set of circumstances
4. Fix an incorrect assertion that used mazerunner v1 steps, rather than v2

**Note**: we should possibly consider different approaches for verifying that no requests are delivered in a specific scenario. Currently it is hard to distinguish between 0 requests being delivered due to the correct behaviour, or 0 requests being delivered due to bugsnag crashing everything. Perhaps updating these scenarios to send a handled exception on the relaunch might be a suitable alternative.
