### PR TITLE
Fix silently failing mazerunner scenarios

### DIFF
--- a/features/async_error_flush.feature
+++ b/features/async_error_flush.feature
@@ -4,13 +4,16 @@ Scenario: Only 1 request sent if connectivity change occurs before launch
     When I run "AsyncErrorConnectivityScenario"
     Then I should receive a request
     And the request is a valid for the error reporting API
+    And the event "context" equals "AsyncErrorConnectivityScenario"
 
 Scenario: Only 1 request sent if multiple connectivity changes occur
     When I run "AsyncErrorDoubleFlushScenario"
     Then I should receive a request
     And the request is a valid for the error reporting API
+    And the event "context" equals "AsyncErrorDoubleFlushScenario"
 
 Scenario: Only 1 request sent if connectivity change occurs after launch
     When I run "AsyncErrorLaunchScenario"
     Then I should receive a request
     And the request is a valid for the error reporting API
+    And the event "context" equals "AsyncErrorLaunchScenario"

--- a/features/detect_anr.feature
+++ b/features/detect_anr.feature
@@ -31,14 +31,6 @@ Scenario: Sleeping the main thread with pending touch events
     Then I should receive 0 requests
 
 @anr
-Scenario: Sleeping the main thread with pending touch events after disabling ANR reporting
-    When I run "AppNotRespondingLaterDisabledScenario"
-    And I tap the screen
-    And I tap the screen
-    And I tap the screen
-    Then I should receive 0 requests
-
-@anr
 Scenario: Sleeping the main thread with pending touch events after the release stage settings change to disable reporting
     When I run "AppNotRespondingOutsideReleaseStagesScenario"
     And I tap the screen

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
@@ -1,0 +1,64 @@
+package com.bugsnag.android;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.AppWithState;
+import com.bugsnag.android.Configuration;
+import com.bugsnag.android.Delivery;
+import com.bugsnag.android.DeliveryParams;
+import com.bugsnag.android.DeliveryStatus;
+import com.bugsnag.android.DeviceBuildInfo;
+import com.bugsnag.android.DeviceWithState;
+import com.bugsnag.android.ImmutableConfig;
+import com.bugsnag.android.ImmutableConfigKt;
+import com.bugsnag.android.NoopLogger;
+import com.bugsnag.android.Report;
+import com.bugsnag.android.SessionPayload;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Date;
+
+public class JavaHooks {
+
+    public static DeviceWithState generateDeviceWithState() {
+        DeviceBuildInfo buildInfo = DeviceBuildInfo.Companion.defaultInfo();
+        return new DeviceWithState(buildInfo, new String[]{}, null, null, null,
+                109230923452L, 22234423124L, 92340255592L, "portrait", new Date(0));
+    }
+
+    public static AppWithState generateAppWithState() {
+        return new AppWithState(generateImmutableConfig(), null, null, null,
+                null, null, null, null);
+    }
+
+    public static Configuration generateConfiguration() {
+        Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
+        configuration.setDelivery(generateDelivery());
+        configuration.setLogger(NoopLogger.INSTANCE);
+        return configuration;
+    }
+
+
+    public static Delivery generateDelivery() {
+        return new Delivery() {
+            @NotNull
+            @Override
+            public DeliveryStatus deliver(@NonNull Report report,
+                                          @NonNull DeliveryParams deliveryParams) {
+                return DeliveryStatus.DELIVERED;
+            }
+
+            @NonNull
+            @Override
+            public DeliveryStatus deliver(@NonNull SessionPayload payload,
+                                          @NonNull DeliveryParams deliveryParams) {
+                return DeliveryStatus.DELIVERED;
+            }
+        };
+    }
+
+    public static ImmutableConfig generateImmutableConfig() {
+        return ImmutableConfigKt.convertToImmutableConfig(generateConfiguration());
+    }
+}

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
@@ -1,7 +1,5 @@
 package com.bugsnag.android;
 
-import androidx.annotation.NonNull;
-
 import com.bugsnag.android.AppWithState;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.Delivery;
@@ -15,23 +13,35 @@ import com.bugsnag.android.NoopLogger;
 import com.bugsnag.android.Report;
 import com.bugsnag.android.SessionPayload;
 
-import org.jetbrains.annotations.NotNull;
+import androidx.annotation.NonNull;
 
 import java.util.Date;
 
 public class JavaHooks {
 
+    /**
+     * Generates fake DeviceWithState
+     */
+    @NonNull
     public static DeviceWithState generateDeviceWithState() {
         DeviceBuildInfo buildInfo = DeviceBuildInfo.Companion.defaultInfo();
         return new DeviceWithState(buildInfo, new String[]{}, null, null, null,
                 109230923452L, 22234423124L, 92340255592L, "portrait", new Date(0));
     }
 
+    /**
+     * Generates fake AppWithState
+     */
+    @NonNull
     public static AppWithState generateAppWithState() {
         return new AppWithState(generateImmutableConfig(), null, null, null,
                 null, null, null, null);
     }
 
+    /**
+     * Generates fake Configuration
+     */
+    @NonNull
     public static Configuration generateConfiguration() {
         Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());
@@ -39,10 +49,13 @@ public class JavaHooks {
         return configuration;
     }
 
-
+    /**
+     * Generates fake Delivery
+     */
+    @NonNull
     public static Delivery generateDelivery() {
         return new Delivery() {
-            @NotNull
+            @NonNull
             @Override
             public DeliveryStatus deliver(@NonNull Report report,
                                           @NonNull DeliveryParams deliveryParams) {
@@ -58,6 +71,10 @@ public class JavaHooks {
         };
     }
 
+    /**
+     * Generates fake ImmutableConfig
+     */
+    @NonNull
     public static ImmutableConfig generateImmutableConfig() {
         return ImmutableConfigKt.convertToImmutableConfig(generateConfiguration());
     }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorConnectivityScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorConnectivityScenario.kt
@@ -18,8 +18,9 @@ internal class AsyncErrorConnectivityScenario(config: Configuration,
 
     override fun run() {
         super.run()
-
-        writeErrorToStore(Bugsnag.getClient())
+        val event = generateEvent(Bugsnag.getClient())
+        event.context = "AsyncErrorConnectivityScenario"
+        writeErrorToStore(Bugsnag.getClient(), event)
         flushErrorStoreAsync(Bugsnag.getClient())
         flushErrorStoreOnLaunch(Bugsnag.getClient())
     }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorDoubleFlushScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorDoubleFlushScenario.kt
@@ -17,7 +17,9 @@ internal class AsyncErrorDoubleFlushScenario(config: Configuration,
     override fun run() {
         super.run()
 
-        writeErrorToStore(Bugsnag.getClient())
+        val event = generateEvent(Bugsnag.getClient())
+        event.context = "AsyncErrorDoubleFlushScenario"
+        writeErrorToStore(Bugsnag.getClient(), event)
         flushErrorStoreAsync(Bugsnag.getClient())
         flushErrorStoreAsync(Bugsnag.getClient())
     }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorLaunchScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorLaunchScenario.kt
@@ -18,7 +18,9 @@ internal class AsyncErrorLaunchScenario(config: Configuration,
     override fun run() {
         super.run()
 
-        writeErrorToStore(Bugsnag.getClient())
+        val event = generateEvent(Bugsnag.getClient())
+        event.context = "AsyncErrorLaunchScenario"
+        writeErrorToStore(Bugsnag.getClient(), event)
         flushErrorStoreOnLaunch(Bugsnag.getClient())
         flushErrorStoreAsync(Bugsnag.getClient())
     }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedReportScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedReportScenario.kt
@@ -10,6 +10,7 @@ import com.bugsnag.android.DeliveryParams
 import com.bugsnag.android.DeliveryStatus
 import com.bugsnag.android.Report
 import com.bugsnag.android.SessionPayload
+import com.bugsnag.android.createDefaultDelivery
 import java.io.File
 
 internal class DeletedReportScenario(config: Configuration,
@@ -24,9 +25,7 @@ internal class DeletedReportScenario(config: Configuration,
             if (eventMetaData != "non-crashy") {
                 disableAllDelivery(config)
             } else {
-                val ctor = Class.forName("com.bugsnag.android.DefaultDelivery").declaredConstructors[0]
-                ctor.isAccessible = true
-                val baseDelivery = ctor.newInstance(null) as Delivery
+                val baseDelivery = createDefaultDelivery()
                 val errDir = File(context.cacheDir, "bugsnag-errors")
 
                 config.delivery = object: Delivery {

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedSessionScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedSessionScenario.kt
@@ -12,6 +12,7 @@ import com.bugsnag.android.DeliveryParams
 import com.bugsnag.android.DeliveryStatus
 import com.bugsnag.android.Report
 import com.bugsnag.android.SessionPayload
+import com.bugsnag.android.createDefaultDelivery
 import com.bugsnag.android.flushAllSessions
 import java.io.File
 
@@ -27,9 +28,7 @@ internal class DeletedSessionScenario(config: Configuration,
             if (eventMetaData != "non-crashy") {
                 disableAllDelivery(config)
             } else {
-                val ctor = Class.forName("com.bugsnag.android.DefaultDelivery").declaredConstructors[0]
-                ctor.isAccessible = true
-                val baseDelivery = ctor.newInstance(null) as Delivery
+                val baseDelivery = createDefaultDelivery()
                 val errDir = File(context.cacheDir, "bugsnag-sessions")
 
                 config.delivery = object: Delivery {

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TestHarnessHooks.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TestHarnessHooks.kt
@@ -1,5 +1,7 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.JavaHooks.generateAppWithState
+import com.bugsnag.android.JavaHooks.generateDeviceWithState
 import java.lang.Thread
 
 /**
@@ -70,11 +72,17 @@ internal fun createDefaultDelivery(): Delivery { // use reflection as DefaultDel
     }) as Delivery
 }
 
-internal fun writeErrorToStore(client: Client) {
+internal fun writeErrorToStore(client: Client, event: Event) {
+    client.eventStore.write(event)
+}
+
+fun generateEvent(client: Client): Event {
     val event = BugsnagPluginInterface.createEvent(
         RuntimeException(),
         client,
         HandledState.REASON_ANR
     )
-    client.eventStore.write(event)
+    event.app = generateAppWithState()
+    event.device = generateDeviceWithState()
+    return event
 }

--- a/tests/features/async_error_flush.feature
+++ b/tests/features/async_error_flush.feature
@@ -5,13 +5,16 @@ Scenario: Only 1 request sent if connectivity change occurs before launch
     And I configure Bugsnag for "AsyncErrorConnectivityScenario"
     Then I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the event "context" equals "AsyncErrorConnectivityScenario"
 
 Scenario: Only 1 request sent if multiple connectivity changes occur
     When I run "AsyncErrorDoubleFlushScenario"
     Then I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the event "context" equals "AsyncErrorDoubleFlushScenario"
 
 Scenario: Only 1 request sent if connectivity change occurs after launch
     When I run "AsyncErrorLaunchScenario"
     Then I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the event "context" equals "AsyncErrorLaunchScenario"

--- a/tests/features/detect_anr.feature
+++ b/tests/features/detect_anr.feature
@@ -30,14 +30,6 @@ Scenario: Sleeping the main thread with pending touch events
     And I clear any error dialogue
     Then I should receive no requests
 
-Scenario: Sleeping the main thread with pending touch events after disabling ANR reporting
-    When I run "AppNotRespondingLaterDisabledScenario"
-    And I wait for 2 seconds
-    And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
-    Then I should receive no requests
-
 Scenario: Sleeping the main thread with pending touch events after the release stage settings change to disable reporting
     When I run "AppNotRespondingOutsideReleaseStagesScenario"
     And I wait for 2 seconds


### PR DESCRIPTION
## Goal

Note: This is reopened PR #755 due to a requested rename of the base branch.

Fixes silent failures of the following, as detected by browserstack logs on the latest mazerunner run:

```
AsyncErrorConnectivityScenario
AsyncErrorDoubleFlushScenario
AsyncErrorLaunchScenario
AppNotRespondingLaterDisabledScenario
DeletedReportScenario
DeletedSessionScenario
```

## Changeset

1. `AppNotRespondingLaterDisabledScenario` tests that ANR detection can be dynamically enabled/disabled, which is no longer relevant as the notifier spec states that this should be decided up-front. The Java scenario which tested this was removed but the scenario was not.
2. `AsyncErrorConnectivityScenario` was failing due to `event.app` and `event.device` being [lateinit properties](https://github.com/bugsnag/bugsnag-android/blob/configuration-immutability-refactor/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt#L43). Test code used to write an `Event` to disk had not been updated to set these properties, resulting in an `UninitializedPropertyAccessException`. Because the scenario didn't check the exception name, the scenario passed anyway. This has been fixed by generating app/device info in the test code and checking the context has been set on the scenario.
3. As part of #672 a `Logger` interface was added to multiple classes, one of which was `DefaultDelivery` where it is now an additional constructor parameter. Test code instantiates `DefaultDelivery` via reflection and some scenarios were not updated to pass a `Logger` parameter, which resulted in a crash.