### PR TITLE
Add enabledErrorTypes configuration option

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -27,9 +27,6 @@ class ManifestConfigLoaderTest {
             assertNull(buildUuid)
 
             // detection
-            assertTrue(autoDetectErrors)
-            assertFalse(autoDetectAnrs)
-            assertFalse(autoDetectNdkCrashes)
             assertTrue(autoTrackSessions)
             assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
             assertFalse(persistUser)
@@ -62,9 +59,6 @@ class ManifestConfigLoaderTest {
             putString("com.bugsnag.android.BUILD_UUID", "fgh123456")
 
             // detection
-            putBoolean("com.bugsnag.android.AUTO_DETECT_ERRORS", false)
-            putBoolean("com.bugsnag.android.AUTO_DETECT_ANRS", true)
-            putBoolean("com.bugsnag.android.AUTO_DETECT_NDK_CRASHES", true)
             putBoolean("com.bugsnag.android.AUTO_TRACK_SESSIONS", false)
             putBoolean("com.bugsnag.android.AUTO_CAPTURE_BREADCRUMBS", false)
             putBoolean("com.bugsnag.android.PERSIST_USER", true)
@@ -96,9 +90,6 @@ class ManifestConfigLoaderTest {
             assertEquals("fgh123456", buildUuid)
 
             // detection
-            assertFalse(autoDetectErrors)
-            assertTrue(autoDetectAnrs)
-            assertTrue(autoDetectNdkCrashes)
             assertFalse(autoTrackSessions)
             assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
             assertTrue(persistUser)
@@ -135,7 +126,6 @@ class ManifestConfigLoaderTest {
 
         with(config) {
             assertEquals("5d1ec5bd39a74caa1267142706a7fb21", apiKey)
-            assertFalse(autoDetectErrors)
         }
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -33,7 +33,7 @@ public class ObserverInterfaceTest {
     public void setUp() {
         Configuration config = generateConfiguration();
         config.setDelivery(BugsnagTestUtils.generateDelivery());
-        config.setAutoDetectErrors(false);
+        config.getEnabledErrorTypes().setUnhandledExceptions(false);
         client = new Client(ApplicationProvider.getApplicationContext(), config);
         observer = new BugsnagTestObserver();
         client.registerObserver(observer);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -203,7 +203,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 immutableConfig, breadcrumbState);
 
         // Install a default exception handler with this client
-        if (immutableConfig.getAutoDetectErrors()) {
+        if (immutableConfig.getEnabledErrorTypes().getUnhandledExceptions()) {
             new ExceptionHandler(this, logger);
         }
 
@@ -279,7 +279,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         if (ndkPluginClz == null) {
             return;
         }
-        if (immutableConfig.getAutoDetectNdkCrashes()) {
+        if (immutableConfig.getEnabledErrorTypes().getNdkCrashes()) {
             BugsnagPluginInterface.INSTANCE.loadPlugin(this, ndkPluginClz);
         } else {
             BugsnagPluginInterface.INSTANCE.unloadPlugin(ndkPluginClz);
@@ -290,7 +290,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         if (anrPluginClz == null) {
             return;
         }
-        if (immutableConfig.getAutoDetectAnrs()) {
+        if (immutableConfig.getEnabledErrorTypes().getAnrs()) {
             BugsnagPluginInterface.INSTANCE.loadPlugin(this, anrPluginClz);
         } else {
             BugsnagPluginInterface.INSTANCE.unloadPlugin(anrPluginClz);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
@@ -9,7 +9,7 @@ internal class ClientObservable : BaseObservable() {
     fun postNdkInstall(conf: ImmutableConfig) {
         notifyObservers(
             StateEvent.Install(
-                conf.autoDetectNdkCrashes, conf.appVersion,
+                conf.enabledErrorTypes.ndkCrashes, conf.appVersion,
                 conf.buildUuid, conf.releaseStage
             )
         )

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -88,28 +88,7 @@ class Configuration(
      */
     var autoTrackSessions: Boolean = true
 
-    /**
-     * Sets whether [ANRs](https://developer.android.com/topic/performance/vitals/anr)
-     * should be reported to Bugsnag. When enabled, Bugsnag will record an ANR whenever the main
-     * thread has been blocked for 5000 milliseconds or longer.
-     *
-     * If you wish to enable ANR detection, you should set this property to true.
-     */
-    var autoDetectAnrs: Boolean = false
-
-    /**
-     * Determines whether NDK crashes such as signals and exceptions should be reported by bugsnag.
-     *
-     * If you are using bugsnag-android this flag is false by default; if you are using
-     * bugsnag-android-ndk this flag is true by default.
-     */
-    var autoDetectNdkCrashes: Boolean = false
-
-    /**
-     * Sets whether Bugsnag should automatically capture and report unhandled errors.
-     * By default, this value is true.
-     */
-    var autoDetectErrors: Boolean = true
+    var enabledErrorTypes: ErrorTypes = ErrorTypes()
 
     /**
      * Intended for internal use only - sets the code bundle id for React Native
@@ -187,7 +166,7 @@ class Configuration(
         this.callbackState = CallbackState()
         this.metadataState = MetadataState()
 
-        autoDetectNdkCrashes = try {
+        enabledErrorTypes.ndkCrashes = try {
             // check if AUTO_DETECT_NDK_CRASHES has been set in bugsnag-android
             // or bugsnag-android-ndk
             val clz = Class.forName("com.bugsnag.android.BuildConfig")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
@@ -1,0 +1,29 @@
+package com.bugsnag.android
+
+class ErrorTypes(
+
+    /**
+     * Sets whether [ANRs](https://developer.android.com/topic/performance/vitals/anr)
+     * should be reported to Bugsnag. When enabled, Bugsnag will record an ANR whenever the main
+     * thread has been blocked for 5000 milliseconds or longer.
+     *
+     * If you wish to enable ANR detection, you should set this property to true.
+     */
+    var anrs: Boolean = true,
+
+    /**
+     * Determines whether NDK crashes such as signals and exceptions should be reported by bugsnag.
+     *
+     * If you are using bugsnag-android this flag is false by default; if you are using
+     * bugsnag-android-ndk this flag is true by default.
+     */
+    var ndkCrashes: Boolean = false,
+
+    /**
+     * Sets whether Bugsnag should automatically capture and report unhandled errors.
+     * By default, this value is true.
+     */
+    var unhandledExceptions: Boolean = true
+) {
+    internal fun copy() = ErrorTypes(anrs, ndkCrashes, unhandledExceptions)
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -7,9 +7,7 @@ import java.util.HashMap
 
 internal data class ImmutableConfig(
     val apiKey: String,
-    val autoDetectErrors: Boolean,
-    val autoDetectAnrs: Boolean,
-    val autoDetectNdkCrashes: Boolean,
+    val enabledErrorTypes: ErrorTypes,
     val autoTrackSessions: Boolean,
     val sendThreads: Thread.ThreadSendPolicy,
     val ignoreClasses: Collection<String>,
@@ -87,9 +85,7 @@ internal data class ImmutableConfig(
 internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
     return ImmutableConfig(
         apiKey = config.apiKey,
-        autoDetectErrors = config.autoDetectErrors,
-        autoDetectAnrs = config.autoDetectAnrs,
-        autoDetectNdkCrashes = config.autoDetectNdkCrashes,
+        enabledErrorTypes = config.enabledErrorTypes.copy(),
         autoTrackSessions = config.autoTrackSessions,
         sendThreads = config.sendThreads,
         ignoreClasses = config.ignoreClasses.toSet(),

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -16,9 +16,6 @@ internal class ManifestConfigLoader {
         internal const val BUILD_UUID = "$BUGSNAG_NS.BUILD_UUID"
 
         // detection
-        private const val AUTO_DETECT_ERRORS = "$BUGSNAG_NS.AUTO_DETECT_ERRORS"
-        private const val AUTO_DETECT_ANRS = "$BUGSNAG_NS.AUTO_DETECT_ANRS"
-        private const val AUTO_DETECT_NDK_CRASHES = "$BUGSNAG_NS.AUTO_DETECT_NDK_CRASHES"
         private const val AUTO_TRACK_SESSIONS = "$BUGSNAG_NS.AUTO_TRACK_SESSIONS"
         private const val PERSIST_USER = "$BUGSNAG_NS.PERSIST_USER"
 
@@ -40,9 +37,6 @@ internal class ManifestConfigLoader {
         private const val LAUNCH_CRASH_THRESHOLD_MS = "$BUGSNAG_NS.LAUNCH_CRASH_THRESHOLD_MS"
         private const val CODE_BUNDLE_ID = "$BUGSNAG_NS.CODE_BUNDLE_ID"
         private const val APP_TYPE = "$BUGSNAG_NS.APP_TYPE"
-
-        // deprecated aliases
-        private const val ENABLE_EXCEPTION_HANDLER = "$BUGSNAG_NS.ENABLE_EXCEPTION_HANDLER"
     }
 
     fun load(ctx: Context, userSuppliedApiKey: String?): Configuration {
@@ -85,10 +79,6 @@ internal class ManifestConfigLoader {
 
     private fun loadDetectionConfig(config: Configuration, data: Bundle) {
         with(config) {
-            autoDetectErrors = data.getBoolean(ENABLE_EXCEPTION_HANDLER, autoDetectErrors)
-            autoDetectErrors = data.getBoolean(AUTO_DETECT_ERRORS, autoDetectErrors)
-            autoDetectAnrs = data.getBoolean(AUTO_DETECT_ANRS, autoDetectAnrs)
-            autoDetectNdkCrashes = data.getBoolean(AUTO_DETECT_NDK_CRASHES, autoDetectNdkCrashes)
             autoTrackSessions = data.getBoolean(AUTO_TRACK_SESSIONS, autoTrackSessions)
             persistUser = data.getBoolean(PERSIST_USER, persistUser)
         }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
@@ -2,14 +2,17 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class AnrConfigTest {
+class EnabledErrorTypesTest {
 
     private val config = generateConfiguration()
 
     @Test
     fun testDetectAnrDefault() {
-        assertFalse(config.autoDetectAnrs)
+        assertTrue(config.enabledErrorTypes.anrs)
+        assertFalse(config.enabledErrorTypes.ndkCrashes)
+        assertTrue(config.enabledErrorTypes.unhandledExceptions)
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -43,9 +45,9 @@ internal class ImmutableConfigTest {
 
             // detection
             assertTrue(autoTrackSessions)
-            assertTrue(autoDetectErrors)
-            assertFalse(autoDetectAnrs)
-            assertFalse(autoDetectNdkCrashes)
+            assertTrue(enabledErrorTypes.unhandledExceptions)
+            assertTrue(enabledErrorTypes.anrs)
+            assertFalse(enabledErrorTypes.ndkCrashes)
             assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
 
             // release stages
@@ -76,9 +78,9 @@ internal class ImmutableConfigTest {
     @Test
     fun convertWithOverrides() {
         seed.autoTrackSessions = false
-        seed.autoDetectErrors = false
-        seed.autoDetectAnrs = true
-        seed.autoDetectNdkCrashes = true
+        seed.enabledErrorTypes.unhandledExceptions = false
+        seed.enabledErrorTypes.anrs = false
+        seed.enabledErrorTypes.ndkCrashes = true
         seed.sendThreads = Thread.ThreadSendPolicy.UNHANDLED_ONLY
 
         seed.ignoreClasses = setOf("foo")
@@ -104,9 +106,10 @@ internal class ImmutableConfigTest {
 
             // detection
             assertFalse(autoTrackSessions)
-            assertFalse(autoDetectErrors)
-            assertTrue(autoDetectAnrs)
-            assertTrue(autoDetectNdkCrashes)
+            assertNotSame(seed.enabledErrorTypes, enabledErrorTypes)
+            assertFalse(enabledErrorTypes.unhandledExceptions)
+            assertFalse(enabledErrorTypes.anrs)
+            assertTrue(enabledErrorTypes.ndkCrashes)
             assertEquals(Thread.ThreadSendPolicy.UNHANDLED_ONLY, sendThreads)
 
             // release stages

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -46,8 +46,8 @@ class MainActivity : Activity() {
         val config = Configuration(intent.getStringExtra("BUGSNAG_API_KEY"))
         val port = intent.getStringExtra("BUGSNAG_PORT")
         config.endpoints = EndpointConfiguration("${findHostname()}:$port", "${findHostname()}:$port")
-        config.autoDetectNdkCrashes = true
-        config.autoDetectAnrs = true
+        config.enabledErrorTypes.ndkCrashes = true
+        config.enabledErrorTypes.anrs = true
         return config
     }
 

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledNdkScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledNdkScenario.kt
@@ -13,8 +13,8 @@ internal class AppNotRespondingDisabledNdkScenario(config: Configuration,
                                                    context: Context) : Scenario(config, context) {
     init {
         config.autoTrackSessions = false
-        config.autoDetectAnrs = true
-        config.autoDetectNdkCrashes = false
+        config.enabledErrorTypes.anrs = true
+        config.enabledErrorTypes.ndkCrashes = false
     }
 
     override fun run() {

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingDisabledScenario.kt
@@ -13,7 +13,7 @@ internal class AppNotRespondingDisabledScenario(config: Configuration,
                                   context: Context) : Scenario(config, context) {
     init {
         config.autoTrackSessions = false
-        config.autoDetectAnrs = false
+        config.enabledErrorTypes.anrs = false
     }
 
     override fun run() {

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
@@ -13,7 +13,7 @@ internal class AppNotRespondingScenario(config: Configuration,
                                         context: Context) : Scenario(config, context) {
     init {
         config.autoTrackSessions = false
-        config.autoDetectAnrs = true
+        config.enabledErrorTypes.anrs = true
     }
 
     override fun run() {

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkDisabledScenario.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkDisabledScenario.java
@@ -21,7 +21,7 @@ public class AutoDetectNdkDisabledScenario extends Scenario {
     public AutoDetectNdkDisabledScenario(@NonNull Configuration config, @NonNull Context context) {
         super(config, context);
         config.setAutoTrackSessions(false);
-        config.setAutoDetectNdkCrashes(false);
+        config.getEnabledErrorTypes().setNdkCrashes(false);
     }
 
     @Override

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkEnabledScenario.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkEnabledScenario.java
@@ -21,7 +21,7 @@ public class AutoDetectNdkEnabledScenario extends Scenario {
     public AutoDetectNdkEnabledScenario(@NonNull Configuration config, @NonNull Context context) {
         super(config, context);
         config.setAutoTrackSessions(false);
-        config.setAutoDetectNdkCrashes(true);
+        config.getEnabledErrorTypes().setNdkCrashes(true);
     }
 
     @Override

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
@@ -11,7 +11,7 @@ internal class DisableAutoDetectErrorsScenario(config: Configuration,
                                                context: Context) : Scenario(config, context) {
     init {
         config.autoTrackSessions = false
-        config.autoDetectErrors = false
+        config.enabledErrorTypes.unhandledExceptions = false
     }
 
     override fun run() {

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -74,8 +74,8 @@ class MainActivity : Activity() {
     private fun prepareConfig(): Configuration {
         val config = Configuration("a35a2a72bd230ac0aa0f52715bbdc6aa")
         config.endpoints = EndpointConfiguration("http://bs-local.com:9339", "http://bs-local.com:9339")
-        config.autoDetectNdkCrashes = true
-        config.autoDetectAnrs = true
+        config.enabledErrorTypes.ndkCrashes = true
+        config.enabledErrorTypes.anrs = true
         return config
     }
 


### PR DESCRIPTION
## Goal

Reworks the configuration for controlling error capture to match the notifier spec, by adding an `ErrorType` class

## Changeset

- Replaces the previous boolean flags with `ErrorType` class on `Configuration`
- Removes the ability to set ANR/NDK/Exception detection from the manifest as these are no longer represented on `Configuration` as primitive types
- Updated existing code to use new `ErrorType` field

## Tests

Updated existing test code to use new `ErrorType` field.
