### PR TITLE
Log a warning when null values are supplied to Event, rather than throwing an exception

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventPayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventPayloadTest.java
@@ -29,7 +29,7 @@ public class EventPayloadTest {
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
         RuntimeException exception = new RuntimeException("Something broke");
         HandledState handledState = HandledState.newInstance(HandledState.REASON_ANR);
-        Event event = new Event(exception, config, handledState);
+        Event event = new Event(exception, config, handledState, NoopLogger.INSTANCE);
         event.setApp(generateAppWithState());
         event.setDevice(generateDeviceWithState());
         eventPayload = new EventPayload("api-key", event);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagPluginInterface.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagPluginInterface.kt
@@ -53,5 +53,5 @@ object BugsnagPluginInterface {
      * and returning the created object. This API is intended for internal use only.
      */
     fun createEvent(exc: Throwable, client: Client, severityReason: String): Event =
-        Event(exc, client.config, HandledState.newInstance(severityReason))
+        Event(exc, client.config, HandledState.newInstance(severityReason), client.config.logger)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -569,7 +569,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     public void notify(@NonNull Throwable exc, @Nullable OnErrorCallback onError) {
         HandledState handledState = HandledState.newInstance(REASON_HANDLED_EXCEPTION);
-        Event event = new Event(exc, immutableConfig, handledState, metadataState.getMetadata());
+        Metadata metadata = metadataState.getMetadata();
+        Event event = new Event(exc, immutableConfig, handledState, metadata, logger);
         notifyInternal(event, onError);
     }
 
@@ -583,8 +584,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                                   @Nullable String attributeValue) {
         HandledState handledState
                 = HandledState.newInstance(severityReason, Severity.ERROR, attributeValue);
-        Event event = new Event(exc, immutableConfig, handledState,
-                Metadata.Companion.merge(metadataState.getMetadata(), metadata));
+        Metadata data = Metadata.Companion.merge(metadataState.getMetadata(), metadata);
+        Event event = new Event(exc, immutableConfig, handledState, data, logger);
         notifyInternal(event, null);
     }
 
@@ -604,7 +605,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
         if (currentSession != null
                 && (immutableConfig.getAutoTrackSessions() || !currentSession.isAutoCaptured())) {
-            event.session = currentSession;
+            event.setSession(currentSession);
         }
 
         // Capture the state of the app and device and attach diagnostics to the event

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -27,14 +27,14 @@ class DeliveryDelegate extends BaseObservable {
     void deliver(@NonNull Event event) {
         // Build the eventPayload
         EventPayload eventPayload = new EventPayload(immutableConfig.getApiKey(), event);
-        Session session = event.session;
+        Session session = event.getSession();
 
         if (session != null) {
             if (event.isUnhandled()) {
-                event.session = session.incrementUnhandledAndCopy();
+                event.setSession(session.incrementUnhandledAndCopy());
                 notifyObservers(StateEvent.NotifyUnhandled.INSTANCE);
             } else {
-                event.session = session.incrementHandledAndCopy();
+                event.setSession(session.incrementHandledAndCopy());
                 notifyObservers(StateEvent.NotifyHandled.INSTANCE);
             }
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.kt
@@ -48,7 +48,7 @@ class Error @JvmOverloads internal constructor(
     }
 
     internal companion object {
-        fun createError(exc: Throwable, projectPackages: Collection<String>, logger: Logger): List<Error> {
+        fun createError(exc: Throwable, projectPackages: Collection<String>, logger: Logger): MutableList<Error> {
             val errors = mutableListOf<Error>()
 
             var currentEx: Throwable? = exc

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -1,0 +1,220 @@
+package com.bugsnag.android;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("ConstantConditions")
+public class Event implements JsonStream.Streamable, MetadataAware, UserAware {
+
+    final EventImpl impl;
+    private final Logger logger;
+
+    Event(@Nullable Throwable originalError,
+          @NonNull ImmutableConfig config,
+          @NonNull HandledState handledState,
+          @NonNull Logger logger) {
+        this(originalError, config, handledState, new Metadata(), logger);
+    }
+
+    Event(@Nullable Throwable originalError,
+          @NonNull ImmutableConfig config,
+          @NonNull HandledState handledState,
+          @NonNull Metadata metadata,
+          @NonNull Logger logger) {
+        this(new EventImpl(originalError, config, handledState, metadata), logger);
+    }
+
+    Event(@NonNull EventImpl impl, @NonNull Logger logger) {
+        this.impl = impl;
+        this.logger = logger;
+    }
+
+    private void logNull(String property) {
+        logger.e("Invalid null value supplied to config." + property + ", ignoring");
+    }
+
+    public boolean getUnhandled() {
+        return impl.isUnhandled();
+    }
+
+    @NonNull
+    public List<Error> getErrors() {
+        return impl.getErrors();
+    }
+
+    @NonNull
+    public List<Thread> getThreads() {
+        return impl.getThreads();
+    }
+
+    @NonNull
+    public List<Breadcrumb> getBreadcrumbs() {
+        return impl.getBreadcrumbs();
+    }
+
+    @NonNull
+    public AppWithState getApp() {
+        return impl.getApp();
+    }
+
+    @NonNull
+    public DeviceWithState getDevice() {
+        return impl.getDevice();
+    }
+
+    public void setApiKey(@NonNull String apiKey) {
+        if (apiKey != null) {
+            impl.setApiKey(apiKey);
+        } else {
+            logNull("apiKey");
+        }
+    }
+
+    @NonNull
+    public String getApiKey() {
+        return impl.getApiKey();
+    }
+
+    public void setSeverity(@NonNull Severity severity) {
+        if (severity != null) {
+            impl.setSeverity(severity);
+        } else {
+            logNull("severity");
+        }
+    }
+
+    @NonNull
+    public Severity getSeverity() {
+        return impl.getSeverity();
+    }
+
+
+    public void setGroupingHash(@Nullable String groupingHash) {
+        impl.setGroupingHash(groupingHash);
+    }
+
+    @Nullable
+    public String getGroupingHash() {
+        return impl.getGroupingHash();
+    }
+
+    public void setContext(@Nullable String context) {
+        impl.setContext(context);
+    }
+
+    @Nullable
+    public String getContext() {
+        return impl.getContext();
+    }
+
+    @Override
+    public void setUser(@Nullable String id, @Nullable String email, @Nullable String name) {
+        impl.setUser(id, email, name);
+    }
+
+    @Override
+    @NonNull
+    public User getUser() {
+        return impl.getUser();
+    }
+
+    @Override
+    public void addMetadata(@NonNull String section, @NonNull Map<String, ?> value) {
+        if (section != null && value != null) {
+            impl.addMetadata(section, value);
+        } else {
+            logNull("addMetadata");
+        }
+    }
+
+    @Override
+    public void addMetadata(@NonNull String section, @NonNull String key, @Nullable Object value) {
+        if (section != null && key != null) {
+            impl.addMetadata(section, key, value);
+        } else {
+            logNull("addMetadata");
+        }
+    }
+
+    @Override
+    public void clearMetadata(@NonNull String section) {
+        if (section != null) {
+            impl.clearMetadata(section);
+        } else {
+            logNull("clearMetadata");
+        }
+    }
+
+    @Override
+    public void clearMetadata(@NonNull String section, @NonNull String key) {
+        if (section != null && key != null) {
+            impl.clearMetadata(section, key);
+        } else {
+            logNull("clearMetadata");
+        }
+    }
+
+    @Override
+    @Nullable
+    public Map<String, Object> getMetadata(@NonNull String section) {
+        if (section != null) {
+            return impl.getMetadata(section);
+        } else {
+            logNull("getMetadata");
+            return null;
+        }
+    }
+
+    @Override
+    @Nullable
+    public Object getMetadata(@NonNull String section, @NonNull String key) {
+        if (section != null && key != null) {
+            return impl.getMetadata(section, key);
+        } else {
+            logNull("getMetadata");
+            return null;
+        }
+    }
+
+    @Override
+    public void toStream(@NonNull JsonStream stream) throws IOException {
+        impl.toStream(stream);
+    }
+
+    public boolean isUnhandled() {
+        return impl.isUnhandled();
+    }
+
+    protected boolean shouldDiscardClass() {
+        return impl.shouldDiscardClass();
+    }
+
+    protected void updateSeverityInternal(@NonNull Severity severity) {
+        impl.updateSeverityInternal(severity);
+    }
+
+    void setApp(@NonNull AppWithState app) {
+        impl.app = app;
+    }
+
+    void setDevice(@NonNull DeviceWithState device) {
+        impl.device = device;
+    }
+
+    void setBreadcrumbs(@NonNull List<Breadcrumb> breadcrumbs) {
+        impl.setBreadcrumbs(breadcrumbs);
+    }
+
+    @Nullable
+    Session getSession() {
+        return impl.session;
+    }
+
+    void setSession(@Nullable Session session) {
+        impl.session = session;
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -303,11 +303,11 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware {
     }
 
     void setApp(@NonNull AppWithState app) {
-        impl.app = app;
+        impl.setApp(app);
     }
 
     void setDevice(@NonNull DeviceWithState device) {
-        impl.device = device;
+        impl.setDevice(device);
     }
 
     void setBreadcrumbs(@NonNull List<Breadcrumb> breadcrumbs) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventImpl.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventImpl.kt
@@ -8,7 +8,7 @@ import java.io.IOException
  * an [OnErrorCallback], where individual properties can be mutated before an error report is sent
  * to Bugsnag's API.
  */
-class Event @JvmOverloads internal constructor(
+internal class EventImpl @JvmOverloads internal constructor(
 
     /**
      * The Throwable object that caused the event in your application.
@@ -67,7 +67,7 @@ class Event @JvmOverloads internal constructor(
      * A list of breadcrumbs leading up to the event. These values can be accessed and amended
      * if necessary. See [Breadcrumb] for details of the data available.
      */
-    var breadcrumbs: List<Breadcrumb> = emptyList()
+    var breadcrumbs: MutableList<Breadcrumb> = mutableListOf()
 
     /**
      * Information extracted from the [Throwable]that caused the event can be found in this field.
@@ -77,8 +77,8 @@ class Event @JvmOverloads internal constructor(
      * A reference to the actual [Throwable] object that caused the event is available through
      * [originalError].
      */
-    var errors: List<Error> = when (originalError) {
-        null -> listOf()
+    var errors: MutableList<Error> = when (originalError) {
+        null -> mutableListOf()
         else -> Error.createError(originalError, config.projectPackages, config.logger)
     }
 
@@ -86,14 +86,14 @@ class Event @JvmOverloads internal constructor(
      * If thread state is being captured along with the event, this field will contain a
      * list of [Thread] objects.
      */
-    var threads: List<Thread>
+    var threads: MutableList<Thread>
 
     init {
         val recordThreads = config.sendThreads == ALWAYS || (config.sendThreads == UNHANDLED_ONLY && isUnhandled)
 
         threads = when {
             recordThreads -> ThreadState(config, if (isUnhandled) originalError else null).threads
-            else -> emptyList()
+            else -> mutableListOf()
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -3,20 +3,7 @@ package com.bugsnag.android
 import com.bugsnag.android.Thread.ThreadSendPolicy.*
 import java.io.IOException
 
-/**
- * An Event object represents a Throwable captured by Bugsnag and is available as a parameter on
- * an [OnErrorCallback], where individual properties can be mutated before an error report is sent
- * to Bugsnag's API.
- */
-internal class EventImpl @JvmOverloads internal constructor(
-
-    /**
-     * The Throwable object that caused the event in your application.
-     *
-     * Manipulating this field does not affect the error information reported to the
-     * Bugsnag dashboard. Use [errors] to access and amend the representation of the error
-     * that will be sent.
-     */
+internal class EventInternal @JvmOverloads internal constructor(
     val originalError: Throwable? = null,
     config: ImmutableConfig,
     private var handledState: HandledState,
@@ -29,63 +16,23 @@ internal class EventImpl @JvmOverloads internal constructor(
     @JvmField
     internal var session: Session? = null
 
-    /**
-     * The severity of the event. By default, unhandled exceptions will be [Severity.ERROR]
-     * and handled exceptions sent with [Bugsnag.notify] [Severity.WARNING].
-     */
     var severity: Severity
         get() = handledState.currentSeverity
         set(value) {
             handledState.currentSeverity = value
         }
 
-    /**
-     * The API key used for events sent to Bugsnag. Even though the API key is set when Bugsnag
-     * is initialized, you may choose to send certain events to a different Bugsnag project.
-     */
     var apiKey: String = config.apiKey
-
-    /**
-     * Information set by the notifier about your app can be found in this field. These values
-     * can be accessed and amended if necessary.
-     */
     lateinit var app: AppWithState
-
-    /**
-     * Information set by the notifier about your device can be found in this field. These values
-     * can be accessed and amended if necessary.
-     */
     lateinit var device: DeviceWithState
-
-    /**
-     * Whether the event was a crash (i.e. unhandled) or handled error in which the system
-     * continued running.
-     */
     val isUnhandled: Boolean = handledState.isUnhandled
-
-    /**
-     * A list of breadcrumbs leading up to the event. These values can be accessed and amended
-     * if necessary. See [Breadcrumb] for details of the data available.
-     */
     var breadcrumbs: MutableList<Breadcrumb> = mutableListOf()
 
-    /**
-     * Information extracted from the [Throwable]that caused the event can be found in this field.
-     * The list contains at least one [Error] that represents the thrown object
-     * with subsequent elements in the list populated from [Throwable.cause].
-     *
-     * A reference to the actual [Throwable] object that caused the event is available through
-     * [originalError].
-     */
     var errors: MutableList<Error> = when (originalError) {
         null -> mutableListOf()
         else -> Error.createError(originalError, config.projectPackages, config.logger)
     }
 
-    /**
-     * If thread state is being captured along with the event, this field will contain a
-     * list of [Thread] objects.
-     */
     var threads: MutableList<Thread>
 
     init {
@@ -97,20 +44,7 @@ internal class EventImpl @JvmOverloads internal constructor(
         }
     }
 
-    /**
-     * Set the grouping hash of the event to override the default grouping on the dashboard.
-     * All events with the same grouping hash will be grouped together into one error. This is an
-     * advanced usage of the library and mis-using it will cause your events not to group properly
-     * in your dashboard.
-     *
-     * As the name implies, this option accepts a hash of sorts.
-     */
     var groupingHash: String? = null
-
-    /**
-     * Returns the context of the error. The context is a summary what what was occurring in the
-     * application at the time of the crash, if available, such as the visible activity.
-     */
     var context: String? = null
 
     /**
@@ -177,47 +111,28 @@ internal class EventImpl @JvmOverloads internal constructor(
         this.severity = severity
     }
 
-    /**
-     * Sets the user associated with the event.
-     */
+
     override fun setUser(id: String?, email: String?, name: String?) {
         _user = User(id, email, name)
     }
 
-    /**
-     * Returns the currently set User information.
-     */
     override fun getUser() = _user
 
-    /**
-     * Adds a map of multiple metadata key-value pairs to the specified section.
-     */
     override fun addMetadata(section: String, value: Map<String, Any?>) = metadata.addMetadata(section, value)
 
-    /**
-     * Adds the specified key and value in the specified section. The value can be of
-     * any primitive type or a collection such as a map, set or array.
-     */
+
     override fun addMetadata(section: String, key: String, value: Any?) =
         metadata.addMetadata(section, key, value)
 
-    /**
-     * Removes all the data from the specified section.
-     */
+
     override fun clearMetadata(section: String) = metadata.clearMetadata(section)
 
-    /**
-     * Removes data with the specified key from the specified section.
-     */
+
     override fun clearMetadata(section: String, key: String) = metadata.clearMetadata(section, key)
 
-    /**
-     * Returns a map of data in the specified section.
-     */
+
     override fun getMetadata(section: String) = metadata.getMetadata(section)
 
-    /**
-     * Returns the value of the specified key in the specified section.
-     */
+
     override fun getMetadata(section: String, key: String) = metadata.getMetadata(section, key)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -50,7 +50,7 @@ class InternalReportDelegate implements EventStore.Delegate {
     public void onErrorIOFailure(Exception exc, File errorFile, String context) {
         // send an internal error to bugsnag with no cache
         HandledState handledState = HandledState.newInstance(REASON_UNHANDLED_EXCEPTION);
-        Event err = new Event(exc, immutableConfig, handledState);
+        Event err = new Event(exc, immutableConfig, handledState, logger);
         err.setContext(context);
 
         err.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "canRead", errorFile.canRead());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/CallbackStateTest.kt
@@ -25,7 +25,7 @@ class CallbackStateTest {
     lateinit var session: Session
 
     private val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
-    private val event = Event(RuntimeException(), config = generateImmutableConfig(), handledState = handledState)
+    private val event = Event(RuntimeException(), generateImmutableConfig(), handledState, NoopLogger)
     private val breadcrumb = Breadcrumb("")
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConcurrentCallbackTest.java
@@ -27,7 +27,7 @@ public class ConcurrentCallbackTest {
     private final HandledState handledState
             = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION);
     private final Event event = new Event(new RuntimeException(),
-            generateImmutableConfig(), handledState);
+            generateImmutableConfig(), handledState, NoopLogger.INSTANCE);
 
     @Test
     public void testOnErrorConcurrentModification() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -22,7 +22,7 @@ internal class DeliveryDelegateTest {
     private val logger = InterceptingLogger()
     lateinit var deliveryDelegate: DeliveryDelegate
     val handledState = HandledState.newInstance(HandledState.REASON_UNHANDLED_EXCEPTION)
-    val event = Event(RuntimeException("Whoops!"), config, handledState)
+    val event = Event(RuntimeException("Whoops!"), config, handledState, NoopLogger)
 
     @Before
     fun setUp() {
@@ -50,7 +50,7 @@ internal class DeliveryDelegateTest {
     @Test
     fun generateHandledReport() {
         val state = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
-        val event = Event(RuntimeException("Whoops!"), config, state)
+        val event = Event(RuntimeException("Whoops!"), config, state, NoopLogger)
         event.session = Session("123", Date(), User(null, null, null), false)
 
         var msg: StateEvent.NotifyHandled? = null
@@ -70,8 +70,8 @@ internal class DeliveryDelegateTest {
     @Test
     fun generateEmptyReport() {
         val state = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
-        val event = Event(RuntimeException("Whoops!"), config, state)
-        event.errors = emptyList()
+        val event = Event(RuntimeException("Whoops!"), config, state, NoopLogger)
+        event.errors.clear()
 
         var msg: StateEvent.NotifyHandled? = null
         deliveryDelegate.addObserver { _, arg ->

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
@@ -22,45 +22,46 @@ internal class EventApiTest {
         event = Event(
             RuntimeException(),
             generateImmutableConfig(),
-            HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
+            HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION),
+            NoopLogger
         )
         event.setUser("1", "fred@example.com", "Fred")
     }
 
     @Test
     fun getUser() {
-        assertEquals(event._user, event.getUser())
+        assertEquals(event.impl._user, event.getUser())
     }
 
     @Test
     fun setUser() {
         event.setUser("99", "boo@example.com", "Boo")
-        assertEquals(User("99", "boo@example.com", "Boo"), event._user)
+        assertEquals(User("99", "boo@example.com", "Boo"), event.impl._user)
     }
 
     @Test
     fun addMetadataTopLevel() {
         event.addMetadata("foo", mapOf(Pair("wham", "bar")))
-        assertEquals(mapOf(Pair("wham", "bar")), event.metadata.getMetadata("foo"))
+        assertEquals(mapOf(Pair("wham", "bar")), event.impl.metadata.getMetadata("foo"))
     }
 
     @Test
     fun addMetadata() {
         event.addMetadata("foo", "wham", "bar")
-        assertEquals("bar", event.metadata.getMetadata("foo", "wham"))
+        assertEquals("bar", event.impl.metadata.getMetadata("foo", "wham"))
     }
 
     @Test
     fun clearMetadataTopLevel() {
         event.addMetadata("foo", mapOf(Pair("wham", "bar")))
         event.clearMetadata("foo")
-        assertNull(event.metadata.getMetadata("foo"))
+        assertNull(event.impl.metadata.getMetadata("foo"))
     }
 
     @Test
     fun clearMetadata() {
         event.addMetadata("foo", "wham", "bar")
         event.clearMetadata("foo", "wham")
-        assertNull(event.metadata.getMetadata("foo", "wham"))
+        assertNull(event.impl.metadata.getMetadata("foo", "wham"))
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFacadeTest.java
@@ -18,6 +18,9 @@ public class EventFacadeTest {
     private InterceptingLogger logger;
     private ImmutableConfig config;
 
+    /**
+     * Constructs an event for testing the wrapper interface
+     */
     @Before
     public void setUp() {
         logger = new InterceptingLogger();

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFacadeTest.java
@@ -1,0 +1,183 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+@SuppressWarnings("ConstantConditions")
+public class EventFacadeTest {
+
+    private Event event;
+    private InterceptingLogger logger;
+    private ImmutableConfig config;
+
+    @Before
+    public void setUp() {
+        logger = new InterceptingLogger();
+        config = BugsnagTestUtils.generateImmutableConfig();
+        event = new Event(new RuntimeException(), config,
+                HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION), logger);
+    }
+
+    @Test
+    public void apiKeyValid() {
+        assertEquals(config.getApiKey(), event.getApiKey());
+        event.setApiKey("5d1ec5bd39a74caa1267142706a7fb21");
+        assertEquals("5d1ec5bd39a74caa1267142706a7fb21", event.getApiKey());
+    }
+
+    @Test
+    public void apiKeyInvalid() {
+        event.setApiKey(null);
+        assertEquals(config.getApiKey(), event.getApiKey());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void severityValid() {
+        assertEquals(Severity.WARNING, event.getSeverity());
+        event.setSeverity(Severity.INFO);
+        assertEquals(Severity.INFO, event.getSeverity());
+    }
+
+    @Test
+    public void severityInvalid() {
+        assertEquals(Severity.WARNING, event.getSeverity());
+        event.setSeverity(null);
+        assertEquals(Severity.WARNING, event.getSeverity());
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void groupingHashValid() {
+        event.setGroupingHash(null);
+        assertNull(event.getGroupingHash());
+        event.setGroupingHash("crash-id");
+        assertEquals("crash-id", event.getGroupingHash());
+    }
+
+    @Test
+    public void contextValid() {
+        event.setContext(null);
+        assertNull(event.getContext());
+        event.setContext("MyActivity");
+        assertEquals("MyActivity", event.getContext());
+    }
+
+    @Test
+    public void addMetadataValid() {
+        Map<String, Boolean> map = Collections.singletonMap("test", true);
+        event.addMetadata("foo", map);
+        assertEquals(map, event.getMetadata("foo"));
+    }
+
+    @Test
+    public void addMetadataInvalid1() {
+        event.addMetadata("foo", null);
+        assertNull(event.getMetadata("foo"));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void addMetadataValueValid() {
+        event.addMetadata("foo", "test", true);
+        assertTrue((Boolean) event.getMetadata("foo", "test"));
+    }
+
+    @Test
+    public void addMetadataValueInvalid1() {
+        event.addMetadata(null, "test", true);
+        assertNull(event.getMetadata("foo", "test"));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void addMetadataValueInvalid2() {
+        event.addMetadata("foo", null, true);
+        assertNull(event.getMetadata("foo", "test"));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void clearMetadataValid() {
+        event.addMetadata("foo", "test", true);
+        event.clearMetadata("foo");
+        assertNull(event.getMetadata("foo"));
+    }
+
+    @Test
+    public void clearMetadataInvalid() {
+        event.addMetadata("foo", "test", true);
+        event.clearMetadata(null);
+        assertTrue((Boolean) event.getMetadata("foo", "test"));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void clearMetadataValueValid() {
+        event.addMetadata("foo", "test", true);
+        event.clearMetadata("foo", "test");
+        assertNull(event.getMetadata("foo", "test"));
+    }
+
+    @Test
+    public void clearMetadataValueInvalid1() {
+        event.addMetadata("foo", "test", true);
+        event.clearMetadata(null, "test");
+        assertTrue((Boolean) event.getMetadata("foo", "test"));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void clearMetadataValueInvalid2() {
+        event.addMetadata("foo", "test", true);
+        event.clearMetadata("foo", null);
+        assertTrue((Boolean) event.getMetadata("foo", "test"));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void getMetadataValid() {
+        event.addMetadata("foo", "test", true);
+        assertTrue((Boolean) event.getMetadata("foo", "test"));
+    }
+
+    @Test
+    public void getMetadataInvalid() {
+        assertNull(event.getMetadata(null));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void getMetadataValueValid() {
+        event.addMetadata("foo", "test", true);
+        assertTrue((Boolean) event.getMetadata("foo", "test"));
+    }
+
+    @Test
+    public void getMetadataValueInvalid1() {
+        event.addMetadata("foo", "test", true);
+        assertNull(event.getMetadata(null, "test"));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void getMetadataValueInvalid2() {
+        event.addMetadata("foo", "test", true);
+        assertNull(event.getMetadata("foo", null));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void setUserValid() {
+        event.setUser(null, null, null);
+        assertEquals(new User(null, null, null), event.getUser());
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventMetadataCloneTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventMetadataCloneTest.kt
@@ -15,11 +15,11 @@ class EventMetadataCloneTest {
 
         val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
         val config = BugsnagTestUtils.generateImmutableConfig()
-        val event = Event(RuntimeException(), config, handledState, data)
+        val event = Event(RuntimeException(), config, handledState, data, NoopLogger)
         event.addMetadata("test_section", "second", "another value")
 
         // metadata object should be deep copied
-        assertNotSame(data, event.metadata)
+        assertNotSame(data, event.impl.metadata)
 
         // validate event metadata
         val origExpected = mapOf(Pair("foo", "bar"))
@@ -27,6 +27,6 @@ class EventMetadataCloneTest {
 
         // validate event metadata
         val eventExpected = mapOf(Pair("foo", "bar"), Pair("second", "another value"))
-        assertEquals(eventExpected, event.metadata.getMetadata("test_section"))
+        assertEquals(eventExpected, event.impl.metadata.getMetadata("test_section"))
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventNameTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventNameTest.kt
@@ -13,7 +13,7 @@ class EventNameTest {
         val config = BugsnagTestUtils.generateImmutableConfig()
         val exception = RuntimeException("Example message", RuntimeException("Another"))
         val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
-        event = Event(exception, config, handledState)
+        event = Event(exception, config, handledState, NoopLogger)
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventRedactionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventRedactionTest.kt
@@ -14,17 +14,18 @@ internal class EventRedactionTest {
         val event = Event(
             null,
             generateImmutableConfig(),
-            HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
+            HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION),
+            NoopLogger
         )
         event.app = generateAppWithState()
         event.device = generateDeviceWithState()
 
         event.addMetadata("app", "password", "foo")
         event.addMetadata("device", "password", "bar")
-        event.metadata.addMetadata("baz", "password", "hunter2")
+        event.impl.metadata.addMetadata("baz", "password", "hunter2")
         val metadata = mutableMapOf<String, Any?>(Pair("password", "whoops"))
         event.breadcrumbs = listOf(Breadcrumb("Whoops", BreadcrumbType.LOG, metadata, Date(0)))
-        event.threads = emptyList()
+        event.threads.clear()
 
         val writer = StringWriter()
         val stream = JsonStream(writer)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -38,7 +38,8 @@ internal class EventSerializationTest {
                 // threads included
                 createEvent {
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
-                    it.threads = mutableListOf(Thread(5, "main", Thread.Type.ANDROID, true, stacktrace))
+                    it.threads.clear()
+                    it.threads.add(Thread(5, "main", Thread.Type.ANDROID, true, stacktrace))
                 },
 
                 // threads included
@@ -53,7 +54,8 @@ internal class EventSerializationTest {
 
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
                     val err = Error("WhoopsException", "Whoops", stacktrace.trace)
-                    it.errors = listOf(err)
+                    it.errors.clear()
+                    it.errors.add(err)
                 }
             )
         }
@@ -62,9 +64,10 @@ internal class EventSerializationTest {
             val event = Event(
                 null,
                 generateImmutableConfig(),
-                HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
+                HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION),
+                NoopLogger
             )
-            event.threads = emptyList()
+            event.threads.clear()
             event.app = generateAppWithState()
             event.device = generateDeviceWithState()
             cb(event)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStateTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStateTest.java
@@ -25,7 +25,7 @@ public class EventStateTest {
         Configuration configuration = BugsnagTestUtils.generateConfiguration();
         ImmutableConfig config = convert(configuration);
         RuntimeException exception = new RuntimeException("Example message");
-        event = new Event(exception, config, handledState);
+        event = new Event(exception, config, handledState, NoopLogger.INSTANCE);
     }
 
     @Test
@@ -33,7 +33,8 @@ public class EventStateTest {
         Configuration configuration = BugsnagTestUtils.generateConfiguration();
         configuration.setDiscardClasses(Collections.singleton("java.io.IOException"));
 
-        event = new Event(new IOException(), BugsnagTestUtils.convert(configuration), handledState);
+        ImmutableConfig conig = convert(configuration);
+        event = new Event(new IOException(), conig, handledState, NoopLogger.INSTANCE);
         assertTrue(event.shouldDiscardClass());
     }
 
@@ -43,7 +44,8 @@ public class EventStateTest {
         configuration.setDiscardClasses(Collections.singleton("java.io.IOException"));
 
         RuntimeException exc = new RuntimeException(new IOException());
-        event = new Event(exc, BugsnagTestUtils.convert(configuration), handledState);
+        ImmutableConfig conig = convert(configuration);
+        event = new Event(exc, conig, handledState, NoopLogger.INSTANCE);
         assertTrue(event.shouldDiscardClass());
     }
 
@@ -51,7 +53,8 @@ public class EventStateTest {
     public void shouldIgnoreDoesNotMatch() {
         Configuration configuration = BugsnagTestUtils.generateConfiguration();
         configuration.setDiscardClasses(Collections.<String>emptySet());
-        event = new Event(new IOException(), BugsnagTestUtils.convert(configuration), handledState);
+        ImmutableConfig config = convert(configuration);
+        event = new Event(new IOException(), config, handledState, NoopLogger.INSTANCE);
         assertFalse(event.shouldDiscardClass());
     }
 
@@ -61,7 +64,8 @@ public class EventStateTest {
         configuration.setDiscardClasses(Collections.<String>emptySet());
         RuntimeException exc = new RuntimeException(new IllegalStateException());
 
-        event = new Event(exc, BugsnagTestUtils.convert(configuration), handledState);
+        ImmutableConfig config = convert(configuration);
+        event = new Event(exc, config, handledState, NoopLogger.INSTANCE);
         assertFalse(event.shouldDiscardClass());
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
@@ -28,18 +28,19 @@ public class EventTest {
         config = BugsnagTestUtils.generateImmutableConfig();
         RuntimeException exception = new RuntimeException("Example message");
         HandledState handledState = this.handledState;
-        event = new Event(exception, config, handledState);
+        event = new Event(exception, config, handledState, NoopLogger.INSTANCE);
     }
 
     @Test
     public void checkExceptionMessageNullity() {
-        Event err = new Event(new RuntimeException(), config, handledState);
+        Event err = new Event(new RuntimeException(), config, handledState, NoopLogger.INSTANCE);
         assertNull(err.getErrors().get(0).getErrorMessage());
     }
 
     @Test
     public void testExceptionName() {
-        Event err = new Event(new RuntimeException("whoops"), config, handledState);
+        RuntimeException exc = new RuntimeException("whoops");
+        Event err = new Event(exc, config, handledState, NoopLogger.INSTANCE);
         err.getErrors().get(0).setErrorClass("Busgang");
         assertEquals("Busgang", err.getErrors().get(0).getErrorClass());
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/InterceptingLogger.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/InterceptingLogger.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android
+
+class InterceptingLogger : Logger {
+
+    var msg: String? = null
+
+    override fun w(msg: String) {
+        this.msg = msg
+    }
+
+    override fun w(msg: String, throwable: Throwable) {
+        this.msg = msg
+    }
+
+    override fun e(msg: String) {
+        this.msg = msg
+    }
+
+    override fun e(msg: String, throwable: Throwable) {
+        this.msg = msg
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
@@ -51,7 +51,7 @@ internal class InternalEventPayloadDelegateTest {
         )
 
         val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
-        val event = Event(RuntimeException(), config, handledState)
+        val event = Event(RuntimeException(), config, handledState, NoopLogger)
         delegate.reportInternalBugsnagError(event)
 
         // app

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
@@ -34,20 +34,21 @@ public class NullMetadataTest {
     @Test
     public void testErrorDefaultMetadata() {
         HandledState handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION);
-        Event event = new Event(throwable, config, handledState);
+        Event event = new Event(throwable, config, handledState, NoopLogger.INSTANCE);
         validateDefaultMetadata(event);
     }
 
     @Test
     public void testSecondErrorDefaultMetadata() {
         HandledState handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION);
-        Event event = new Event(new RuntimeException(), config, handledState);
+        Event event = new Event(new RuntimeException(), config, handledState, NoopLogger.INSTANCE);
         List<String> projectPackages = Collections.emptyList();
         Stacktrace stacktrace = new Stacktrace(new StackTraceElement[]{}, projectPackages,
                 NoopLogger.INSTANCE);
         Error err = new Error("RuntimeException", "Something broke",
                 stacktrace.getTrace());
-        event.setErrors(Collections.singletonList(err));
+        event.getErrors().clear();
+        event.getErrors().add(err);
         validateDefaultMetadata(event);
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/OnErrorCallbackTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/OnErrorCallbackTest.kt
@@ -20,7 +20,7 @@ class OnErrorCallbackTest {
         }
 
         val handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
-        val error = Event(RuntimeException("Test"), config, handledState)
+        val error = Event(RuntimeException("Test"), config, handledState, NoopLogger)
         onError.onError(error)
         assertEquals(context, error.context)
     }


### PR DESCRIPTION
## Goal

Logs a warning when null values are supplied to Event, rather than throwing an exception.

## Changeset

It may be easier to review the first two commits in isolation. The first implements code changes, whereas the second implements docs changes.

- Renamed `Event.kt` to `EventInternal.kt` and made it non-public
- Added `Event.java` which uses the [decorator pattern](https://en.wikipedia.org/wiki/Decorator_pattern) on a `EventInternal` field and acts as the public interface
- If a null value is passed to a non-null config option, a warning is now logged
- Moved code documentation to `Event.java`
- Updated existing code to match nullability of latest version of notifier spec and to pass tests
- Altered errors/breadcrumbs/threads on `Event` to be a readonly mutable list, as this better reflects the spec as it is currently written


## Tests

Added unit tests to verify that the correct method on `EventInternal` is invoked when a valid value is set, and that a warning message is logged when null is passed.
