### PR TITLE
Change default system broadcast breadcrumb type to state

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
@@ -64,7 +64,7 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
             BreadcrumbType type = actions.get(fullAction);
 
             if (type == null) {
-                type = BreadcrumbType.LOG;
+                type = BreadcrumbType.STATE;
             }
             client.leaveBreadcrumb(shortAction, type, meta);
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
@@ -50,7 +50,7 @@ class SystemBroadcastReceiverTest {
         receiver.onReceive(context, intent)
 
         val metadata = mapOf(Pair("Intent Action", "SomeTitle"), Pair("foo", "[bar]"))
-        verify(client, times(1)).leaveBreadcrumb("SomeTitle", BreadcrumbType.LOG, metadata)
+        verify(client, times(1)).leaveBreadcrumb("SomeTitle", BreadcrumbType.STATE, metadata)
     }
 
     @Test


### PR DESCRIPTION
The default breadcrumb type should be state, rather than log, as a broadcast better reflects a state change in the application than a user writing a message to a logger.