### PR TITLE
Sync initial metadata values over to NDK

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.ConcurrentHashMap
  * Diagnostic information is presented on your Bugsnag dashboard in tabs.
  */
 internal data class Metadata @JvmOverloads constructor(
-    private val store: MutableMap<String, Any> = ConcurrentHashMap(),
+    internal val store: MutableMap<String, Any> = ConcurrentHashMap(),
     val jsonStreamer: ObjectJsonStreamer = ObjectJsonStreamer(),
     val redactedKeys: Set<String> = jsonStreamer.redactedKeys
 ) : JsonStream.Streamable, MetadataAware {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -1,22 +1,23 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.StateEvent.AddMetadata
+
 internal data class MetadataState(val metadata: Metadata = Metadata()) : BaseObservable(),
     MetadataAware {
 
-    override fun addMetadata(section: String, value: Map<String, Any?>) = metadata.addMetadata(section, value)
+    override fun addMetadata(section: String, value: Map<String, Any?>) =
+        metadata.addMetadata(section, value)
+
     override fun addMetadata(section: String, key: String, value: Any?) {
         metadata.addMetadata(section, key, value)
-
-        when (value) {
-            null -> notifyClear(section, key)
-            else -> notifyObservers(StateEvent.AddMetadata(section, key, metadata.getMetadata(section, key)))
-        }
+        notifyMetadataAdded(section, key, value)
     }
 
     override fun clearMetadata(section: String) {
         metadata.clearMetadata(section)
         notifyClear(section, null)
     }
+
     override fun clearMetadata(section: String, key: String) {
         metadata.clearMetadata(section, key)
         notifyClear(section, key)
@@ -31,4 +32,27 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) : BaseObs
 
     override fun getMetadata(section: String) = metadata.getMetadata(section)
     override fun getMetadata(section: String, key: String) = metadata.getMetadata(section, key)
+
+    /**
+     * Fires the initial observable messages for all the metadata which has been added before an
+     * Observer was added. This is used initially to populate the NDK with data.
+     */
+    fun initObservableMessages() {
+        val sections = metadata.store.keys
+
+        for (section in sections) {
+            val data = metadata.getMetadata(section)
+
+            data?.entries?.forEach {
+                notifyMetadataAdded(section, it.key, it.value)
+            }
+        }
+    }
+
+    private fun notifyMetadataAdded(section: String, key: String, value: Any?) {
+        when (value) {
+            null -> notifyClear(section, key)
+            else -> notifyObservers(AddMetadata(section, key, metadata.getMetadata(section, key)))
+        }
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
@@ -43,4 +43,19 @@ internal class MetadataStateTest {
         state.clearMetadata("foo", "wham")
         assertNull(state.getMetadata("foo"))
     }
+
+    @Test
+    fun initObservableMessages() {
+        state.addMetadata("foo", "wham", "baz")
+        state.addMetadata("bar", "another", true)
+
+        val data = mutableSetOf<String>()
+        state.addObserver { _, arg ->
+            val msg = arg as StateEvent.AddMetadata
+            data.add(msg.section)
+        }
+
+        state.initObservableMessages()
+        assertEquals(setOf("foo", "bar"), data)
+    }
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -192,20 +192,23 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
   for (int i = 0; i < map_size && i < metadata_size; i++) {
     jstring _key = (*env)->CallObjectMethod(env, keylist,
                                             jni_cache->arraylist_get, (jint)i);
-    jstring _value =
-        (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);
+    jobject _value = (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);
+
     if (_key == NULL || _value == NULL) {
       (*env)->DeleteLocalRef(env, _key);
       (*env)->DeleteLocalRef(env, _value);
     } else {
-      char *key = (char *)(*env)->GetStringUTFChars(env, _key, 0);
-      char *value = (char *)(*env)->GetStringUTFChars(env, _value, 0);
-      bsg_strncpy_safe(crumb->metadata[i].key, key,
-                       sizeof(crumb->metadata[i].key));
-      bsg_strncpy_safe(crumb->metadata[i].value, value,
-                       sizeof(crumb->metadata[i].value));
-      (*env)->ReleaseStringUTFChars(env, _key, key);
-      (*env)->ReleaseStringUTFChars(env, _value, value);
+      if ((*env)->IsInstanceOf(env, _value, jni_cache->string)) {
+        char *key = (char *)(*env)->GetStringUTFChars(env, _key, 0);
+        char *value = (char *)(*env)->GetStringUTFChars(env, _value, 0);
+        bsg_strncpy_safe(crumb->metadata[i].key, key,
+                         sizeof(crumb->metadata[i].key));
+
+        bsg_strncpy_safe(crumb->metadata[i].value, value,
+                         sizeof(crumb->metadata[i].value));
+        (*env)->ReleaseStringUTFChars(env, _key, key);
+        (*env)->ReleaseStringUTFChars(env, _value, value);
+      }
     }
   }
   free(jni_cache);


### PR DESCRIPTION
## Goal

Syncs initial metadata values added in `Configuration` over to the NDK layer.

## Changeset
This changeset relies on #804 which has not yet been merged.

Added a method to `MetadataState` which sends an observable message `StateEvent.AddMetadata` for each piece of metadata added in `Configuration`. Fired this message in the `Client` after initialising the NDK plugin.

## Tests
Ran an example app with a local artefact and confirmed that metadata added in `Configuration` makes it to the payload. Also added unit test coverage to the delivery of the `Observable` message in `MetadataState`.
