### PR TITLE
Make notifier publicly accessible on session/event

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
@@ -14,6 +14,7 @@ class EventPayload : JsonStream.Streamable {
     var apiKey: String?
     private val eventFile: File?
     val event: Event?
+    val notifier: Notifier = Notifier
 
     internal constructor(apiKey: String?, eventFile: File) {
         this.apiKey = apiKey
@@ -32,7 +33,7 @@ class EventPayload : JsonStream.Streamable {
         writer.beginObject()
         writer.name("apiKey").value(apiKey)
         writer.name("payloadVersion").value("4.0")
-        writer.name("notifier").value(Notifier)
+        writer.name("notifier").value(notifier)
 
         writer.name("events").beginArray()
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -5,7 +5,7 @@ import java.io.IOException
 /**
  * Information about this library, including name and version.
  */
-internal object Notifier : JsonStream.Streamable {
+object Notifier : JsonStream.Streamable {
 
     var name: String = "Android Bugsnag Notifier"
     var version: String = "4.21.0"

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
@@ -26,6 +26,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
     private final AtomicInteger handledCount = new AtomicInteger();
     private final AtomicBoolean tracked = new AtomicBoolean(false);
     final AtomicBoolean isPaused = new AtomicBoolean(false);
+    private Notifier notifier = Notifier.INSTANCE;
 
     static Session copySession(Session session) {
         Session copy = new Session(session.id, session.startedAt,
@@ -119,6 +120,11 @@ public final class Session implements JsonStream.Streamable, UserAware {
         return device;
     }
 
+    @NonNull
+    public Notifier getNotifier() {
+        return notifier;
+    }
+
     void setApp(App app) {
         this.app = app;
     }
@@ -177,7 +183,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
             }
         } else {
             writer.beginObject();
-            writer.name("notifier").value(Notifier.INSTANCE);
+            writer.name("notifier").value(notifier);
             writer.name("app").value(app);
             writer.name("device").value(device);
             writer.name("sessions").beginArray();
@@ -193,7 +199,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
 
     private void serializeV1Payload(@NonNull JsonStream writer) throws IOException {
         writer.beginObject();
-        writer.name("notifier").value(Notifier.INSTANCE);
+        writer.name("notifier").value(notifier);
         writer.name("app").value(app);
         writer.name("device").value(device);
         writer.name("sessions").beginArray();


### PR DESCRIPTION
Makes the `notifier` property publicly accessible on `Session/EventPayload`. This allows users to access it if they have implemented a custom `Delivery`.