### PR TITLE
Allow mutation of stacktrace in ndk payload

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -56,6 +56,16 @@ typedef struct {
     char id[64];
 } bsg_user_t;
 
+typedef struct {
+    uintptr_t frame_address;
+    uintptr_t symbol_address;
+    uintptr_t load_address;
+    uintptr_t line_number;
+
+    char filename[256];
+    char method[256];
+} bsg_stackframe_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -153,6 +163,9 @@ void bugsnag_error_set_error_message(void *event_ptr, char *value);
 char *bugsnag_error_get_error_type(void *event_ptr);
 void bugsnag_error_set_error_type(void *event_ptr, char *value);
 
+void bugsnag_error_get_stacktrace(void *event_ptr, bsg_stackframe_t value[200]);
+void bugsnag_error_set_stacktrace(void *event_ptr, bsg_stackframe_t value[200]);
+
 void bugsnag_event_set_user(void *event_ptr, char* id, char* email, char* name);
 
 bsg_severity_t bugsnag_event_get_severity(void *event_ptr);
@@ -162,6 +175,7 @@ bool bugsnag_event_is_unhandled(void *event_ptr);
 
 char *bugsnag_event_get_grouping_hash(void *event_ptr);
 void bugsnag_event_set_grouping_hash(void *event_ptr, char *value);
+
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -81,7 +81,7 @@ void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
 
 void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
                         bsg_severity_t severity) {
-  bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+  bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX];
   ssize_t frame_count =
       bsg_unwind_stack(bsg_configured_unwind_style(), stacktrace, NULL, NULL);
 
@@ -101,7 +101,7 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
       (*env)->FindClass(env, "java/lang/StackTraceElement"), NULL);
 
   for (int i = 0; i < frame_count; i++) {
-    bsg_stackframe frame = stacktrace[i];
+    bsg_stackframe_t frame = stacktrace[i];
     jstring class = (*env)->NewStringUTF(env, "");
     jstring filename = (*env)->NewStringUTF(env, frame.filename);
     jstring method;

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -381,6 +381,36 @@ void bugsnag_error_set_error_type(void *event_ptr, char *value) {
   bsg_strncpy_safe(event->error.type, value, sizeof(event->error.type));
 }
 
+void bsg_copy_stacktrace(bsg_stackframe_t dst[200], bsg_stackframe_t *src, ssize_t frame_count) {
+  for (int k = 0; k < 200; k++) {
+    if (k < frame_count) {
+      bsg_strncpy_safe(dst[k].method, src->method, sizeof(dst[k].method));
+      bsg_strncpy_safe(dst[k].filename, src->filename, sizeof(dst[k].filename));
+      dst[k].line_number = src->line_number;
+      dst[k].load_address = src->load_address;
+      dst[k].symbol_address = src->symbol_address;
+      dst[k].frame_address = src->frame_address;
+    } else {
+      bsg_strncpy_safe(dst[k].method, NULL, sizeof(dst[k].method));
+      bsg_strncpy_safe(dst[k].filename, NULL, sizeof(dst[k].filename));
+      dst[k].line_number = 0;
+      dst[k].load_address = 0;
+      dst[k].symbol_address = 0;
+      dst[k].frame_address = 0;
+    }
+  }
+}
+
+void bugsnag_error_get_stacktrace(void *event_ptr, bsg_stackframe_t value[200]) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_copy_stacktrace(value, event->error.stacktrace, event->error.frame_count);
+}
+
+void bugsnag_error_set_stacktrace(void *event_ptr, bsg_stackframe_t value[200]) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_copy_stacktrace(event->error.stacktrace, value, 200);
+}
+
 bsg_severity_t bugsnag_event_get_severity(void *event_ptr) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
   return event->severity;

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -15,7 +15,7 @@
 /**
  *  Number of frames in a stacktrace. Configures a default if not defined.
  */
-#define BUGSNAG_FRAMES_MAX 192
+#define BUGSNAG_FRAMES_MAX 200
 #endif
 #ifndef BUGSNAG_CRUMBS_MAX
 /**
@@ -42,16 +42,6 @@ extern "C" {
 /*********************************
  * (start) NDK-SPECIFIC BITS
  *********************************/
-
-typedef struct {
-    uintptr_t frame_address;
-    uintptr_t symbol_address;
-    uintptr_t load_address;
-    uintptr_t line_number;
-
-    char filename[256];
-    char method[256];
-} bsg_stackframe;
 
 typedef struct {
     char name[64];
@@ -191,7 +181,7 @@ typedef struct {
     /**
      * An ordered list of stack frames from the oldest to the most recent
      */
-    bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+    bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX];
 } bsg_error;
 
 typedef struct {

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -42,7 +42,7 @@ typedef struct {
     /**
      * An ordered list of stack frames from the oldest to the most recent
      */
-    bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+    bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX];
 } bsg_exception;
 
 typedef struct {

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -142,7 +142,7 @@ bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2) {
     strcpy(event->error.errorMessage, report_v2->exception.message);
     strcpy(event->error.type, report_v2->exception.type);
     event->error.frame_count = report_v2->exception.frame_count;
-    size_t error_size = sizeof(bsg_stackframe) * BUGSNAG_FRAMES_MAX;
+    size_t error_size = sizeof(bsg_stackframe_t) * BUGSNAG_FRAMES_MAX;
     memcpy(&event->error.stacktrace, report_v2->exception.stacktrace, error_size);
 
     // Fatal C errors are always true by default, previously this was hardcoded and
@@ -432,12 +432,12 @@ void bsg_serialize_error(bsg_error exc, JSON_Object *exception, JSON_Array *stac
   json_object_set_string(exception, "message", exc.errorMessage);
   json_object_set_string(exception, "type", "c");
   for (int findex = 0; findex < exc.frame_count; findex++) {
-    bsg_stackframe stackframe = exc.stacktrace[findex];
+    bsg_stackframe_t stackframe = exc.stacktrace[findex];
     bsg_serialize_stackframe(&stackframe, stacktrace);
   }
 }
 
-void bsg_serialize_stackframe(bsg_stackframe *stackframe, JSON_Array *stacktrace) {
+void bsg_serialize_stackframe(bsg_stackframe_t *stackframe, JSON_Array *stacktrace) {
   JSON_Value *frame_val = json_value_init_object();
   JSON_Object *frame = json_value_get_object(frame_val);
   json_object_set_number(frame, "frameAddress", (*stackframe).frame_address);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -26,7 +26,7 @@ void bsg_serialize_device_metadata(const bsg_device_info device, JSON_Object *ev
 void bsg_serialize_custom_metadata(const bugsnag_metadata metadata, JSON_Object *event_obj);
 void bsg_serialize_user(const bsg_user_t user, JSON_Object *event_obj);
 void bsg_serialize_session(bugsnag_event *event, JSON_Object *event_obj);
-void bsg_serialize_stackframe(bsg_stackframe *stackframe, JSON_Array *stacktrace);
+void bsg_serialize_stackframe(bsg_stackframe_t *stackframe, JSON_Array *stacktrace);
 void bsg_serialize_error(bsg_error exc, JSON_Object *exception, JSON_Array *stacktrace);
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.c
@@ -42,7 +42,7 @@ void bsg_set_unwind_types(int apiLevel, bool is32bit, bsg_unwinder *signal_type,
 }
 
 void bsg_insert_fileinfo(ssize_t frame_count,
-                         bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX]) {
+                         bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX]) {
   static Dl_info info;
   for (int i = 0; i < frame_count; ++i) {
     if (dladdr((void *)stacktrace[i].frame_address, &info) != 0) {
@@ -61,7 +61,7 @@ void bsg_insert_fileinfo(ssize_t frame_count,
 }
 
 ssize_t bsg_unwind_stack(bsg_unwinder unwind_style,
-                         bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+                         bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                          siginfo_t *info, void *user_context) {
   ssize_t frame_count = 0;
   if (unwind_style == BSG_LIBUNWINDSTACK) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.h
@@ -37,7 +37,7 @@ void bsg_set_unwind_types(int apiLevel, bool is32bit,
  * @return the number of frames
  */
 ssize_t bsg_unwind_stack(bsg_unwinder unwind_style,
-                     bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+                     bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                          siginfo_t *info, void *user_context) __asyncsafe;
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libcorkscrew.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libcorkscrew.c
@@ -66,7 +66,7 @@ bool bsg_configure_libcorkscrew(void) {
 }
 
 ssize_t
-bsg_unwind_stack_libcorkscrew(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+bsg_unwind_stack_libcorkscrew(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                               siginfo_t *info, void *user_context) {
   backtrace_frame_t frames[BUGSNAG_FRAMES_MAX];
   backtrace_symbol_t symbols[BUGSNAG_FRAMES_MAX];

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libcorkscrew.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libcorkscrew.h
@@ -7,6 +7,6 @@
 bool bsg_configure_libcorkscrew(void);
 
 ssize_t
-bsg_unwind_stack_libcorkscrew(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+bsg_unwind_stack_libcorkscrew(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                               siginfo_t *info, void *user_context);
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwind.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwind.c
@@ -41,7 +41,7 @@ bsg_libunwind_callback(struct _Unwind_Context *context, void *arg) __asyncsafe {
 
 #if defined(__arm__)
 ssize_t
-bsg_unwind_stack_libunwind_arm32(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+bsg_unwind_stack_libunwind_arm32(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                                  siginfo_t *info, void *user_context) __asyncsafe {
   unw_cursor_t cursor;
   unw_context_t uc;
@@ -94,7 +94,7 @@ bsg_unwind_stack_libunwind_arm32(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
 }
 #endif
 ssize_t
-bsg_unwind_stack_libunwind(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+bsg_unwind_stack_libunwind(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                            siginfo_t *info, void *user_context) {
 #if defined(__arm__)
   if (bsg_libunwind_global_is32bit) { // avoid this code path if a 64-bit device

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwind.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwind.h
@@ -7,7 +7,7 @@
 bool bsg_configure_libunwind(bool is32bit);
 
 ssize_t
-bsg_unwind_stack_libunwind(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+bsg_unwind_stack_libunwind(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                            siginfo_t *info, void *user_context);
 
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwindstack.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwindstack.cpp
@@ -9,7 +9,7 @@
 #include <unwindstack/Regs.h>
 
 ssize_t
-bsg_unwind_stack_libunwindstack(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+bsg_unwind_stack_libunwindstack(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                                 siginfo_t *info, void *user_context) {
   if (user_context == NULL) {
     return 0; // only handle unwinding from signals

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwindstack.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwindstack.h
@@ -8,6 +8,6 @@
 extern "C"
 #endif
 ssize_t
-bsg_unwind_stack_libunwindstack(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+bsg_unwind_stack_libunwindstack(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                                 siginfo_t *info, void *user_context);
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_simple.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_simple.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <ucontext.h>
 
-ssize_t bsg_unwind_stack_simple(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+ssize_t bsg_unwind_stack_simple(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                                 siginfo_t *info, void *user_context) {
   if (user_context != NULL) {
     // program counter / instruction pointer

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_simple.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_simple.h
@@ -4,6 +4,6 @@
 #include "../event.h"
 #include <signal.h>
 
-ssize_t bsg_unwind_stack_simple(bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+ssize_t bsg_unwind_stack_simple(bsg_stackframe_t stacktrace[BUGSNAG_FRAMES_MAX],
                                 siginfo_t *info, void *user_context);
 #endif

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -262,7 +262,7 @@ JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_BreadcrumbStateSerializationT
 TEST test_stackframe_serialization(test_case *test_case) {
     JSON_Value *event_val = json_value_init_array();
     JSON_Array *event = json_value_get_array(event_val);
-    bsg_stackframe *frame = test_case->data_ptr;
+    bsg_stackframe_t *frame = test_case->data_ptr;
     bsg_serialize_stackframe(frame, event);
     free(frame);
     return validate_serialized_json(test_case, event_val);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -115,8 +115,8 @@ bugsnag_event * loadBreadcrumbsTestCase(jint num) {
     return data;
 }
 
-bsg_stackframe * loadStackframeTestCase(jint num) {
-    bsg_stackframe *data = malloc(sizeof(bsg_stackframe));
+bsg_stackframe_t * loadStackframeTestCase(jint num) {
+    bsg_stackframe_t *data = malloc(sizeof(bsg_stackframe_t));
     data->frame_address = 0x20000000;
     data->symbol_address = 0x16000000;
     data->load_address = 0x12000000;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
@@ -22,5 +22,5 @@ bugsnag_event * loadContextTestCase(jint num);
 bugsnag_event * loadHandledStateTestCase(jint num);
 bugsnag_event * loadSessionTestCase(jint num);
 bugsnag_event * loadBreadcrumbsTestCase(jint num);
-bsg_stackframe * loadStackframeTestCase(jint num);
+bsg_stackframe_t * loadStackframeTestCase(jint num);
 bsg_error * loadExceptionTestCase(jint num);


### PR DESCRIPTION
## Goal

Allows for the stacktrace to be inspected and altered in the NDK payload, as per the notifier spec.

## Changeset

- Made `bsg_stackframe` a public type
- Added getter/setter method for the error stacktrace
- Increased `BUGSNAG_FRAMES_MAX` to 200 to match the notifier spec limits
-  Copied stacktrace values from one to another array

## Tests

Added a unit test which covers the new accessor method.
