### PR TITLE
Add android 8.1 and 10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -325,3 +325,15 @@ steps:
       NDK_VERSION: "r19"
     concurrency: 5
     concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 21 SDK 10.0 Instrumentation tests'
+    timeout_in_minutes: 60
+    plugins:
+        - docker-compose#v2.6.0:
+              run: android-instrumentation-tests
+    env:
+        APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
+        INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
+        NDK_VERSION: "r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -202,7 +202,20 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Android 8 end-to-end tests'
+  - label: ':android: Android 8.0 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+        artifacts#v1.2.0:
+            download: "build/fixture.apk"
+        docker-compose#v2.6.0:
+            run: android-maze-runner
+    env:
+        DEVICE_TYPE: "ANDROID_8_0"
+        APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 8.1 end-to-end tests'
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -128,7 +128,7 @@ steps:
       docker-compose#v2.6.0:
         run: android-maze-runner
     env:
-      DEVICE_TYPE: "ANDROID_9"
+      DEVICE_TYPE: "ANDROID_9_0"
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 5
     concurrency_group: 'browserstack-app'
@@ -141,7 +141,7 @@ steps:
         docker-compose#v2.6.0:
             run: android-maze-runner
     env:
-        DEVICE_TYPE: "ANDROID_10"
+        DEVICE_TYPE: "ANDROID_10_0"
         APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 5
     concurrency_group: 'browserstack-app'
@@ -171,7 +171,7 @@ steps:
       docker-compose#v2.6.0:
         run: android-maze-runner
     env:
-      DEVICE_TYPE: "ANDROID_5"
+      DEVICE_TYPE: "ANDROID_5_0"
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 5
     concurrency_group: 'browserstack-app'
@@ -184,7 +184,7 @@ steps:
       docker-compose#v2.6.0:
         run: android-maze-runner
     env:
-      DEVICE_TYPE: "ANDROID_6"
+      DEVICE_TYPE: "ANDROID_6_0"
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 5
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,6 +133,21 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
 
+  - label: ':android: Android 10 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+        artifacts#v1.2.0:
+            download: "build/fixture.apk"
+        docker-compose#v2.6.0:
+            run: android-maze-runner
+    env:
+        DEVICE_TYPE: "ANDROID_10"
+        APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+        - exit_status: "*"
+
   - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
     timeout_in_minutes: 60
     plugins:
@@ -182,7 +197,7 @@ steps:
       docker-compose#v2.6.0:
         run: android-maze-runner
     env:
-      DEVICE_TYPE: "ANDROID_7"
+      DEVICE_TYPE: "ANDROID_7_1"
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 5
     concurrency_group: 'browserstack-app'
@@ -195,7 +210,7 @@ steps:
       docker-compose#v2.6.0:
         run: android-maze-runner
     env:
-      DEVICE_TYPE: "ANDROID_8"
+      DEVICE_TYPE: "ANDROID_8_1"
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 5
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -227,6 +227,8 @@ steps:
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 5
     concurrency_group: 'browserstack-app'
+    soft_fail:
+        - exit_status: "*"
 
   - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
     timeout_in_minutes: 60

--- a/dockerfiles/Dockerfile.android
+++ b/dockerfiles/Dockerfile.android
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:add-android-8.1-and-10-cli as android-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:v2-cli as android-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 
 COPY tests/features features

--- a/dockerfiles/Dockerfile.android
+++ b/dockerfiles/Dockerfile.android
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:v2-cli as android-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:add-android-8.1-and-10-cli as android-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 
 COPY tests/features features

--- a/tests/features/strict_mode.feature
+++ b/tests/features/strict_mode.feature
@@ -1,7 +1,7 @@
 Feature: Reporting Strict Mode Exceptions
 
 # These scenarios are being skipped on Android 9 until ROAD-757 is resolved
-@skip_android_9
+@skip_above_android_8
 Scenario: StrictMode DiscWrite violation
     When I run "StrictModeDiscScenario" and relaunch the app
     And I configure Bugsnag for "StrictModeDiscScenario"
@@ -10,7 +10,7 @@ Scenario: StrictMode DiscWrite violation
     And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
     And the event "metaData.StrictMode.Violation" equals "DiskWrite"
 
-@skip_android_9
+@skip_above_android_8
 Scenario: StrictMode Network on Main Thread violation
     When I run "StrictModeNetworkScenario" and relaunch the app
     And I configure Bugsnag for "StrictModeNetworkScenario"

--- a/tests/features/support/env.rb
+++ b/tests/features/support/env.rb
@@ -13,19 +13,19 @@ After do |scenario|
 end
 
 Before('@skip_above_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") if %w['ANDROID_9 ANDROID_10'].include? bs_device
+  skip_this_scenario("Skipping scenario") if %w[ANDROID_9_0 ANDROID_10_0].include? bs_device
 end
 
 Before('@skip_above_android_7') do |scenario|
-  skip_this_scenario("Skipping scenario") if %w['ANDROID_8 ANDROID_8_1 ANDROID_9 ANDROID_10'].include? bs_device
+  skip_this_scenario("Skipping scenario") if %w[ANDROID_8_0 ANDROID_8_1 ANDROID_9_0 ANDROID_10_0].include? bs_device
 end
 
 Before('@skip_below_android_9') do |scenario|
-  skip_this_scenario("Skipping scenario") unless %w['ANDROID_9 ANDROID_10'].include? bs_device
+  skip_this_scenario("Skipping scenario") unless %w[ANDROID_9_0 ANDROID_10_0].include? bs_device
 end
 
 Before('@skip_below_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") unless %w['ANDROID_8 ANDROID_8_1 ANDROID_9 ANDROID_10'].include? bs_device
+  skip_this_scenario("Skipping scenario") unless %w[ANDROID_8_0 ANDROID_8_1 ANDROID_9_0 ANDROID_10_0].include? bs_device
 end
 
 AfterConfiguration do |config|

--- a/tests/features/support/env.rb
+++ b/tests/features/support/env.rb
@@ -12,20 +12,20 @@ After do |scenario|
   $driver.reset
 end
 
-Before('@skip_android_9') do |scenario|
-  skip_this_scenario("Skipping scenario") if bs_device == 'ANDROID_9'
-end
-
-Before('@skip_below_android_9') do |scenario|
-  skip_this_scenario("Skipping scenario") if bs_device != 'ANDROID_9'
-end
-
-Before('@skip_below_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") if bs_device != 'ANDROID_8' && bs_device != 'ANDROID_9'
+Before('@skip_above_android_8') do |scenario|
+  skip_this_scenario("Skipping scenario") if %w['ANDROID_9 ANDROID_10'].include? bs_device
 end
 
 Before('@skip_above_android_7') do |scenario|
-  skip_this_scenario("Skipping scenario") if bs_device == 'ANDROID_8' || bs_device == 'ANDROID_9'
+  skip_this_scenario("Skipping scenario") if %w['ANDROID_8 ANDROID_8_1 ANDROID_9 ANDROID_10'].include? bs_device
+end
+
+Before('@skip_below_android_9') do |scenario|
+  skip_this_scenario("Skipping scenario") unless %w['ANDROID_9 ANDROID_10'].include? bs_device
+end
+
+Before('@skip_below_android_8') do |scenario|
+  skip_this_scenario("Skipping scenario") unless %w['ANDROID_8 ANDROID_8_1 ANDROID_9 ANDROID_10'].include? bs_device
 end
 
 AfterConfiguration do |config|


### PR DESCRIPTION
## Goal

Add Android 8.1 and 10.0 Maze Runner tests, as well as Instrumentation tests on Android 10 to the CI build.

## Design

Following existing pattern for builds, except using the "soft fail" functionality of BuildKite for the Maze Runner tests.  We know there are issues causing some tests to fail and these need more investigation in due course, but for now we would rather receive the feedback from running them and failing than having nothing at all.

## Changeset

Pipeline build updated to include new versions.
Logic for determining skipping of tests on specific versions of Android updated to account for new device names in Maze Runner.

## Tests

Verified by inspecting the build output.
