### PR TITLE
Remove uses-library android.test.runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Remove unnecessary uses-library android.test.runner from AndroidManifest
+  [#783](https://github.com/bugsnag/bugsnag-android/pull/783)
+
 ## 4.22.3 (2020-01-22)
 
 * Allow disabling previous signal handler invocation for Unity ANRs

--- a/bugsnag-android-core/src/main/AndroidManifest.xml
+++ b/bugsnag-android-core/src/main/AndroidManifest.xml
@@ -5,10 +5,4 @@
     <!-- Required: Used to deliver Bugsnag crash reports -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-    <application>
-        <uses-library
-            android:name="android.test.runner"
-            android:required="false" />
-    </application>
 </manifest>


### PR DESCRIPTION
Opening in favour of #782 so that CI can be run.