### PR TITLE
Add ndk accessor for device.cpuAbi

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -113,6 +113,8 @@ void bugsnag_app_set_in_foreground(void *event_ptr, bool value);
 
 /* Accessors for event.device */
 
+void bugsnag_device_get_cpu_abi(void *event_ptr, char value[8][32]);
+void bugsnag_device_set_cpu_abi(void *event_ptr, char value[8][32]);
 
 bool bugsnag_device_get_jailbroken(void *event_ptr);
 void bugsnag_device_set_jailbroken(void *event_ptr, bool value);

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -250,6 +250,29 @@ void bugsnag_app_set_in_foreground(void *event_ptr, bool value) {
 
 /* Accessors for event.device */
 
+void bugsnag_device_get_cpu_abi(void *event_ptr, char value[8][32]) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+
+  for (int k = 0; k < 8; k++) {
+    if (k < event->device.cpu_abi_count) {
+      bsg_strncpy_safe(value[k], event->device.cpu_abi[k].value, sizeof(value[k]));
+    } else {
+      bsg_strncpy_safe(value[k], NULL, sizeof(value[k]));
+    }
+  }
+}
+
+void bugsnag_device_set_cpu_abi(void *event_ptr, char value[8][32]) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+
+  for (int k = 0; k < 8; k++) {
+    if (k < event->device.cpu_abi_count && value[k] != NULL) {
+      bsg_strncpy_safe(event->device.cpu_abi[k].value, value[k], sizeof(value[k]));
+    } else {
+      bsg_strncpy_safe(event->device.cpu_abi[k].value, NULL, sizeof(event->device.cpu_abi[k].value));
+    }
+  }
+}
 
 bool bugsnag_device_get_jailbroken(void *event_ptr) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -42,6 +42,10 @@ bugsnag_event *init_event() {
     bsg_strncpy_safe(event->error.errorClass, "SIGSEGV", sizeof(event->error.errorClass));
     bsg_strncpy_safe(event->error.errorMessage, "Whoops!", sizeof(event->error.errorMessage));
     bsg_strncpy_safe(event->error.type, "C", sizeof(event->error.type));
+
+    event->device.cpu_abi_count = 2;
+    bsg_strncpy_safe(event->device.cpu_abi[0].value, "x86", sizeof(event->device.cpu_abi[0].value));
+    bsg_strncpy_safe(event->device.cpu_abi[1].value, "armeabi-v7a", sizeof(event->device.cpu_abi[1].value));
     return event;
 }
 
@@ -297,6 +301,26 @@ TEST test_event_unhandled(void) {
     free(event);
     PASS();
 }
+
+TEST test_device_cpu_abi(void) {
+    bugsnag_event *event = init_event();
+
+    char dst[8][32];
+    bugsnag_device_get_cpu_abi(event, dst);
+    ASSERT_STR_EQ("x86", dst[0]);
+    ASSERT_STR_EQ("armeabi-v7a", dst[1]);
+
+    // test setting cpuabi
+    bsg_strncpy_safe(dst[1], "mips", sizeof(dst[1]));
+    bugsnag_device_set_cpu_abi(event, dst);
+    bugsnag_device_get_cpu_abi(event, dst);
+    ASSERT_STR_EQ("x86", dst[0]);
+    ASSERT_STR_EQ("mips", dst[1]);
+
+    free(event);
+    PASS();
+}
+
 SUITE(event_mutators) {
     RUN_TEST(test_event_context);
     RUN_TEST(test_event_severity);
@@ -323,6 +347,7 @@ SUITE(event_mutators) {
     RUN_TEST(test_device_orientation);
     RUN_TEST(test_device_time);
     RUN_TEST(test_device_os_name);
+    RUN_TEST(test_device_cpu_abi);
     RUN_TEST(test_error_class);
     RUN_TEST(test_error_message);
     RUN_TEST(test_error_type);


### PR DESCRIPTION
## Goal

Adds a getter/setter for the `event.device.cpuAbi` field, which finishes the work of adding getters/setters to all of the fields which will remain on the `bsg_device` struct.

## Changeset

Added a getter/setter which copy the value into/from a char array.

## Tests

Added a unit test for the new accessor methods.
