### PR TITLE
Add accessors for ndk error class/message/type

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -137,8 +137,16 @@ void bugsnag_device_set_time(void *event_ptr, time_t value);
 char *bugsnag_device_get_os_name(void *event_ptr);
 void bugsnag_device_set_os_name(void *event_ptr, char *value);
 
+char *bugsnag_error_get_error_class(void *event_ptr);
+void bugsnag_error_set_error_class(void *event_ptr, char *value);
+
+char *bugsnag_error_get_error_message(void *event_ptr);
+void bugsnag_error_set_error_message(void *event_ptr, char *value);
+
+char *bugsnag_error_get_error_type(void *event_ptr);
+void bugsnag_error_set_error_type(void *event_ptr, char *value);
+
 #ifdef __cplusplus
 }
 #endif
-
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -343,3 +343,33 @@ void bugsnag_device_set_os_name(void *event_ptr, char *value) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
   bsg_strncpy_safe(event->device.os_name, value, sizeof(event->device.os_name));
 }
+
+char *bugsnag_error_get_error_class(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->error.errorClass;
+}
+
+void bugsnag_error_set_error_class(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->error.errorClass, value, sizeof(event->error.errorClass));
+}
+
+char *bugsnag_error_get_error_message(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->error.errorMessage;
+}
+
+void bugsnag_error_set_error_message(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->error.errorMessage, value, sizeof(event->error.errorMessage));
+}
+
+char *bugsnag_error_get_error_type(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->error.type;
+}
+
+void bugsnag_error_set_error_type(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->error.type, value, sizeof(event->error.type));
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -30,6 +30,9 @@ bugsnag_event *init_event() {
     bsg_strncpy_safe(event->device.orientation, "portrait", sizeof(event->device.orientation));
     event->device.time = 7609;
 
+    bsg_strncpy_safe(event->error.errorClass, "SIGSEGV", sizeof(event->error.errorClass));
+    bsg_strncpy_safe(event->error.errorMessage, "Whoops!", sizeof(event->error.errorMessage));
+    bsg_strncpy_safe(event->error.type, "C", sizeof(event->error.type));
     return event;
 }
 
@@ -223,6 +226,33 @@ TEST test_device_os_name(void) {
     PASS();
 }
 
+TEST test_error_class(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("SIGSEGV", event->error.errorClass);
+    bugsnag_error_set_error_class(event, "SIGTRAP");
+    ASSERT_STR_EQ("SIGTRAP", bugsnag_error_get_error_class(event));
+    free(event);
+    PASS();
+}
+
+TEST test_error_message(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("Whoops!", event->error.errorMessage);
+    bugsnag_error_set_error_message(event, "Invalid Foo");
+    ASSERT_STR_EQ("Invalid Foo", bugsnag_error_get_error_message(event));
+    free(event);
+    PASS();
+}
+
+TEST test_error_type(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("C", event->error.type);
+    bugsnag_error_set_error_type(event, "C++");
+    ASSERT_STR_EQ("C++", bugsnag_error_get_error_type(event));
+    free(event);
+    PASS();
+}
+
 SUITE(event_mutators) {
     RUN_TEST(test_event_context);
     RUN_TEST(test_app_binary_arch);
@@ -245,4 +275,7 @@ SUITE(event_mutators) {
     RUN_TEST(test_device_orientation);
     RUN_TEST(test_device_time);
     RUN_TEST(test_device_os_name);
+    RUN_TEST(test_error_class);
+    RUN_TEST(test_error_message);
+    RUN_TEST(test_error_type);
 }


### PR DESCRIPTION
## Goal

Adds accessor methods for manipulating the fields on `event.error`. This is necessary now that the `bugsnag_event` pointer is exposed in an `on_error` callback, and allows users to mutate the generated report.

## Changeset

Added get/set methods for each primitive field defined on `event.error` that is present in the notifier spec.

## Tests

Added unit tests for each new accessor method.
