### PR TITLE
Add grouping_hash to ndk event interface

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -160,6 +160,9 @@ void bugsnag_event_set_severity(void *event_ptr, bsg_severity_t value);
 
 bool bugsnag_event_is_unhandled(void *event_ptr);
 
+char *bugsnag_event_get_grouping_hash(void *event_ptr);
+void bugsnag_event_set_grouping_hash(void *event_ptr, char *value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -400,3 +400,13 @@ bsg_user_t bugsnag_event_get_user(void *event_ptr) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
   return event->user;
 }
+
+char *bugsnag_event_get_grouping_hash(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->grouping_hash;
+}
+
+void bugsnag_event_set_grouping_hash(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->grouping_hash, value, sizeof(event->grouping_hash));
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -239,6 +239,7 @@ typedef struct {
     char session_start[33];
     int handled_events;
     int unhandled_events;
+    char grouping_hash[64];
     bool unhandled;
 } bugsnag_event;
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -282,6 +282,12 @@ void bsg_serialize_context(const bugsnag_event *event, JSON_Object *event_obj) {
   }
 }
 
+void bsg_serialize_grouping_hash(const bugsnag_event *event, JSON_Object *event_obj) {
+  if (strlen(event->grouping_hash) > 0) {
+    json_object_set_string(event_obj, "groupingHash", event->grouping_hash);
+  }
+}
+
 void bsg_serialize_handled_state(const bugsnag_event *event, JSON_Object *event_obj) {
   // FUTURE(dm): severityReason/unhandled attributes are currently
   // over-optimized for signal handling. in the future we may want to handle
@@ -481,6 +487,7 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   char *serialized_string = NULL;
   {
     bsg_serialize_context(event, event_obj);
+    bsg_serialize_grouping_hash(event, event_obj);
     bsg_serialize_handled_state(event, event_obj);
     bsg_serialize_app(event->app, event_obj);
     bsg_serialize_app_metadata(event->app, event_obj);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -26,6 +26,7 @@ bugsnag_event *init_event() {
     event->app.duration = 9019;
     event->app.duration_in_foreground = 7017;
     event->app.in_foreground = true;
+    bsg_strncpy_safe(event->grouping_hash, "Bar", sizeof(event->grouping_hash));
 
     event->device.jailbroken = true;
     event->device.total_memory = 1095092340;
@@ -132,6 +133,15 @@ TEST test_event_user(void) {
     ASSERT_STR_EQ("456", user.id);
     ASSERT_STR_EQ("sue@example.com", user.email);
     ASSERT_STR_EQ("Sue Smith", user.name);
+    free(event);
+    PASS();
+}
+
+TEST test_event_grouping_hash(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("Bar", event->grouping_hash);
+    bugsnag_event_set_grouping_hash(event, "Wham");
+    ASSERT_STR_EQ("Wham", bugsnag_event_get_grouping_hash(event));
     free(event);
     PASS();
 }
@@ -292,6 +302,7 @@ SUITE(event_mutators) {
     RUN_TEST(test_event_severity);
     RUN_TEST(test_event_unhandled);
     RUN_TEST(test_event_user);
+    RUN_TEST(test_event_grouping_hash);
     RUN_TEST(test_app_binary_arch);
     RUN_TEST(test_app_build_uuid);
     RUN_TEST(test_app_id);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -8,6 +8,7 @@
 bugsnag_breadcrumb *init_breadcrumb(const char *name, const char *message, bsg_breadcrumb_t type);
 
 void generate_basic_report(bugsnag_event *event) {
+  strcpy(event->grouping_hash, "foo-hash");
   strcpy(event->context, "SomeActivity");
   strcpy(event->error.errorClass, "SIGBUS");
   strcpy(event->error.errorMessage, "POSIX is serious about oncoming traffic");
@@ -210,6 +211,14 @@ TEST test_session_handled_counts(void) {
   PASS();
 }
 
+TEST test_grouping_hash_to_json(void) {
+  JSON_Value *root_value = bsg_generate_json();
+  JSON_Object *event = json_value_get_object(root_value);
+  ASSERT(event != NULL);
+  ASSERT_STR_EQ("foo-hash", json_object_get_string(event, "groupingHash"));
+  PASS();
+}
+
 TEST test_context_to_json(void) {
   JSON_Value *root_value = bsg_generate_json();
   JSON_Object *event = json_value_get_object(root_value);
@@ -302,6 +311,7 @@ SUITE(serialize_utils) {
   RUN_TEST(test_report_v2_migration);
   RUN_TEST(test_session_handled_counts);
   RUN_TEST(test_context_to_json);
+  RUN_TEST(test_grouping_hash_to_json);
   RUN_TEST(test_app_info_to_json);
   RUN_TEST(test_device_info_to_json);
   RUN_TEST(test_user_info_to_json);


### PR DESCRIPTION
## Goal

Adds `grouping_hash` to `bugsnag_event` so that users can alter the grouping on the `bugsnag_event` exposed in an `on_error` callback.

## Tests

Added unit tests for each new accessor method, and to verify that the new field is serialized correctly.
