### PR TITLE
Log a warning when null values are supplied to Breadcrumb, rather than throwing an exception

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -38,7 +38,7 @@ class BreadcrumbStateTest {
 
         for (breadcrumb in store) {
             if (MANUAL == breadcrumb.type && "manual" == breadcrumb.message
-                && breadcrumb.metadata["message"] == "Hello World") {
+                && breadcrumb.metadata!!["message"] == "Hello World") {
                 count++
             }
         }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -146,7 +146,8 @@ public class ObserverInterfaceTest {
 
     @Test
     public void testLeaveStringBreadcrumbDirectlySendsMessage() {
-        client.breadcrumbState.add(new Breadcrumb("Drift 4 units left"));
+        Breadcrumb obj = new Breadcrumb("Drift 4 units left", NoopLogger.INSTANCE);
+        client.breadcrumbState.add(obj);
         StateEvent.AddBreadcrumb crumb = findMessageInQueue(StateEvent.AddBreadcrumb.class);
         assertEquals(BreadcrumbType.MANUAL, crumb.getType());
         assertEquals("manual", crumb.getMessage());

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -1,0 +1,78 @@
+package com.bugsnag.android;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+
+@SuppressWarnings("ConstantConditions")
+public class Breadcrumb implements JsonStream.Streamable {
+
+    private final BreadcrumbImpl impl;
+    private final Logger logger;
+
+    Breadcrumb(@NonNull String message, @NonNull Logger logger) {
+        this.impl = new BreadcrumbImpl(message);
+        this.logger = logger;
+    }
+
+    Breadcrumb(@NonNull String message,
+               @NonNull BreadcrumbType type,
+               @Nullable Map<String, Object> metadata,
+               @NonNull Date timestamp,
+               @NonNull Logger logger) {
+        this.impl = new BreadcrumbImpl(message, type, metadata, timestamp);
+        this.logger = logger;
+    }
+
+    private void error(String property) {
+        logger.e("Invalid null value supplied to breadcrumb." + property + ", ignoring");
+    }
+
+    public void setMessage(@NonNull String message) {
+        if (message != null) {
+            impl.setMessage(message);
+        } else {
+            error("message");
+        }
+    }
+
+    @NonNull
+    public String getMessage() {
+        return impl.getMessage();
+    }
+
+    public void setType(@NonNull BreadcrumbType type) {
+        if (type != null) {
+            impl.setType(type);
+        } else {
+            error("type");
+        }
+    }
+
+    @NonNull
+    public BreadcrumbType getType() {
+        return impl.getType();
+    }
+
+    public void setMetadata(@NonNull Map<String, Object> metadata) {
+        impl.setMetadata(metadata);
+    }
+
+    @NonNull
+    public Map<String, Object> getMetadata() {
+        return impl.getMetadata();
+    }
+
+    @NonNull
+    public Date getTimestamp() {
+        return impl.getTimestamp();
+    }
+
+    @Override
+    public void toStream(@NonNull JsonStream stream) throws IOException {
+        impl.toStream(stream);
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -10,11 +10,11 @@ import java.util.Map;
 @SuppressWarnings("ConstantConditions")
 public class Breadcrumb implements JsonStream.Streamable {
 
-    private final BreadcrumbImpl impl;
+    private final BreadcrumbInternal impl;
     private final Logger logger;
 
     Breadcrumb(@NonNull String message, @NonNull Logger logger) {
-        this.impl = new BreadcrumbImpl(message);
+        this.impl = new BreadcrumbInternal(message);
         this.logger = logger;
     }
 
@@ -23,11 +23,11 @@ public class Breadcrumb implements JsonStream.Streamable {
                @Nullable Map<String, Object> metadata,
                @NonNull Date timestamp,
                @NonNull Logger logger) {
-        this.impl = new BreadcrumbImpl(message, type, metadata, timestamp);
+        this.impl = new BreadcrumbInternal(message, type, metadata, timestamp);
         this.logger = logger;
     }
 
-    private void error(String property) {
+    private void logNull(String property) {
         logger.e("Invalid null value supplied to breadcrumb." + property + ", ignoring");
     }
 
@@ -38,7 +38,7 @@ public class Breadcrumb implements JsonStream.Streamable {
         if (message != null) {
             impl.setMessage(message);
         } else {
-            error("message");
+            logNull("message");
         }
     }
 
@@ -58,7 +58,7 @@ public class Breadcrumb implements JsonStream.Streamable {
         if (type != null) {
             impl.setType(type);
         } else {
-            error("type");
+            logNull("type");
         }
     }
 
@@ -74,14 +74,14 @@ public class Breadcrumb implements JsonStream.Streamable {
     /**
      * Sets diagnostic data relating to the breadcrumb
      */
-    public void setMetadata(@NonNull Map<String, Object> metadata) {
+    public void setMetadata(@Nullable Map<String, Object> metadata) {
         impl.setMetadata(metadata);
     }
 
     /**
      * Gets diagnostic data relating to the breadcrumb
      */
-    @NonNull
+    @Nullable
     public Map<String, Object> getMetadata() {
         return impl.getMetadata();
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -31,6 +31,9 @@ public class Breadcrumb implements JsonStream.Streamable {
         logger.e("Invalid null value supplied to breadcrumb." + property + ", ignoring");
     }
 
+    /**
+     * Sets the description of the breadcrumb
+     */
     public void setMessage(@NonNull String message) {
         if (message != null) {
             impl.setMessage(message);
@@ -39,11 +42,18 @@ public class Breadcrumb implements JsonStream.Streamable {
         }
     }
 
+    /**
+     * Gets the description of the breadcrumb
+     */
     @NonNull
     public String getMessage() {
         return impl.getMessage();
     }
 
+    /**
+     * Sets the type of breadcrumb left - one of those enabled in
+     * {@link Configuration#getEnabledBreadcrumbTypes()}
+     */
     public void setType(@NonNull BreadcrumbType type) {
         if (type != null) {
             impl.setType(type);
@@ -52,20 +62,33 @@ public class Breadcrumb implements JsonStream.Streamable {
         }
     }
 
+    /**
+     * Gets the type of breadcrumb left - one of those enabled in
+     * {@link Configuration#getEnabledBreadcrumbTypes()}
+     */
     @NonNull
     public BreadcrumbType getType() {
         return impl.getType();
     }
 
+    /**
+     * Sets diagnostic data relating to the breadcrumb
+     */
     public void setMetadata(@NonNull Map<String, Object> metadata) {
         impl.setMetadata(metadata);
     }
 
+    /**
+     * Gets diagnostic data relating to the breadcrumb
+     */
     @NonNull
     public Map<String, Object> getMetadata() {
         return impl.getMetadata();
     }
 
+    /**
+     * The timestamp that the breadcrumb was left
+     */
     @NonNull
     public Date getTimestamp() {
         return impl.getTimestamp();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
@@ -8,26 +8,10 @@ import java.util.Date
  * to leave short log statements that we call breadcrumbs. Breadcrumbs are
  * attached to a crash to help diagnose what events lead to the error.
  */
-class BreadcrumbImpl internal constructor(
-
-    /**
-     * The description of the breadcrumb
-     */
+internal class BreadcrumbImpl internal constructor(
     var message: String,
-
-    /**
-     * The type of breadcrumb left - one of those enabled in [Configuration.enabledBreadcrumbTypes]
-     */
     var type: BreadcrumbType,
-
-    /**
-     * Diagnostic data relating to the breadcrumb
-     */
     var metadata: MutableMap<String, Any?>?,
-
-    /**
-     * The timestamp that the breadcrumb was left
-     */
     val timestamp: Date = Date()
 ) : JsonStream.Streamable {
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
@@ -8,22 +8,22 @@ import java.util.Date
  * to leave short log statements that we call breadcrumbs. Breadcrumbs are
  * attached to a crash to help diagnose what events lead to the error.
  */
-class Breadcrumb internal constructor(
+class BreadcrumbImpl internal constructor(
 
     /**
      * The description of the breadcrumb
      */
-    val message: String,
+    var message: String,
 
     /**
      * The type of breadcrumb left - one of those enabled in [Configuration.enabledBreadcrumbTypes]
      */
-    val type: BreadcrumbType,
+    var type: BreadcrumbType,
 
     /**
      * Diagnostic data relating to the breadcrumb
      */
-    val metadata: MutableMap<String, Any?>,
+    var metadata: MutableMap<String, Any?>?,
 
     /**
      * The timestamp that the breadcrumb was left

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
@@ -8,7 +8,7 @@ import java.util.Date
  * to leave short log statements that we call breadcrumbs. Breadcrumbs are
  * attached to a crash to help diagnose what events lead to the error.
  */
-internal class BreadcrumbImpl internal constructor(
+internal class BreadcrumbInternal internal constructor(
     var message: String,
     var type: BreadcrumbType,
     var metadata: MutableMap<String, Any?>?,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -41,7 +41,7 @@ internal class BreadcrumbState(
                 breadcrumb.message,
                 breadcrumb.type,
                 DateUtils.toIso8601(breadcrumb.timestamp),
-                breadcrumb.metadata
+                breadcrumb.metadata ?: mutableMapOf()
             )
         )
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -824,7 +824,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     public void leaveBreadcrumb(@NonNull String message) {
         if (message != null) {
-            breadcrumbState.add(new Breadcrumb(message));
+            breadcrumbState.add(new Breadcrumb(message, logger));
         } else {
             logNull("leaveBreadcrumb");
         }
@@ -842,7 +842,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                                 @NonNull BreadcrumbType type,
                                 @NonNull Map<String, Object> metadata) {
         if (message != null && type != null && metadata != null) {
-            breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date()));
+            breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date(), logger));
         } else {
             logNull("leaveBreadcrumb");
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -110,7 +110,8 @@ class DeliveryDelegate extends BaseObservable {
             data.put("message", message);
             data.put("unhandled", String.valueOf(event.isUnhandled()));
             data.put("severity", event.getSeverity().toString());
-            breadcrumbState.add(new Breadcrumb(errorClass, BreadcrumbType.ERROR, data, new Date()));
+            breadcrumbState.add(new Breadcrumb(errorClass,
+                    BreadcrumbType.ERROR, data, new Date(), logger));
         }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbFacadeTest.java
@@ -1,0 +1,78 @@
+package com.bugsnag.android;
+
+import static com.bugsnag.android.BreadcrumbType.MANUAL;
+import static com.bugsnag.android.BreadcrumbType.NAVIGATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("ConstantConditions") // suppress warning about making redundant null checks
+public class BreadcrumbFacadeTest {
+
+    private Breadcrumb crumb;
+    private InterceptingLogger logger;
+    private HashMap<String, Object> metadata;
+
+    /**
+     * Constructs a Breadcrumb wrapper object
+     */
+    @Before
+    public void setUp() {
+        metadata = new HashMap<>();
+        logger = new InterceptingLogger();
+        crumb = new Breadcrumb("Panini", NAVIGATION, metadata, new Date(0), logger);
+    }
+
+    @Test
+    public void messageValid() {
+        assertEquals("Panini", crumb.getMessage());
+        crumb.setMessage("Croissant");
+        assertEquals("Croissant", crumb.getMessage());
+    }
+
+    @Test
+    public void messageInvalid() {
+        assertEquals("Panini", crumb.getMessage());
+        crumb.setMessage(null);
+        assertEquals("Panini", crumb.getMessage());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void typeValid() {
+        assertEquals(NAVIGATION, crumb.getType());
+        crumb.setType(MANUAL);
+        assertEquals(MANUAL, crumb.getType());
+    }
+
+    @Test
+    public void typeInvalid() {
+        assertEquals(NAVIGATION, crumb.getType());
+        crumb.setType(null);
+        assertEquals(NAVIGATION, crumb.getType());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void metadataValid() {
+        assertEquals(metadata, crumb.getMetadata());
+        Map<String, Object> map = Collections.<String, Object>singletonMap("foo", true);
+        crumb.setMetadata(map);
+        assertEquals(map, crumb.getMetadata());
+        crumb.setMetadata(null);
+        assertNull(crumb.getMetadata());
+    }
+
+    @Test
+    public void dateValid() {
+        assertEquals(new Date(0).getTime(), crumb.getTimestamp().getTime());
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
@@ -9,7 +9,7 @@ class BreadcrumbMutabilityTest {
     fun breadcrumbProtectsMetadata() {
         val data = mutableMapOf<String, Any?>()
         val breadcrumb = Breadcrumb("foo", BreadcrumbType.MANUAL, data, Date(0), NoopLogger)
-        breadcrumb.metadata["a"] = "bar"
-        assertFalse(breadcrumb.metadata.isEmpty())
+        breadcrumb.metadata!!["a"] = "bar"
+        assertFalse(breadcrumb.metadata!!.isEmpty())
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbMutabilityTest.kt
@@ -2,12 +2,13 @@ package com.bugsnag.android
 
 import org.junit.Assert.assertFalse
 import org.junit.Test
+import java.util.Date
 
 class BreadcrumbMutabilityTest {
     @Test
     fun breadcrumbProtectsMetadata() {
         val data = mutableMapOf<String, Any?>()
-        val breadcrumb = Breadcrumb("foo", BreadcrumbType.MANUAL, data)
+        val breadcrumb = Breadcrumb("foo", BreadcrumbType.MANUAL, data, Date(0), NoopLogger)
         breadcrumb.metadata["a"] = "bar"
         assertFalse(breadcrumb.metadata.isEmpty())
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbSerializationTest.kt
@@ -17,12 +17,13 @@ internal class BreadcrumbSerializationTest {
             val timestamp = Date(0)
             return generateSerializationTestCases(
                 "breadcrumb",
-                Breadcrumb("hello world", BreadcrumbType.MANUAL, mutableMapOf(), timestamp),
+                Breadcrumb("hello world", BreadcrumbType.MANUAL, mutableMapOf(), timestamp, NoopLogger),
                 Breadcrumb(
                     "metadata",
                     BreadcrumbType.PROCESS,
-                    mutableMapOf(Pair("foo", true)),
-                    timestamp
+                    mutableMapOf<String, Any?>(Pair("foo", true)),
+                    timestamp,
+                    NoopLogger
                 )
             )
         }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateSerializationTest.kt
@@ -16,7 +16,7 @@ internal class BreadcrumbStateSerializationTest {
         fun testCases(): Collection<Pair<JsonStream.Streamable, String>> {
             val breadcrumbs = BreadcrumbState(50, CallbackState(), NoopLogger)
             val metadata = mutableMapOf<String, Any?>(Pair("direction", "left"))
-            breadcrumbs.add(Breadcrumb("hello world", BreadcrumbType.MANUAL, metadata, Date(0)))
+            breadcrumbs.add(Breadcrumb("hello world", BreadcrumbType.MANUAL, metadata, Date(0), NoopLogger))
             return generateSerializationTestCases("breadcrumb_state", breadcrumbs)
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -37,7 +37,7 @@ class BreadcrumbStateTest {
 
         val crumbs = breadcrumbState.store.toList()
         assertEquals(3, crumbs.size)
-        assertEquals(longStr, crumbs[2].metadata["message"])
+        assertEquals(longStr, crumbs[2].metadata!!["message"])
     }
 
     /**
@@ -52,8 +52,8 @@ class BreadcrumbStateTest {
         }
 
         val crumbs = breadcrumbState.store.toList()
-        assertEquals("2", crumbs.first().metadata["message"])
-        assertEquals("6", crumbs.last().metadata["message"])
+        assertEquals("2", crumbs.first().metadata!!["message"])
+        assertEquals("6", crumbs.last().metadata!!["message"])
     }
 
     /**

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.Date
 
 import java.util.HashMap
 import java.util.Locale
@@ -26,13 +27,13 @@ class BreadcrumbStateTest {
      */
     @Test
     fun testMessageTruncation() {
-        breadcrumbState.add(Breadcrumb("Started app"))
-        breadcrumbState.add(Breadcrumb("Clicked a button"))
+        breadcrumbState.add(Breadcrumb("Started app", NoopLogger))
+        breadcrumbState.add(Breadcrumb("Clicked a button", NoopLogger))
         val longStr = ("Lorem ipsum dolor sit amet, consectetur adipiscing elit,"
                 + " sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad "
                 + "minim veniam, quis nostrud exercitation ullamco laboris nisi"
                 + " ut aliquip ex ea commodo consequat.")
-        breadcrumbState.add(Breadcrumb(longStr))
+        breadcrumbState.add(Breadcrumb(longStr, NoopLogger))
 
         val crumbs = breadcrumbState.store.toList()
         assertEquals(3, crumbs.size)
@@ -47,7 +48,7 @@ class BreadcrumbStateTest {
         breadcrumbState = BreadcrumbState(5, CallbackState(), NoopLogger)
 
         for (k in 1..6) {
-            breadcrumbState.add(Breadcrumb("$k"))
+            breadcrumbState.add(Breadcrumb("$k", NoopLogger))
         }
 
         val crumbs = breadcrumbState.store.toList()
@@ -61,8 +62,8 @@ class BreadcrumbStateTest {
     @Test
     fun testSetSizeEmpty() {
         breadcrumbState = BreadcrumbState(0, CallbackState(), NoopLogger)
-        breadcrumbState.add(Breadcrumb("1"))
-        breadcrumbState.add(Breadcrumb("2"))
+        breadcrumbState.add(Breadcrumb("1", NoopLogger))
+        breadcrumbState.add(Breadcrumb("2", NoopLogger))
         assertTrue(breadcrumbState.store.isEmpty())
     }
 
@@ -72,7 +73,7 @@ class BreadcrumbStateTest {
     @Test
     fun testSetSizeNegative() {
         breadcrumbState = BreadcrumbState(-1, CallbackState(), NoopLogger)
-        breadcrumbState.add(Breadcrumb("1"))
+        breadcrumbState.add(Breadcrumb("1", NoopLogger))
         assertEquals(0, breadcrumbState.store.size)
     }
 
@@ -81,7 +82,7 @@ class BreadcrumbStateTest {
      */
     @Test
     fun testDefaultBreadcrumbType() {
-        breadcrumbState.add(Breadcrumb("1"))
+        breadcrumbState.add(Breadcrumb("1", NoopLogger))
         assertEquals(MANUAL, breadcrumbState.store.peek().type)
     }
 
@@ -94,7 +95,7 @@ class BreadcrumbStateTest {
         for (i in 0..399) {
             metadata[String.format(Locale.US, "%d", i)] = "!!"
         }
-        breadcrumbState.add(Breadcrumb("Rotated Menu", BreadcrumbType.STATE, metadata))
+        breadcrumbState.add(Breadcrumb("Rotated Menu", BreadcrumbType.STATE, metadata, Date(0), NoopLogger))
         assertFalse(breadcrumbState.store.isEmpty())
     }
 
@@ -122,7 +123,7 @@ class BreadcrumbStateTest {
     @Test
     fun testOnBreadcrumbCallback() {
         breadcrumbState.callbackState.addOnBreadcrumb(OnBreadcrumbCallback { false })
-        breadcrumbState.add(Breadcrumb("Whoops"))
+        breadcrumbState.add(Breadcrumb("Whoops", NoopLogger))
         assertTrue(breadcrumbState.store.isEmpty())
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
@@ -26,7 +26,7 @@ class CallbackStateTest {
 
     private val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
     private val event = Event(RuntimeException(), generateImmutableConfig(), handledState, NoopLogger)
-    private val breadcrumb = Breadcrumb("")
+    private val breadcrumb = Breadcrumb("", NoopLogger)
 
     @Test
     fun testCopy() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -58,7 +58,8 @@ public class ConcurrentCallbackTest {
             }
         });
         config.addOnBreadcrumb(new OnBreadcrumbCallbackSkeleton());
-        config.runOnBreadcrumbTasks(new Breadcrumb("Foo"), NoopLogger.INSTANCE);
+        Breadcrumb crumb = new Breadcrumb("Foo", NoopLogger.INSTANCE);
+        config.runOnBreadcrumbTasks(crumb, NoopLogger.INSTANCE);
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -92,10 +92,10 @@ internal class DeliveryDelegateTest {
         val breadcrumb = breadcrumbState.store.peek()
         assertEquals(BreadcrumbType.ERROR, breadcrumb.type)
         assertEquals("java.lang.RuntimeException", breadcrumb.message)
-        assertEquals("java.lang.RuntimeException", breadcrumb.metadata["errorClass"])
-        assertEquals("Whoops!", breadcrumb.metadata["message"])
-        assertEquals("true", breadcrumb.metadata["unhandled"])
-        assertEquals("ERROR", breadcrumb.metadata["severity"])
+        assertEquals("java.lang.RuntimeException", breadcrumb.metadata!!["errorClass"])
+        assertEquals("Whoops!", breadcrumb.metadata!!["message"])
+        assertEquals("true", breadcrumb.metadata!!["unhandled"])
+        assertEquals("ERROR", breadcrumb.metadata!!["severity"])
     }
 
     private class InterceptingLogger : Logger {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventRedactionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventRedactionTest.kt
@@ -24,7 +24,7 @@ internal class EventRedactionTest {
         event.addMetadata("device", "password", "bar")
         event.impl.metadata.addMetadata("baz", "password", "hunter2")
         val metadata = mutableMapOf<String, Any?>(Pair("password", "whoops"))
-        event.breadcrumbs = listOf(Breadcrumb("Whoops", BreadcrumbType.LOG, metadata, Date(0)))
+        event.breadcrumbs = listOf(Breadcrumb("Whoops", BreadcrumbType.LOG, metadata, Date(0), NoopLogger))
         event.threads.clear()
 
         val writer = StringWriter()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -49,7 +49,7 @@ internal class EventSerializationTest {
                     it.addMetadata("wham", "some_key", "A value")
                     it.setUser(null, null, "Jamie")
 
-                    val crumb = Breadcrumb("hello world", BreadcrumbType.MANUAL, mutableMapOf(), Date(0))
+                    val crumb = Breadcrumb("hello world", BreadcrumbType.MANUAL, mutableMapOf(), Date(0), NoopLogger)
                     it.breadcrumbs = listOf(crumb)
 
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JsonStreamTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JsonStreamTest.kt
@@ -41,7 +41,7 @@ class JsonStreamTest {
     fun testSaneValues() {
         val writer = StringWriter()
         val stream = JsonStream(writer)
-        val breadcrumb = Breadcrumb("whoops", BreadcrumbType.LOG, mutableMapOf(), Date(0))
+        val breadcrumb = Breadcrumb("whoops", BreadcrumbType.LOG, mutableMapOf(), Date(0), NoopLogger)
 
         stream.beginObject()
         stream.name("bool").value(true)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -115,7 +115,7 @@ internal class NativeInterfaceApiTest {
 
     @Test
     fun getBreadcrumbs() {
-        val breadcrumbs = listOf(Breadcrumb("Whoops"))
+        val breadcrumbs = listOf(Breadcrumb("Whoops", NoopLogger))
         `when`(client.breadcrumbs).thenReturn(breadcrumbs)
         assertEquals(breadcrumbs[0], NativeInterface.getBreadcrumbs()[0])
     }


### PR DESCRIPTION
## Goal

Logs a warning when null values are supplied to Breadcrumb, rather than throwing an exception.

## Changeset

It may be easier to review the first two commits in isolation. The first implements code changes, whereas the second implements docs changes.

- Renamed `Breadcrumb.kt` to `BreadcrumbImpl.kt` and made it non-public
- Added `Breadcrumb.java` which uses the [decorator pattern](https://en.wikipedia.org/wiki/Decorator_pattern) on a `BreadcrumbImpl` field and acts as the public interface
- If a null value is passed to a non-null config option, a warning is now logged
- Moved code documentation to `Breadcrumb.java`
- Updated existing code to match nullability of latest version of notifier spec and to pass tests
- Passed in `logger` as required to `Breadcrumb` constructor
- Updated breadcrumb properties to be mutable on `Breadcrumb.kt`

## Tests

Added unit tests to verify that the correct method on `BreadcrumbImpl` is invoked when a valid value is set, and that a warning message is logged when null is passed.
