### PR TITLE
Log a warning when null values are supplied to Client, rather than throwing an exception

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -16,6 +16,7 @@ import android.os.storage.StorageManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import kotlin.Unit;
 import kotlin.jvm.functions.Function2;
@@ -40,7 +41,7 @@ import java.util.concurrent.RejectedExecutionException;
  *
  * @see Bugsnag
  */
-@SuppressWarnings("checkstyle:JavadocTagContinuationIndentation")
+@SuppressWarnings({"checkstyle:JavadocTagContinuationIndentation", "ConstantConditions"})
 public class Client implements MetadataAware, CallbackAware, UserAware {
 
     private static final String SHARED_PREF_KEY = "com.bugsnag.android";
@@ -267,6 +268,55 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         leaveBreadcrumb("Bugsnag loaded", BreadcrumbType.STATE, data);
     }
 
+    @VisibleForTesting
+    Client(
+            ImmutableConfig immutableConfig,
+            MetadataState metadataState,
+            ContextState contextState,
+            CallbackState callbackState,
+            UserState userState,
+            Context appContext,
+            @NonNull DeviceDataCollector deviceDataCollector,
+            @NonNull AppDataCollector appDataCollector,
+            @NonNull BreadcrumbState breadcrumbState,
+            @NonNull EventStore eventStore,
+            SessionStore sessionStore,
+            SystemBroadcastReceiver systemBroadcastReceiver,
+            SessionTracker sessionTracker,
+            ActivityBreadcrumbCollector activityBreadcrumbCollector,
+            SessionLifecycleCallback sessionLifecycleCallback,
+            SharedPreferences sharedPrefs,
+            Connectivity connectivity,
+            StorageManager storageManager,
+            Logger logger,
+            DeliveryDelegate deliveryDelegate
+    ) {
+        this.immutableConfig = immutableConfig;
+        this.metadataState = metadataState;
+        this.contextState = contextState;
+        this.callbackState = callbackState;
+        this.userState = userState;
+        this.appContext = appContext;
+        this.deviceDataCollector = deviceDataCollector;
+        this.appDataCollector = appDataCollector;
+        this.breadcrumbState = breadcrumbState;
+        this.eventStore = eventStore;
+        this.sessionStore = sessionStore;
+        this.systemBroadcastReceiver = systemBroadcastReceiver;
+        this.sessionTracker = sessionTracker;
+        this.activityBreadcrumbCollector = activityBreadcrumbCollector;
+        this.sessionLifecycleCallback = sessionLifecycleCallback;
+        this.sharedPrefs = sharedPrefs;
+        this.connectivity = connectivity;
+        this.storageManager = storageManager;
+        this.logger = logger;
+        this.deliveryDelegate = deliveryDelegate;
+    }
+
+    private void logNull(String property) {
+        logger.e("Invalid null value supplied to client." + property + ", ignoring");
+    }
+
     private MetadataState copyMetadataState(@NonNull Configuration configuration) {
         // performs deep copy of metadata to preserve immutability of Configuration interface
         Metadata orig = configuration.metadataState.getMetadata();
@@ -475,7 +525,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void addOnError(@NonNull OnErrorCallback onError) {
-        callbackState.addOnError(onError);
+        if (onError != null) {
+            callbackState.addOnError(onError);
+        } else {
+            logNull("addOnError");
+        }
     }
 
     /**
@@ -484,7 +538,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void removeOnError(@NonNull OnErrorCallback onError) {
-        callbackState.removeOnError(onError);
+        if (onError != null) {
+            callbackState.removeOnError(onError);
+        } else {
+            logNull("removeOnError");
+        }
     }
 
     /**
@@ -507,7 +565,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void addOnBreadcrumb(@NonNull OnBreadcrumbCallback onBreadcrumb) {
-        callbackState.addOnBreadcrumb(onBreadcrumb);
+        if (onBreadcrumb != null) {
+            callbackState.addOnBreadcrumb(onBreadcrumb);
+        } else {
+            logNull("addOnBreadcrumb");
+        }
     }
 
     /**
@@ -516,7 +578,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void removeOnBreadcrumb(@NonNull OnBreadcrumbCallback onBreadcrumb) {
-        callbackState.removeOnBreadcrumb(onBreadcrumb);
+        if (onBreadcrumb != null) {
+            callbackState.removeOnBreadcrumb(onBreadcrumb);
+        } else {
+            logNull("removeOnBreadcrumb");
+        }
     }
 
     /**
@@ -539,7 +605,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void addOnSession(@NonNull OnSessionCallback onSession) {
-        callbackState.addOnSession(onSession);
+        if (onSession != null) {
+            callbackState.addOnSession(onSession);
+        } else {
+            logNull("addOnSession");
+        }
     }
 
     /**
@@ -548,7 +618,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void removeOnSession(@NonNull OnSessionCallback onSession) {
-        callbackState.removeOnSession(onSession);
+        if (onSession != null) {
+            callbackState.removeOnSession(onSession);
+        } else {
+            logNull("removeOnSession");
+        }
     }
 
     /**
@@ -568,10 +642,14 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      *                  additional modification
      */
     public void notify(@NonNull Throwable exc, @Nullable OnErrorCallback onError) {
-        HandledState handledState = HandledState.newInstance(REASON_HANDLED_EXCEPTION);
-        Metadata metadata = metadataState.getMetadata();
-        Event event = new Event(exc, immutableConfig, handledState, metadata, logger);
-        notifyInternal(event, onError);
+        if (exc != null) {
+            HandledState handledState = HandledState.newInstance(REASON_HANDLED_EXCEPTION);
+            Metadata metadata = metadataState.getMetadata();
+            Event event = new Event(exc, immutableConfig, handledState, metadata, logger);
+            notifyInternal(event, onError);
+        } else {
+            logNull("notify");
+        }
     }
 
     /**
@@ -660,7 +738,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void addMetadata(@NonNull String section, @NonNull Map<String, ?> value) {
-        metadataState.addMetadata(section, value);
+        if (section != null && value != null) {
+            metadataState.addMetadata(section, value);
+        } else {
+            logNull("addMetadata");
+        }
     }
 
     /**
@@ -669,7 +751,12 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void addMetadata(@NonNull String section, @NonNull String key, @Nullable Object value) {
-        metadataState.addMetadata(section, key, value);
+        if (section != null && key != null) {
+            metadataState.addMetadata(section, key, value);
+
+        } else {
+            logNull("addMetadata");
+        }
     }
 
     /**
@@ -677,7 +764,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void clearMetadata(@NonNull String section) {
-        metadataState.clearMetadata(section);
+        if (section != null) {
+            metadataState.clearMetadata(section);
+        } else {
+            logNull("clearMetadata");
+        }
     }
 
     /**
@@ -685,7 +776,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @Override
     public void clearMetadata(@NonNull String section, @NonNull String key) {
-        metadataState.clearMetadata(section, key);
+        if (section != null && key != null) {
+            metadataState.clearMetadata(section, key);
+        } else {
+            logNull("clearMetadata");
+        }
     }
 
     /**
@@ -694,7 +789,12 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     @Nullable
     @Override
     public Map<String, Object> getMetadata(@NonNull String section) {
-        return metadataState.getMetadata(section);
+        if (section != null) {
+            return metadataState.getMetadata(section);
+        } else {
+            logNull("getMetadata");
+            return null;
+        }
     }
 
     /**
@@ -703,7 +803,12 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     @Override
     @Nullable
     public Object getMetadata(@NonNull String section, @NonNull String key) {
-        return metadataState.getMetadata(section, key);
+        if (section != null && key != null) {
+            return metadataState.getMetadata(section, key);
+        } else {
+            logNull("getMetadata");
+            return null;
+        }
     }
 
     @NonNull
@@ -718,7 +823,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * @param message the log message to leave
      */
     public void leaveBreadcrumb(@NonNull String message) {
-        breadcrumbState.add(new Breadcrumb(message));
+        if (message != null) {
+            breadcrumbState.add(new Breadcrumb(message));
+        } else {
+            logNull("leaveBreadcrumb");
+        }
     }
 
     /**
@@ -732,7 +841,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     public void leaveBreadcrumb(@NonNull String message,
                                 @NonNull BreadcrumbType type,
                                 @NonNull Map<String, Object> metadata) {
-        breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date()));
+        if (message != null && type != null && metadata != null) {
+            breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date()));
+        } else {
+            logNull("leaveBreadcrumb");
+        }
     }
 
     SessionTracker getSessionTracker() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -1,0 +1,464 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.storage.StorageManager;
+
+import androidx.annotation.NonNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("ConstantConditions")
+@RunWith(MockitoJUnitRunner.class)
+public class ClientFacadeTest {
+
+    @Mock
+    ImmutableConfig immutableConfig;
+
+    @Mock
+    MetadataState metadataState;
+
+    @Mock
+    ContextState contextState;
+
+    @Mock
+    CallbackState callbackState;
+
+    @Mock
+    UserState userState;
+
+    @Mock
+    Context appContext;
+
+    @Mock
+    DeviceDataCollector deviceDataCollector;
+
+    @Mock
+    AppDataCollector appDataCollector;
+
+    @Mock
+    BreadcrumbState breadcrumbState;
+
+    @Mock
+    EventStore eventStore;
+
+    @Mock
+    SessionStore sessionStore;
+
+    @Mock
+    SystemBroadcastReceiver systemBroadcastReceiver;
+
+    @Mock
+    SessionTracker sessionTracker;
+
+    @Mock
+    ActivityBreadcrumbCollector activityBreadcrumbCollector;
+
+    @Mock
+    SessionLifecycleCallback sessionLifecycleCallback;
+
+    @Mock
+    SharedPreferences sharedPrefs;
+
+    @Mock
+    Connectivity connectivity;
+
+    @Mock
+    StorageManager storageManager;
+
+    @Mock
+    DeliveryDelegate deliveryDelegate;
+
+    @Mock
+    AppWithState app;
+
+    @Mock
+    DeviceWithState device;
+
+    private Client client;
+    private InterceptingLogger logger;
+
+    /**
+     * Constructs a client with mock dependencies
+     */
+    @Before
+    public void setUp() {
+        logger = new InterceptingLogger();
+        client = new Client(
+                immutableConfig,
+                metadataState,
+                contextState,
+                callbackState,
+                userState,
+                appContext,
+                deviceDataCollector,
+                appDataCollector,
+                breadcrumbState,
+                eventStore,
+                sessionStore,
+                systemBroadcastReceiver,
+                sessionTracker,
+                activityBreadcrumbCollector,
+                sessionLifecycleCallback,
+                sharedPrefs,
+                connectivity,
+                storageManager,
+                logger,
+                deliveryDelegate
+        );
+
+        // required fields for generating an event
+        when(metadataState.getMetadata()).thenReturn(new Metadata());
+        when(immutableConfig.getLogger()).thenReturn(logger);
+        when(immutableConfig.shouldNotifyForReleaseStage()).thenReturn(true);
+
+        when(deviceDataCollector.generateDeviceWithState(anyLong())).thenReturn(device);
+        when(deviceDataCollector.getDeviceMetadata()).thenReturn(new HashMap<String, Object>());
+        when(appDataCollector.generateAppWithState()).thenReturn(app);
+        when(appDataCollector.getAppDataMetadata()).thenReturn(new HashMap<String, Object>());
+
+        when(breadcrumbState.getStore()).thenReturn(new ArrayDeque<Breadcrumb>());
+        when(userState.getUser()).thenReturn(new User());
+        when(callbackState.runOnErrorTasks(any(Event.class), any(Logger.class))).thenReturn(true);
+    }
+
+    @Test
+    public void startSessionValid() {
+        client.startSession();
+        verify(sessionTracker, times(1)).startSession(false);
+    }
+
+    @Test
+    public void pauseSessionValid() {
+        client.pauseSession();
+        verify(sessionTracker, times(1)).pauseSession();
+    }
+
+    @Test
+    public void resumeSessionValid() {
+        client.resumeSession();
+        verify(sessionTracker, times(1)).resumeSession();
+    }
+
+    @Test
+    public void setContextValid() {
+        client.setContext("foo");
+        verify(contextState, times(1)).setContext("foo");
+        client.setContext(null);
+        verify(contextState, times(1)).setContext(null);
+    }
+
+    @Test
+    public void setUserValid() {
+        client.setUser("123", "joe@example.com", "Joe");
+        verify(userState, times(1)).setUser("123", "joe@example.com", "Joe");
+        client.setUser(null, null, null);
+        verify(userState, times(1)).setUser(null, null, null);
+    }
+
+    @Test
+    public void addOnErrorValid() {
+        OnErrorCallback cb = new OnErrorCallback() {
+            @Override
+            public boolean onError(@NonNull Event event) {
+                return false;
+            }
+        };
+        client.addOnError(cb);
+        verify(callbackState, times(1)).addOnError(cb);
+    }
+
+    @Test
+    public void addOnErrorInvalid() {
+        client.addOnError(null);
+        verify(callbackState, times(0)).addOnError(null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void removeOnErrorValid() {
+        OnErrorCallback cb = new OnErrorCallback() {
+            @Override
+            public boolean onError(@NonNull Event event) {
+                return false;
+            }
+        };
+        client.removeOnError(cb);
+        verify(callbackState, times(1)).removeOnError(cb);
+    }
+
+    @Test
+    public void removeOnErrorInvalid() {
+        client.removeOnError(null);
+        verify(callbackState, times(0)).removeOnError(null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void addOnBreadcrumbValid() {
+        OnBreadcrumbCallback cb = new OnBreadcrumbCallback() {
+            @Override
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
+                return false;
+            }
+        };
+        client.addOnBreadcrumb(cb);
+        verify(callbackState, times(1)).addOnBreadcrumb(cb);
+    }
+
+    @Test
+    public void addOnBreadcrumbInvalid() {
+        client.addOnBreadcrumb(null);
+        verify(callbackState, times(0)).addOnBreadcrumb(null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void removeOnBreadcrumbValid() {
+        OnBreadcrumbCallback cb = new OnBreadcrumbCallback() {
+            @Override
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
+                return false;
+            }
+        };
+        client.removeOnBreadcrumb(cb);
+        verify(callbackState, times(1)).removeOnBreadcrumb(cb);
+    }
+
+    @Test
+    public void removeOnBreadcrumbInvalid() {
+        client.removeOnBreadcrumb(null);
+        verify(callbackState, times(0)).removeOnBreadcrumb(null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void addOnSessionValid() {
+        OnSessionCallback cb = new OnSessionCallback() {
+            @Override
+            public boolean onSession(@NonNull Session session) {
+                return false;
+            }
+        };
+        client.addOnSession(cb);
+        verify(callbackState, times(1)).addOnSession(cb);
+    }
+
+    @Test
+    public void addOnSessionInvalid() {
+        client.addOnSession(null);
+        verify(callbackState, times(0)).addOnSession(null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void removeOnSessionValid() {
+        OnSessionCallback cb = new OnSessionCallback() {
+            @Override
+            public boolean onSession(@NonNull Session session) {
+                return false;
+            }
+        };
+        client.removeOnSession(cb);
+        verify(callbackState, times(1)).removeOnSession(cb);
+    }
+
+    @Test
+    public void removeOnSessionInvalid() {
+        client.removeOnSession(null);
+        verify(callbackState, times(0)).removeOnSession(null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void notifyValid() {
+        RuntimeException exc = new RuntimeException();
+        client.notify(exc);
+        verify(deliveryDelegate, times(1)).deliver(any(Event.class));
+    }
+
+    @Test
+    public void notifyInvalid() {
+        client.notify(null);
+        verify(deliveryDelegate, times(0)).deliver(any(Event.class));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void notifyCallbackValid() {
+        RuntimeException exc = new RuntimeException();
+        client.notify(exc, null);
+        verify(deliveryDelegate, times(1)).deliver(any(Event.class));
+    }
+
+    @Test
+    public void notifyCallbackInvalid() {
+        client.notify(null, null);
+        verify(deliveryDelegate, times(0)).deliver(any(Event.class));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void addMetadataValid() {
+        Map<String, Boolean> map = Collections.singletonMap("test", true);
+        client.addMetadata("foo", map);
+        verify(metadataState, times(1)).addMetadata("foo", map);
+    }
+
+    @Test
+    public void addMetadataInvalid1() {
+        client.addMetadata("foo", null);
+        verify(metadataState, times(0)).addMetadata("foo", null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void addMetadataValueValid() {
+        client.addMetadata("foo", "test", true);
+        verify(metadataState, times(1)).addMetadata("foo", "test", true);
+    }
+
+    @Test
+    public void addMetadataValueInvalid1() {
+        client.addMetadata(null, "test", true);
+        verify(metadataState, times(0)).addMetadata(null, "test", true);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void addMetadataValueInvalid2() {
+        client.addMetadata("foo", null, true);
+        verify(metadataState, times(0)).addMetadata("foo", null, true);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void clearMetadataValid() {
+        client.addMetadata("foo", "test", true);
+        client.clearMetadata("foo");
+        verify(metadataState, times(1)).clearMetadata("foo");
+    }
+
+    @Test
+    public void clearMetadataInvalid() {
+        client.clearMetadata(null);
+        verify(metadataState, times(0)).clearMetadata(null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void clearMetadataValueValid() {
+        client.addMetadata("foo", "test", true);
+        client.clearMetadata("foo", "test");
+        verify(metadataState, times(1)).clearMetadata("foo", "test");
+    }
+
+    @Test
+    public void clearMetadataValueInvalid1() {
+        client.addMetadata("foo", "test", true);
+        client.clearMetadata(null, "test");
+        verify(metadataState, times(0)).clearMetadata(null, "test");
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void clearMetadataValueInvalid2() {
+        client.addMetadata("foo", "test", true);
+        client.clearMetadata("foo", null);
+        verify(metadataState, times(0)).clearMetadata("foo", null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void getMetadataValid() {
+        client.getMetadata("foo", "test");
+        verify(metadataState, times(1)).getMetadata("foo", "test");
+    }
+
+    @Test
+    public void getMetadataInvalid() {
+        client.getMetadata(null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void getMetadataValueValid() {
+        client.addMetadata("foo", "test", true);
+        client.getMetadata("foo", "test");
+        verify(metadataState, times(1)).getMetadata("foo", "test");
+    }
+
+    @Test
+    public void getMetadataValueInvalid1() {
+        client.addMetadata("foo", "test", true);
+        client.getMetadata(null, "test");
+        verify(metadataState, times(0)).getMetadata(null, "test");
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void getMetadataValueInvalid2() {
+        client.addMetadata("foo", "test", true);
+        client.getMetadata("foo", null);
+        verify(metadataState, times(0)).getMetadata("foo", null);
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void leaveBreadcrumbValid() {
+        client.leaveBreadcrumb("foo");
+        verify(breadcrumbState, times(1)).add(any(Breadcrumb.class));
+    }
+
+    @Test
+    public void leaveBreadcrumbInvalid() {
+        client.leaveBreadcrumb(null);
+        verify(breadcrumbState, times(0)).add(any(Breadcrumb.class));
+        assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void leaveComplexBreadcrumbValid() {
+        HashMap<String, Object> metadata = new HashMap<>();
+        client.leaveBreadcrumb("foo", BreadcrumbType.NAVIGATION, metadata);
+        verify(breadcrumbState, times(1)).add(any(Breadcrumb.class));
+    }
+
+    @Test
+    public void leaveComplexBreadcrumbInvalid1() {
+        HashMap<String, Object> metadata = new HashMap<>();
+        client.leaveBreadcrumb(null, BreadcrumbType.NAVIGATION, metadata);
+        verify(breadcrumbState, times(0)).add(any(Breadcrumb.class));
+    }
+
+    @Test
+    public void leaveComplexBreadcrumbInvalid2() {
+        HashMap<String, Object> metadata = new HashMap<>();
+        client.leaveBreadcrumb("foo", null, metadata);
+        verify(breadcrumbState, times(0)).add(any(Breadcrumb.class));
+    }
+
+    @Test
+    public void leaveComplexBreadcrumbInvalid3() {
+        client.leaveBreadcrumb("foo", BreadcrumbType.NAVIGATION, null);
+        verify(breadcrumbState, times(0)).add(any(Breadcrumb.class));
+    }
+}


### PR DESCRIPTION
## Goal

Logs a warning when null values are supplied to Client, rather than throwing an exception.

Note: this also applies to the `Bugsnag.java` facade. It is assumed that the `BugsnagApiTest` suite gives sufficient coverage to test that class.

## Changeset

- If a null value is passed to a non-null parameter, a warning is now logged
- Added a package-visible constructor to allow injection of mocks for unit testing

## Tests

Added unit tests to verify that the correct method on a `Client` field is invoked when a method on the public API is invoked, and that a message is logged when appropriate.
