### PR TITLE
Rename Bugsnag.init to Bugsnag.start

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -12,7 +12,7 @@ import java.util.Map;
  * Static access to a Bugsnag Client, the easiest way to use Bugsnag in your Android app.
  * For example:
  * <p>
- * Bugsnag.init(this, "your-api-key");
+ * Bugsnag.start(this, "your-api-key");
  * Bugsnag.notify(new RuntimeException("something broke!"));
  *
  * @see Client
@@ -34,8 +34,8 @@ public final class Bugsnag {
      * @param androidContext an Android context, usually <code>this</code>
      */
     @NonNull
-    public static Client init(@NonNull Context androidContext) {
-        return init(androidContext, Configuration.load(androidContext));
+    public static Client start(@NonNull Context androidContext) {
+        return start(androidContext, Configuration.load(androidContext));
     }
 
     /**
@@ -45,8 +45,8 @@ public final class Bugsnag {
      * @param apiKey         your Bugsnag API key from your Bugsnag dashboard
      */
     @NonNull
-    public static Client init(@NonNull Context androidContext, @NonNull String apiKey) {
-        return init(androidContext, Configuration.load(androidContext, apiKey));
+    public static Client start(@NonNull Context androidContext, @NonNull String apiKey) {
+        return start(androidContext, Configuration.load(androidContext, apiKey));
     }
 
     /**
@@ -56,7 +56,7 @@ public final class Bugsnag {
      * @param config         a configuration for the Client
      */
     @NonNull
-    public static Client init(@NonNull Context androidContext, @NonNull Configuration config) {
+    public static Client start(@NonNull Context androidContext, @NonNull Configuration config) {
         synchronized (lock) {
             if (client == null) {
                 client = new Client(androidContext, config);
@@ -68,7 +68,7 @@ public final class Bugsnag {
     }
 
     private static void logClientInitWarning() {
-        getClient().logger.w("Multiple Bugsnag.init calls detected. Ignoring.");
+        getClient().logger.w("Multiple Bugsnag.start calls detected. Ignoring.");
     }
 
     /**
@@ -322,7 +322,7 @@ public final class Bugsnag {
     @NonNull
     public static Client getClient() {
         if (client == null) {
-            throw new IllegalStateException("You must call Bugsnag.init before any"
+            throw new IllegalStateException("You must call Bugsnag.start before any"
                 + " other Bugsnag methods");
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -65,7 +65,7 @@ class Configuration(
      * Sets the threshold in ms for an uncaught error to be considered as a crash on launch.
      * If a crash is detected on launch, Bugsnag will attempt to send the report synchronously.
      *
-     * The app's launch time is tracked as the time at which [Bugsnag.init] was
+     * The app's launch time is tracked as the time at which [Bugsnag.start] was
      * called.
      *
      * By default, this value is set at 5,000ms.

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -21,7 +21,7 @@ public class NativeInterface {
     private static Charset UTF8Charset = Charset.defaultCharset();
 
     /**
-     * Static reference used if not using Bugsnag.init()
+     * Static reference used if not using Bugsnag.start()
      */
     @SuppressLint("StaticFieldLeak")
     private static Client client;

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagClientMirrorInterfaceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagClientMirrorInterfaceTest.kt
@@ -15,7 +15,7 @@ import java.lang.reflect.Method
  */
 class BugsnagClientMirrorInterfaceTest {
 
-    private val bugsnagBlacklist = setOf("init", "getClient")
+    private val bugsnagBlacklist = setOf("start", "getClient")
     private val clientBlacklist = setOf(
         "update",
         "notifyObservers",

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
@@ -12,7 +12,7 @@ extern "C" {
  * Configure the Bugsnag interface, optionally including the JNI environment.
  * @param env  The JNI environment to use when using convenience methods
  */
-void bugsnag_init(JNIEnv *env);
+void bugsnag_start(JNIEnv *env);
 /**
  * Sends an error report to Bugsnag
  * @param name     The name of the error

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -14,7 +14,7 @@ static JNIEnv *bsg_global_jni_env = NULL;
 
 void bugsnag_set_binary_arch(JNIEnv *env);
 
-void bugsnag_init(JNIEnv *env) { bsg_global_jni_env = env; }
+void bugsnag_start(JNIEnv *env) { bsg_global_jni_env = env; }
 
 void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
                         bsg_severity_t severity);
@@ -26,7 +26,7 @@ void bugsnag_notify(char *name, char *message, bsg_severity_t severity) {
   if (bsg_global_jni_env != NULL) {
     bugsnag_notify_env(bsg_global_jni_env, name, message, severity);
   } else {
-    BUGSNAG_LOG("Cannot bugsnag_notify before initializing with bugsnag_init");
+    BUGSNAG_LOG("Cannot bugsnag_notify before initializing with bugsnag_start");
   }
 }
 
@@ -35,7 +35,7 @@ void bugsnag_set_user(char *id, char *email, char *name) {
     bugsnag_set_user_env(bsg_global_jni_env, id, email, name);
   } else {
     BUGSNAG_LOG(
-        "Cannot bugsnag_set_user before initializing with bugsnag_init");
+        "Cannot bugsnag_set_user before initializing with bugsnag_start");
   }
 }
 
@@ -44,7 +44,7 @@ void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_t type) {
     bugsnag_leave_breadcrumb_env(bsg_global_jni_env, message, type);
   } else {
     BUGSNAG_LOG("Cannot bugsnag_leave_breadcrumb_env before initializing with "
-                "bugsnag_init");
+                "bugsnag_start");
   }
 }
 

--- a/examples/sdk-app-example/src/main/java/com.bugsnag.android/example/ExampleApplication.kt
+++ b/examples/sdk-app-example/src/main/java/com.bugsnag.android/example/ExampleApplication.kt
@@ -7,7 +7,7 @@ class ExampleApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        Bugsnag.init(this)
+        Bugsnag.start(this)
     }
 
 }

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : Activity() {
         val config = prepareConfig()
         val testCase = loadScenario(config)
 
-        Bugsnag.init(this, config)
+        Bugsnag.start(this, config)
 
         /**
          * Enqueues the test case with a delay on the main thread. This avoids the Activity wrapping

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionScenario.kt
@@ -14,7 +14,7 @@ internal class AutoSessionScenario(config: Configuration,
     override fun run() {
         super.run()
         config.autoTrackSessions = true
-        Bugsnag.init(context, config)
+        Bugsnag.start(context, config)
         Bugsnag.setUser("123", "user@example.com", "Joe Bloggs")
         context.startActivity(Intent("com.bugsnag.android.mazerunner.UPDATE_CONTEXT"))
     }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BugsnagInitScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BugsnagInitScenario.kt
@@ -26,9 +26,9 @@ internal class BugsnagInitScenario(
         val callables = mutableListOf<Callable<Client?>>()
 
         IntRange(1, 25).forEach {
-            callables.add(Callable { Bugsnag.init(context) })
-            callables.add(Callable { Bugsnag.init(context, config.apiKey) })
-            callables.add(Callable { Bugsnag.init(context, Configuration(config.apiKey)) })
+            callables.add(Callable { Bugsnag.start(context) })
+            callables.add(Callable { Bugsnag.start(context, config.apiKey) })
+            callables.add(Callable { Bugsnag.start(context, Configuration(config.apiKey)) })
         }
 
         val futures = threadPool.invokeAll(callables)

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -44,14 +44,14 @@ class MainActivity : Activity() {
         val config = prepareConfig()
         loadScenario(config, eventType, metaData)
 
-        Bugsnag.init(this, config)
+        Bugsnag.start(this, config)
     }
 
     private fun executeScenario(eventType: String, metaData: String) {
         val config = prepareConfig()
         val testCase = loadScenario(config, eventType, metaData)
 
-        Bugsnag.init(this, config)
+        Bugsnag.start(this, config)
 
         /**
          * Enqueues the test case with a delay on the main thread. This avoids the Activity wrapping


### PR DESCRIPTION
Renames `Bugsnag.init()` to `Bugsnag.start()` to achieve compliance with the notifier spec naming conventions.