### PR TITLE
Add methods for manipulating breadcrumbs in event payload

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
@@ -36,8 +36,8 @@ void bugsnag_set_user_env(JNIEnv *env, char* id, char* email, char* name);
  * Leave a breadcrumb, indicating an event of significance which will be logged in subsequent
  * error reports
  */
-void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_t type);
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message, bsg_breadcrumb_t type);
+void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_type_t type);
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message, bsg_breadcrumb_type_t type);
 
 /**
  * Adds a callback which is invoked whenever a fatal error occurs. The callback will be passed a

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -48,6 +48,12 @@ typedef enum {
    *  User event, such as authentication or control events
    */
   BSG_CRUMB_USER,
+} bsg_breadcrumb_type_t;
+
+typedef struct {
+    char message[128];
+    char timestamp[37];
+    bsg_breadcrumb_type_t type;
 } bsg_breadcrumb_t;
 
 typedef struct {
@@ -183,6 +189,13 @@ bsg_metadata_t bugsnag_event_has_metadata(void *event_ptr, char *section, char *
 double bugsnag_event_get_metadata_double(void *event_ptr, char *section, char *name);
 char *bugsnag_event_get_metadata_string(void *event_ptr, char *section, char *name);
 bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section, char *name);
+
+/* Breadcrumbs */
+
+void bugsnag_event_clear_breadcrumbs(void *event_ptr);
+int bugsnag_event_get_breadcrumbs_size(void *event_ptr);
+bsg_breadcrumb_t bugsnag_event_get_breadcrumb(void *event_ptr, int index);
+void bugsnag_event_set_breadcrumb(void *event_ptr, bsg_breadcrumb_t breadcrumb, int index);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -21,7 +21,7 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
                         bsg_severity_t severity);
 void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name);
 void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
-                                  bsg_breadcrumb_t type);
+                                  bsg_breadcrumb_type_t type);
 
 void bugsnag_notify(char *name, char *message, bsg_severity_t severity) {
   if (bsg_global_jni_env != NULL) {
@@ -40,7 +40,7 @@ void bugsnag_set_user(char *id, char *email, char *name) {
   }
 }
 
-void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_t type) {
+void bugsnag_leave_breadcrumb(char *message, bsg_breadcrumb_type_t type) {
   if (bsg_global_jni_env != NULL) {
     bugsnag_leave_breadcrumb_env(bsg_global_jni_env, message, type);
   } else {
@@ -184,7 +184,7 @@ void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
   (*env)->DeleteLocalRef(env, interface_class);
 }
 
-jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bsg_breadcrumb_t type,
+jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bsg_breadcrumb_type_t type,
                                jclass type_class) {
   const char *type_sig = "Lcom/bugsnag/android/BreadcrumbType;";
   if (type == BSG_CRUMB_USER) {
@@ -207,7 +207,7 @@ jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bsg_breadcrumb_t type,
 }
 
 void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
-                                  bsg_breadcrumb_t type) {
+                                  bsg_breadcrumb_type_t type) {
   jclass interface_class =
       (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
   jmethodID leave_breadcrumb_method = (*env)->GetStaticMethodID(

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -241,7 +241,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
   const char *type = (*env)->GetStringUTFChars(env, crumb_type, 0);
   const char *timestamp = (*env)->GetStringUTFChars(env, timestamp_, 0);
   bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
-  strncpy(crumb->name, name, sizeof(crumb->name));
+  strncpy(crumb->message, name, sizeof(crumb->message));
   strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
   if (strcmp(type, "user") == 0) {
     crumb->type = BSG_CRUMB_USER;

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -187,9 +187,31 @@ void bugsnag_event_add_breadcrumb(bugsnag_event *event,
   memcpy(&event->breadcrumbs[crumb_index], crumb, sizeof(bugsnag_breadcrumb));
 }
 
-void bugsnag_event_clear_breadcrumbs(bugsnag_event *event) {
+void bugsnag_event_clear_breadcrumbs(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
   event->crumb_count = 0;
   event->crumb_first_index = 0;
+}
+
+int bugsnag_event_get_breadcrumbs_size(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->crumb_count;
+}
+
+bsg_breadcrumb_t bugsnag_event_get_breadcrumb(void *event_ptr, int index) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_breadcrumb_t crumb;
+  crumb.type = event->breadcrumbs[index].type;
+  bsg_strncpy_safe(crumb.timestamp, event->breadcrumbs[index].timestamp, sizeof(event->breadcrumbs[index].timestamp));
+  bsg_strncpy_safe(crumb.message, event->breadcrumbs[index].message, sizeof(event->breadcrumbs[index].message));
+  return crumb;
+}
+
+void bugsnag_event_set_breadcrumb(void *event_ptr, bsg_breadcrumb_t breadcrumb, int index) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  event->breadcrumbs[index].type = breadcrumb.type;
+  bsg_strncpy_safe(event->breadcrumbs[index].timestamp, breadcrumb.timestamp, sizeof(breadcrumb.timestamp));
+  bsg_strncpy_safe(event->breadcrumbs[index].message, breadcrumb.message, sizeof(breadcrumb.message));
 }
 
 bool bugsnag_event_has_session(bugsnag_event *event) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -193,9 +193,9 @@ typedef struct {
 } bsg_char_metadata_pair;
 
 typedef struct {
-    char name[33];
+    char message[128];
     char timestamp[37];
-    bsg_breadcrumb_t type;
+    bsg_breadcrumb_type_t type;
 
     /**
      * Key/value pairs of related information for debugging
@@ -236,7 +236,6 @@ typedef struct {
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,
                                   bugsnag_breadcrumb *crumb);
-void bugsnag_event_clear_breadcrumbs(bugsnag_event *event);
 void bugsnag_event_set_user_email(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_id(bugsnag_event *event, char *value);
 void bugsnag_event_set_user_name(bugsnag_event *event, char *value);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -46,6 +46,17 @@ typedef struct {
 } bsg_exception;
 
 typedef struct {
+    char message[33];
+    char timestamp[37];
+    bsg_breadcrumb_type_t type;
+
+    /**
+     * Key/value pairs of related information for debugging
+     */
+    bsg_char_metadata_pair metadata[8];
+} bugsnag_breadcrumb_v1;
+
+typedef struct {
     char name[64];
     char id[64];
     char package_name[64];
@@ -102,7 +113,7 @@ typedef struct {
     // Breadcrumbs are a ring; the first index moves as the
     // structure is filled and replaced.
     int crumb_first_index;
-    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+    bugsnag_breadcrumb_v1 breadcrumbs[BUGSNAG_CRUMBS_MAX];
 
     char context[64];
     bsg_severity_t severity;
@@ -124,7 +135,7 @@ typedef struct {
     // Breadcrumbs are a ring; the first index moves as the
     // structure is filled and replaced.
     int crumb_first_index;
-    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+    bugsnag_breadcrumb_v1 breadcrumbs[BUGSNAG_CRUMBS_MAX];
 
     char context[64];
     bsg_severity_t severity;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
@@ -2,10 +2,10 @@
 #include <event.h>
 #include <time.h>
 
-bugsnag_breadcrumb *init_breadcrumb(const char *name, const char *message, bsg_breadcrumb_t type) {
+bugsnag_breadcrumb *init_breadcrumb(const char *name, const char *message, bsg_breadcrumb_type_t type) {
   bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
   crumb->type = type;
-  strcpy(crumb->name, name);
+  strcpy(crumb->message, name);
   strcpy(crumb->timestamp, "2018-08-29T21:41:39Z");
   strcpy(crumb->metadata[0].key, "message");
   strcpy(crumb->metadata[0].value, message);
@@ -19,7 +19,7 @@ TEST test_add_breadcrumb(void) {
   bugsnag_event_add_breadcrumb(event, crumb);
   ASSERT_EQ(1, event->crumb_count);
   ASSERT_EQ(0, event->crumb_first_index);
-  ASSERT(strcmp("stroll", event->breadcrumbs[0].name) == 0);
+  ASSERT(strcmp("stroll", event->breadcrumbs[0].message) == 0);
   ASSERT(strcmp("message", event->breadcrumbs[0].metadata[0].key) == 0);
   ASSERT(strcmp("this is a drill.", event->breadcrumbs[0].metadata[0].value) == 0);
   free(crumb);
@@ -27,10 +27,10 @@ TEST test_add_breadcrumb(void) {
   bugsnag_event_add_breadcrumb(event, crumb2);
   ASSERT_EQ(2, event->crumb_count);
   ASSERT_EQ(0, event->crumb_first_index);
-  ASSERT(strcmp("stroll", event->breadcrumbs[0].name) == 0);
+  ASSERT(strcmp("stroll", event->breadcrumbs[0].message) == 0);
   ASSERT(strcmp("message", event->breadcrumbs[0].metadata[0].key) == 0);
   ASSERT(strcmp("this is a drill.", event->breadcrumbs[0].metadata[0].value) == 0);
-  ASSERT(strcmp("walking...", event->breadcrumbs[1].name) == 0);
+  ASSERT(strcmp("walking...", event->breadcrumbs[1].message) == 0);
   ASSERT(strcmp("message", event->breadcrumbs[1].metadata[0].key) == 0);
   ASSERT(strcmp("this is not a drill.", event->breadcrumbs[1].metadata[0].value) == 0);
 
@@ -51,14 +51,14 @@ TEST test_add_breadcrumbs_over_max(void) {
     free(crumb);
     free(format);
   }
-  ASSERT(strcmp("crumb: 60", event->breadcrumbs[0].name) == 0);
-  ASSERT(strcmp("crumb: 61", event->breadcrumbs[1].name) == 0);
-  ASSERT(strcmp("crumb: 62", event->breadcrumbs[2].name) == 0);
-  ASSERT(strcmp("crumb: 63", event->breadcrumbs[3].name) == 0);
-  ASSERT(strcmp("crumb: 34", event->breadcrumbs[4].name) == 0);
-  ASSERT(strcmp("crumb: 35", event->breadcrumbs[5].name) == 0);
-  ASSERT(strcmp("crumb: 58", event->breadcrumbs[28].name) == 0);
-  ASSERT(strcmp("crumb: 59", event->breadcrumbs[29].name) == 0);
+  ASSERT(strcmp("crumb: 60", event->breadcrumbs[0].message) == 0);
+  ASSERT(strcmp("crumb: 61", event->breadcrumbs[1].message) == 0);
+  ASSERT(strcmp("crumb: 62", event->breadcrumbs[2].message) == 0);
+  ASSERT(strcmp("crumb: 63", event->breadcrumbs[3].message) == 0);
+  ASSERT(strcmp("crumb: 34", event->breadcrumbs[4].message) == 0);
+  ASSERT(strcmp("crumb: 35", event->breadcrumbs[5].message) == 0);
+  ASSERT(strcmp("crumb: 58", event->breadcrumbs[28].message) == 0);
+  ASSERT(strcmp("crumb: 59", event->breadcrumbs[29].message) == 0);
   ASSERT_EQ(BUGSNAG_CRUMBS_MAX, event->crumb_count);
   ASSERT_EQ(4, event->crumb_first_index);
   free(event);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -5,7 +5,7 @@
 
 #define SERIALIZE_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo.crash"
 
-bugsnag_breadcrumb *init_breadcrumb(const char *name, const char *message, bsg_breadcrumb_t type);
+bugsnag_breadcrumb *init_breadcrumb(const char *name, const char *message, bsg_breadcrumb_type_t type);
 
 void generate_basic_report(bugsnag_event *event) {
   strcpy(event->grouping_hash, "foo-hash");
@@ -67,6 +67,11 @@ bugsnag_report_v2 *bsg_generate_report_v2(void) {
 
   strcpy(report->app.package_name, "com.example.foo");
   strcpy(report->app.version_name, "2.5");
+
+  report->crumb_first_index = 0;
+  report->crumb_count = 1;
+  report->breadcrumbs[0].type = BSG_CRUMB_STATE;
+  strcpy(report->breadcrumbs[0].message, "decrease torque");
   return report;
 }
 
@@ -174,6 +179,10 @@ TEST test_report_v2_migration(void) {
   // package_name/version_name are migrated to metadata
   ASSERT_STR_EQ("com.example.foo", event->metadata.values[0].char_value);
   ASSERT_STR_EQ("2.5", event->metadata.values[1].char_value);
+
+  // event.breadcrumbs
+  ASSERT_STR_EQ("decrease torque", event->breadcrumbs[0].message);
+  ASSERT_EQ(BSG_CRUMB_STATE, event->breadcrumbs[0].type);
 
   free(generated_report);
   free(env);


### PR DESCRIPTION
## Goal

Adds methods for manipulating breadcrumbs in the event payload, as per the notifier spec.

## Changeset

- Renamed breadcrumb type to `bsg_breadcrumb_type_t`
- Made `bsg_breadcrumb_t` public
- Added method for getting/setting breadcrumbs, which map the internal breadcrumb struct onto the externally visible struct

**Note:** the metadata is not currently accessible on the breadcrumb struct, and the `onBreadcrumb` callback has not yet been implemented. This will be addressed in separate PRs.

## Tests

Added a unit test to verify clearing, getting, and setting breadcrumbs.
