### PR TITLE
Serialize device.time correctly

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -561,7 +561,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         }
 
         // Capture the state of the app and device and attach diagnostics to the event
-        event.setDevice(deviceDataCollector.generateDeviceWithState());
+        event.setDevice(deviceDataCollector.generateDeviceWithState(new Date().getTime()));
         event.addMetadata("device", deviceDataCollector.getDeviceMetadata());
 
         // add additional info that belongs in metadata

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
@@ -44,7 +44,7 @@ internal class DeviceDataCollector(
         calculateTotalMemory()
     )
 
-    fun generateDeviceWithState() = DeviceWithState(
+    fun generateDeviceWithState(now: Long) = DeviceWithState(
         buildInfo,
         cpuAbi,
         rooted,
@@ -54,7 +54,7 @@ internal class DeviceDataCollector(
         calculateFreeMemory(),
         calculateFreeDisk(),
         calculateOrientation(),
-        Date(0)
+        Date(now)
     )
 
     fun getDeviceMetadata(): Map<String, Any?> {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -88,7 +89,7 @@ class InternalReportDelegate implements EventStore.Delegate {
      */
     void reportInternalBugsnagError(@NonNull Event event) {
         event.setApp(appDataCollector.generateAppWithState());
-        event.setDevice(deviceDataCollector.generateDeviceWithState());
+        event.setDevice(deviceDataCollector.generateDeviceWithState(new Date().getTime()));
 
         Notifier notifier = Notifier.INSTANCE;
         event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "notifierName", notifier.getName());

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -98,7 +98,7 @@ public class NativeInterface {
         DeviceDataCollector source = getClient().getDeviceDataCollector();
         HashMap<String, Object> deviceData = new HashMap<>(source.getDeviceMetadata());
 
-        DeviceWithState src = source.generateDeviceWithState();
+        DeviceWithState src = source.generateDeviceWithState(new Date().getTime());
         deviceData.put("freeDisk", src.getFreeDisk());
         deviceData.put("freeMemory", src.getFreeMemory());
         deviceData.put("orientation", src.getOrientation());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataCollectorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataCollectorSerializationTest.kt
@@ -61,7 +61,7 @@ internal class DeviceDataCollectorSerializationTest {
             return generateSerializationTestCases(
                 "device_data",
                 deviceData.generateDevice(),
-                deviceData.generateDeviceWithState()
+                deviceData.generateDeviceWithState(0)
             )
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
@@ -8,6 +8,7 @@ import com.bugsnag.android.BugsnagTestUtils.generateAppWithState
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.junit.MockitoJUnitRunner
@@ -36,7 +37,7 @@ internal class InternalEventPayloadDelegateTest {
         `when`(this.appDataCollector.generateAppWithState()).thenReturn(app)
         app.durationInForeground = 500L
         app.inForeground = true
-        `when`(deviceDataCollector.generateDeviceWithState()).thenReturn(generateDeviceWithState())
+        `when`(deviceDataCollector.generateDeviceWithState(ArgumentMatchers.anyLong())).thenReturn(generateDeviceWithState())
 
         val config = generateImmutableConfig()
         val delegate = InternalReportDelegate(

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -10,6 +10,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
@@ -94,7 +95,7 @@ internal class NativeInterfaceApiTest {
 
     @Test
     fun getDeviceData() {
-        `when`(deviceDataCollector.generateDeviceWithState()).thenReturn(generateDeviceWithState())
+        `when`(deviceDataCollector.generateDeviceWithState(anyLong())).thenReturn(generateDeviceWithState())
         `when`(deviceDataCollector.getDeviceMetadata()).thenReturn(mapOf(Pair("metadata", true)))
         assertTrue(NativeInterface.getDevice()["metadata"] as Boolean)
     }


### PR DESCRIPTION
## Goal

Serializes `device.time` correctly in JVM reports, rather than always sending `Date(0)`.

This would have affected the breadcrumb times displayed in the dashboard as they would have based the calculations of 1 Jan 1970. I have verified the fix by sending an example report to the dashboard and inspecting breadcrumb times and `device.time`.
