### PR TITLE
Support loading additional options from manifest

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -64,10 +64,11 @@ class ManifestConfigLoaderTest {
             putBoolean("com.bugsnag.android.AUTO_DETECT_ERRORS", false)
             putBoolean("com.bugsnag.android.AUTO_CAPTURE_BREADCRUMBS", false)
             putBoolean("com.bugsnag.android.PERSIST_USER", true)
+            putString("com.bugsnag.android.SEND_THREADS", "UNHANDLED_ONLY")
 
             // endpoints
-            putString("com.bugsnag.android.ENDPOINT", "http://localhost:1234")
-            putString("com.bugsnag.android.SESSIONS_ENDPOINT", "http://localhost:2345")
+            putString("com.bugsnag.android.ENDPOINT_NOTIFY", "http://localhost:1234")
+            putString("com.bugsnag.android.ENDPOINT_SESSIONS", "http://localhost:2345")
 
             // app/project packages
             putString("com.bugsnag.android.APP_VERSION", "5.23.7")
@@ -94,7 +95,7 @@ class ManifestConfigLoaderTest {
             // detection
             assertFalse(autoDetectErrors)
             assertFalse(autoTrackSessions)
-            assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
+            assertEquals(Thread.ThreadSendPolicy.UNHANDLED_ONLY, sendThreads)
             assertTrue(persistUser)
 
             // endpoints

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -19,10 +19,11 @@ internal class ManifestConfigLoader {
         private const val AUTO_TRACK_SESSIONS = "$BUGSNAG_NS.AUTO_TRACK_SESSIONS"
         private const val AUTO_DETECT_ERRORS = "$BUGSNAG_NS.AUTO_DETECT_ERRORS"
         private const val PERSIST_USER = "$BUGSNAG_NS.PERSIST_USER"
+        private const val SEND_THREADS = "$BUGSNAG_NS.SEND_THREADS"
 
         // endpoints
-        private const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT"
-        private const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.SESSIONS_ENDPOINT"
+        private const val ENDPOINT_NOTIFY = "$BUGSNAG_NS.ENDPOINT_NOTIFY"
+        private const val ENDPOINT_SESSIONS = "$BUGSNAG_NS.ENDPOINT_SESSIONS"
 
         // app/project packages
         private const val APP_VERSION = "$BUGSNAG_NS.APP_VERSION"
@@ -83,6 +84,12 @@ internal class ManifestConfigLoader {
             autoTrackSessions = data.getBoolean(AUTO_TRACK_SESSIONS, autoTrackSessions)
             autoDetectErrors = data.getBoolean(AUTO_DETECT_ERRORS, autoDetectErrors)
             persistUser = data.getBoolean(PERSIST_USER, persistUser)
+
+            val str = data.getString(SEND_THREADS)
+
+            if (str != null) {
+                sendThreads = Thread.ThreadSendPolicy.fromString(str)
+            }
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.kt
@@ -21,7 +21,11 @@ class Thread internal constructor(
     enum class ThreadSendPolicy {
         ALWAYS,
         UNHANDLED_ONLY,
-        NEVER
+        NEVER;
+
+        internal companion object {
+            fun fromString(str: String) = values().find { it.name == str } ?: ALWAYS
+        }
     }
 
     var stacktrace: MutableList<Stackframe> = stacktrace.trace.toMutableList()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSendPolicyTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSendPolicyTest.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.Thread.ThreadSendPolicy
+import com.bugsnag.android.Thread.ThreadSendPolicy.ALWAYS
+import com.bugsnag.android.Thread.ThreadSendPolicy.NEVER
+import com.bugsnag.android.Thread.ThreadSendPolicy.UNHANDLED_ONLY
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ThreadSendPolicyTest {
+
+    @Test
+    fun invalidFromString() {
+        assertEquals(ALWAYS, ThreadSendPolicy.fromString(""))
+        assertEquals(ALWAYS, ThreadSendPolicy.fromString("foo"))
+    }
+
+    @Test
+    fun validFromString() {
+        assertEquals(ALWAYS, ThreadSendPolicy.fromString("ALWAYS"))
+        assertEquals(NEVER, ThreadSendPolicy.fromString("NEVER"))
+        assertEquals(UNHANDLED_ONLY, ThreadSendPolicy.fromString("UNHANDLED_ONLY"))
+    }
+}


### PR DESCRIPTION
## Goal

Supports loading the `sendThreads` and `endpoints` options from the manifest, as per the notifier spec.

## Changeset

- Read `com.bugsnag.android.SEND_THREADS` as a string from the manifest, and coerced it into `ThreadSendPolicy`, reverting to a default if the option is not recognised
- Read `com.bugsnag.android.ENDPOINT_NOTIFY` and `com.bugsnag.android.ENDPOINT_SESSIONS` from the manifest

## Tests

Added a new unit test for `ThreadSendPolicy`, relied on existing test coverage for endpoint loading
