### PR TITLE
Log a warning when null values are supplied to Session

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -55,7 +55,7 @@ final class BugsnagTestUtils {
     }
 
     static Session generateSession() {
-        return new Session("test", new Date(), new User(), false);
+        return new Session("test", new Date(), new User(), false, NoopLogger.INSTANCE);
     }
 
     static Configuration generateConfiguration() {

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionV1PayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionV1PayloadTest.java
@@ -73,7 +73,7 @@ public class SessionV1PayloadTest {
      */
     @Test
     public void testSessionFromFile() throws Exception {
-        Session payload = new Session(file);
+        Session payload = new Session(file, NoopLogger.INSTANCE);
         payload.setApp(generateApp());
         payload.setDevice(generateDevice());
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionV2PayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionV2PayloadTest.java
@@ -66,7 +66,7 @@ public class SessionV2PayloadTest {
     public void testSessionFromFile() throws Exception {
         sessionStore.write(session);
         List<File> storedFiles = sessionStore.findStoredFiles();
-        Session payload = new Session(storedFiles.get(0));
+        Session payload = new Session(storedFiles.get(0), NoopLogger.INSTANCE);
         JSONObject rootNode = streamableToJson(payload);
         assertNotNull(rootNode);
 
@@ -84,7 +84,7 @@ public class SessionV2PayloadTest {
 
     @Test
     public void testAutoCapturedOverride() throws Exception {
-        session = new Session("id", new Date(), null, false);
+        session = new Session("id", new Date(), null, false, NoopLogger.INSTANCE);
         assertFalse(session.isAutoCaptured());
         session.setAutoCaptured(true);
         assertTrue(session.isAutoCaptured());

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
@@ -59,7 +59,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
         this.logger = logger;
     }
 
-    private void error(String property) {
+    private void logNull(String property) {
         logger.e("Invalid null value supplied to session." + property + ", ignoring");
     }
 
@@ -78,7 +78,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
         if (id != null) {
             this.id = id;
         } else {
-            error("id");
+            logNull("id");
         }
     }
 
@@ -97,7 +97,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
         if (startedAt != null) {
             this.startedAt = startedAt;
         } else {
-            error("startedAt");
+            logNull("startedAt");
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -69,7 +69,8 @@ class SessionTracker extends BaseObservable {
     @VisibleForTesting
     Session startNewSession(@NonNull Date date, @Nullable User user,
                             boolean autoCaptured) {
-        Session session = new Session(UUID.randomUUID().toString(), date, user, autoCaptured);
+        String id = UUID.randomUUID().toString();
+        Session session = new Session(id, date, user, autoCaptured, logger);
         currentSession.set(session);
         trackSessionIfNeeded(session);
         return session;
@@ -128,7 +129,7 @@ class SessionTracker extends BaseObservable {
                                     int handledCount) {
         Session session = null;
         if (date != null && sessionId != null) {
-            session = new Session(sessionId, date, user, unhandledCount, handledCount);
+            session = new Session(sessionId, date, user, unhandledCount, handledCount, logger);
             notifySessionStartObserver(session);
         } else {
             notifyObservers(StateEvent.PauseSession.INSTANCE);
@@ -245,7 +246,7 @@ class SessionTracker extends BaseObservable {
     }
 
     void flushStoredSession(File storedFile) {
-        Session payload = new Session(storedFile);
+        Session payload = new Session(storedFile, logger);
 
         if (!payload.isV2Payload()) { // collect data here
             payload.setApp(client.getAppDataCollector().generateApp());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -28,7 +28,7 @@ internal class DeliveryDelegateTest {
     fun setUp() {
         deliveryDelegate =
             DeliveryDelegate(logger, eventStore, config, breadcrumbState)
-        event.session = Session("123", Date(), User(null, null, null), false)
+        event.session = Session("123", Date(), User(null, null, null), false, NoopLogger)
     }
 
     @Test
@@ -51,7 +51,7 @@ internal class DeliveryDelegateTest {
     fun generateHandledReport() {
         val state = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
         val event = Event(RuntimeException("Whoops!"), config, state, NoopLogger)
-        event.session = Session("123", Date(), User(null, null, null), false)
+        event.session = Session("123", Date(), User(null, null, null), false, NoopLogger)
 
         var msg: StateEvent.NotifyHandled? = null
         deliveryDelegate.addObserver { _, arg ->

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -32,7 +32,7 @@ internal class EventSerializationTest {
                 // session included
                 createEvent {
                     val user = User("123", "foo@example.com", "Joe")
-                    it.session = Session("123", Date(0), user, false)
+                    it.session = Session("123", Date(0), user, false, NoopLogger)
                 },
 
                 // threads included

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionFacadeTest.java
@@ -1,0 +1,52 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+@SuppressWarnings("ConstantConditions")
+public class SessionFacadeTest {
+
+    private Session session;
+    private InterceptingLogger logger;
+
+    @Before
+    public void setUp() {
+        logger = new InterceptingLogger();
+        session = new Session("123", new Date(0), new User(), true, logger);
+    }
+
+    @Test
+    public void validId() {
+        assertEquals("123", session.getId());
+        session.setId("456");
+        assertEquals("456", session.getId());
+    }
+
+    @Test
+    public void invalidId() {
+        assertEquals("123", session.getId());
+        session.setId(null);
+        assertEquals("123", session.getId());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void validStartedAt() {
+        assertEquals(new Date(0).getTime(), session.getStartedAt().getTime());
+        session.setStartedAt(new Date(5));
+        assertEquals(new Date(5).getTime(), session.getStartedAt().getTime());
+    }
+
+    @Test
+    public void invalidStartedAt() {
+        assertEquals(new Date(0).getTime(), session.getStartedAt().getTime());
+        session.setStartedAt(null);
+        assertEquals(new Date(0).getTime(), session.getStartedAt().getTime());
+        assertNotNull(logger.getMsg());
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionSerializationTest.kt
@@ -16,7 +16,7 @@ internal class SessionSerializationTest {
         @JvmStatic
         @Parameters
         fun testCases(): Collection<Pair<Any, String>> {
-            val session = Session("123", Date(0), User(null, null, null), 1, 0)
+            val session = Session("123", Date(0), User(null, null, null), 1, 0, NoopLogger)
             Notifier.version = "9.9.9"
             Notifier.name = "AndroidBugsnagNotifier"
             Notifier.url = "https://bugsnag.com"

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
@@ -22,7 +22,7 @@ class SessionTest {
     @Mock
     lateinit var app: AppWithState
 
-    private val session = Session("123", Date(0), User(), true)
+    private val session = Session("123", Date(0), User(), true, NoopLogger)
 
     /**
      * Verifies that all the fields in session are copied into a new object correctly
@@ -88,8 +88,11 @@ class SessionTest {
     @Test
     fun isV2() {
         assertFalse(session.isV2Payload)
-        assertFalse(Session(File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json")).isV2Payload)
-        assertTrue(Session(File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc_v2.json")).isV2Payload)
+        assertFalse(Session(File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json"), NoopLogger).isV2Payload)
+        assertTrue(Session(
+            File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc_v2.json"),
+            NoopLogger
+        ).isV2Payload)
     }
 
     private fun validateSessionCopied(copy: Session) {


### PR DESCRIPTION
## Goal

Logs a warning when null values are supplied to Session, rather than allowing an NPE if the user invokes a getter.

## Changeset

- If a null value is passed to a non-null option, a warning is now logged
- Passed in `logger` as required to `Session` constructors

## Tests

Added unit tests to verify that the correct method on `Session` is invoked when a valid value is set, and that a warning message is logged when null is passed.
