### PR TITLE
Add setUser accessor to event

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -146,6 +146,8 @@ void bugsnag_error_set_error_message(void *event_ptr, char *value);
 char *bugsnag_error_get_error_type(void *event_ptr);
 void bugsnag_error_set_error_type(void *event_ptr, char *value);
 
+void bugsnag_event_set_user(void *event_ptr, char* id, char* email, char* name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -113,6 +113,13 @@ void bugsnag_event_set_user_id(bugsnag_event *event, char *value) {
   bsg_strncpy_safe(event->user.id, value, sizeof(event->user.id));
 }
 
+void bugsnag_event_set_user(void *event_ptr, char* id, char* email, char* name) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event_set_user_id(event, id);
+  bugsnag_event_set_user_email(event, email);
+  bugsnag_event_set_user_name(event, name);
+}
+
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,
                                   bugsnag_breadcrumb *crumb) {
   int crumb_index;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -7,6 +7,9 @@
 bugsnag_event *init_event() {
     bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
     bsg_strncpy_safe(event->context, "Foo", sizeof(event->context));
+    bsg_strncpy_safe(event->user.id, "123", sizeof(event->user.id));
+    bsg_strncpy_safe(event->user.email, "bob@example.com", sizeof(event->user.email));
+    bsg_strncpy_safe(event->user.name, "Bob Bobbiton", sizeof(event->user.name));
 
     bsg_strncpy_safe(event->app.binaryArch, "x86", sizeof(event->app.binaryArch));
     bsg_strncpy_safe(event->app.build_uuid, "123", sizeof(event->app.build_uuid));
@@ -253,8 +256,22 @@ TEST test_error_type(void) {
     PASS();
 }
 
+TEST test_event_user(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("123", event->user.id);
+    ASSERT_STR_EQ("bob@example.com", event->user.email);
+    ASSERT_STR_EQ("Bob Bobbiton", event->user.name);
+    bugsnag_event_set_user(event, "456", "sue@example.com", "Sue Smith");
+    ASSERT_STR_EQ("456", event->user.id);
+    ASSERT_STR_EQ("sue@example.com", event->user.email);
+    ASSERT_STR_EQ("Sue Smith", event->user.name);
+    free(event);
+    PASS();
+}
+
 SUITE(event_mutators) {
     RUN_TEST(test_event_context);
+    RUN_TEST(test_event_user);
     RUN_TEST(test_app_binary_arch);
     RUN_TEST(test_app_build_uuid);
     RUN_TEST(test_app_id);


### PR DESCRIPTION
## Goal

Adds accessor methods for manipulating `event.user`. This is necessary now that the `bugsnag_event` pointer is exposed in an `on_error` callback, and allows users to mutate the generated report.

## Changeset

Added a setter method for `event.user`.

Note that a getter method has not been added. This would also require adding a getter method to the main `Bugsnag` interface, and exposing some form of a `bsg_user` struct - as this would be an additive change this has been left for #768 

## Tests

Added unit tests for each new accessor method.
