### PR TITLE
Make config.appType nullable as per spec

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.kt
@@ -132,7 +132,7 @@ class Configuration(
      *
      * By default, this value is set to 'android'.
      */
-    var appType: String = "android"
+    var appType: String? = "android"
 
     /**
      * By default, the notifier's log messages will be logged using [android.util.Log]

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -21,7 +21,7 @@ internal data class ImmutableConfig(
     val appVersion: String?,
     val versionCode: Int,
     val codeBundleId: String?,
-    val appType: String,
+    val appType: String?,
     val delivery: Delivery,
     val endpoints: EndpointConfiguration,
     val persistUser: Boolean,


### PR DESCRIPTION
Makes `config.appType` nullable as per the notifier spec.