### PR TITLE
Implement on_error in NDK layer

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
@@ -8,6 +8,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef bool (*bsg_on_error)(void *);
+
 /**
  * Configure the Bugsnag interface, optionally including the JNI environment.
  * @param env  The JNI environment to use when using convenience methods
@@ -35,6 +38,12 @@ void bugsnag_set_user_env(JNIEnv *env, char* id, char* email, char* name);
  */
 void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_t type);
 void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message, bsg_breadcrumb_t type);
+
+void bugsnag_add_on_error(bsg_on_error on_error);
+void bugsnag_remove_on_error(bsg_on_error on_error);
+
+char *bugsnag_event_get_context(void *event_ptr);
+void bugsnag_event_set_context(void *event_ptr, char *value);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
@@ -39,10 +39,30 @@ void bugsnag_set_user_env(JNIEnv *env, char* id, char* email, char* name);
 void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_t type);
 void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message, bsg_breadcrumb_t type);
 
+/**
+ * Adds a callback which is invoked whenever a fatal error occurs. The callback will be passed a
+ * pointer to the event payload as a parameter, allowing for data to be added/removed.
+ * @param on_error the callback
+ */
 void bugsnag_add_on_error(bsg_on_error on_error);
-void bugsnag_remove_on_error(bsg_on_error on_error);
 
+/**
+ * Removes any callback previously added in bugsnag_add_on_error
+ */
+void bugsnag_remove_on_error();
+
+/**
+ * Retrieves the event context
+ * @param event_ptr a pointer to the event supplied in an on_error callback
+ * @return the event context, or NULL if this has not been set
+ */
 char *bugsnag_event_get_context(void *event_ptr);
+
+/**
+ * Sets the event context
+ * @param event_ptr a pointer to the event supplied in an on_error callback
+ * @param value the new event context value, which can be NULL
+ */
 void bugsnag_event_set_context(void *event_ptr, char *value);
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -5,6 +5,7 @@
 #include "utils/stack_unwinder.h"
 #include "utils/string.h"
 #include "metadata.h"
+#include "../assets/include/bugsnag.h"
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -48,7 +48,7 @@ void bugsnag_add_on_error(bsg_on_error on_error) {
   }
 }
 
-void bugsnag_remove_on_error(bsg_on_error on_error) {
+void bugsnag_remove_on_error() {
   if (bsg_global_env != NULL) {
     bsg_global_env->on_error = NULL;
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -42,6 +42,26 @@ bsg_unwinder bsg_configured_unwind_style() {
   return BSG_CUSTOM_UNWIND;
 }
 
+void bugsnag_add_on_error(bsg_on_error on_error) {
+  if (bsg_global_env != NULL) {
+    bsg_global_env->on_error = on_error;
+  }
+}
+
+void bugsnag_remove_on_error(bsg_on_error on_error) {
+  if (bsg_global_env != NULL) {
+    bsg_global_env->on_error = NULL;
+  }
+}
+
+bool bsg_run_on_error() {
+  bsg_on_error on_error = bsg_global_env->on_error;
+  if (on_error != NULL) {
+      return on_error(&bsg_global_env->next_event);
+  }
+  return true;
+}
+
 JNIEXPORT void JNICALL Java_com_bugsnag_android_NdkPlugin_enableCrashReporting(
         JNIEnv *env, jobject _this) {
   if (bsg_global_env == NULL) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -64,6 +64,13 @@ typedef struct {
 
 bsg_unwinder bsg_configured_unwind_style();
 
+/**
+ * Invokes the user-supplied on_error callback, if it has been set. This allows users to mutate
+ * the bugsnag_event payload before it is persisted to disk, and to discard the report
+ * by returning false..
+ *
+ * @return true if the report should be delivered, false if it should be discarded
+ */
 bool bsg_run_on_error();
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -9,6 +9,7 @@
 
 #include "event.h"
 #include "utils/stack_unwinder.h"
+#include "../assets/include/bugsnag.h"
 
 #ifndef BUGSNAG_LOG
 #define BUGSNAG_LOG(fmt, ...)                                                  \
@@ -57,9 +58,13 @@ typedef struct {
      * true if a handler has completed crash handling
      */
     bool crash_handled;
+
+    bsg_on_error on_error;
 } bsg_environment;
 
 bsg_unwinder bsg_configured_unwind_style();
+
+bool bsg_run_on_error();
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -91,7 +91,13 @@ void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
   event->unhandled_events = unhandled_count;
 }
 
-void bugsnag_event_set_context(bugsnag_event *event, char *value) {
+char *bugsnag_event_get_context(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->context;
+}
+
+void bugsnag_event_set_context(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
   bsg_strncpy_safe(event->context, value, sizeof(event->context));
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -260,7 +260,6 @@ void bugsnag_event_clear_breadcrumbs(bugsnag_event *event);
 void bugsnag_event_remove_metadata(bugsnag_event *event, char *section,
                                    char *name);
 void bugsnag_event_remove_metadata_tab(bugsnag_event *event, char *section);
-void bugsnag_event_set_context(bugsnag_event *event, char *value);
 void bugsnag_event_set_orientation(bugsnag_event *event, int value);
 void bugsnag_event_set_app_version(bugsnag_event *event, char *value);
 void bugsnag_event_set_build_uuid(bugsnag_event *event, char *value);

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -107,7 +107,9 @@ void bsg_handle_cpp_terminate() {
   bsg_strncpy(bsg_global_env->next_event.error.errorMessage, (char *)message,
               message_length);
 
-  bsg_serialize_event_to_file(bsg_global_env);
+  if (bsg_run_on_error()) {
+    bsg_serialize_event_to_file(bsg_global_env);
+  }
   bsg_global_env->crash_handled = true;
   bsg_handler_uninstall_cpp();
   if (bsg_global_terminate_previous != NULL) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -195,7 +195,9 @@ void bsg_handle_signal(int signum, siginfo_t *info,
       break;
     }
   }
-  bsg_serialize_event_to_file(bsg_global_env);
+  if (bsg_run_on_error()) {
+    bsg_serialize_event_to_file(bsg_global_env);
+  }
   bsg_handler_uninstall_signal();
   bsg_invoke_previous_signal_handler(signum, info, user_context);
 }

--- a/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
@@ -9,5 +9,7 @@ add_library(bugsnag-ndk-test SHARED
     cpp/test_utils_string.c
     cpp/test_utils_serialize.c
     cpp/test_serializer.c
-    cpp/test_breadcrumbs.c)
+    cpp/test_breadcrumbs.c
+    cpp/test_bsg_event.c
+)
 target_link_libraries(bugsnag-ndk-test bugsnag-ndk)

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -13,6 +13,7 @@
 SUITE(string_utils);
 SUITE(serialize_utils);
 SUITE(breadcrumbs);
+SUITE(event_mutators);
 
 GREATEST_MAIN_DEFS();
 
@@ -24,6 +25,7 @@ JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_NativeCXXTest_run(
     RUN_SUITE(string_utils);
     RUN_SUITE(serialize_utils);
     RUN_SUITE(breadcrumbs);
+    RUN_SUITE(event_mutators);
     GREATEST_MAIN_END();
 }
 

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -1,0 +1,23 @@
+#include <greatest/greatest.h>
+#include <event.h>
+#include <utils/string.h>
+#include "../../main/assets/include/bugsnag.h"
+
+bugsnag_event *init_event() {
+    bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+    bsg_strncpy_safe(event->context, "Foo", sizeof(event->context));
+    return event;
+}
+
+TEST test_event_context(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("Foo", event->context);
+    bugsnag_event_set_context(event, "SomeContext");
+    ASSERT_STR_EQ("SomeContext", event->context);
+    free(event);
+    PASS();
+}
+
+SUITE(event_mutators) {
+    RUN_TEST(test_event_context);
+}

--- a/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
+++ b/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
@@ -1,6 +1,9 @@
 #include <bugsnag.h>
+#include <event.h>
 #include <jni.h>
 #include <stdlib.h>
+#include <stdexcept>
+#include <android/log.h>
 
 extern "C" {
 JNIEXPORT void JNICALL
@@ -189,10 +192,95 @@ return 512345;
 JNIEXPORT int JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_AutoDetectNdkEnabledScenario_crash(
     JNIEnv *env,
-jobject instance) {
-int x = 47;
-if (x > 0)
-__builtin_trap();
-return 12633;
+    jobject instance) {
+  int x = 47;
+  if (x > 0)
+    __builtin_trap();
+  return 12633;
 }
+
+bool on_err_true(void *event_ptr) {
+  bugsnag_event_set_context(event_ptr, "Some custom context");
+  return true;
+}
+
+bool on_err_false(void *event_ptr) {
+  printf("Received Bugsnag error report, logging callback!");
+  return false;
+}
+
+bool __attribute__((noinline)) f_run_away(bool value) {
+  if (value)
+    throw new std::runtime_error("How about NO");
+  return false;
+}
+
+
+bool __attribute__((noinline)) f_run_back(int value, int boundary) {
+  printf("boundary: %d\n", boundary);
+  if (value > -boundary)
+    throw 42;
+  return false;
+}
+
+int __attribute__((noinline)) f_throw_an_object(bool value, int boundary) {
+  if (value) {
+    printf("Now we know what they mean by 'advanced' tactical training: %d", boundary);
+    return (int)f_run_back(value, boundary);
+  }
+  return boundary * 2;
+}
+
+int __attribute__((noinline)) f_trigger_an_exception(bool value) {
+  printf("Shields up! Rrrrred alert!.\n");
+  if (value)
+    return (int)f_run_away(value);
+  else
+    return 405;
+}
+
+JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXSignalOnErrorFalseScenario_crash(
+        JNIEnv *env,
+        jobject instance) {
+  bugsnag_add_on_error(&on_err_false);
+  int x = 47;
+  if (x > 0)
+    __builtin_trap();
+  return 12633;
+}
+
+JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXSignalOnErrorTrueScenario_crash(
+        JNIEnv *env,
+        jobject instance) {
+  bugsnag_add_on_error(&on_err_true);
+  int x = 47;
+  if (x > 0)
+    __builtin_trap();
+  return 12633;
+}
+
+JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXExceptionOnErrorFalseScenario_crash(
+        JNIEnv *env,
+        jobject instance) {
+  bugsnag_add_on_error(&on_err_false);
+  int x = 61;
+  printf("This one here: %ld\n", (long) f_trigger_an_exception(x > 0));
+  printf("This one here: %ld\n", (long) f_throw_an_object(x > 0, x));
+  return 22;
+}
+
+JNIEXPORT int JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXExceptionOnErrorTrueScenario_crash(
+        JNIEnv *env,
+        jobject instance) {
+  bugsnag_add_on_error(&on_err_true);
+  int x = 61;
+  printf("This one here: %ld\n", (long) f_trigger_an_exception(x > 0));
+  printf("This one here: %ld\n", (long) f_throw_an_object(x > 0, x));
+  return 55;
+}
+
 }

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.Configuration;
+
+public class CXXExceptionOnErrorFalseScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public CXXExceptionOnErrorFalseScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoTrackSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorTrueScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorTrueScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.Configuration;
+
+public class CXXExceptionOnErrorTrueScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public CXXExceptionOnErrorTrueScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoTrackSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.Configuration;
+
+public class CXXSignalOnErrorFalseScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public CXXSignalOnErrorFalseScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoTrackSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorTrueScenario.java
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorTrueScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.Configuration;
+
+public class CXXSignalOnErrorTrueScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public CXXSignalOnErrorTrueScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoTrackSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/features/native_on_error.feature
+++ b/features/native_on_error.feature
@@ -1,0 +1,29 @@
+Feature: Native on error callbacks are invoked
+
+  Scenario: on_error returning false prevents C signal being reported
+    When I run "CXXSignalOnErrorFalseScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive no requests
+
+  Scenario: on_error returning false prevents C++ exception being reported
+    When I run "CXXExceptionOnErrorFalseScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive no requests
+
+  Scenario: C signal with on_error that modifies data
+    When I run "CXXSignalOnErrorTrueScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive a request
+    And the request payload contains a completed unhandled native report
+    And the event "context" equals "Some custom context"
+
+  Scenario: Cxx exception with on_error that modifies data
+    When I run "CXXExceptionOnErrorTrueScenario"
+    And I configure the app to run in the "non-crashy" state
+    And I relaunch the app
+    Then I should receive a request
+    And the request payload contains a completed unhandled native report
+    And the event "context" equals "Some custom context"

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.Configuration;
+
+public class CXXExceptionOnErrorFalseScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public CXXExceptionOnErrorFalseScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoTrackSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorTrueScenario.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorTrueScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.Configuration;
+
+public class CXXExceptionOnErrorTrueScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public CXXExceptionOnErrorTrueScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoTrackSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.Configuration;
+
+public class CXXSignalOnErrorFalseScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public CXXSignalOnErrorFalseScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoTrackSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorTrueScenario.java
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorTrueScenario.java
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.bugsnag.android.Configuration;
+
+public class CXXSignalOnErrorTrueScenario extends Scenario {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("monochrome");
+        System.loadLibrary("entrypoint");
+    }
+
+    public native void crash();
+
+    public CXXSignalOnErrorTrueScenario(@NonNull Configuration config, @NonNull Context context) {
+        super(config, context);
+        config.setAutoTrackSessions(false);
+    }
+
+    @Override
+    public void run() {
+        super.run();
+        String metadata = getEventMetaData();
+        if (metadata != null && metadata.equals("non-crashy")) {
+            return;
+        }
+        crash();
+    }
+}

--- a/tests/features/native_on_error.feature
+++ b/tests/features/native_on_error.feature
@@ -1,0 +1,25 @@
+Feature: Native on error callbacks are invoked
+
+  Scenario: on_error returning false prevents C signal being reported
+    When I run "CXXSignalOnErrorFalseScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSignalOnErrorFalseScenario"
+    Then I should receive no requests
+
+  Scenario: on_error returning false prevents C++ exception being reported
+    When I run "CXXExceptionOnErrorFalseScenario" and relaunch the app
+    And I configure Bugsnag for "CXXExceptionOnErrorFalseScenario"
+    Then I should receive no requests
+
+  Scenario: C signal with on_error that modifies data
+    When I run "CXXSignalOnErrorTrueScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSignalOnErrorTrueScenario"
+    And I wait to receive a request
+    And the request payload contains a completed unhandled native report
+    And the event "context" equals "Some custom context"
+
+  Scenario: Cxx exception with on_error that modifies data
+    When I run "CXXExceptionOnErrorTrueScenario" and relaunch the app
+    And I configure Bugsnag for "CXXExceptionOnErrorTrueScenario"
+    And I wait to receive a request
+    And the request payload contains a completed unhandled native report
+    And the event "context" equals "Some custom context"


### PR DESCRIPTION
## Goal

Note: This is reopened PR #744 due to a requested rename of the base branch.

Adds an `on_error` implementation which consists of a callback that is invoked when a fatal signal/exception occurs. This will allow users to discard native errors at the time of capture and to append additional metadata if required.

It's worth noting that the intention is to expose more methods that will allow for the manipulation of the `bugsnag_event` struct in future PRs. This changeset focuses mainly on the ability to add/remove `on_error` callbacks and only adds mutators as required for testing.

## Changeset

- Added a public `on_error` typedef that consists of a single-param method with an `intptr_t` to a non-public `bugsnag_event` struct
- Added `add_on_error/remove_on_error`, which sets the value of a single global `on_error` variable which is invoked when a fatal error occurs. This is a slight deviation from the notifier specification but I believe it makes more sense in C than allowing a user to specify multiple callbacks
- Added `bugsnag_event_set_context` which allows users to alter the context of the `bugsnag_event` supplied in an `on_error` callback
- Invoked the `on_error` callback within the signal/C++ exception handler and conditionally serialized the event to disk depending on its return value

## Spec deviation

This changeset deviates from the notifier specification by only allowing for one `on_error` callback to be added.

The rationale behind this is to limit the complexity of callback implementations. This is because code in a callback needs to be async-safe and never crash, because if it is not the program may terminate and bugsnag-android will be unable to capture any useful information. This is in contrast to the JVM where we can just catch the thrown exception and carry on.

There is no technical reason preventing us from allowing multiple callbacks, but my feeling is we should only allow users to supply one to reduce the complexity in their implementation, which reduces the risk of a crash.

## Tests

Added E2E tests to verify that the event context can be mutated in `on_error` and that the return value dictates whether an event is serialized or not, for both signals and C++ exceptions.

Added an additional unit test to verify that `bugsnag_event_set_context/bugsnag_event_get_context` allow for the `context` field to be mutated. Going forward the intention is that all fields in the struct will be tested at the unit level this way.
