### PR TITLE
Add getter for user struct on event

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -50,10 +50,17 @@ typedef enum {
   BSG_CRUMB_USER,
 } bsg_breadcrumb_t;
 
+typedef struct {
+    char name[64];
+    char email[64];
+    char id[64];
+} bsg_user_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+bsg_user_t bugsnag_event_get_user(void *event_ptr);
 
 /**
  * Retrieves the event context

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -395,3 +395,8 @@ bool bugsnag_event_is_unhandled(void *event_ptr) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
   return event->unhandled;
 }
+
+bsg_user_t bugsnag_event_get_user(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->user;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -34,7 +34,7 @@
  */
 #define BUGSNAG_EVENT_VERSION 3
 
-#define BUGSNAG_USER_INFO_LEN 64
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -176,12 +176,6 @@ typedef struct {
     bsg_metadata_value values[BUGSNAG_METADATA_MAX];
 } bugsnag_metadata;
 
-typedef struct {
-    char name[BUGSNAG_USER_INFO_LEN];
-    char email[BUGSNAG_USER_INFO_LEN];
-    char id[BUGSNAG_USER_INFO_LEN];
-} bsg_user;
-
 /** a Bugsnag exception */
 typedef struct {
     /** The exception name or stringified code */
@@ -228,7 +222,7 @@ typedef struct {
     bsg_notifier notifier;
     bsg_app_info app;
     bsg_device_info device;
-    bsg_user user;
+    bsg_user_t user;
     bsg_error error;
     bugsnag_metadata metadata;
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -73,7 +73,7 @@ typedef struct {
     bsg_library notifier;
     bsg_app_info app;
     bsg_device_info_v1 device;
-    bsg_user user;
+    bsg_user_t user;
     bsg_exception exception;
     bugsnag_metadata metadata;
 
@@ -95,7 +95,7 @@ typedef struct {
     bsg_library notifier;
     bsg_app_info app;
     bsg_device_info_v1 device;
-    bsg_user user;
+    bsg_user_t user;
     bsg_exception exception;
     bugsnag_metadata metadata;
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -379,7 +379,7 @@ void bsg_serialize_custom_metadata(const bugsnag_metadata metadata, JSON_Object 
   }
 }
 
-void bsg_serialize_user(const bsg_user user, JSON_Object *event_obj) {
+void bsg_serialize_user(const bsg_user_t user, JSON_Object *event_obj) {
   if (strlen(user.name) > 0)
     json_object_dotset_string(event_obj, "user.name", user.name);
   if (strlen(user.email) > 0)

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -24,7 +24,7 @@ void bsg_serialize_app_metadata(const bsg_app_info app, JSON_Object *event_obj);
 void bsg_serialize_device(const bsg_device_info device, JSON_Object *event_obj);
 void bsg_serialize_device_metadata(const bsg_device_info device, JSON_Object *event_obj);
 void bsg_serialize_custom_metadata(const bugsnag_metadata metadata, JSON_Object *event_obj);
-void bsg_serialize_user(const bsg_user user, JSON_Object *event_obj);
+void bsg_serialize_user(const bsg_user_t user, JSON_Object *event_obj);
 void bsg_serialize_session(bugsnag_event *event, JSON_Object *event_obj);
 void bsg_serialize_stackframe(bsg_stackframe *stackframe, JSON_Array *stacktrace);
 void bsg_serialize_error(bsg_error exc, JSON_Object *exception, JSON_Array *stacktrace);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -32,7 +32,7 @@ JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_NativeCXXTest_run(
 TEST test_user_serialization(test_case *test_case) {
     JSON_Value *event_val = json_value_init_object();
     JSON_Object *event = json_value_get_object(event_val);
-    bsg_user *user = test_case->data_ptr;
+    bsg_user_t *user = test_case->data_ptr;
     bsg_serialize_user(*user, event);
     free(user);
     return validate_serialized_json(test_case, event_val);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -7,6 +7,9 @@
 bugsnag_event *init_event() {
     bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
     bsg_strncpy_safe(event->context, "Foo", sizeof(event->context));
+    bsg_strncpy_safe(event->user.id, "123", sizeof(event->user.id));
+    bsg_strncpy_safe(event->user.email, "jane@example.com", sizeof(event->user.email));
+    bsg_strncpy_safe(event->user.name, "Jane Doe", sizeof(event->user.name));
     event->severity = BSG_SEVERITY_INFO;
     event->unhandled = true;
     bsg_strncpy_safe(event->user.id, "123", sizeof(event->user.id));
@@ -118,6 +121,17 @@ TEST test_app_version_code(void) {
     ASSERT_EQ(55, bugsnag_app_get_version_code(event));
     bugsnag_app_set_version_code(event, 99);
     ASSERT_EQ(99, bugsnag_app_get_version_code(event));
+    free(event);
+    PASS();
+}
+
+TEST test_event_user(void) {
+    bugsnag_event *event = init_event();
+    bugsnag_event_set_user(event, "456", "sue@example.com", "Sue Smith");
+    bsg_user_t user = bugsnag_event_get_user(event);
+    ASSERT_STR_EQ("456", user.id);
+    ASSERT_STR_EQ("sue@example.com", user.email);
+    ASSERT_STR_EQ("Sue Smith", user.name);
     free(event);
     PASS();
 }
@@ -263,19 +277,6 @@ TEST test_error_type(void) {
     ASSERT_STR_EQ("C", event->error.type);
     bugsnag_error_set_error_type(event, "C++");
     ASSERT_STR_EQ("C++", bugsnag_error_get_error_type(event));
-    free(event);
-    PASS();
-}
-
-TEST test_event_user(void) {
-    bugsnag_event *event = init_event();
-    ASSERT_STR_EQ("123", event->user.id);
-    ASSERT_STR_EQ("bob@example.com", event->user.email);
-    ASSERT_STR_EQ("Bob Bobbiton", event->user.name);
-    bugsnag_event_set_user(event, "456", "sue@example.com", "Sue Smith");
-    ASSERT_STR_EQ("456", event->user.id);
-    ASSERT_STR_EQ("sue@example.com", event->user.email);
-    ASSERT_STR_EQ("Sue Smith", event->user.name);
     free(event);
     PASS();
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -13,16 +13,16 @@ enum greatest_test_res validate_serialized_json(const test_case *test_case,
     PASS();
 }
 
-bsg_user * loadUserTestCase(jint num) {
-    bsg_user *user;
+bsg_user_t * loadUserTestCase(jint num) {
+    bsg_user_t *user;
 
     if (num == 0) {
-        user = malloc(sizeof(bsg_user));
+        user = malloc(sizeof(bsg_user_t));
         strcpy(user->id, "1234");
         strcpy(user->email, "fenton@io.example.com");
         strcpy(user->name, "Fenton");
     } else {
-        user = malloc(sizeof(bsg_user));
+        user = malloc(sizeof(bsg_user_t));
         strcpy(user->id, "456");
         strcpy(user->email, "jamie@bugsnag.com");
         strcpy(user->name, "Jamie");

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
@@ -12,7 +12,7 @@ typedef struct {
 
 enum greatest_test_res validate_serialized_json(const test_case *test_case,
                                                 JSON_Value *event_val);
-bsg_user * loadUserTestCase(jint num);
+bsg_user_t * loadUserTestCase(jint num);
 bsg_app_info * loadAppTestCase(jint num);
 bsg_app_info * loadAppMetadataTestCase(jint num);
 bsg_device_info * loadDeviceTestCase(jint num);


### PR DESCRIPTION
## Goal

Adds an accessor method for getting `event.user`.

Note that this method returns a public exposed struct. I believe this is the most idiomatic way of achieving compliance with the notifier spec. One alternative would be to return a pointer to the event (or user) struct, and add separate accessor methods for each individual field on the struct.

Related to #764 

## Changeset

- Added a getter to return the `event.user` value
- Renamed `bugsnag_user` to `bugsnag_user_t` for consistency with other types in event.h
- Avoided using macro to size `bugsnag_user_t` fields of the struct as this can be overridden by end-users
- Added a test to verify the accessor method retrieves the struct
