### PR TITLE
Log a warning when null values are supplied to Error, rather than throwing an exception

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
@@ -1,0 +1,76 @@
+package com.bugsnag.android;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+@SuppressWarnings("ConstantConditions")
+public class Error implements JsonStream.Streamable {
+
+    private final ErrorImpl impl;
+    private final Logger logger;
+
+    Error(@NonNull ErrorImpl impl,
+          @NonNull Logger logger) {
+        this.impl = impl;
+        this.logger = logger;
+    }
+
+    private void error(String property) {
+        logger.e("Invalid null value supplied to error." + property + ", ignoring");
+    }
+
+    public void setErrorClass(@NonNull String errorClass) {
+        if (errorClass != null) {
+            impl.setErrorClass(errorClass);
+        } else {
+            error("errorClass");
+        }
+    }
+
+    @NonNull
+    public String getErrorClass() {
+        return impl.getErrorClass();
+    }
+
+    public void setErrorMessage(@Nullable String errorMessage) {
+        impl.setErrorMessage(errorMessage);
+    }
+
+    @Nullable
+    public String getErrorMessage() {
+        return impl.getErrorMessage();
+    }
+
+    public void setType(@NonNull ErrorType type) {
+        if (type != null) {
+            impl.setType(type);
+        } else {
+            error("type");
+        }
+    }
+
+    @NonNull
+    public ErrorType getType() {
+        return impl.getType();
+    }
+
+    @NonNull
+    public List<Stackframe> getStacktrace() {
+        return impl.getStacktrace();
+    }
+
+    @Override
+    public void toStream(@NonNull JsonStream stream) throws IOException {
+        impl.toStream(stream);
+    }
+
+    static List<Error> createError(@NonNull Throwable exc,
+                                   @NonNull Collection<String> projectPackages,
+                                   @NonNull Logger logger) {
+        return ErrorImpl.Companion.createError(exc, projectPackages, logger);
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
@@ -7,6 +7,10 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+
+/**
+ * An Error represents information extracted from a {@link Throwable}.
+ */
 @SuppressWarnings("ConstantConditions")
 public class Error implements JsonStream.Streamable {
 
@@ -23,6 +27,9 @@ public class Error implements JsonStream.Streamable {
         logger.e("Invalid null value supplied to error." + property + ", ignoring");
     }
 
+    /**
+     * Sets the fully-qualified class name of the {@link Throwable}
+     */
     public void setErrorClass(@NonNull String errorClass) {
         if (errorClass != null) {
             impl.setErrorClass(errorClass);
@@ -31,20 +38,32 @@ public class Error implements JsonStream.Streamable {
         }
     }
 
+    /**
+     * Gets the fully-qualified class name of the {@link Throwable}
+     */
     @NonNull
     public String getErrorClass() {
         return impl.getErrorClass();
     }
 
+    /**
+     * The message string from the {@link Throwable}
+     */
     public void setErrorMessage(@Nullable String errorMessage) {
         impl.setErrorMessage(errorMessage);
     }
 
+    /**
+     * The message string from the {@link Throwable}
+     */
     @Nullable
     public String getErrorMessage() {
         return impl.getErrorMessage();
     }
 
+    /**
+     * Sets the type of error based on the originating platform (intended for internal use only)
+     */
     public void setType(@NonNull ErrorType type) {
         if (type != null) {
             impl.setType(type);
@@ -53,11 +72,17 @@ public class Error implements JsonStream.Streamable {
         }
     }
 
+    /**
+     * Sets the type of error based on the originating platform (intended for internal use only)
+     */
     @NonNull
     public ErrorType getType() {
         return impl.getType();
     }
 
+    /**
+     * Gets a representation of the stacktrace
+     */
     @NonNull
     public List<Stackframe> getStacktrace() {
         return impl.getStacktrace();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
@@ -14,16 +14,16 @@ import java.util.List;
 @SuppressWarnings("ConstantConditions")
 public class Error implements JsonStream.Streamable {
 
-    private final ErrorImpl impl;
+    private final ErrorInternal impl;
     private final Logger logger;
 
-    Error(@NonNull ErrorImpl impl,
+    Error(@NonNull ErrorInternal impl,
           @NonNull Logger logger) {
         this.impl = impl;
         this.logger = logger;
     }
 
-    private void error(String property) {
+    private void logNull(String property) {
         logger.e("Invalid null value supplied to error." + property + ", ignoring");
     }
 
@@ -34,7 +34,7 @@ public class Error implements JsonStream.Streamable {
         if (errorClass != null) {
             impl.setErrorClass(errorClass);
         } else {
-            error("errorClass");
+            logNull("errorClass");
         }
     }
 
@@ -68,7 +68,7 @@ public class Error implements JsonStream.Streamable {
         if (type != null) {
             impl.setType(type);
         } else {
-            error("type");
+            logNull("type");
         }
     }
 
@@ -96,6 +96,6 @@ public class Error implements JsonStream.Streamable {
     static List<Error> createError(@NonNull Throwable exc,
                                    @NonNull Collection<String> projectPackages,
                                    @NonNull Logger logger) {
-        return ErrorImpl.Companion.createError(exc, projectPackages, logger);
+        return ErrorInternal.Companion.createError(exc, projectPackages, logger);
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorImpl.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorImpl.kt
@@ -1,28 +1,9 @@
 package com.bugsnag.android
 
-/**
- * An [Error] represents information extracted from a [Throwable].
- */
 internal class ErrorImpl @JvmOverloads internal constructor(
-
-    /**
-     * The fully-qualified class name of the [Throwable]
-     */
     var errorClass: String,
-
-    /**
-     * The message string from the [Throwable]
-     */
     var errorMessage: String?,
-
-    /**
-     * A representation of the stacktrace
-     */
     val stacktrace: List<Stackframe>,
-
-    /**
-     * The type of error based on the originating platform (intended for internal use only)
-     */
     var type: ErrorType = ErrorType.ANDROID
 ): JsonStream.Streamable {
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorImpl.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorImpl.kt
@@ -3,7 +3,7 @@ package com.bugsnag.android
 /**
  * An [Error] represents information extracted from a [Throwable].
  */
-class Error @JvmOverloads internal constructor(
+internal class ErrorImpl @JvmOverloads internal constructor(
 
     /**
      * The fully-qualified class name of the [Throwable]
@@ -18,46 +18,25 @@ class Error @JvmOverloads internal constructor(
     /**
      * A representation of the stacktrace
      */
-    var stacktrace: List<Stackframe>,
+    val stacktrace: List<Stackframe>,
 
     /**
      * The type of error based on the originating platform (intended for internal use only)
      */
-    var type: Type = Type.ANDROID
+    var type: ErrorType = ErrorType.ANDROID
 ): JsonStream.Streamable {
-
-    /**
-     * Represents the type of error captured
-     */
-    enum class Type(internal val desc: String) {
-
-        /**
-         * An error captured from Android's JVM layer
-         */
-        ANDROID("android"),
-
-        /**
-         * An error captured from JavaScript
-         */
-        BROWSER_JS("browserjs"),
-
-        /**
-         * An error captured from Android's C layer
-         */
-        C("c")
-    }
 
     internal companion object {
         fun createError(exc: Throwable, projectPackages: Collection<String>, logger: Logger): MutableList<Error> {
-            val errors = mutableListOf<Error>()
+            val errors = mutableListOf<ErrorImpl>()
 
             var currentEx: Throwable? = exc
             while (currentEx != null) {
                 val trace = Stacktrace(currentEx.stackTrace, projectPackages, logger)
-                errors.add(Error(currentEx.javaClass.name, currentEx.localizedMessage, trace.trace))
+                errors.add(ErrorImpl(currentEx.javaClass.name, currentEx.localizedMessage, trace.trace))
                 currentEx = currentEx.cause
             }
-            return errors
+            return errors.map { Error(it, logger) }.toMutableList()
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-internal class ErrorImpl @JvmOverloads internal constructor(
+internal class ErrorInternal @JvmOverloads internal constructor(
     var errorClass: String,
     var errorMessage: String?,
     val stacktrace: List<Stackframe>,
@@ -9,12 +9,12 @@ internal class ErrorImpl @JvmOverloads internal constructor(
 
     internal companion object {
         fun createError(exc: Throwable, projectPackages: Collection<String>, logger: Logger): MutableList<Error> {
-            val errors = mutableListOf<ErrorImpl>()
+            val errors = mutableListOf<ErrorInternal>()
 
             var currentEx: Throwable? = exc
             while (currentEx != null) {
                 val trace = Stacktrace(currentEx.stackTrace, projectPackages, logger)
-                errors.add(ErrorImpl(currentEx.javaClass.name, currentEx.localizedMessage, trace.trace))
+                errors.add(ErrorInternal(currentEx.javaClass.name, currentEx.localizedMessage, trace.trace))
                 currentEx = currentEx.cause
             }
             return errors.map { Error(it, logger) }.toMutableList()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorType.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorType.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android
+
+/**
+ * Represents the type of error captured
+ */
+enum class ErrorType(internal val desc: String) {
+
+    /**
+     * An error captured from Android's JVM layer
+     */
+    ANDROID("android"),
+
+    /**
+     * An error captured from JavaScript
+     */
+    BROWSER_JS("browserjs"),
+
+    /**
+     * An error captured from Android's C layer
+     */
+    C("c")
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -365,7 +365,7 @@ public class NativeInterface {
                     errors.get(0).setErrorMessage(message);
 
                     for (Error error : errors) {
-                        error.setType(Error.Type.C);
+                        error.setType(ErrorType.C);
                     }
                 }
                 return true;

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -1,0 +1,75 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+@SuppressWarnings("ConstantConditions")
+public class ErrorFacadeTest {
+
+    private InterceptingLogger logger;
+    private Error error;
+    private List<Stackframe> trace;
+
+    /**
+     * Sets up an error object
+     */
+    @Before
+    public void setUp() {
+        logger = new InterceptingLogger();
+        trace = Collections.emptyList();
+        ErrorImpl impl = new ErrorImpl("com.bar.CrashyClass", "Whoops", trace, ErrorType.ANDROID);
+        error = new Error(impl, logger);
+    }
+
+    @Test
+    public void errorClassValid() {
+        assertEquals("com.bar.CrashyClass", error.getErrorClass());
+        error.setErrorClass("com.Foo");
+        assertEquals("com.Foo", error.getErrorClass());
+    }
+
+    @Test
+    public void errorClassInvalid() {
+        assertEquals("com.bar.CrashyClass", error.getErrorClass());
+        error.setErrorClass(null);
+        assertEquals("com.bar.CrashyClass", error.getErrorClass());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void errorMessageValid() {
+        assertEquals("Whoops", error.getErrorMessage());
+        error.setErrorMessage("Oh dear oh dear");
+        assertEquals("Oh dear oh dear", error.getErrorMessage());
+
+        error.setErrorMessage(null);
+        assertNull(error.getErrorMessage());
+    }
+
+    @Test
+    public void typeValid() {
+        assertEquals(ErrorType.ANDROID, error.getType());
+        error.setType(ErrorType.BROWSER_JS);
+        assertEquals(ErrorType.BROWSER_JS, error.getType());
+    }
+
+    @Test
+    public void typeInvalid() {
+        assertEquals(ErrorType.ANDROID, error.getType());
+        error.setType(null);
+        assertEquals(ErrorType.ANDROID, error.getType());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void stacktraceValid() {
+        assertEquals(trace, error.getStacktrace());
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -24,7 +24,8 @@ public class ErrorFacadeTest {
     public void setUp() {
         logger = new InterceptingLogger();
         trace = Collections.emptyList();
-        ErrorImpl impl = new ErrorImpl("com.bar.CrashyClass", "Whoops", trace, ErrorType.ANDROID);
+        ErrorInternal impl = new ErrorInternal("com.bar.CrashyClass",
+                "Whoops", trace, ErrorType.ANDROID);
         error = new Error(impl, logger);
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
@@ -14,7 +14,7 @@ internal class ErrorSerializationTest {
         @Parameters
         fun testCases() = generateSerializationTestCases(
             "error",
-            Error("foo", "bar", listOf())
+            Error(ErrorImpl("foo", "bar", listOf()), NoopLogger)
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
@@ -14,7 +14,7 @@ internal class ErrorSerializationTest {
         @Parameters
         fun testCases() = generateSerializationTestCases(
             "error",
-            Error(ErrorImpl("foo", "bar", listOf()), NoopLogger)
+            Error(ErrorInternal("foo", "bar", listOf()), NoopLogger)
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -53,7 +53,7 @@ internal class EventSerializationTest {
                     it.breadcrumbs = listOf(crumb)
 
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
-                    val err = Error(ErrorImpl("WhoopsException", "Whoops", stacktrace.trace), NoopLogger)
+                    val err = Error(ErrorInternal("WhoopsException", "Whoops", stacktrace.trace), NoopLogger)
                     it.errors.clear()
                     it.errors.add(err)
                 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -53,7 +53,7 @@ internal class EventSerializationTest {
                     it.breadcrumbs = listOf(crumb)
 
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
-                    val err = Error("WhoopsException", "Whoops", stacktrace.trace)
+                    val err = Error(ErrorImpl("WhoopsException", "Whoops", stacktrace.trace), NoopLogger)
                     it.errors.clear()
                     it.errors.add(err)
                 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
@@ -45,8 +45,8 @@ public class NullMetadataTest {
         List<String> projectPackages = Collections.emptyList();
         Stacktrace stacktrace = new Stacktrace(new StackTraceElement[]{}, projectPackages,
                 NoopLogger.INSTANCE);
-        Error err = new Error("RuntimeException", "Something broke",
-                stacktrace.getTrace());
+        Error err = new Error(new ErrorImpl("RuntimeException", "Something broke",
+                stacktrace.getTrace()), NoopLogger.INSTANCE);
         event.getErrors().clear();
         event.getErrors().add(err);
         validateDefaultMetadata(event);

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
@@ -45,7 +45,7 @@ public class NullMetadataTest {
         List<String> projectPackages = Collections.emptyList();
         Stacktrace stacktrace = new Stacktrace(new StackTraceElement[]{}, projectPackages,
                 NoopLogger.INSTANCE);
-        Error err = new Error(new ErrorImpl("RuntimeException", "Something broke",
+        Error err = new Error(new ErrorInternal("RuntimeException", "Something broke",
                 stacktrace.getTrace()), NoopLogger.INSTANCE);
         event.getErrors().clear();
         event.getErrors().add(err);


### PR DESCRIPTION
## Goal

Logs a warning when null values are supplied to Error, rather than throwing an exception.

## Changeset

It may be easier to review the first two commits in isolation. The first implements code changes, whereas the second implements docs changes.

- Renamed `Error.kt` to `ErrorImpl.kt` and made it non-public
- Added `Error.java` which uses the [decorator pattern](https://en.wikipedia.org/wiki/Decorator_pattern) on a `ErrorImpl` field and acts as the public interface
- If a null value is passed to a non-null config option, a warning is now logged
- Moved code documentation to `Error.java`
- Updated existing code to match nullability of latest version of notifier spec and to pass tests
- Passed in `logger` as required to `Error` constructor
- Moved `Error.Type` to its own file

## Tests

Added unit tests to verify that the correct method on `ErrorImpl` is invoked when a valid value is set, and that a warning message is logged when null is passed.
