### PR TITLE
Add ndk accessors for event.device

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -54,6 +54,7 @@ typedef enum {
 extern "C" {
 #endif
 
+
 /**
  * Retrieves the event context
  * @param event_ptr a pointer to the event supplied in an on_error callback
@@ -101,6 +102,40 @@ void bugsnag_app_set_duration_in_foreground(void *event_ptr, time_t value);
 
 bool bugsnag_app_get_in_foreground(void *event_ptr);
 void bugsnag_app_set_in_foreground(void *event_ptr, bool value);
+
+
+/* Accessors for event.device */
+
+
+bool bugsnag_device_get_jailbroken(void *event_ptr);
+void bugsnag_device_set_jailbroken(void *event_ptr, bool value);
+
+char *bugsnag_device_get_id(void *event_ptr);
+void bugsnag_device_set_id(void *event_ptr, char *value);
+
+char *bugsnag_device_get_locale(void *event_ptr);
+void bugsnag_device_set_locale(void *event_ptr, char *value);
+
+char *bugsnag_device_get_manufacturer(void *event_ptr);
+void bugsnag_device_set_manufacturer(void *event_ptr, char *value);
+
+char *bugsnag_device_get_model(void *event_ptr);
+void bugsnag_app_set_model(void *event_ptr, char *value);
+
+char *bugsnag_device_get_os_version(void *event_ptr);
+void bugsnag_device_set_os_version(void *event_ptr, char *value);
+
+long bugsnag_device_get_total_memory(void *event_ptr);
+void bugsnag_device_set_total_memory(void *event_ptr, long value);
+
+char *bugsnag_device_get_orientation(void *event_ptr);
+void bugsnag_device_set_orientation(void *event_ptr, char *value);
+
+time_t bugsnag_device_get_time(void *event_ptr);
+void bugsnag_device_set_time(void *event_ptr, time_t value);
+
+char *bugsnag_device_get_os_name(void *event_ptr);
+void bugsnag_device_set_os_name(void *event_ptr, char *value);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -355,6 +355,20 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateLowMemory(JNIEnv *env,
   bsg_release_env_write_lock();
 }
 
+const char *bsg_orientation_from_degrees(int orientation) {
+  if (orientation < 0) {
+    return "unknown";
+  } else if (orientation >= 315 || orientation <= 45) {
+    return "portrait";
+  } else if (orientation <= 135) {
+    return "landscape";
+  } else if (orientation <= 225) {
+    return "portrait";
+  } else {
+    return "landscape";
+  }
+}
+
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
                                                             jobject _this,
@@ -363,7 +377,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
     return;
 
   bsg_request_env_write_lock();
-  bugsnag_event_set_orientation(&bsg_global_env->next_event, orientation);
+  bugsnag_device_set_orientation(&bsg_global_env->next_event,
+                                 (char *) bsg_orientation_from_degrees(orientation));
   bsg_release_env_write_lock();
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -101,26 +101,6 @@ void bugsnag_event_set_context(void *event_ptr, char *value) {
   bsg_strncpy_safe(event->context, value, sizeof(event->context));
 }
 
-const char *bsg_orientation_from_degrees(int orientation) {
-  if (orientation < 0) {
-    return "unknown";
-  } else if (orientation >= 315 || orientation <= 45) {
-    return "portrait";
-  } else if (orientation <= 135) {
-    return "landscape";
-  } else if (orientation <= 225) {
-    return "portrait";
-  } else {
-    return "landscape";
-  }
-}
-
-void bugsnag_event_set_orientation(bugsnag_event *event, int value) {
-  bsg_strncpy_safe(event->device.orientation,
-                   (char *)bsg_orientation_from_degrees(value),
-                   sizeof(event->device.orientation));
-}
-
 void bugsnag_event_set_user_email(bugsnag_event *event, char *value) {
   bsg_strncpy_safe(event->user.email, value, sizeof(event->user.email));
 }
@@ -258,4 +238,108 @@ bool bugsnag_app_get_in_foreground(void *event_ptr) {
 void bugsnag_app_set_in_foreground(void *event_ptr, bool value) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
   event->app.in_foreground = value;
+}
+
+
+/* Accessors for event.device */
+
+
+bool bugsnag_device_get_jailbroken(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.jailbroken;
+}
+
+void bugsnag_device_set_jailbroken(void *event_ptr, bool value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->device.jailbroken = value;
+}
+
+char *bugsnag_device_get_id(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.id;
+}
+
+void bugsnag_device_set_id(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->device.id, value, sizeof(event->device.id));
+}
+
+char *bugsnag_device_get_locale(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.locale;
+}
+
+void bugsnag_device_set_locale(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->device.locale, value, sizeof(event->device.locale));
+}
+
+char *bugsnag_device_get_manufacturer(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.manufacturer;
+}
+
+void bugsnag_device_set_manufacturer(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->device.manufacturer, value, sizeof(event->device.manufacturer));
+}
+
+char *bugsnag_device_get_model(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.model;
+}
+
+void bugsnag_app_set_model(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->device.model, value, sizeof(event->device.model));
+}
+
+char *bugsnag_device_get_os_version(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.os_version;
+}
+
+void bugsnag_device_set_os_version(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->device.os_version, value, sizeof(event->device.os_version));
+}
+
+long bugsnag_device_get_total_memory(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.total_memory;
+}
+
+void bugsnag_device_set_total_memory(void *event_ptr, long value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->device.total_memory = value;
+}
+
+char *bugsnag_device_get_orientation(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.orientation;
+}
+
+void bugsnag_device_set_orientation(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->device.orientation, value, sizeof(event->device.orientation));
+}
+
+time_t bugsnag_device_get_time(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.time;
+}
+
+void bugsnag_device_set_time(void *event_ptr, time_t value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->device.time = value;
+}
+
+char *bugsnag_device_get_os_name(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->device.os_name;
+}
+
+void bugsnag_device_set_os_name(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->device.os_name, value, sizeof(event->device.os_name));
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -107,6 +107,7 @@ typedef struct {
     char network_access[64];
     char os_build[64];
     char os_version[64];
+    char os_name[64];
     float screen_density;
     char screen_resolution[32];
     long total_memory;
@@ -258,7 +259,6 @@ void bugsnag_event_clear_breadcrumbs(bugsnag_event *event);
 void bugsnag_event_remove_metadata(bugsnag_event *event, char *section,
                                    char *name);
 void bugsnag_event_remove_metadata_tab(bugsnag_event *event, char *section);
-void bugsnag_event_set_orientation(bugsnag_event *event, int value);
 void bugsnag_event_set_user_email(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_id(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_name(bugsnag_event *event, char *value);

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -266,6 +266,10 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   (*env)->DeleteLocalRef(env, data);
 }
 
+char *bsg_os_name() {
+  return "android";
+}
+
 void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                               bugsnag_event *event) {
   jobject data = (*env)->CallStaticObjectMethod(
@@ -297,6 +301,7 @@ void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   bsg_copy_map_value_string(env, jni_cache, data, "screenResolution",
                             event->device.screen_resolution,
                             sizeof(event->device.screen_resolution));
+  bsg_strcpy(event->device.os_name, bsg_os_name());
   event->device.emulator =
       bsg_get_map_value_bool(env, jni_cache, data, "emulator");
   event->device.jailbroken =

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
@@ -22,4 +22,6 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
 
 char *bsg_binary_arch();
 
+char *bsg_os_name();
+
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -46,9 +46,33 @@ typedef struct {
 } bsg_exception;
 
 typedef struct {
+    int api_level;
+    double battery_level;
+    char brand[64];
+    int cpu_abi_count;
+    bsg_cpu_abi cpu_abi[8];
+    int dpi;
+    bool emulator;
+    char orientation[32];
+    time_t time;
+    char id[64];
+    bool jailbroken;
+    char locale[32];
+    char location_status[32];
+    char manufacturer[64];
+    char model[64];
+    char network_access[64];
+    char os_build[64];
+    char os_version[64];
+    float screen_density;
+    char screen_resolution[32];
+    long total_memory;
+} bsg_device_info_v1;
+
+typedef struct {
     bsg_library notifier;
     bsg_app_info app;
-    bsg_device_info device;
+    bsg_device_info_v1 device;
     bsg_user user;
     bsg_exception exception;
     bugsnag_metadata metadata;
@@ -70,7 +94,7 @@ typedef struct {
 typedef struct {
     bsg_library notifier;
     bsg_app_info app;
-    bsg_device_info device;
+    bsg_device_info_v1 device;
     bsg_user user;
     bsg_exception exception;
     bugsnag_metadata metadata;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -1,6 +1,7 @@
 #include <greatest/greatest.h>
 #include <event.h>
 #include <utils/string.h>
+#include "../../main/assets/include/bugsnag.h"
 #include <event.h>
 
 bugsnag_event *init_event() {
@@ -17,6 +18,18 @@ bugsnag_event *init_event() {
     event->app.duration = 9019;
     event->app.duration_in_foreground = 7017;
     event->app.in_foreground = true;
+
+    event->device.jailbroken = true;
+    event->device.total_memory = 1095092340;
+    bsg_strncpy_safe(event->device.id, "my-id-123", sizeof(event->device.id));
+    bsg_strncpy_safe(event->device.locale, "en", sizeof(event->device.locale));
+    bsg_strncpy_safe(event->device.os_name, "android", sizeof(event->device.os_name));
+    bsg_strncpy_safe(event->device.manufacturer, "Google", sizeof(event->device.manufacturer));
+    bsg_strncpy_safe(event->device.model, "Nexus", sizeof(event->device.model));
+    bsg_strncpy_safe(event->device.os_version, "9.1", sizeof(event->device.os_version));
+    bsg_strncpy_safe(event->device.orientation, "portrait", sizeof(event->device.orientation));
+    event->device.time = 7609;
+
     return event;
 }
 
@@ -29,7 +42,7 @@ TEST test_event_context(void) {
     PASS();
 }
 
-TEST test_event_binary_arch(void) {
+TEST test_app_binary_arch(void) {
     bugsnag_event *event = init_event();
     ASSERT_STR_EQ("x86", bugsnag_app_get_binary_arch(event));
     bugsnag_app_set_binary_arch(event, "armeabi-v7a");
@@ -38,7 +51,7 @@ TEST test_event_binary_arch(void) {
     PASS();
 }
 
-TEST test_event_build_uuid(void) {
+TEST test_app_build_uuid(void) {
     bugsnag_event *event = init_event();
     ASSERT_STR_EQ("123", bugsnag_app_get_build_uuid(event));
     bugsnag_app_set_build_uuid(event, "my-id-123");
@@ -47,7 +60,7 @@ TEST test_event_build_uuid(void) {
     PASS();
 }
 
-TEST test_event_id(void) {
+TEST test_app_id(void) {
     bugsnag_event *event = init_event();
     ASSERT_STR_EQ("fa02", bugsnag_app_get_id(event));
     bugsnag_app_set_id(event, "my-id-123");
@@ -56,7 +69,7 @@ TEST test_event_id(void) {
     PASS();
 }
 
-TEST test_event_release_stage(void) {
+TEST test_app_release_stage(void) {
     bugsnag_event *event = init_event();
     ASSERT_STR_EQ("dev", bugsnag_app_get_release_stage(event));
     bugsnag_app_set_release_stage(event, "beta");
@@ -65,7 +78,7 @@ TEST test_event_release_stage(void) {
     PASS();
 }
 
-TEST test_event_type(void) {
+TEST test_app_type(void) {
     bugsnag_event *event = init_event();
     ASSERT_STR_EQ("C", bugsnag_app_get_type(event));
     bugsnag_app_set_type(event, "C++");
@@ -74,7 +87,7 @@ TEST test_event_type(void) {
     PASS();
 }
 
-TEST test_event_version(void) {
+TEST test_app_version(void) {
     bugsnag_event *event = init_event();
     ASSERT_STR_EQ("1.0", bugsnag_app_get_version(event));
     bugsnag_app_set_version(event, "2.2");
@@ -83,7 +96,7 @@ TEST test_event_version(void) {
     PASS();
 }
 
-TEST test_event_version_code(void) {
+TEST test_app_version_code(void) {
     bugsnag_event *event = init_event();
     ASSERT_EQ(55, bugsnag_app_get_version_code(event));
     bugsnag_app_set_version_code(event, 99);
@@ -92,7 +105,7 @@ TEST test_event_version_code(void) {
     PASS();
 }
 
-TEST test_event_duration(void) {
+TEST test_app_duration(void) {
     bugsnag_event *event = init_event();
     ASSERT_EQ(9019, bugsnag_app_get_duration(event));
     bugsnag_app_set_duration(event, 552);
@@ -101,7 +114,7 @@ TEST test_event_duration(void) {
     PASS();
 }
 
-TEST test_event_duration_in_foreground(void) {
+TEST test_app_duration_in_foreground(void) {
     bugsnag_event *event = init_event();
     ASSERT_EQ(7017, bugsnag_app_get_duration_in_foreground(event));
     bugsnag_app_set_duration_in_foreground(event, 209);
@@ -110,7 +123,7 @@ TEST test_event_duration_in_foreground(void) {
     PASS();
 }
 
-TEST test_event_in_foreground(void) {
+TEST test_app_in_foreground(void) {
     bugsnag_event *event = init_event();
     ASSERT(bugsnag_app_get_in_foreground(event));
     bugsnag_app_set_in_foreground(event, false);
@@ -120,16 +133,116 @@ TEST test_event_in_foreground(void) {
 }
 
 
+TEST test_device_jailbroken(void) {
+    bugsnag_event *event = init_event();
+    ASSERT(bugsnag_device_get_jailbroken(event));
+    bugsnag_device_set_jailbroken(event, false);
+    ASSERT_FALSE(bugsnag_device_get_jailbroken(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_id(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("my-id-123", event->device.id);
+    bugsnag_device_set_id(event, "SomeId");
+    ASSERT_STR_EQ("SomeId", bugsnag_device_get_id(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_locale(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("en", event->device.locale);
+    bugsnag_device_set_locale(event, "hue");
+    ASSERT_STR_EQ("hue", bugsnag_device_get_locale(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_manufacturer(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("Google", event->device.manufacturer);
+    bugsnag_device_set_manufacturer(event, "Apple");
+    ASSERT_STR_EQ("Apple", bugsnag_device_get_manufacturer(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_model(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("Nexus", event->device.model);
+    bugsnag_app_set_model(event, "Pixel");
+    ASSERT_STR_EQ("Pixel", bugsnag_device_get_model(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_os_version(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("9.1", event->device.os_version);
+    bugsnag_device_set_os_version(event, "7.0");
+    ASSERT_STR_EQ("7.0", bugsnag_device_get_os_version(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_total_memory(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_EQ(1095092340, event->device.total_memory);
+    bugsnag_device_set_total_memory(event, 200923409);
+    ASSERT_EQ(200923409, bugsnag_device_get_total_memory(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_orientation(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("portrait", event->device.orientation);
+    bugsnag_device_set_orientation(event, "landscape");
+    ASSERT_STR_EQ("landscape", bugsnag_device_get_orientation(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_time(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_EQ(7609, event->device.time);
+    bugsnag_device_set_time(event, 1509);
+    ASSERT_EQ(1509, bugsnag_device_get_time(event));
+    free(event);
+    PASS();
+}
+
+TEST test_device_os_name(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("android", event->device.os_name);
+    bugsnag_device_set_os_name(event, "samsung");
+    ASSERT_STR_EQ("samsung", bugsnag_device_get_os_name(event));
+    free(event);
+    PASS();
+}
+
 SUITE(event_mutators) {
     RUN_TEST(test_event_context);
-    RUN_TEST(test_event_binary_arch);
-    RUN_TEST(test_event_build_uuid);
-    RUN_TEST(test_event_id);
-    RUN_TEST(test_event_release_stage);
-    RUN_TEST(test_event_type);
-    RUN_TEST(test_event_version);
-    RUN_TEST(test_event_version_code);
-    RUN_TEST(test_event_duration);
-    RUN_TEST(test_event_duration_in_foreground);
-    RUN_TEST(test_event_in_foreground);
+    RUN_TEST(test_app_binary_arch);
+    RUN_TEST(test_app_build_uuid);
+    RUN_TEST(test_app_id);
+    RUN_TEST(test_app_release_stage);
+    RUN_TEST(test_app_type);
+    RUN_TEST(test_app_version);
+    RUN_TEST(test_app_version_code);
+    RUN_TEST(test_app_duration);
+    RUN_TEST(test_app_duration_in_foreground);
+    RUN_TEST(test_app_in_foreground);
+    RUN_TEST(test_device_jailbroken);
+    RUN_TEST(test_device_id);
+    RUN_TEST(test_device_locale);
+    RUN_TEST(test_device_manufacturer);
+    RUN_TEST(test_device_model);
+    RUN_TEST(test_device_os_version);
+    RUN_TEST(test_device_total_memory);
+    RUN_TEST(test_device_orientation);
+    RUN_TEST(test_device_time);
+    RUN_TEST(test_device_os_name);
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -58,6 +58,7 @@ bsg_app_info * loadAppMetadataTestCase(jint num) {
 bsg_device_info * loadDeviceTestCase(jint num) {
     bsg_device_info *device = malloc(sizeof(bsg_device_info));
     strcpy(device->id, "f5gh7");
+    strcpy(device->os_name, "android");
     strcpy(device->os_version, "8.1");
     strcpy(device->manufacturer, "Samsung");
     strcpy(device->model, "S7");


### PR DESCRIPTION
## Goal

Adds accessor methods for manipulating the fields on `event.device`. This is necessary now that the `bugsnag_event` pointer is exposed in an `on_error` callback, and allows users to mutate the generated report.

## Changeset

- Added get/set methods for each field defined on `event.device` that is present in the notifier spec.
- Updated `bugsnag_event_set_orientation` to use new public accessor method
- Added a migration for `bsg_device_info_v1` as the struct value has changed

**Note:** this PR does _not_ include accessors for `cpuAbi` and `runtimeVersions`. I'm not 100% sure how we'd want to approach exposing array values from the `bugsnag_event` struct, and am also not convinced that users would want to manipulate these fields in the context of a crashing process.

## Tests

Added unit tests for each new accessor method, and migration tests for any changed structs.
