### PR TITLE
Allow setting api key in config

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -11,9 +11,14 @@ class Configuration(
     /**
      * Changes the API key used for events sent to Bugsnag.
      */
-    val apiKey: String
+    apiKey: String
 ) : CallbackAware, MetadataAware, UserAware {
 
+    var apiKey = apiKey
+        set(value) {
+            require(value.matches(API_KEY_REGEX.toRegex())) { "You must provide a valid Bugsnag API key" }
+            field = value
+        }
     private var user = User()
 
     @JvmField

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyValidationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyValidationTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ApiKeyValidationTest {
@@ -17,5 +18,31 @@ class ApiKeyValidationTest {
     @Test(expected = IllegalArgumentException::class)
     fun testNonHexApiKey() {
         Configuration("yej0492j55z92z2p")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSettingEmptyApiKey() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        config.apiKey = ""
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSettingWrongSizeApiKey() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        config.apiKey = "abfe05f"
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSettingNonHexApiKey() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        config.apiKey = "yej0492j55z92z2p"
+    }
+
+    @Test
+    fun setApiKey() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        assertEquals("5d1ec5bd39a74caa1267142706a7fb21", config.apiKey)
+        config.apiKey = "000005bd39a74caa1267142706a7fb21"
+        assertEquals("000005bd39a74caa1267142706a7fb21", config.apiKey)
     }
 }


### PR DESCRIPTION
Allows setting the API key in configuration after an object has been initialised. Previously this field was immutable.