### PR TITLE
Add connectivity change breadcrumb

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -152,21 +152,21 @@ public class ClientTest {
     @Test
     public void testMaxBreadcrumbs() {
         Configuration config = generateConfiguration();
-        List<BreadcrumbType> breadcrumbTypes
-                = Arrays.asList(BreadcrumbType.MANUAL, BreadcrumbType.STATE);
+        List<BreadcrumbType> breadcrumbTypes = Arrays.asList(BreadcrumbType.MANUAL);
         config.setEnabledBreadcrumbTypes(new HashSet<>(breadcrumbTypes));
         config.setMaxBreadcrumbs(2);
         client = generateClient(config);
-        assertEquals(1, client.breadcrumbState.getStore().size());
+        assertEquals(0, client.breadcrumbState.getStore().size());
 
         client.leaveBreadcrumb("test");
         client.leaveBreadcrumb("another");
+        client.leaveBreadcrumb("yet another");
         assertEquals(2, client.breadcrumbState.getStore().size());
 
         Breadcrumb poll = client.breadcrumbState.getStore().poll();
         assertEquals(BreadcrumbType.MANUAL, poll.getType());
         assertEquals("manual", poll.getMessage());
-        assertEquals("test", poll.getMetadata().get("message"));
+        assertEquals("another", poll.getMetadata().get("message"));
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -15,8 +15,10 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.Set;
 
 @SmallTest
 @SuppressWarnings("unchecked")
@@ -34,6 +36,11 @@ public class ObserverInterfaceTest {
         Configuration config = generateConfiguration();
         config.setDelivery(BugsnagTestUtils.generateDelivery());
         config.getEnabledErrorTypes().setUnhandledExceptions(false);
+
+        Set<BreadcrumbType> breadcrumbTypes = new HashSet<>();
+        breadcrumbTypes.add(BreadcrumbType.LOG);
+        breadcrumbTypes.add(BreadcrumbType.MANUAL);
+        config.setEnabledBreadcrumbTypes(breadcrumbTypes);
         client = new Client(ApplicationProvider.getApplicationContext(), config);
         observer = new BugsnagTestObserver();
         client.registerObserver(observer);

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbCallbackStateTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbCallbackStateTest.java
@@ -14,6 +14,8 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 @SmallTest
 public class OnBreadcrumbCallbackStateTest {
@@ -27,9 +29,13 @@ public class OnBreadcrumbCallbackStateTest {
     @Before
     public void setUp() {
         Configuration configuration = generateConfiguration();
-        configuration.setEnabledBreadcrumbTypes(Collections.<BreadcrumbType>emptySet());
-        client = generateClient();
-        assertEquals(1, client.breadcrumbState.getStore().size());
+
+        Set<BreadcrumbType> breadcrumbTypes = new HashSet<>();
+        breadcrumbTypes.add(BreadcrumbType.MANUAL);
+        breadcrumbTypes.add(BreadcrumbType.USER);
+        configuration.setEnabledBreadcrumbTypes(breadcrumbTypes);
+        client = generateClient(configuration);
+        assertEquals(0, client.breadcrumbState.getStore().size());
     }
 
     @After
@@ -40,7 +46,7 @@ public class OnBreadcrumbCallbackStateTest {
     @Test
     public void noCallback() {
         client.leaveBreadcrumb("Hello");
-        assertEquals(2, client.breadcrumbState.getStore().size());
+        assertEquals(1, client.breadcrumbState.getStore().size());
     }
 
     @Test
@@ -52,7 +58,7 @@ public class OnBreadcrumbCallbackStateTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, client.breadcrumbState.getStore().size());
+        assertEquals(0, client.breadcrumbState.getStore().size());
     }
 
     @Test
@@ -64,7 +70,7 @@ public class OnBreadcrumbCallbackStateTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(2, client.breadcrumbState.getStore().size());
+        assertEquals(1, client.breadcrumbState.getStore().size());
     }
 
     @Test
@@ -82,7 +88,7 @@ public class OnBreadcrumbCallbackStateTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, client.breadcrumbState.getStore().size());
+        assertEquals(0, client.breadcrumbState.getStore().size());
     }
 
     @Test
@@ -156,7 +162,7 @@ public class OnBreadcrumbCallbackStateTest {
         client.leaveBreadcrumb("Hello");
         client.removeOnBreadcrumb(cb);
         client.leaveBreadcrumb("Hello");
-        assertEquals(2, client.breadcrumbState.getStore().size());
+        assertEquals(1, client.breadcrumbState.getStore().size());
     }
 
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
@@ -10,7 +10,7 @@ import android.net.NetworkCapabilities
 import android.os.Build
 import androidx.annotation.RequiresApi
 
-internal typealias NetworkChangeCallback = (connected: Boolean) -> Unit
+internal typealias NetworkChangeCallback = (hasConnection: Boolean, networkState: String) -> Unit
 
 internal interface Connectivity {
     fun registerForNetworkChanges()
@@ -82,7 +82,7 @@ internal class ConnectivityLegacy(
     private inner class ConnectivityChangeReceiver(private val cb: NetworkChangeCallback?) :
         BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
-            cb?.invoke(hasNetworkConnection())
+            cb?.invoke(hasNetworkConnection(), retrieveNetworkAccessState())
         }
     }
 }
@@ -120,13 +120,13 @@ internal class ConnectivityApi24(
         override fun onUnavailable() {
             super.onUnavailable()
             activeNetwork = null
-            cb?.invoke(false)
+            cb?.invoke(false, retrieveNetworkAccessState())
         }
 
         override fun onAvailable(network: Network?) {
             super.onAvailable(network)
             activeNetwork = network
-            cb?.invoke(true)
+            cb?.invoke(true, retrieveNetworkAccessState())
         }
     }
 }

--- a/features/breadcrumb.feature
+++ b/features/breadcrumb.feature
@@ -7,18 +7,13 @@ Scenario: Manually added breadcrumbs are sent in report
     And the exception "message" equals "BreadcrumbScenario"
     And the event "breadcrumbs" is not null
 
-    And the event "breadcrumbs.2.timestamp" is not null
-    And the event "breadcrumbs.2.name" equals "Another Breadcrumb"
-    And the event "breadcrumbs.2.type" equals "user"
-    And the event "breadcrumbs.2.metaData.Foo" equals "Bar"
-
     And the event "breadcrumbs.1.timestamp" is not null
-    And the event "breadcrumbs.1.name" equals "manual"
-    And the event "breadcrumbs.1.type" equals "manual"
-    And the event "breadcrumbs.1.metaData" is not null
-    And the event "breadcrumbs.1.metaData.message" equals "Hello Breadcrumb!"
+    And the event "breadcrumbs.1.name" equals "Another Breadcrumb"
+    And the event "breadcrumbs.1.type" equals "user"
+    And the event "breadcrumbs.1.metaData.Foo" equals "Bar"
 
     And the event "breadcrumbs.0.timestamp" is not null
-    And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
-    And the event "breadcrumbs.0.type" equals "state"
+    And the event "breadcrumbs.0.name" equals "manual"
+    And the event "breadcrumbs.0.type" equals "manual"
     And the event "breadcrumbs.0.metaData" is not null
+    And the event "breadcrumbs.0.metaData.message" equals "Hello Breadcrumb!"

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
@@ -15,7 +15,7 @@ internal class BreadcrumbScenario(config: Configuration,
                                   context: Context) : Scenario(config, context) {
     init {
         config.autoTrackSessions = false
-        config.enabledBreadcrumbTypes = setOf(BreadcrumbType.MANUAL, BreadcrumbType.USER, BreadcrumbType.STATE)
+        config.enabledBreadcrumbTypes = setOf(BreadcrumbType.MANUAL, BreadcrumbType.USER)
     }
 
     override fun run() {

--- a/tests/features/breadcrumb.feature
+++ b/tests/features/breadcrumb.feature
@@ -7,18 +7,13 @@ Scenario: Manually added breadcrumbs are sent in report
     And the exception "message" equals "BreadcrumbScenario"
     And the event "breadcrumbs" is not null
 
-    And the event "breadcrumbs.2.timestamp" is not null
-    And the event "breadcrumbs.2.name" equals "Another Breadcrumb"
-    And the event "breadcrumbs.2.type" equals "user"
-    And the event "breadcrumbs.2.metaData.Foo" equals "Bar"
-
     And the event "breadcrumbs.1.timestamp" is not null
-    And the event "breadcrumbs.1.name" equals "manual"
-    And the event "breadcrumbs.1.type" equals "manual"
-    And the event "breadcrumbs.1.metaData" is not null
-    And the event "breadcrumbs.1.metaData.message" equals "Hello Breadcrumb!"
+    And the event "breadcrumbs.1.name" equals "Another Breadcrumb"
+    And the event "breadcrumbs.1.type" equals "user"
+    And the event "breadcrumbs.1.metaData.Foo" equals "Bar"
 
     And the event "breadcrumbs.0.timestamp" is not null
-    And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
-    And the event "breadcrumbs.0.type" equals "state"
+    And the event "breadcrumbs.0.name" equals "manual"
+    And the event "breadcrumbs.0.type" equals "manual"
     And the event "breadcrumbs.0.metaData" is not null
+    And the event "breadcrumbs.0.metaData.message" equals "Hello Breadcrumb!"


### PR DESCRIPTION
## Goal

Adds a breadcrumb which is logged when the connectivity changes. This makes the notifier conform with the notifier spec.

## Changeset

- Updated the `NetworkChangeCallback` to pass `networkState` as a parameter also
- Left a breadcrumb in the network change callback implementation
- Reordered `Client` constructor so that the `OnBreadcrumb` callback that implements `enabledBreadcrumbTypes` filtering is always set before the connectivity change callback. This avoids a race where the connectivity breadcrumb might potentially be added before this filter is set

## Tests

Manually verified that a breadcrumb appears as expected when changing the connectivity in an emulator.

Updated the unit tests and mazerunner scenarios so that the connectivity changed/bugsnag loaded breadcrumbs are filtered out from tests, and so that we do not verify their structure. This is because the order in which these happen is indeterminate and this could introduce flakiness to our tests.

<img width="270" alt="Screenshot 2020-02-07 at 11 31 29" src="https://user-images.githubusercontent.com/11800640/74026327-d6c2b880-499d-11ea-8652-6df7b43a317e.png">