### PR TITLE
Add accessors for unhandled/severity

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -148,7 +148,13 @@ void bugsnag_error_set_error_type(void *event_ptr, char *value);
 
 void bugsnag_event_set_user(void *event_ptr, char* id, char* email, char* name);
 
+bsg_severity_t bugsnag_event_get_severity(void *event_ptr);
+void bugsnag_event_set_severity(void *event_ptr, bsg_severity_t value);
+
+bool bugsnag_event_is_unhandled(void *event_ptr);
+
 #ifdef __cplusplus
 }
 #endif
+
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -380,3 +380,18 @@ void bugsnag_error_set_error_type(void *event_ptr, char *value) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
   bsg_strncpy_safe(event->error.type, value, sizeof(event->error.type));
 }
+
+bsg_severity_t bugsnag_event_get_severity(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->severity;
+}
+
+void bugsnag_event_set_severity(void *event_ptr, bsg_severity_t value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->severity = value;
+}
+
+bool bugsnag_event_is_unhandled(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->unhandled;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -245,6 +245,7 @@ typedef struct {
     char session_start[33];
     int handled_events;
     int unhandled_events;
+    bool unhandled;
 } bugsnag_event;
 
 void bugsnag_event_add_metadata_double(bugsnag_event *event, char *section,

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -90,6 +90,7 @@ void bsg_handle_cpp_terminate() {
 
   bsg_global_env->handling_crash = true;
   bsg_populate_event_as(bsg_global_env);
+  bsg_global_env->next_event.unhandled = true;
   bsg_global_env->next_event.unhandled_events++;
   bsg_global_env->next_event.error.frame_count = bsg_unwind_stack(
       bsg_global_env->unwind_style,

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -179,6 +179,7 @@ void bsg_handle_signal(int signum, siginfo_t *info,
   }
 
   bsg_global_env->handling_crash = true;
+  bsg_global_env->next_event.unhandled = true;
   bsg_populate_event_as(bsg_global_env);
   bsg_global_env->next_event.unhandled_events++;
   bsg_global_env->next_event.error.frame_count = bsg_unwind_stack(

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -143,6 +143,10 @@ bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2) {
     event->error.frame_count = report_v2->exception.frame_count;
     size_t error_size = sizeof(bsg_stackframe) * BUGSNAG_FRAMES_MAX;
     memcpy(&event->error.stacktrace, report_v2->exception.stacktrace, error_size);
+
+    // Fatal C errors are always true by default, previously this was hardcoded and
+    // not a field on the struct
+    event->unhandled = true;
   }
   free(report_v2);
   return event;
@@ -283,7 +287,7 @@ void bsg_serialize_handled_state(const bugsnag_event *event, JSON_Object *event_
   // over-optimized for signal handling. in the future we may want to handle
   // C++ exceptions, etc as well.
   json_object_set_string(event_obj, "severity", bsg_severity_string(event->severity));
-  json_object_dotset_boolean(event_obj, "unhandled", true);
+  json_object_dotset_boolean(event_obj, "unhandled", event->unhandled);
   json_object_dotset_string(event_obj, "severityReason.type", "signal");
   json_object_dotset_string(event_obj, "severityReason.attributes.signalType", event->error.errorClass);
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -7,6 +7,8 @@
 bugsnag_event *init_event() {
     bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
     bsg_strncpy_safe(event->context, "Foo", sizeof(event->context));
+    event->severity = BSG_SEVERITY_INFO;
+    event->unhandled = true;
     bsg_strncpy_safe(event->user.id, "123", sizeof(event->user.id));
     bsg_strncpy_safe(event->user.email, "bob@example.com", sizeof(event->user.email));
     bsg_strncpy_safe(event->user.name, "Bob Bobbiton", sizeof(event->user.name));
@@ -44,6 +46,15 @@ TEST test_event_context(void) {
     ASSERT_STR_EQ("Foo", bugsnag_event_get_context(event));
     bugsnag_event_set_context(event, "SomeContext");
     ASSERT_STR_EQ("SomeContext", bugsnag_event_get_context(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_severity(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_EQ(BSG_SEVERITY_INFO, event->severity);
+    bugsnag_event_set_severity(event, BSG_SEVERITY_ERR);
+    ASSERT_EQ(BSG_SEVERITY_ERR, bugsnag_event_get_severity(event));
     free(event);
     PASS();
 }
@@ -269,8 +280,16 @@ TEST test_event_user(void) {
     PASS();
 }
 
+TEST test_event_unhandled(void) {
+    bugsnag_event *event = init_event();
+    bugsnag_event_is_unhandled(event);
+    free(event);
+    PASS();
+}
 SUITE(event_mutators) {
     RUN_TEST(test_event_context);
+    RUN_TEST(test_event_severity);
+    RUN_TEST(test_event_unhandled);
     RUN_TEST(test_event_user);
     RUN_TEST(test_app_binary_arch);
     RUN_TEST(test_app_build_uuid);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -103,6 +103,7 @@ bugsnag_event * loadContextTestCase(jint num) {
 
 bugsnag_event * loadHandledStateTestCase(jint num) {
     bugsnag_event *data = malloc(sizeof(bugsnag_event));
+    data->unhandled = true;
     return data;
 }
 


### PR DESCRIPTION
## Goal

Adds accessor methods for manipulating the `unhandled` and `severity` fields on `event`. This is necessary now that the `bugsnag_event` pointer is exposed in an `on_error` callback, and allows users to mutate the generated report.

## Changeset

Added get/set methods for `severity`, and a getter only for `unhandled`.

## Tests

Added unit tests for each new accessor method.
