### PR TITLE
Convert sendThreads from boolean to enum

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -31,7 +31,7 @@ class ManifestConfigLoaderTest {
             assertFalse(autoDetectAnrs)
             assertFalse(autoDetectNdkCrashes)
             assertTrue(autoTrackSessions)
-            assertTrue(sendThreads)
+            assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
             assertFalse(persistUser)
 
             // endpoints
@@ -67,7 +67,6 @@ class ManifestConfigLoaderTest {
             putBoolean("com.bugsnag.android.AUTO_DETECT_NDK_CRASHES", true)
             putBoolean("com.bugsnag.android.AUTO_TRACK_SESSIONS", false)
             putBoolean("com.bugsnag.android.AUTO_CAPTURE_BREADCRUMBS", false)
-            putBoolean("com.bugsnag.android.SEND_THREADS", false)
             putBoolean("com.bugsnag.android.PERSIST_USER", true)
 
             // endpoints
@@ -101,7 +100,7 @@ class ManifestConfigLoaderTest {
             assertTrue(autoDetectAnrs)
             assertTrue(autoDetectNdkCrashes)
             assertFalse(autoTrackSessions)
-            assertFalse(sendThreads)
+            assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
             assertTrue(persistUser)
 
             // endpoints

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -51,9 +51,9 @@ class Configuration(
 
     /**
      * Set whether to send thread-state with report.
-     * By default, this will be true.
+     * By default, this will be [Thread.ThreadSendPolicy.ALWAYS].
      */
-    var sendThreads: Boolean = true
+    var sendThreads: Thread.ThreadSendPolicy = Thread.ThreadSendPolicy.ALWAYS
 
     /**
      * Set whether or not Bugsnag should persist user information between application settings

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.Thread.ThreadSendPolicy.*
 import java.io.IOException
 import java.util.HashMap
 
@@ -51,9 +52,15 @@ class Event @JvmOverloads internal constructor(
         else -> Error.createError(originalError, config.projectPackages, config.logger)
     }
 
-    var threads: List<Thread> = when {
-        config.sendThreads -> ThreadState(config, if (isUnhandled) originalError else null).threads
-        else -> emptyList()
+    var threads: List<Thread>
+
+    init {
+        val recordThreads = config.sendThreads == ALWAYS || (config.sendThreads == UNHANDLED_ONLY && isUnhandled)
+
+        threads = when {
+            recordThreads -> ThreadState(config, if (isUnhandled) originalError else null).threads
+            else -> emptyList()
+        }
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -11,7 +11,7 @@ internal data class ImmutableConfig(
     val autoDetectAnrs: Boolean,
     val autoDetectNdkCrashes: Boolean,
     val autoTrackSessions: Boolean,
-    val sendThreads: Boolean,
+    val sendThreads: Thread.ThreadSendPolicy,
     val ignoreClasses: Collection<String>,
     val enabledReleaseStages: Collection<String>,
     val projectPackages: Collection<String>,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -20,7 +20,6 @@ internal class ManifestConfigLoader {
         private const val AUTO_DETECT_ANRS = "$BUGSNAG_NS.AUTO_DETECT_ANRS"
         private const val AUTO_DETECT_NDK_CRASHES = "$BUGSNAG_NS.AUTO_DETECT_NDK_CRASHES"
         private const val AUTO_TRACK_SESSIONS = "$BUGSNAG_NS.AUTO_TRACK_SESSIONS"
-        private const val SEND_THREADS = "$BUGSNAG_NS.SEND_THREADS"
         private const val PERSIST_USER = "$BUGSNAG_NS.PERSIST_USER"
 
         // endpoints
@@ -91,7 +90,6 @@ internal class ManifestConfigLoader {
             autoDetectAnrs = data.getBoolean(AUTO_DETECT_ANRS, autoDetectAnrs)
             autoDetectNdkCrashes = data.getBoolean(AUTO_DETECT_NDK_CRASHES, autoDetectNdkCrashes)
             autoTrackSessions = data.getBoolean(AUTO_TRACK_SESSIONS, autoTrackSessions)
-            sendThreads = data.getBoolean(SEND_THREADS, sendThreads)
             persistUser = data.getBoolean(PERSIST_USER, persistUser)
         }
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
@@ -18,6 +18,12 @@ class Thread internal constructor(
         BROWSER_JS("browserjs")
     }
 
+    enum class ThreadSendPolicy {
+        ALWAYS,
+        UNHANDLED_ONLY,
+        NEVER
+    }
+
     var stacktrace: MutableList<Stackframe> = stacktrace.trace.toMutableList()
 
     @Throws(IOException::class)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -45,7 +45,7 @@ internal class ImmutableConfigTest {
             assertTrue(autoDetectErrors)
             assertFalse(autoDetectAnrs)
             assertFalse(autoDetectNdkCrashes)
-            assertTrue(sendThreads)
+            assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
 
             // release stages
             assertTrue(ignoreClasses.isEmpty())
@@ -78,7 +78,7 @@ internal class ImmutableConfigTest {
         seed.autoDetectErrors = false
         seed.autoDetectAnrs = true
         seed.autoDetectNdkCrashes = true
-        seed.sendThreads = false
+        seed.sendThreads = Thread.ThreadSendPolicy.UNHANDLED_ONLY
 
         seed.ignoreClasses = setOf("foo")
         seed.enabledReleaseStages = setOf("bar")
@@ -106,7 +106,7 @@ internal class ImmutableConfigTest {
             assertFalse(autoDetectErrors)
             assertTrue(autoDetectAnrs)
             assertTrue(autoDetectNdkCrashes)
-            assertFalse(sendThreads)
+            assertEquals(Thread.ThreadSendPolicy.UNHANDLED_ONLY, sendThreads)
 
             // release stages
             assertEquals(setOf("foo"), ignoreClasses)


### PR DESCRIPTION
## Goal

Converts the `sendThreads` configuration option from a boolean to an enum type. This allows for multiple states to be specified in future, and also allows for a distinction between always reporting thread traces, never reporting, and reporting only for unhandled errors.

## Changeset

- Updated `Event` logic that gates whether a thread trace should be collected or not
- Removed `com.bugsnag.android.SEND_THREADS` as a key that can be specified in the manifest as this is no longer a primitive type
- Updated existing test coverage to assert the new default values/overrides for the `sendThreads` option
