### PR TITLE
Null array values should be interpreted as true

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -42,7 +42,7 @@ class ManifestConfigLoaderTest {
             assertNull(appVersion)
             assertEquals(0, versionCode)
             assertNull(releaseStage)
-            assertEquals(emptySet<String>(), enabledReleaseStages)
+            assertNull(enabledReleaseStages)
             assertEquals(emptySet<String>(), ignoreClasses)
             assertEquals(emptySet<String>(), projectPackages)
             assertEquals(setOf("password"), redactedKeys)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Observer;
+import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 
 /**
@@ -236,7 +237,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
             public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
-                return immutableConfig.getEnabledBreadcrumbTypes().contains(breadcrumb.getType());
+                return immutableConfig.shouldRecordBreadcrumbType(breadcrumb.getType());
             }
         });
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -213,9 +213,9 @@ class Configuration(
      *
      * client.setEnabledReleaseStages("production");
      */
-    var enabledReleaseStages: Set<String> = emptySet()
+    var enabledReleaseStages: Set<String>? = null
 
-    var enabledBreadcrumbTypes: Set<BreadcrumbType> = BreadcrumbType.values().toSet()
+    var enabledBreadcrumbTypes: Set<BreadcrumbType>? = BreadcrumbType.values().toSet()
 
     /**
      * Set which packages should be considered part of your application.

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -13,9 +13,9 @@ internal data class ImmutableConfig(
     val autoTrackSessions: Boolean,
     val sendThreads: Thread.ThreadSendPolicy,
     val ignoreClasses: Collection<String>,
-    val enabledReleaseStages: Collection<String>,
+    val enabledReleaseStages: Collection<String>?,
     val projectPackages: Collection<String>,
-    val enabledBreadcrumbTypes: Set<BreadcrumbType>,
+    val enabledBreadcrumbTypes: Set<BreadcrumbType>?,
     val releaseStage: String?,
     val buildUuid: String?,
     val appVersion: String?,
@@ -44,7 +44,11 @@ internal data class ImmutableConfig(
      */
     @JvmName("shouldNotifyForReleaseStage")
     internal fun shouldNotifyForReleaseStage() =
-        enabledReleaseStages.isEmpty() || enabledReleaseStages.contains(releaseStage)
+        enabledReleaseStages == null || enabledReleaseStages.contains(releaseStage)
+
+    @JvmName("shouldRecordBreadcrumbType")
+    internal fun shouldRecordBreadcrumbType(type: BreadcrumbType) =
+        enabledBreadcrumbTypes == null || enabledBreadcrumbTypes.contains(type)
 
     @JvmName("getErrorApiDeliveryParams")
     internal fun getErrorApiDeliveryParams() = DeliveryParams(endpoints.notify, errorApiHeaders())
@@ -89,7 +93,7 @@ internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
         autoTrackSessions = config.autoTrackSessions,
         sendThreads = config.sendThreads,
         ignoreClasses = config.ignoreClasses.toSet(),
-        enabledReleaseStages = config.enabledReleaseStages.toSet(),
+        enabledReleaseStages = config.enabledReleaseStages?.toSet(),
         projectPackages = config.projectPackages.toSet(),
         releaseStage = config.releaseStage,
         buildUuid = config.buildUuid,
@@ -103,7 +107,7 @@ internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
         launchCrashThresholdMs = config.launchCrashThresholdMs,
         logger = config.logger!!,
         maxBreadcrumbs = config.maxBreadcrumbs,
-        enabledBreadcrumbTypes = config.enabledBreadcrumbTypes.toSet()
+        enabledBreadcrumbTypes = config.enabledBreadcrumbTypes?.toSet()
     )
 }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -112,7 +112,9 @@ internal class ManifestConfigLoader {
             if (data.containsKey(VERSION_CODE)) {
                 versionCode = data.getInt(VERSION_CODE)
             }
-            enabledReleaseStages = getStrArray(data, ENABLED_RELEASE_STAGES, enabledReleaseStages)
+            if (data.containsKey(ENABLED_RELEASE_STAGES)) {
+                enabledReleaseStages = getStrArray(data, ENABLED_RELEASE_STAGES, emptySet())
+            }
             ignoreClasses = getStrArray(data, IGNORE_CLASSES, ignoreClasses)
             projectPackages = getStrArray(data, PROJECT_PACKAGES, projectPackages)
             redactedKeys = getStrArray(data, REDACTED_KEYS, redactedKeys)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -274,7 +274,7 @@ public class NativeInterface {
     /**
      * Return which release stages notify
      */
-    @NonNull
+    @Nullable
     public static Collection<String> getEnabledReleaseStages() {
         return getClient().getConfig().getEnabledReleaseStages();
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.BugsnagTestUtils.convert;
 import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -37,8 +38,13 @@ public class ConfigurationTest {
         // Should notify if enabledReleaseStages is null
         ImmutableConfig immutableConfig;
         immutableConfig = createConfigWithReleaseStages(config,
-                config.getEnabledReleaseStages(), "development");
+                null, "development");
         assertTrue(immutableConfig.shouldNotifyForReleaseStage());
+
+        // Should not notify if enabledReleaseStages is null
+        immutableConfig = createConfigWithReleaseStages(config,
+                Collections.<String>emptySet(), "development");
+        assertFalse(immutableConfig.shouldNotifyForReleaseStage());
 
         // Shouldn't notify if enabledReleaseStages is set and releaseStage is null
         Set<String> example = Collections.singleton("example");
@@ -53,6 +59,31 @@ public class ConfigurationTest {
         // Should notify if releaseStage in enabledReleaseStages
         immutableConfig = createConfigWithReleaseStages(config, stages, "production");
         assertTrue(immutableConfig.shouldNotifyForReleaseStage());
+    }
+
+    @Test
+    public void testShouldSendBreadcrumb() {
+        ImmutableConfig immutableConfig;
+
+        // Should notify if enabledBreadcrumbTypes is null
+        config.setEnabledBreadcrumbTypes(null);
+        immutableConfig = BugsnagTestUtils.convert(config);
+        assertTrue(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
+
+        // Should not notify if enabledBreadcrumbTypes is empty
+        config.setEnabledBreadcrumbTypes(Collections.<BreadcrumbType>emptySet());
+        immutableConfig = BugsnagTestUtils.convert(config);
+        assertFalse(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
+
+        // Should notify if present in enabled types
+        config.setEnabledBreadcrumbTypes(Collections.singleton(BreadcrumbType.MANUAL));
+        immutableConfig = BugsnagTestUtils.convert(config);
+        assertTrue(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
+
+        // Should not notify if not present in enabled types
+        config.setEnabledBreadcrumbTypes(Collections.singleton(BreadcrumbType.ERROR));
+        immutableConfig = BugsnagTestUtils.convert(config);
+        assertFalse(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
     }
 
     private ImmutableConfig createConfigWithReleaseStages(Configuration config,

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -5,6 +5,7 @@ import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -49,7 +50,7 @@ internal class ImmutableConfigTest {
 
             // release stages
             assertTrue(ignoreClasses.isEmpty())
-            assertTrue(enabledReleaseStages.isEmpty())
+            assertNull(enabledReleaseStages)
             assertTrue(projectPackages.isEmpty())
             assertEquals(seed.releaseStage, releaseStage)
 
@@ -129,7 +130,7 @@ internal class ImmutableConfigTest {
             assertEquals(NoopLogger, seed.logger)
             assertEquals(37, seed.maxBreadcrumbs)
             assertTrue(seed.persistUser)
-            assertTrue(seed.enabledBreadcrumbTypes.isEmpty())
+            assertTrue(seed.enabledBreadcrumbTypes!!.isEmpty())
         }
     }
 


### PR DESCRIPTION
## Goal

If an array value is null, it should be interpreted as having all potential values in it. This applies specifically to the `enabledReleaseStages` and `enabledBreadcrumbTypes` configuration options - if a value is null here, we should always report an error/breadcrumb.

## Changeset

- Made `enabledReleaseStages/enabledBreadcrumbTypes` nullable
- Updated code to handle nullability of fields

## Tests

- Updated existing unit test assertions to add a check for behaviour when a field is null
