### PR TITLE
Allow setting user on Configuration object

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -281,4 +281,23 @@ public class ClientTest {
         data.put("second", "another value");
         assertEquals(data, client.getMetadata("test_section"));
     }
+
+    @Test
+    public void testUserCloned() {
+        config.setUser("123", "test@example.com", "Tess Derby");
+        client = new Client(context, config);
+        User user = client.getUser();
+        assertEquals("123", user.getId());
+        assertEquals("Tess Derby", user.getName());
+        assertEquals("test@example.com", user.getEmail());
+    }
+
+    @Test
+    public void testUserNotCloned() {
+        client = new Client(context, config);
+        User user = client.getUser();
+        assertNotNull(user.getId()); // use an auto-generated-id
+        assertNull(user.getName());
+        assertNull(user.getEmail());
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -169,6 +169,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         UserRepository userRepository = new UserRepository(sharedPrefs,
                 immutableConfig.getPersistUser());
         userState = new UserState(userRepository);
+        User user = configuration.getUser();
+
+        if (user.getId() != null || user.getEmail() != null || user.getName() != null) {
+            userState.setUser(user.getId(), user.getEmail(), user.getName());
+        }
 
         String id = userState.getUser().getId();
         DeviceBuildInfo info = DeviceBuildInfo.Companion.defaultInfo();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -12,7 +12,9 @@ class Configuration(
      * Gets the API key to send reports to
      */
     val apiKey: String
-) : CallbackAware, MetadataAware {
+) : CallbackAware, MetadataAware, UserAware {
+
+    private var user = User()
 
     @JvmField
     internal val callbackState: CallbackState
@@ -295,6 +297,11 @@ class Configuration(
 
     override fun getMetadata(section: String) = metadataState.getMetadata(section)
     override fun getMetadata(section: String, key: String) = metadataState.getMetadata(section, key)
+
+    override fun getUser(): User = user
+    override fun setUser(id: String?, email: String?, name: String?) {
+        user = User(id, email, name)
+    }
 
     companion object {
         private const val DEFAULT_MAX_SIZE = 25


### PR DESCRIPTION
## Goal

Allows setting an initial `User` object on `Configuration`, which brings bugsnag-android into line with the notifier spec.

## Changeset

Made `Configuration` implement `UserAware` and copied `user` field to `Client` if it has been mutated from the default

## Tests

Added an instrumentation test to verify the behaviour for when user should and shouldn't be cloned
