### PR TITLE
Rename Report to EventPayload

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -100,7 +100,7 @@ final class BugsnagTestUtils {
         return new Delivery() {
             @NotNull
             @Override
-            public DeliveryStatus deliver(@NonNull Report report,
+            public DeliveryStatus deliver(@NonNull EventPayload payload,
                                           @NonNull DeliveryParams deliveryParams) {
                 return DeliveryStatus.DELIVERED;
             }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientConfigTest.java
@@ -49,7 +49,7 @@ public class ClientConfigTest {
         Delivery customDelivery = new Delivery() {
             @NotNull
             @Override
-            public DeliveryStatus deliver(@NotNull Report report,
+            public DeliveryStatus deliver(@NotNull EventPayload payload,
                                           @NotNull DeliveryParams deliveryParams) {
                 return DeliveryStatus.DELIVERED;
             }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventPayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventPayloadTest.java
@@ -16,12 +16,12 @@ import org.junit.Test;
 import java.io.IOException;
 
 @SmallTest
-public class ReportTest {
+public class EventPayloadTest {
 
-    private Report report;
+    private EventPayload eventPayload;
 
     /**
-     * Generates a report
+     * Generates a eventPayload
      *
      */
     @Before
@@ -32,21 +32,21 @@ public class ReportTest {
         Event event = new Event(exception, config, handledState);
         event.setApp(generateAppWithState());
         event.setDevice(generateDeviceWithState());
-        report = new Report("api-key", event);
+        eventPayload = new EventPayload("api-key", event);
     }
 
     @Test
     public void testInMemoryError() throws JSONException, IOException {
-        JSONObject reportJson = streamableToJson(report);
+        JSONObject reportJson = streamableToJson(eventPayload);
         assertEquals(1, reportJson.getJSONArray("events").length());
     }
 
     @Test
     public void testModifyingGroupingHash() throws JSONException, IOException {
         String groupingHash = "File.java:300429";
-        report.getEvent().setGroupingHash(groupingHash);
+        eventPayload.getEvent().setGroupingHash(groupingHash);
 
-        JSONObject reportJson = streamableToJson(report);
+        JSONObject reportJson = streamableToJson(eventPayload);
         JSONArray events = reportJson.getJSONArray("events");
         JSONObject event = events.getJSONObject(0);
         assertEquals(groupingHash, event.getString("groupingHash"));

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
@@ -20,8 +20,8 @@ internal class DefaultDelivery(private val connectivity: Connectivity?, val logg
         return status
     }
 
-    override fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus {
-        val status = deliver(deliveryParams.endpoint, report, deliveryParams.headers)
+    override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
+        val status = deliver(deliveryParams.endpoint, payload, deliveryParams.headers)
         logger.i("Error API request finished with status $status")
         return status
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Delivery.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Delivery.kt
@@ -57,9 +57,9 @@ interface Delivery {
      * See [https://docs.bugsnag.com/api/error-reporting/]
      * (https://docs.bugsnag.com/api/error-reporting/)
      *
-     * @param report         The error report
+     * @param payload         The error payload
      * @param deliveryParams The delivery parameters to be used for this request
      * @return the end-result of your delivery attempt
      */
-    fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus
+    fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -3,7 +3,6 @@ package com.bugsnag.android;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -26,8 +25,8 @@ class DeliveryDelegate extends BaseObservable {
     }
 
     void deliver(@NonNull Event event) {
-        // Build the report
-        Report report = new Report(immutableConfig.getApiKey(), event);
+        // Build the eventPayload
+        EventPayload eventPayload = new EventPayload(immutableConfig.getApiKey(), event);
         Session session = event.getSession();
 
         if (session != null) {
@@ -43,20 +42,20 @@ class DeliveryDelegate extends BaseObservable {
         if (event.isUnhandled()) {
             cacheEvent(event, true);
         } else {
-            deliverReportAsync(event, report);
+            deliverPayloadAsync(event, eventPayload);
         }
     }
 
-    private void deliverReportAsync(@NonNull Event event, Report report) {
-        final Report finalReport = report;
+    private void deliverPayloadAsync(@NonNull Event event, EventPayload eventPayload) {
+        final EventPayload finalEventPayload = eventPayload;
         final Event finalEvent = event;
 
-        // Attempt to send the report in the background
+        // Attempt to send the eventPayload in the background
         try {
             Async.run(new Runnable() {
                 @Override
                 public void run() {
-                    deliverReportInternal(finalReport, finalEvent);
+                    deliverPayloadInternal(finalEventPayload, finalEvent);
                 }
             });
         } catch (RejectedExecutionException exception) {
@@ -66,10 +65,10 @@ class DeliveryDelegate extends BaseObservable {
     }
 
     @VisibleForTesting
-    DeliveryStatus deliverReportInternal(@NonNull Report report, @NonNull Event event) {
+    DeliveryStatus deliverPayloadInternal(@NonNull EventPayload payload, @NonNull Event event) {
         DeliveryParams deliveryParams = immutableConfig.getErrorApiDeliveryParams();
         Delivery delivery = immutableConfig.getDelivery();
-        DeliveryStatus deliveryStatus = delivery.deliver(report, deliveryParams);
+        DeliveryStatus deliveryStatus = delivery.deliver(payload, deliveryParams);
 
         switch (deliveryStatus) {
             case DELIVERED:

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
@@ -9,7 +9,7 @@ import java.io.IOException
  * This payload contains an error report and identifies the source application
  * using your API key.
  */
-class Report : JsonStream.Streamable {
+class EventPayload : JsonStream.Streamable {
 
     var apiKey: String?
     private val eventFile: File?

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
@@ -144,9 +143,9 @@ class EventStore extends FileStore {
 
     private void flushEventFile(File eventFile) {
         try {
-            Report report = new Report(config.getApiKey(), eventFile);
+            EventPayload payload = new EventPayload(config.getApiKey(), eventFile);
             DeliveryParams deliveryParams = config.getErrorApiDeliveryParams();
-            DeliveryStatus deliveryStatus = config.getDelivery().deliver(report, deliveryParams);
+            DeliveryStatus deliveryStatus = config.getDelivery().deliver(payload, deliveryParams);
 
             switch (deliveryStatus) {
                 case DELIVERED:
@@ -159,7 +158,7 @@ class EventStore extends FileStore {
                             + " to Bugsnag, will try again later");
                     break;
                 case FAILURE:
-                    Exception exc = new RuntimeException("Failed to deliver report");
+                    Exception exc = new RuntimeException("Failed to deliver event payload");
                     handleEventFlushFailure(exc, eventFile);
                     break;
                 default:

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -95,7 +95,7 @@ class InternalReportDelegate implements EventStore.Delegate {
         event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "notifierVersion", notifier.getVersion());
         event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "apiKey", immutableConfig.getApiKey());
 
-        final Report report = new Report(null, event);
+        final EventPayload eventPayload = new EventPayload(null, event);
         try {
             Async.run(new Runnable() {
                 @Override
@@ -110,7 +110,7 @@ class InternalReportDelegate implements EventStore.Delegate {
                             headers.put(HEADER_INTERNAL_ERROR, "true");
                             headers.remove(HEADER_API_KEY);
                             DefaultDelivery defaultDelivery = (DefaultDelivery) delivery;
-                            defaultDelivery.deliver(params.getEndpoint(), report, headers);
+                            defaultDelivery.deliver(params.getEndpoint(), eventPayload, headers);
                         }
 
                     } catch (Exception exception) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
@@ -3,7 +3,7 @@ package com.bugsnag.android
 import java.io.IOException
 
 /**
- * A representation of a thread recorded in a [Report]
+ * A representation of a thread recorded in an [Event]
  */
 class Thread internal constructor(
     val id: Long,

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -44,7 +44,7 @@ final class BugsnagTestUtils {
         return new Delivery() {
             @NotNull
             @Override
-            public DeliveryStatus deliver(@NotNull Report report,
+            public DeliveryStatus deliver(@NotNull EventPayload payload,
                                           @NotNull DeliveryParams deliveryParams) {
                 return DeliveryStatus.DELIVERED;
             }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -1,6 +1,5 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.BugsnagTestUtils.convert;
 import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -163,7 +162,7 @@ public class ConfigurationTest {
 
             @NotNull
             @Override
-            public DeliveryStatus deliver(@NotNull Report report,
+            public DeliveryStatus deliver(@NotNull EventPayload payload,
                                           @NotNull DeliveryParams deliveryParams) {
                 return null;
             }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -4,7 +4,6 @@ import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -86,7 +85,7 @@ internal class DeliveryDelegateTest {
 
     @Test
     fun deliverReport() {
-        val status = deliveryDelegate.deliverReportInternal(Report("api-key", event), event)
+        val status = deliveryDelegate.deliverPayloadInternal(EventPayload("api-key", event), event)
         assertEquals(DeliveryStatus.DELIVERED, status)
         assertEquals("Sent 1 new event to Bugsnag", logger.msg)
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventPayloadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventPayloadSerializationTest.kt
@@ -8,7 +8,7 @@ import org.junit.runners.Parameterized.Parameters
 import java.io.File
 
 @RunWith(Parameterized::class)
-internal class ReportSerializationTest {
+internal class EventPayloadSerializationTest {
 
     companion object {
         @JvmStatic
@@ -19,13 +19,13 @@ internal class ReportSerializationTest {
             Notifier.url = "https://bugsnag.com"
             return generateSerializationTestCases(
                 "report",
-                Report("api-key", File(""))
+                EventPayload("api-key", File(""))
             )
         }
     }
 
     @Parameter
-    lateinit var testCase: Pair<Report, String>
+    lateinit var testCase: Pair<EventPayload, String>
 
     @Test
     fun testJsonSerialisation() = verifyJsonMatches(testCase.first, testCase.second)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
@@ -13,7 +13,7 @@ import org.mockito.Mockito.*
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
-internal class InternalReportDelegateTest {
+internal class InternalEventPayloadDelegateTest {
 
     @Mock
     lateinit var context: Context

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -27,7 +27,7 @@ final class BugsnagTestUtils {
         return new Delivery() {
             @NotNull
             @Override
-            public DeliveryStatus deliver(@NotNull Report report,
+            public DeliveryStatus deliver(@NotNull EventPayload payload,
                                           @NotNull DeliveryParams deliveryParams) {
                 return DeliveryStatus.DELIVERED;
             }

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -126,7 +126,7 @@ class NativeBridge : Observer {
                     }
                 }
             } else {
-                logger.w("Report directory does not exist, cannot read pending reports")
+                logger.w("Payload directory does not exist, cannot read pending reports")
             }
         } catch (ex: Exception) {
             logger.w("Failed to parse/write pending reports: $ex")

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
@@ -7,10 +7,10 @@ import com.bugsnag.android.DeliveryParams;
 import com.bugsnag.android.DeliveryStatus;
 import com.bugsnag.android.DeviceBuildInfo;
 import com.bugsnag.android.DeviceWithState;
+import com.bugsnag.android.EventPayload;
 import com.bugsnag.android.ImmutableConfig;
 import com.bugsnag.android.ImmutableConfigKt;
 import com.bugsnag.android.NoopLogger;
-import com.bugsnag.android.Report;
 import com.bugsnag.android.SessionPayload;
 
 import androidx.annotation.NonNull;
@@ -57,7 +57,7 @@ public class JavaHooks {
         return new Delivery() {
             @NonNull
             @Override
-            public DeliveryStatus deliver(@NonNull Report report,
+            public DeliveryStatus deliver(@NonNull EventPayload payload,
                                           @NonNull DeliveryParams deliveryParams) {
                 return DeliveryStatus.DELIVERED;
             }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedReportScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedReportScenario.kt
@@ -8,7 +8,7 @@ import com.bugsnag.android.Configuration
 import com.bugsnag.android.Delivery
 import com.bugsnag.android.DeliveryParams
 import com.bugsnag.android.DeliveryStatus
-import com.bugsnag.android.Report
+import com.bugsnag.android.EventPayload
 import com.bugsnag.android.SessionPayload
 import com.bugsnag.android.createDefaultDelivery
 import java.io.File
@@ -33,13 +33,13 @@ internal class DeletedReportScenario(config: Configuration,
                         return baseDelivery.deliver(payload, deliveryParams)
                     }
 
-                    override fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus {
+                    override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
                         // delete files before they can be delivered
                         val files = errDir.listFiles()
                         files.forEach {
                             it.delete()
                         }
-                        return baseDelivery.deliver(report, deliveryParams)
+                        return baseDelivery.deliver(payload, deliveryParams)
                     }
                 }
             }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedSessionScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedSessionScenario.kt
@@ -10,7 +10,7 @@ import com.bugsnag.android.Configuration
 import com.bugsnag.android.Delivery
 import com.bugsnag.android.DeliveryParams
 import com.bugsnag.android.DeliveryStatus
-import com.bugsnag.android.Report
+import com.bugsnag.android.EventPayload
 import com.bugsnag.android.SessionPayload
 import com.bugsnag.android.createDefaultDelivery
 import com.bugsnag.android.flushAllSessions
@@ -42,8 +42,8 @@ internal class DeletedSessionScenario(config: Configuration,
                         return baseDelivery.deliver(payload, deliveryParams)
                     }
 
-                    override fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus {
-                        return baseDelivery.deliver(report, deliveryParams)
+                    override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
+                        return baseDelivery.deliver(payload, deliveryParams)
                     }
                 }
             }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -24,8 +24,8 @@ abstract class Scenario(
     protected fun disableSessionDelivery(config: Configuration) {
         val baseDelivery = createDefaultDelivery()
         config.delivery = object: Delivery {
-            override fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus {
-                return baseDelivery.deliver(report, deliveryParams)
+            override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
+                return baseDelivery.deliver(payload, deliveryParams)
             }
 
             override fun deliver(payload: SessionPayload, deliveryParams: DeliveryParams): DeliveryStatus {
@@ -40,7 +40,7 @@ abstract class Scenario(
     protected fun disableReportDelivery(config: Configuration) {
         val baseDelivery = createDefaultDelivery()
         config.delivery = object: Delivery {
-            override fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus {
+            override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
                 return DeliveryStatus.UNDELIVERED
             }
 
@@ -52,7 +52,7 @@ abstract class Scenario(
 
     protected fun disableAllDelivery(config: Configuration) {
         config.delivery = object: Delivery {
-            override fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus {
+            override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
                 return DeliveryStatus.UNDELIVERED
             }
 

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TestHarnessHooks.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TestHarnessHooks.kt
@@ -26,9 +26,9 @@ internal fun createSlowDelivery(): Delivery {
     val delivery = createDefaultDelivery()
 
     return object : Delivery {
-        override fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus {
+        override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
             Thread.sleep(500)
-            return delivery.deliver(report, deliveryParams)
+            return delivery.deliver(payload, deliveryParams)
         }
 
         override fun deliver(payload: SessionPayload, deliveryParams: DeliveryParams): DeliveryStatus {
@@ -46,8 +46,8 @@ internal fun createCustomHeaderDelivery(): Delivery {
             return delivery.deliver(payload, mutateDeliveryParams(deliveryParams))
         }
 
-        override fun deliver(report: Report, deliveryParams: DeliveryParams): DeliveryStatus {
-            return delivery.deliver(report, mutateDeliveryParams(deliveryParams))
+        override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
+            return delivery.deliver(payload, mutateDeliveryParams(deliveryParams))
         }
 
         fun mutateDeliveryParams(params: DeliveryParams): DeliveryParams {


### PR DESCRIPTION
Renames the `Report` class to `EventPayload`. This is consistent with how `SessionPayload` is named.