### PR TITLE
Allow editing metadata in ndk payload

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -56,6 +56,13 @@ typedef struct {
     char id[64];
 } bsg_user_t;
 
+typedef enum {
+    BSG_NONE_VALUE,
+    BSG_BOOL_VALUE,
+    BSG_CHAR_VALUE,
+    BSG_NUMBER_VALUE,
+} bsg_metadata_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -162,6 +169,20 @@ bool bugsnag_event_is_unhandled(void *event_ptr);
 
 char *bugsnag_event_get_grouping_hash(void *event_ptr);
 void bugsnag_event_set_grouping_hash(void *event_ptr, char *value);
+
+/* Metadata */
+
+void bugsnag_event_add_metadata_double(void *event_ptr, char *section, char *name, double value);
+void bugsnag_event_add_metadata_string(void *event_ptr, char *section, char *name, char *value);
+void bugsnag_event_add_metadata_bool(void *event_ptr, char *section, char *name, bool value);
+
+void bugsnag_event_clear_metadata_section(void *event_ptr, char *section);
+void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name);
+
+bsg_metadata_t bugsnag_event_has_metadata(void *event_ptr, char *section, char *name);
+double bugsnag_event_get_metadata_double(void *event_ptr, char *section, char *name);
+char *bugsnag_event_get_metadata_string(void *event_ptr, char *section, char *name);
+bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section, char *name);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -500,7 +500,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_clearMetadataTab(JNIEnv *env,
     return;
   char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
   bsg_request_env_write_lock();
-  bugsnag_event_remove_metadata_tab(&bsg_global_env->next_event, tab);
+  bugsnag_event_clear_metadata_section(&bsg_global_env->next_event, tab);
   bsg_release_env_write_lock();
   (*env)->ReleaseStringUTFChars(env, tab_, tab);
 }
@@ -513,7 +513,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_removeMetadata(
   char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
 
   bsg_request_env_write_lock();
-  bugsnag_event_remove_metadata(&bsg_global_env->next_event, tab, key);
+  bugsnag_event_clear_metadata(&bsg_global_env->next_event, tab, key);
   bsg_release_env_write_lock();
 
   (*env)->ReleaseStringUTFChars(env, tab_, tab);

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -130,13 +130,6 @@ typedef struct {
     char os_build[64];
 } bsg_report_header;
 
-typedef enum {
-    BSG_NONE_VALUE,
-    BSG_BOOL_VALUE,
-    BSG_CHAR_VALUE,
-    BSG_NUMBER_VALUE,
-} bsg_metadata_t;
-
 /**
  * A single value in metadata
  */
@@ -241,18 +234,9 @@ typedef struct {
     bool unhandled;
 } bugsnag_event;
 
-void bugsnag_event_add_metadata_double(bugsnag_event *event, char *section,
-                                       char *name, double value);
-void bugsnag_event_add_metadata_string(bugsnag_event *event, char *section,
-                                       char *name, char *value);
-void bugsnag_event_add_metadata_bool(bugsnag_event *event, char *section,
-                                     char *name, bool value);
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,
                                   bugsnag_breadcrumb *crumb);
 void bugsnag_event_clear_breadcrumbs(bugsnag_event *event);
-void bugsnag_event_remove_metadata(bugsnag_event *event, char *section,
-                                   char *name);
-void bugsnag_event_remove_metadata_tab(bugsnag_event *event, char *section);
 void bugsnag_event_set_user_email(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_id(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_name(bugsnag_event *event, char *value);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -297,6 +297,49 @@ TEST test_event_unhandled(void) {
     free(event);
     PASS();
 }
+
+TEST test_event_metadata(void) {
+    bugsnag_event *event = init_event();
+    bugsnag_event_add_metadata_string(event, "str", "foo", "hello");
+    bugsnag_event_add_metadata_string(event, "str", "foo2", "hello again");
+    bugsnag_event_add_metadata_string(event, "str", "foo3", "hello, is anybody out there");
+    bugsnag_event_add_metadata_double(event, "double", "foo", 5.9);
+    bugsnag_event_add_metadata_bool(event, "bool", "foo", true);
+
+    // check key exists
+    ASSERT_EQ(BSG_NONE_VALUE, bugsnag_event_has_metadata(event, "non-existent", "foo"));
+    ASSERT_EQ(BSG_CHAR_VALUE, bugsnag_event_has_metadata(event, "str", "foo"));
+    ASSERT_EQ(BSG_NUMBER_VALUE, bugsnag_event_has_metadata(event, "double", "foo"));
+    ASSERT_EQ(BSG_BOOL_VALUE, bugsnag_event_has_metadata(event, "bool", "foo"));
+
+    // test return value for missing key
+    ASSERT_EQ(NULL, bugsnag_event_get_metadata_string(event, "non-existent", "foo"));
+    ASSERT_EQ(false, bugsnag_event_get_metadata_bool(event, "non-existent", "foo"));
+    ASSERT_EQ(0.0, bugsnag_event_get_metadata_double(event, "non-existent", "foo"));
+
+    // test return value for present key
+    ASSERT_STR_EQ("hello", bugsnag_event_get_metadata_string(event, "str", "foo"));
+    ASSERT_EQ(5.9, bugsnag_event_get_metadata_double(event, "double", "foo"));
+    ASSERT_EQ(true, bugsnag_event_get_metadata_bool(event, "bool", "foo"));
+
+    // test clearing one value
+    bugsnag_event_clear_metadata(event, "str", "foo3");
+    ASSERT_EQ(BSG_NONE_VALUE, bugsnag_event_has_metadata(event, "str", "foo3"));
+    ASSERT_EQ(BSG_CHAR_VALUE, bugsnag_event_has_metadata(event, "str", "foo2"));
+    ASSERT_EQ(BSG_CHAR_VALUE, bugsnag_event_has_metadata(event, "str", "foo"));
+
+    // test clearing section values
+    bugsnag_event_clear_metadata_section(event, "str");
+    ASSERT_EQ(BSG_NONE_VALUE, bugsnag_event_has_metadata(event, "str", "foo3"));
+    ASSERT_EQ(BSG_NONE_VALUE, bugsnag_event_has_metadata(event, "str", "foo2"));
+    ASSERT_EQ(BSG_NONE_VALUE, bugsnag_event_has_metadata(event, "str", "foo"));
+
+    bugsnag_event_clear_metadata_section(event, "bool");
+    ASSERT_EQ(BSG_NONE_VALUE, bugsnag_event_has_metadata(event, "bool", "foo"));
+    free(event);
+    PASS();
+}
+
 SUITE(event_mutators) {
     RUN_TEST(test_event_context);
     RUN_TEST(test_event_severity);
@@ -326,4 +369,5 @@ SUITE(event_mutators) {
     RUN_TEST(test_error_class);
     RUN_TEST(test_error_message);
     RUN_TEST(test_error_type);
+    RUN_TEST(test_event_metadata);
 }


### PR DESCRIPTION
## Goal

Allows accessing and manipulating data in the NDK `bugsnag_event` struct.

## Changeset

As C doesn't allow overloading methods this implementation deviates slightly from the notifier spec. The changes include:

- Made `bsg_metadata_t` a public type
- Added method for getting metadata for char/bool/double: `bsg_get_metadata_<type>`
- Added method for adding metadata for char/bool/double: `bsg_add_metadata_<type>`
- Added `bsg_clear_metadata/bsg_clear_metadata_section`
- Added `bsg_has_metadata` - it is expected that users call this to discern the type of metadata for the given key/section, if any

**Note**: this implementation focuses on adding these methods to access fields on the `bugsnag_event` payload only. Once this PR has been approved a similar approach will be followed on the `bugsnag` interface and the `breadcrumb` interface.

## Tests

Added unit tests to verify new methods.
