### PR TITLE
Remove uses-library android.test.runner

### DIFF
--- a/bugsnag-android-core/src/main/AndroidManifest.xml
+++ b/bugsnag-android-core/src/main/AndroidManifest.xml
@@ -5,10 +5,4 @@
     <!-- Required: Used to deliver Bugsnag crash reports -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-    <application>
-        <uses-library
-            android:name="android.test.runner"
-            android:required="false" />
-    </application>
 </manifest>


### PR DESCRIPTION
This was added during the Android X migration: https://github.com/bugsnag/bugsnag-android/commit/26e4360928c45849778916bee07ba7febe3e3121

There's no comment explaining why it's there. I handled the Android X migration at Square and this was definitely not a thing. It seems really wrong to ship this in a production app, I'm not clear why bugsnag ships with this (even with required false).

I'm trying to update to a recent bugsnag version and its changing our manifest which doesn't seem right.

## Goal

Bugsnag should not add a dependency on testing in a production app, even as required false.

## Changeset

Removed uses-library from the core manifest.

## Tests

Your own CI should validate this :) .
