### PR TITLE
Populate releaseStage in config during initial sanitisation

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -26,7 +26,7 @@ internal class AppDataCollector(
 
     private var binaryArch: String? = null
     private val appName = getAppName()
-    private val releaseStage = guessReleaseStage()
+    private val releaseStage = config.releaseStage
     private val versionName = config.appVersion ?: packageInfo?.versionName
 
     fun generateApp(): App = App(config, binaryArch, packageName, releaseStage, versionName)
@@ -87,21 +87,6 @@ internal class AppDataCollector(
     }
 
     /**
-     * Guess the release stage of the running Android app by checking the
-     * android:debuggable flag from AndroidManifest.xml. If the release stage was set in
-     * [Configuration], this value will be returned instead.
-     */
-    private fun guessReleaseStage(): String {
-        return when {
-            config.releaseStage != null -> config.releaseStage
-            appInfo != null && (appInfo!!.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) -> {
-                RELEASE_STAGE_DEVELOPMENT
-            }
-            else -> RELEASE_STAGE_PRODUCTION
-        }
-    }
-
-    /**
      * The name of the running Android app, from android:label in
      * AndroidManifest.xml
      */
@@ -114,11 +99,7 @@ internal class AppDataCollector(
     }
 
     companion object {
-
         internal val startTimeMs = SystemClock.elapsedRealtime()
-
-        private const val RELEASE_STAGE_DEVELOPMENT = "development"
-        const val RELEASE_STAGE_PRODUCTION = "production"
 
         /**
          * Get the time in milliseconds since Bugsnag was initialized, which is a

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import static com.bugsnag.android.HandledState.REASON_HANDLED_EXCEPTION;
+import static com.bugsnag.android.ImmutableConfigKt.RELEASE_STAGE_PRODUCTION;
 
 import android.app.ActivityManager;
 import android.app.Application;
@@ -118,8 +119,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         // if the user has set the releaseStage to production manually, disable logging
         if (configuration.getLogger() == null) {
             String releaseStage = configuration.getReleaseStage();
-            boolean loggingEnabled
-                    = !AppDataCollector.RELEASE_STAGE_PRODUCTION.equals(releaseStage);
+            boolean loggingEnabled = !RELEASE_STAGE_PRODUCTION.equals(releaseStage);
 
             if (loggingEnabled) {
                 configuration.setLogger(DebugLogger.INSTANCE);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import static com.bugsnag.android.HandledState.REASON_HANDLED_EXCEPTION;
 import static com.bugsnag.android.ImmutableConfigKt.RELEASE_STAGE_PRODUCTION;
+import static com.bugsnag.android.ImmutableConfigKt.sanitiseConfiguration;
 
 import android.app.ActivityManager;
 import android.app.Application;
@@ -17,8 +18,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import kotlin.Unit;
-import kotlin.jvm.functions.Function0;
-import kotlin.jvm.functions.Function1;
 import kotlin.jvm.functions.Function2;
 
 import java.util.ArrayList;
@@ -163,8 +162,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             }
         });
 
-        ImmutableConfigKt.sanitiseConfiguration(appContext, configuration, connectivity);
-        immutableConfig = ImmutableConfigKt.convertToImmutableConfig(configuration);
+        immutableConfig = sanitiseConfiguration(appContext, configuration, connectivity);
 
         contextState = new ContextState();
         contextState.setContext(configuration.getContext());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertEquals
@@ -165,11 +166,17 @@ internal class ImmutableConfigTest {
         `when`(context.packageName).thenReturn("com.example.foo")
         `when`(context.packageManager).thenReturn(packageManager)
 
+        val packageInfo = PackageInfo()
+        @Suppress("DEPRECATION")
+        packageInfo.versionCode = 55
+        `when`(packageManager.getPackageInfo("com.example.foo", 0)).thenReturn(packageInfo)
+
         val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
         seed.logger = NoopLogger
         val config = sanitiseConfiguration(context, seed, connectivity)
         assertEquals(setOf("com.example.foo"), config.projectPackages)
         assertEquals("production", config.releaseStage)
+        assertEquals(55, config.versionCode)
 
         assertNotNull(config.delivery)
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -1,6 +1,8 @@
 package com.bugsnag.android
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -13,6 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.Mockito.*
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
@@ -28,6 +31,9 @@ internal class ImmutableConfigTest {
 
     @Mock
     lateinit var context: Context
+
+    @Mock
+    lateinit var packageManager: PackageManager
 
     @Before
     fun setUp() {
@@ -156,11 +162,14 @@ internal class ImmutableConfigTest {
 
     @Test
     fun configSanitisation() {
-        Mockito.`when`(context.packageName).thenReturn("com.example.foo")
+        `when`(context.packageName).thenReturn("com.example.foo")
+        `when`(context.packageManager).thenReturn(packageManager)
+
         val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
         seed.logger = NoopLogger
         val config = sanitiseConfiguration(context, seed, connectivity)
         assertEquals(setOf("com.example.foo"), config.projectPackages)
+        assertEquals("production", config.releaseStage)
 
         assertNotNull(config.delivery)
     }


### PR DESCRIPTION
## Goal

The `releaseStage` was not set on the `ImmutableConfig` object when a `Client` was initialised, meaning it remained null if not set explicitly. This updates the sanitiser function to set a default value on the field, rather than just the serialized payload.

## Changeset

Moved the `guessReleaseStage` method to `ImmutableConfig` which is populated on `Client` initialisation.

## Tests

Added a unit test to verify that the field is set to a sensible default.
