### PR TITLE
Log a warning when null values are supplied to Thread, rather than throwing an exception

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -29,7 +29,7 @@ class ManifestConfigLoaderTest {
             // detection
             assertTrue(autoDetectErrors)
             assertTrue(autoTrackSessions)
-            assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
+            assertEquals(ThreadSendPolicy.ALWAYS, sendThreads)
             assertFalse(persistUser)
 
             // endpoints
@@ -95,7 +95,7 @@ class ManifestConfigLoaderTest {
             // detection
             assertFalse(autoDetectErrors)
             assertFalse(autoTrackSessions)
-            assertEquals(Thread.ThreadSendPolicy.UNHANDLED_ONLY, sendThreads)
+            assertEquals(ThreadSendPolicy.UNHANDLED_ONLY, sendThreads)
             assertTrue(persistUser)
 
             // endpoints

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadTest.java
@@ -29,7 +29,8 @@ public class ThreadTest {
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
         Stacktrace trace = new Stacktrace(stacktrace, Collections.<String>emptyList(),
                 NoopLogger.INSTANCE);
-        Thread thread = new Thread(24, "main-one", Thread.Type.ANDROID, true, trace);
+        Thread thread = new Thread(24, "main-one", ThreadType.ANDROID, true, trace,
+                NoopLogger.INSTANCE);
         JSONObject result = streamableToJson(thread);
         assertEquals(24, result.getLong("id"));
         assertEquals("main-one", result.getString("name"));
@@ -60,7 +61,8 @@ public class ThreadTest {
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
         Stacktrace trace = new Stacktrace(stacktrace, Collections.<String>emptyList(),
                 NoopLogger.INSTANCE);
-        Thread thread = new Thread(24, "main-one", Thread.Type.ANDROID,false, trace);
+        Thread thread = new Thread(24, "main-one", ThreadType.ANDROID,false, trace,
+                NoopLogger.INSTANCE);
         JSONObject result = streamableToJson(thread);
         assertEquals(24, result.getLong("id"));
         assertEquals("main-one", result.getString("name"));

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -17,7 +17,7 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     var appVersion: String? = null
     var versionCode: Int? = 0
     var releaseStage: String? = null
-    var sendThreads: Thread.ThreadSendPolicy = Thread.ThreadSendPolicy.ALWAYS
+    var sendThreads: ThreadSendPolicy = ThreadSendPolicy.ALWAYS
     var persistUser: Boolean = false
 
     var launchCrashThresholdMs: Long = DEFAULT_LAUNCH_CRASH_THRESHOLD_MS

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -168,7 +168,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
      * to only do so for unhandled errors.
      */
     @NonNull
-    public Thread.ThreadSendPolicy getSendThreads() {
+    public ThreadSendPolicy getSendThreads() {
         return impl.getSendThreads();
     }
 
@@ -180,7 +180,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
      * Thread.ThreadSendPolicy.NEVER to disable or Thread.ThreadSendPolicy.UNHANDLED_ONLY
      * to only do so for unhandled errors.
      */
-    public void setSendThreads(@NonNull Thread.ThreadSendPolicy sendThreads) {
+    public void setSendThreads(@NonNull ThreadSendPolicy sendThreads) {
         if (sendThreads != null) {
             impl.setSendThreads(sendThreads);
         } else {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.Thread.ThreadSendPolicy.*
+import com.bugsnag.android.ThreadSendPolicy.*
 import java.io.IOException
 
 internal class EventInternal @JvmOverloads internal constructor(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -11,7 +11,7 @@ internal data class ImmutableConfig(
     val enabledErrorTypes: ErrorTypes,
     val autoDetectErrors: Boolean,
     val autoTrackSessions: Boolean,
-    val sendThreads: Thread.ThreadSendPolicy,
+    val sendThreads: ThreadSendPolicy,
     val discardClasses: Collection<String>,
     val enabledReleaseStages: Collection<String>?,
     val projectPackages: Collection<String>,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -88,7 +88,7 @@ internal class ManifestConfigLoader {
             val str = data.getString(SEND_THREADS)
 
             if (str != null) {
-                sendThreads = Thread.ThreadSendPolicy.fromString(str)
+                sendThreads = ThreadSendPolicy.fromString(str)
             }
         }
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -1,0 +1,74 @@
+package com.bugsnag.android;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+
+@SuppressWarnings("ConstantConditions")
+public class Thread implements JsonStream.Streamable {
+
+    private final ThreadImpl impl;
+    private final Logger logger;
+
+    Thread(
+            long id,
+            @NonNull String name,
+            @NonNull ThreadType type,
+            boolean errorReportingThread,
+            @NonNull Stacktrace stacktrace,
+            @NonNull Logger logger) {
+        this.impl = new ThreadImpl(id, name, type, errorReportingThread, stacktrace);
+        this.logger = logger;
+    }
+
+    private void error(String property) {
+        logger.e("Invalid null value supplied to thread." + property + ", ignoring");
+    }
+
+    public void setId(long id) {
+        impl.setId(id);
+    }
+
+    public long getId() {
+        return impl.getId();
+    }
+
+    public void setName(@NonNull String name) {
+        if (name != null) {
+            impl.setName(name);
+        } else {
+            error("name");
+        }
+    }
+
+    @NonNull
+    public String getName() {
+        return impl.getName();
+    }
+
+    public void setType(@NonNull ThreadType type) {
+        if (type != null) {
+            impl.setType(type);
+        } else {
+            error("type");
+        }
+    }
+
+    @NonNull
+    public ThreadType getType() {
+        return impl.getType();
+    }
+
+    public void setErrorReportingThread(boolean errorReportingThread) {
+        impl.setErrorReportingThread(errorReportingThread);
+    }
+
+    public boolean getErrorReportingThread() {
+        return impl.isErrorReportingThread();
+    }
+
+    @Override
+    public void toStream(@NonNull JsonStream stream) throws IOException {
+        impl.toStream(stream);
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -11,7 +11,7 @@ import java.util.List;
 @SuppressWarnings("ConstantConditions")
 public class Thread implements JsonStream.Streamable {
 
-    private final ThreadImpl impl;
+    private final ThreadInternal impl;
     private final Logger logger;
 
     Thread(
@@ -21,11 +21,11 @@ public class Thread implements JsonStream.Streamable {
             boolean errorReportingThread,
             @NonNull Stacktrace stacktrace,
             @NonNull Logger logger) {
-        this.impl = new ThreadImpl(id, name, type, errorReportingThread, stacktrace);
+        this.impl = new ThreadInternal(id, name, type, errorReportingThread, stacktrace);
         this.logger = logger;
     }
 
-    private void error(String property) {
+    private void logNull(String property) {
         logger.e("Invalid null value supplied to thread." + property + ", ignoring");
     }
 
@@ -50,7 +50,7 @@ public class Thread implements JsonStream.Streamable {
         if (name != null) {
             impl.setName(name);
         } else {
-            error("name");
+            logNull("name");
         }
     }
 
@@ -69,7 +69,7 @@ public class Thread implements JsonStream.Streamable {
         if (type != null) {
             impl.setType(type);
         } else {
-            error("type");
+            logNull("type");
         }
     }
 
@@ -99,10 +99,10 @@ public class Thread implements JsonStream.Streamable {
      * Sets a representation of the thread's stacktrace
      */
     public void setStacktrace(@NonNull List<Stackframe> stacktrace) {
-        if (stacktrace != null) {
+        if (!CollectionUtils.containsNullElements(stacktrace)) {
             impl.setStacktrace(stacktrace);
         } else {
-            error("stacktrace");
+            logNull("stacktrace");
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import androidx.annotation.NonNull;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * A representation of a thread recorded in an {@link Event}
@@ -92,6 +93,25 @@ public class Thread implements JsonStream.Streamable {
      */
     public boolean getErrorReportingThread() {
         return impl.isErrorReportingThread();
+    }
+
+    /**
+     * Sets a representation of the thread's stacktrace
+     */
+    public void setStacktrace(@NonNull List<Stackframe> stacktrace) {
+        if (stacktrace != null) {
+            impl.setStacktrace(stacktrace);
+        } else {
+            error("stacktrace");
+        }
+    }
+
+    /**
+     * Gets a representation of the thread's stacktrace
+     */
+    @NonNull
+    public List<Stackframe> getStacktrace() {
+        return impl.getStacktrace();
     }
 
     @Override

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -4,6 +4,9 @@ import androidx.annotation.NonNull;
 
 import java.io.IOException;
 
+/**
+ * A representation of a thread recorded in an {@link Event}
+ */
 @SuppressWarnings("ConstantConditions")
 public class Thread implements JsonStream.Streamable {
 
@@ -25,14 +28,23 @@ public class Thread implements JsonStream.Streamable {
         logger.e("Invalid null value supplied to thread." + property + ", ignoring");
     }
 
+    /**
+     * Sets the unique ID of the thread (from {@link java.lang.Thread})
+     */
     public void setId(long id) {
         impl.setId(id);
     }
 
+    /**
+     * Gets the unique ID of the thread (from {@link java.lang.Thread})
+     */
     public long getId() {
         return impl.getId();
     }
 
+    /**
+     * Sets the name of the thread (from {@link java.lang.Thread})
+     */
     public void setName(@NonNull String name) {
         if (name != null) {
             impl.setName(name);
@@ -41,11 +53,17 @@ public class Thread implements JsonStream.Streamable {
         }
     }
 
+    /**
+     * Gets the name of the thread (from {@link java.lang.Thread})
+     */
     @NonNull
     public String getName() {
         return impl.getName();
     }
 
+    /**
+     * Sets the type of thread based on the originating platform (intended for internal use only)
+     */
     public void setType(@NonNull ThreadType type) {
         if (type != null) {
             impl.setType(type);
@@ -54,15 +72,24 @@ public class Thread implements JsonStream.Streamable {
         }
     }
 
+    /**
+     * Gets the type of thread based on the originating platform (intended for internal use only)
+     */
     @NonNull
     public ThreadType getType() {
         return impl.getType();
     }
 
+    /**
+     * Sets whether the thread was the thread that caused the event
+     */
     public void setErrorReportingThread(boolean errorReportingThread) {
         impl.setErrorReportingThread(errorReportingThread);
     }
 
+    /**
+     * Gets whether the thread was the thread that caused the event
+     */
     public boolean getErrorReportingThread() {
         return impl.isErrorReportingThread();
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadImpl.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadImpl.kt
@@ -10,9 +10,6 @@ class ThreadImpl internal constructor(
     stacktrace: Stacktrace
 ) : JsonStream.Streamable {
 
-    /**
-     * A representation of the thread's stacktrace
-     */
     var stacktrace: MutableList<Stackframe> = stacktrace.trace.toMutableList()
 
     @Throws(IOException::class)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadImpl.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadImpl.kt
@@ -2,29 +2,10 @@ package com.bugsnag.android
 
 import java.io.IOException
 
-/**
- * A representation of a thread recorded in an [Event]
- */
 class ThreadImpl internal constructor(
-
-    /**
-     * The unique ID of the thread (from [java.lang.Thread])
-     */
     var id: Long,
-
-    /**
-     * The name of the thread (from [java.lang.Thread])
-     */
     var name: String,
-
-    /**
-     * The type of thread based on the originating platform (intended for internal use only)
-     */
     var type: ThreadType,
-
-    /**
-     * Whether the thread was the thread that caused the event
-     */
     var isErrorReportingThread: Boolean,
     stacktrace: Stacktrace
 ) : JsonStream.Streamable {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadImpl.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadImpl.kt
@@ -5,71 +5,29 @@ import java.io.IOException
 /**
  * A representation of a thread recorded in an [Event]
  */
-class Thread internal constructor(
+class ThreadImpl internal constructor(
 
     /**
      * The unique ID of the thread (from [java.lang.Thread])
      */
-    val id: Long,
+    var id: Long,
 
     /**
      * The name of the thread (from [java.lang.Thread])
      */
-    val name: String,
+    var name: String,
 
     /**
      * The type of thread based on the originating platform (intended for internal use only)
      */
-    val type: Type,
+    var type: ThreadType,
 
     /**
      * Whether the thread was the thread that caused the event
      */
-    val isErrorReportingThread: Boolean,
+    var isErrorReportingThread: Boolean,
     stacktrace: Stacktrace
 ) : JsonStream.Streamable {
-
-    /**
-     * Represents the type of thread captured
-     */
-    enum class Type(internal val desc: String) {
-
-        /**
-         * A thread captured from Android's JVM layer
-         */
-        ANDROID("android"),
-
-        /**
-         * A thread captured from JavaScript
-         */
-        BROWSER_JS("browserjs")
-    }
-
-    /**
-     * Controls whether we should capture and serialize the state of all threads at the time
-     * of an error.
-     */
-    enum class ThreadSendPolicy {
-
-        /**
-         * Threads should be captured for all events.
-         */
-        ALWAYS,
-
-        /**
-         * Threads should be captured for unhandled events only.
-         */
-        UNHANDLED_ONLY,
-
-        /**
-         * Threads should never be captured.
-         */
-        NEVER;
-
-        internal companion object {
-            fun fromString(str: String) = values().find { it.name == str } ?: ALWAYS
-        }
-    }
 
     /**
      * A representation of the thread's stacktrace

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -2,7 +2,7 @@ package com.bugsnag.android
 
 import java.io.IOException
 
-class ThreadImpl internal constructor(
+class ThreadInternal internal constructor(
     var id: Long,
     var name: String,
     var type: ThreadType,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadSendPolicy.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadSendPolicy.kt
@@ -1,0 +1,27 @@
+package com.bugsnag.android
+
+/**
+ * Controls whether we should capture and serialize the state of all threads at the time
+ * of an error.
+ */
+enum class ThreadSendPolicy {
+
+    /**
+     * Threads should be captured for all events.
+     */
+    ALWAYS,
+
+    /**
+     * Threads should be captured for unhandled events only.
+     */
+    UNHANDLED_ONLY,
+
+    /**
+     * Threads should never be captured.
+     */
+    NEVER;
+
+    internal companion object {
+        fun fromString(str: String) = values().find { it.name == str } ?: ALWAYS
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -31,7 +31,7 @@ internal class ThreadState @JvmOverloads constructor
             .sortedBy { it.id }
             .map {
                 val stacktrace = Stacktrace(stackTraces[it]!!, config.projectPackages, logger)
-                Thread(it.id, it.name, Thread.Type.ANDROID, it.id == currentThreadId, stacktrace)
+                Thread(it.id, it.name, ThreadType.ANDROID, it.id == currentThreadId, stacktrace, logger)
             }.toMutableList()
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadType.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadType.kt
@@ -1,0 +1,17 @@
+package com.bugsnag.android
+
+/**
+ * Represents the type of thread captured
+ */
+enum class ThreadType(internal val desc: String) {
+
+    /**
+     * A thread captured from Android's JVM layer
+     */
+    ANDROID("android"),
+
+    /**
+     * A thread captured from JavaScript
+     */
+    BROWSER_JS("browserjs")
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
@@ -79,14 +79,14 @@ public class ConfigurationFacadeTest {
 
     @Test
     public void sendThreadsValid() {
-        config.setSendThreads(Thread.ThreadSendPolicy.UNHANDLED_ONLY);
-        assertEquals(Thread.ThreadSendPolicy.UNHANDLED_ONLY, config.impl.getSendThreads());
+        config.setSendThreads(ThreadSendPolicy.UNHANDLED_ONLY);
+        assertEquals(ThreadSendPolicy.UNHANDLED_ONLY, config.impl.getSendThreads());
     }
 
     @Test
     public void sendThreadsInvalid() {
         config.setSendThreads(null);
-        assertEquals(Thread.ThreadSendPolicy.ALWAYS, config.impl.getSendThreads());
+        assertEquals(ThreadSendPolicy.ALWAYS, config.impl.getSendThreads());
         assertNotNull(logger.getMsg());
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -39,7 +39,7 @@ internal class EventSerializationTest {
                 createEvent {
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
                     it.threads.clear()
-                    it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, stacktrace))
+                    it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, stacktrace, NoopLogger))
                 },
 
                 // threads included

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -39,7 +39,7 @@ internal class EventSerializationTest {
                 createEvent {
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
                     it.threads.clear()
-                    it.threads.add(Thread(5, "main", Thread.Type.ANDROID, true, stacktrace))
+                    it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, stacktrace))
                 },
 
                 // threads included

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -52,7 +52,7 @@ internal class ImmutableConfigTest {
             assertTrue(enabledErrorTypes.unhandledExceptions)
             assertTrue(enabledErrorTypes.anrs)
             assertFalse(enabledErrorTypes.ndkCrashes)
-            assertEquals(Thread.ThreadSendPolicy.ALWAYS, sendThreads)
+            assertEquals(ThreadSendPolicy.ALWAYS, sendThreads)
 
             // release stages
             assertTrue(discardClasses.isEmpty())
@@ -85,7 +85,7 @@ internal class ImmutableConfigTest {
         seed.enabledErrorTypes.unhandledExceptions = false
         seed.enabledErrorTypes.anrs = false
         seed.enabledErrorTypes.ndkCrashes = true
-        seed.sendThreads = Thread.ThreadSendPolicy.UNHANDLED_ONLY
+        seed.sendThreads = ThreadSendPolicy.UNHANDLED_ONLY
 
         seed.discardClasses = setOf("foo")
         seed.enabledReleaseStages = setOf("bar")
@@ -114,7 +114,7 @@ internal class ImmutableConfigTest {
             assertFalse(enabledErrorTypes.unhandledExceptions)
             assertFalse(enabledErrorTypes.anrs)
             assertTrue(enabledErrorTypes.ndkCrashes)
-            assertEquals(Thread.ThreadSendPolicy.UNHANDLED_ONLY, sendThreads)
+            assertEquals(ThreadSendPolicy.UNHANDLED_ONLY, sendThreads)
 
             // release stages
             assertEquals(setOf("foo"), discardClasses)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -17,6 +17,7 @@ public class ThreadFacadeTest {
 
     private Thread thread;
     private InterceptingLogger logger;
+    private Stacktrace stacktrace;
 
     /**
      * Constructs a Thread wrapper object
@@ -24,8 +25,8 @@ public class ThreadFacadeTest {
     @Before
     public void setUp() {
         logger = new InterceptingLogger();
-        List<Map<String, Object>> frames = Collections.<Map<String, Object>>emptyList();
-        Stacktrace stacktrace = new Stacktrace(frames, logger);
+        List<Map<String, Object>> frames = Collections.emptyList();
+        stacktrace = new Stacktrace(frames, logger);
         thread = new Thread(1, "thread-2", ThreadType.ANDROID, false, stacktrace, logger);
     }
 
@@ -71,5 +72,22 @@ public class ThreadFacadeTest {
         assertFalse(thread.getErrorReportingThread());
         thread.setErrorReportingThread(true);
         assertTrue(thread.getErrorReportingThread());
+    }
+
+    @Test
+    public void stacktraceValid() {
+        assertEquals(stacktrace.getTrace(), thread.getStacktrace());
+        List<Map<String, Object>> frames = Collections.emptyList();
+        Stacktrace other = new Stacktrace(frames, logger);
+        thread.setStacktrace(other.getTrace());
+        assertEquals(other.getTrace(), thread.getStacktrace());
+    }
+
+    @Test
+    public void stacktraceInvalid() {
+        assertEquals(stacktrace.getTrace(), thread.getStacktrace());
+        thread.setStacktrace(null);
+        assertEquals(stacktrace.getTrace(), thread.getStacktrace());
+        assertNotNull(logger.getMsg());
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -1,0 +1,75 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("ConstantConditions")
+public class ThreadFacadeTest {
+
+    private Thread thread;
+    private InterceptingLogger logger;
+
+    /**
+     * Constructs a Thread wrapper object
+     */
+    @Before
+    public void setUp() {
+        logger = new InterceptingLogger();
+        List<Map<String, Object>> frames = Collections.<Map<String, Object>>emptyList();
+        Stacktrace stacktrace = new Stacktrace(frames, logger);
+        thread = new Thread(1, "thread-2", ThreadType.ANDROID, false, stacktrace, logger);
+    }
+
+    @Test
+    public void idValid() {
+        assertEquals(1, thread.getId());
+        thread.setId(55);
+        assertEquals(55, thread.getId());
+    }
+
+    @Test
+    public void nameValid() {
+        assertEquals("thread-2", thread.getName());
+        thread.setName("foo");
+        assertEquals("foo", thread.getName());
+    }
+
+    @Test
+    public void nameInvalid() {
+        assertEquals("thread-2", thread.getName());
+        thread.setName(null);
+        assertEquals("thread-2", thread.getName());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void typeValid() {
+        assertEquals(ThreadType.ANDROID, thread.getType());
+        thread.setType(ThreadType.BROWSER_JS);
+        assertEquals(ThreadType.BROWSER_JS, thread.getType());
+    }
+
+    @Test
+    public void typeInvalid() {
+        assertEquals(ThreadType.ANDROID, thread.getType());
+        thread.setType(null);
+        assertEquals(ThreadType.ANDROID, thread.getType());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void errorReportingThreadValid() {
+        assertFalse(thread.getErrorReportingThread());
+        thread.setErrorReportingThread(true);
+        assertTrue(thread.getErrorReportingThread());
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSendPolicyTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSendPolicyTest.kt
@@ -1,9 +1,8 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.Thread.ThreadSendPolicy
-import com.bugsnag.android.Thread.ThreadSendPolicy.ALWAYS
-import com.bugsnag.android.Thread.ThreadSendPolicy.NEVER
-import com.bugsnag.android.Thread.ThreadSendPolicy.UNHANDLED_ONLY
+import com.bugsnag.android.ThreadSendPolicy.ALWAYS
+import com.bugsnag.android.ThreadSendPolicy.NEVER
+import com.bugsnag.android.ThreadSendPolicy.UNHANDLED_ONLY
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
@@ -19,11 +19,11 @@ internal class ThreadSerializationTest {
                 StackTraceElement("App", "launch", "App.java", 70)
             )
 
-            val thread = Thread(24, "main-one", Thread.Type.ANDROID, true, Stacktrace(
+            val thread = Thread(24, "main-one", ThreadType.ANDROID, true, Stacktrace(
                 stacktrace,
                 emptySet(),
                 NoopLogger
-            ))
+            ), NoopLogger)
 
             val stacktrace1 = arrayOf(
                 StackTraceElement("", "run_func", "librunner.so", 5038),
@@ -31,11 +31,11 @@ internal class ThreadSerializationTest {
                 StackTraceElement("App", "launch", "App.java", 70)
             )
 
-            val thread1 = Thread(24, "main-one", Thread.Type.ANDROID, false, Stacktrace(
+            val thread1 = Thread(24, "main-one", ThreadType.ANDROID, false, Stacktrace(
                 stacktrace1,
                 emptySet(),
                 NoopLogger
-            ))
+            ), NoopLogger)
             return generateSerializationTestCases("thread", thread, thread1)
         }
     }


### PR DESCRIPTION
## Goal

Logs a warning when null values are supplied to Thread, rather than throwing an exception.

## Changeset

It may be easier to review the first two commits in isolation. The first implements code changes, whereas the second implements docs changes.

- Renamed `Thread.kt` to `ThreadImpl.kt` and made it non-public
- Added `Thread.java` which uses the [decorator pattern](https://en.wikipedia.org/wiki/Decorator_pattern) on a `BreadcrumbImpl` field and acts as the public interface
- If a null value is passed to a non-null config option, a warning is now logged
- Moved code documentation to `Thread.java`
- Updated existing code to match nullability of latest version of notifier spec and to pass tests
- Passed in `logger` as required to `Thread` constructor
- Updated properties to be mutable on `Thread.kt`
- Moved `Thread.Type` and `Thread.ThreadSendPolicy` to live in separate Kotlin files, renamed usages accordingly

## Tests

Added unit tests to verify that the correct method on `BreadcrumbImpl` is invoked when a valid value is set, and that a warning message is logged when null is passed.
