### PR TITLE
[WIP] Enable better BrowserStack test naming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,12 @@ services:
       BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}
       DEVICE_TYPE:
       APP_LOCATION:
+      BUILDKITE_BRANCH:
+      BUILDKITE_PIPELINE_NAME:
+      BUILDKITE_RETRY_COUNT:
+      BUILDKITE:
+      BUILDKITE_BUILD_NUMBER:
+      BUILDKITE_STEP_KEY:
     command: --tags ~@ignore
     volumes:
       - ./build:/app/build


### PR DESCRIPTION
## Goal

Enable various Buildkite environment variables to be passed through to maze-runner which will help with linking particular Buildkite jobs to BrowserStack runs.