### PR TITLE
Remove versionName/packageName from NDK payload

### DIFF
--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/app_meta_data_serialization_0.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/app_meta_data_serialization_0.json
@@ -1,1 +1,1 @@
-{"metaData":{"app":{"packageName":"com.bugsnag.example","versionName":"5.0","activeScreen":"MainActivity","name":"PhotoSnap","lowMemory":true}}}
+{"metaData":{"app":{"activeScreen":"MainActivity","name":"PhotoSnap","lowMemory":true}}}

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -149,12 +149,12 @@ bool bugsnag_event_has_session(bugsnag_event *event) {
 
 char *bugsnag_app_get_binary_arch(void *event_ptr) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
-  return event->app.binaryArch;
+  return event->app.binary_arch;
 }
 
 void bugsnag_app_set_binary_arch(void *event_ptr, char *value) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
-  bsg_strncpy_safe(event->app.binaryArch, value, sizeof(event->app.binaryArch));
+  bsg_strncpy_safe(event->app.binary_arch, value, sizeof(event->app.binary_arch));
 }
 
 char *bugsnag_app_get_build_uuid(void *event_ptr) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -56,11 +56,9 @@ typedef struct {
 typedef struct {
     char name[64];
     char id[64];
-    char package_name[64];
     char release_stage[64];
     char type[32];
     char version[32];
-    char version_name[32];
     char active_screen[64];
     int version_code;
     char build_uuid[64];
@@ -81,7 +79,7 @@ typedef struct {
     bool in_foreground;
     bool low_memory;
     size_t memory_usage;
-    char binaryArch[32];
+    char binary_arch[32];
 } bsg_app_info;
 
 typedef struct {

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -233,12 +233,6 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
       env, jni_cache->native_interface, jni_cache->get_app_data);
   bsg_copy_map_value_string(env, jni_cache, data, "version",
                             event->app.version, sizeof(event->app.version));
-  bsg_copy_map_value_string(env, jni_cache, data, "versionName",
-                            event->app.version_name,
-                            sizeof(event->app.version_name));
-  bsg_copy_map_value_string(env, jni_cache, data, "packageName",
-                            event->app.package_name,
-                            sizeof(event->app.package_name));
   bsg_copy_map_value_string(env, jni_cache, data, "releaseStage",
                             event->app.release_stage,
                             sizeof(event->app.release_stage));
@@ -260,9 +254,9 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   event->app.in_foreground =
       bsg_get_map_value_bool(env, jni_cache, data, "inForeground");
 
-  bsg_strncpy_safe(event->app.binaryArch,
+  bsg_strncpy_safe(event->app.binary_arch,
                      bsg_binary_arch(),
-                     sizeof(event->app.binaryArch));
+                     sizeof(event->app.binary_arch));
   (*env)->DeleteLocalRef(env, data);
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -46,6 +46,27 @@ typedef struct {
 } bsg_exception;
 
 typedef struct {
+    char name[64];
+    char id[64];
+    char package_name[64];
+    char release_stage[64];
+    char type[32];
+    char version[32];
+    char version_name[32];
+    char active_screen[64];
+    int version_code;
+    char build_uuid[64];
+    time_t duration;
+    time_t duration_in_foreground;
+    time_t duration_ms_offset;
+    time_t duration_in_foreground_ms_offset;
+    bool in_foreground;
+    bool low_memory;
+    size_t memory_usage;
+    char binaryArch[32];
+} bsg_app_info_v1;
+
+typedef struct {
     int api_level;
     double battery_level;
     char brand[64];
@@ -71,7 +92,7 @@ typedef struct {
 
 typedef struct {
     bsg_library notifier;
-    bsg_app_info app;
+    bsg_app_info_v1 app;
     bsg_device_info_v1 device;
     bsg_user_t user;
     bsg_exception exception;
@@ -93,7 +114,7 @@ typedef struct {
 
 typedef struct {
     bsg_library notifier;
-    bsg_app_info app;
+    bsg_app_info_v1 app;
     bsg_device_info_v1 device;
     bsg_user_t user;
     bsg_exception exception;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -16,7 +16,7 @@ bugsnag_event *init_event() {
     bsg_strncpy_safe(event->user.email, "bob@example.com", sizeof(event->user.email));
     bsg_strncpy_safe(event->user.name, "Bob Bobbiton", sizeof(event->user.name));
 
-    bsg_strncpy_safe(event->app.binaryArch, "x86", sizeof(event->app.binaryArch));
+    bsg_strncpy_safe(event->app.binary_arch, "x86", sizeof(event->app.binary_arch));
     bsg_strncpy_safe(event->app.build_uuid, "123", sizeof(event->app.build_uuid));
     bsg_strncpy_safe(event->app.id, "fa02", sizeof(event->app.id));
     bsg_strncpy_safe(event->app.release_stage, "dev", sizeof(event->app.release_stage));

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -38,7 +38,7 @@ bsg_app_info * loadAppTestCase(jint num) {
     strcpy(app->release_stage, "prod");
     app->version_code = 55;
     strcpy(app->build_uuid, "1234-uuid");
-    strcpy(app->binaryArch, "x86");
+    strcpy(app->binary_arch, "x86");
     app->duration = 6502;
     app->duration_in_foreground = 6502;
     app->in_foreground = true;
@@ -47,8 +47,6 @@ bsg_app_info * loadAppTestCase(jint num) {
 
 bsg_app_info * loadAppMetadataTestCase(jint num) {
     bsg_app_info *app = malloc(sizeof(bsg_app_info));
-    strcpy(app->package_name, "com.bugsnag.example");
-    strcpy(app->version_name, "5.0");
     strcpy(app->active_screen, "MainActivity");
     strcpy(app->name, "PhotoSnap");
     app->low_memory = true;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -19,11 +19,9 @@ void generate_basic_report(bugsnag_event *event) {
   strcpy(event->error.stacktrace[0].method, "makinBacon");
   strcpy(event->app.name, "PhotoSnap Plus");
   strcpy(event->app.id, "com.example.PhotoSnapPlus");
-  strcpy(event->app.package_name, "com.example.PhotoSnapPlus");
   strcpy(event->app.release_stage, "リリース");
   strcpy(event->app.version, "2.0.52");
   event->app.version_code = 57;
-  strcpy(event->app.version_name, "2.0");
   strcpy(event->app.build_uuid, "1234-9876-adfe");
   strcpy(event->device.manufacturer, "HI-TEC™");
   strcpy(event->device.model, "Rasseur");
@@ -66,6 +64,9 @@ bugsnag_report_v2 *bsg_generate_report_v2(void) {
   report->exception.frame_count = 1;
   strcpy(report->exception.type, "C");
   strcpy(report->exception.stacktrace[0].method, "makinBacon");
+
+  strcpy(report->app.package_name, "com.example.foo");
+  strcpy(report->app.version_name, "2.5");
   return report;
 }
 
@@ -170,6 +171,10 @@ TEST test_report_v2_migration(void) {
   // event.device
   ASSERT_STR_EQ("android", event->device.os_name);
 
+  // package_name/version_name are migrated to metadata
+  ASSERT_STR_EQ("com.example.foo", event->metadata.values[0].char_value);
+  ASSERT_STR_EQ("2.5", event->metadata.values[1].char_value);
+
   free(generated_report);
   free(env);
   free(event);
@@ -191,11 +196,9 @@ TEST test_app_info_to_json(void) {
   JSON_Object *event = json_value_get_object(root_value);
   ASSERT(strcmp("2.0.52", json_object_dotget_string(event, "app.version")) == 0);
   ASSERT(strcmp( "PhotoSnap Plus", json_object_dotget_string(event, "metaData.app.name")) == 0);
-  ASSERT(strcmp( "com.example.PhotoSnapPlus", json_object_dotget_string(event, "metaData.app.packageName")) == 0);
   ASSERT(strcmp( "com.example.PhotoSnapPlus", json_object_dotget_string(event, "app.id")) == 0);
   ASSERT(strcmp( "リリース", json_object_dotget_string(event, "app.releaseStage")) == 0);
   ASSERT_EQ(57, json_object_dotget_number(event, "app.versionCode"));
-  ASSERT(strcmp( "2.0", json_object_dotget_string(event, "metaData.app.versionName")) == 0);
   ASSERT(strcmp( "1234-9876-adfe", json_object_dotget_string(event, "app.buildUUID")) == 0);
   json_value_free(root_value);
   PASS();


### PR DESCRIPTION
## Goal

Removes the `packageName` and `versionName` fields from the serialized payload in `event.app`. These are replaced by `id` and `version` respectively, so are redundant.

The fields have already been removed from the JVM payload - this removes them from the NDK payload.

## Tests

Verified in an example app that the payload is not present for a fatal C error.
