### PR TITLE
Add autoDetectErrors flag to Configuration

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -27,6 +27,7 @@ class ManifestConfigLoaderTest {
             assertNull(buildUuid)
 
             // detection
+            assertTrue(autoDetectErrors)
             assertTrue(autoTrackSessions)
             assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
             assertFalse(persistUser)
@@ -60,6 +61,7 @@ class ManifestConfigLoaderTest {
 
             // detection
             putBoolean("com.bugsnag.android.AUTO_TRACK_SESSIONS", false)
+            putBoolean("com.bugsnag.android.AUTO_DETECT_ERRORS", false)
             putBoolean("com.bugsnag.android.AUTO_CAPTURE_BREADCRUMBS", false)
             putBoolean("com.bugsnag.android.PERSIST_USER", true)
 
@@ -90,6 +92,7 @@ class ManifestConfigLoaderTest {
             assertEquals("fgh123456", buildUuid)
 
             // detection
+            assertFalse(autoDetectErrors)
             assertFalse(autoTrackSessions)
             assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
             assertTrue(persistUser)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -89,6 +89,7 @@ class Configuration(
     var autoTrackSessions: Boolean = true
 
     var enabledErrorTypes: ErrorTypes = ErrorTypes()
+    var autoDetectErrors: Boolean = true
 
     /**
      * Intended for internal use only - sets the code bundle id for React Native

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
@@ -25,5 +25,7 @@ class ErrorTypes(
      */
     var unhandledExceptions: Boolean = true
 ) {
+    internal constructor(detectErrors: Boolean) : this(detectErrors, detectErrors, detectErrors)
+
     internal fun copy() = ErrorTypes(anrs, ndkCrashes, unhandledExceptions)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -8,6 +8,7 @@ import java.util.HashMap
 internal data class ImmutableConfig(
     val apiKey: String,
     val enabledErrorTypes: ErrorTypes,
+    val autoDetectErrors: Boolean,
     val autoTrackSessions: Boolean,
     val sendThreads: Thread.ThreadSendPolicy,
     val ignoreClasses: Collection<String>,
@@ -83,9 +84,15 @@ internal data class ImmutableConfig(
 }
 
 internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
+    val errorTypes = when {
+        config.autoDetectErrors -> config.enabledErrorTypes.copy()
+        else -> ErrorTypes(false)
+    }
+
     return ImmutableConfig(
         apiKey = config.apiKey,
-        enabledErrorTypes = config.enabledErrorTypes.copy(),
+        enabledErrorTypes = errorTypes,
+        autoDetectErrors = config.autoDetectErrors,
         autoTrackSessions = config.autoTrackSessions,
         sendThreads = config.sendThreads,
         ignoreClasses = config.ignoreClasses.toSet(),

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -17,6 +17,7 @@ internal class ManifestConfigLoader {
 
         // detection
         private const val AUTO_TRACK_SESSIONS = "$BUGSNAG_NS.AUTO_TRACK_SESSIONS"
+        private const val AUTO_DETECT_ERRORS = "$BUGSNAG_NS.AUTO_DETECT_ERRORS"
         private const val PERSIST_USER = "$BUGSNAG_NS.PERSIST_USER"
 
         // endpoints
@@ -80,6 +81,7 @@ internal class ManifestConfigLoader {
     private fun loadDetectionConfig(config: Configuration, data: Bundle) {
         with(config) {
             autoTrackSessions = data.getBoolean(AUTO_TRACK_SESSIONS, autoTrackSessions)
+            autoDetectErrors = data.getBoolean(AUTO_DETECT_ERRORS, autoDetectErrors)
             persistUser = data.getBoolean(PERSIST_USER, persistUser)
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
@@ -11,8 +11,40 @@ class EnabledErrorTypesTest {
 
     @Test
     fun testDetectAnrDefault() {
+        assertTrue(config.autoDetectErrors)
         assertTrue(config.enabledErrorTypes.anrs)
         assertFalse(config.enabledErrorTypes.ndkCrashes)
         assertTrue(config.enabledErrorTypes.unhandledExceptions)
+    }
+
+    @Test
+    fun autoDetectErrorsTrueConfig() {
+        config.autoDetectErrors = true
+
+        with(convertToImmutableConfig(config).enabledErrorTypes) {
+            assertTrue(anrs)
+            assertFalse(ndkCrashes)
+            assertTrue(unhandledExceptions)
+        }
+    }
+
+    @Test
+    fun autoDetectErrorsFalseConfig() {
+        config.autoDetectErrors = false
+
+        with(convertToImmutableConfig(config).enabledErrorTypes) {
+            assertFalse(anrs)
+            assertFalse(ndkCrashes)
+            assertFalse(unhandledExceptions)
+        }
+    }
+
+    @Test
+    fun errorTypeFalseConstructor() {
+        with(ErrorTypes(false)) {
+            assertFalse(anrs)
+            assertFalse(ndkCrashes)
+            assertFalse(unhandledExceptions)
+        }
     }
 }


### PR DESCRIPTION
## Goal

Adds the `autoDetectErrors` flag to `Configuration` which disables all error capture, matching the notifier spec.

## Changeset

- Added `autoDetectErrors` boolean field to `Configuration`
- Added `com.bugsnag.android.AUTO_DETECT_ERRORS` as boolean field that can be read from manifest
- Disabled all error detection if `autoDetectErrors` is false when constructing an `ImmutableConfig` object

## Tests

Added to existing unit/instrumentation tests.
