### PR TITLE
Make event.session non-public

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -600,7 +600,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
         if (currentSession != null
                 && (immutableConfig.getAutoTrackSessions() || !currentSession.isAutoCaptured())) {
-            event.setSession(currentSession);
+            event.session = currentSession;
         }
 
         // Capture the state of the app and device and attach diagnostics to the event

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -27,14 +27,14 @@ class DeliveryDelegate extends BaseObservable {
     void deliver(@NonNull Event event) {
         // Build the eventPayload
         EventPayload eventPayload = new EventPayload(immutableConfig.getApiKey(), event);
-        Session session = event.getSession();
+        Session session = event.session;
 
         if (session != null) {
             if (event.isUnhandled()) {
-                event.setSession(session.incrementUnhandledAndCopy());
+                event.session = session.incrementUnhandledAndCopy();
                 notifyObservers(StateEvent.NotifyUnhandled.INSTANCE);
             } else {
-                event.setSession(session.incrementHandledAndCopy());
+                event.session = session.incrementHandledAndCopy();
                 notifyObservers(StateEvent.NotifyHandled.INSTANCE);
             }
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.kt
@@ -26,7 +26,8 @@ class Event @JvmOverloads internal constructor(
     internal val metadata: Metadata = data.copy()
     private val discardClasses: Set<String> = config.discardClasses.toSet()
 
-    var session: Session? = null
+    @JvmField
+    internal var session: Session? = null
 
     /**
      * The severity of the event. By default, unhandled exceptions will be [Severity.ERROR]


### PR DESCRIPTION
Makes `event.session` non-public as per the notifier spec.

This has been defined as an internal JVM field instead, so that we can continue to access it from Java and in existing unit tests.