### PR TITLE
Add docs for Configuration options

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
@@ -4,10 +4,9 @@ class ErrorTypes(
 
     /**
      * Sets whether [ANRs](https://developer.android.com/topic/performance/vitals/anr)
-     * should be reported to Bugsnag. When enabled, Bugsnag will record an ANR whenever the main
-     * thread has been blocked for 5000 milliseconds or longer.
+     * should be reported to Bugsnag.
      *
-     * If you wish to enable ANR detection, you should set this property to true.
+     * If you wish to disable ANR detection, you should set this property to false.
      */
     var anrs: Boolean = true,
 


### PR DESCRIPTION
Aligns the KDoc to match what has been written for the docs website on Configuration Options. This aims to cover only properties which are unique to `Configuration` at this stage - `Client` methods will be documented once a corresponding docs PR has been raised for this section.

There have been minor edits to reference code where possible - e.g. `[releaseStages]` would link to the `releaseStages` property. Configuration options have also been slightly reworded when the documentation format would not make sense. For example, some docs state this:

```
If you wish to update this property, do the following:
```

Which does not make sense for this particular format.