### PR TITLE
Improve native serialization test assertions

### DIFF
--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/breadcrumbs_serialization_0.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/breadcrumbs_serialization_0.json
@@ -1,1 +1,1 @@
-[]
+[{"name":"Jane","timestamp":"2018-10-08T12:07:09Z","type":"user","metaData":{"foo":"bar"}}]

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/custom_meta_data_serialization_0.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/custom_meta_data_serialization_0.json
@@ -1,1 +1,1 @@
-{}
+{"metaData":{"custom":{"str":"Foo","bool":true,"num":55}}}

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/exception_serialization_0.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/exception_serialization_0.json
@@ -1,1 +1,1 @@
-{"stacktrace":[{"frameAddress":0,"symbolAddress":0,"loadAddress":0,"lineNumber":0,"method":"0x0"}],"errorClass":"signal","message":"whoops something went wrong","type":"c"}
+{"stacktrace":[{"frameAddress":536870912,"symbolAddress":369098752,"loadAddress":301989888,"lineNumber":52,"file":"foo.c","method":"bar()"}],"errorClass":"signal","message":"whoops something went wrong","type":"c"}

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/handled_state_serialization_0.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/handled_state_serialization_0.json
@@ -1,1 +1,1 @@
-{"severity":"error","unhandled":true,"severityReason":{"type":"signal","attributes":{"signalType":""}}}
+{"severity":"error","unhandled":true,"severityReason":{"type":"signal","attributes":{"signalType":"SIGABRT"}}}

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/session_serialization_0.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/session_serialization_0.json
@@ -1,1 +1,1 @@
-{}
+{"session":{"startedAt":"2018-10-08T12:07:09Z","id":"123","events":{"handled":2,"unhandled":1}}}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -18,63 +18,84 @@ bugsnag_user * loadUserTestCase(jint num) {
 
     if (num == 0) {
         user = malloc(sizeof(bugsnag_user));
-        strcpy(user->id, "1234");
-        strcpy(user->email, "fenton@io.example.com");
         strcpy(user->name, "Fenton");
+        strcpy(user->email, "fenton@io.example.com");
+        strcpy(user->id, "1234");
     } else {
         user = malloc(sizeof(bugsnag_user));
-        strcpy(user->id, "456");
-        strcpy(user->email, "jamie@bugsnag.com");
         strcpy(user->name, "Jamie");
+        strcpy(user->email, "jamie@bugsnag.com");
+        strcpy(user->id, "456");
     }
     return user;
 }
 
 bsg_app_info * loadAppTestCase(jint num) {
     bsg_app_info *app = malloc(sizeof(bsg_app_info));
-    strcpy(app->version, "22");
     strcpy(app->id, "com.bugsnag.example");
-    strcpy(app->type, "android");
     strcpy(app->release_stage, "prod");
+    strcpy(app->type, "android");
+    strcpy(app->version, "22");
+    strcpy(app->active_screen, "MainActivity");
     app->version_code = 55;
     strcpy(app->build_uuid, "1234-uuid");
-    strcpy(app->binary_arch, "x86");
     app->duration = 6502;
     app->duration_in_foreground = 6502;
+    app->duration_ms_offset = 0;
+    app->duration_in_foreground_ms_offset = 0;
     app->in_foreground = true;
+    strcpy(app->binary_arch, "x86");
     return app;
 }
 
 bsg_app_info * loadAppMetadataTestCase(jint num) {
-    bsg_app_info *app = malloc(sizeof(bsg_app_info));
-    strcpy(app->active_screen, "MainActivity");
+    bsg_app_info *app = loadAppTestCase(num);
     return app;
 }
 
 bsg_device_info * loadDeviceTestCase(jint num) {
     bsg_device_info *device = malloc(sizeof(bsg_device_info));
-    strcpy(device->id, "f5gh7");
-    strcpy(device->os_name, "android");
-    strcpy(device->os_version, "8.1");
-    strcpy(device->manufacturer, "Samsung");
-    strcpy(device->model, "S7");
-    strcpy(device->orientation, "portrait");
-    strcpy(device->os_build, "BullDog 5.2");
-    device->total_memory = 512340922;
     device->api_level = 29;
-    strcpy(device->locale, "En");
-
     bsg_strncpy_safe(device->cpu_abi[0].value, "x86", sizeof(device->cpu_abi[0].value));
     device->cpu_abi_count = 1;
+    strcpy(device->orientation, "portrait");
 
     struct tm time = { 0, 0, 0, 1, 12, 128 };
     device->time = mktime(&time);
+    strcpy(device->id, "f5gh7");
     device->jailbroken = true;
+    strcpy(device->locale, "En");
+    strcpy(device->manufacturer, "Samsung");
+    strcpy(device->model, "S7");
+    strcpy(device->os_build, "BullDog 5.2");
+    strcpy(device->os_version, "8.1");
+    strcpy(device->os_name, "android");
+    device->total_memory = 512340922;
     return device;
 }
 
 bugsnag_metadata * loadCustomMetadataTestCase(jint num) {
     bugsnag_metadata *data = malloc(sizeof(bugsnag_metadata));
+    data->value_count = 4;
+
+    data->values[0].type = BSG_METADATA_CHAR_VALUE;
+    strcpy(data->values[0].section, "custom");
+    strcpy(data->values[0].name, "str");
+    strcpy(data->values[0].char_value, "Foo");
+
+    data->values[1].type = BSG_METADATA_BOOL_VALUE;
+    strcpy(data->values[1].section, "custom");
+    strcpy(data->values[1].name, "bool");
+    data->values[1].bool_value = true;
+
+    data->values[2].type = BSG_METADATA_NUMBER_VALUE;
+    strcpy(data->values[2].section, "custom");
+    strcpy(data->values[2].name, "num");
+    data->values[2].double_value = 55;
+
+    data->values[3].type = BSG_METADATA_NONE_VALUE;
+    strcpy(data->values[3].section, "custom");
+    strcpy(data->values[3].name, "none");
     return data;
 }
 
@@ -88,16 +109,29 @@ bugsnag_event * loadContextTestCase(jint num) {
 bugsnag_event * loadHandledStateTestCase(jint num) {
     bugsnag_event *data = malloc(sizeof(bugsnag_event));
     data->unhandled = true;
+    data->severity = BSG_SEVERITY_ERR;
+    strcpy(data->error.errorClass, "SIGABRT");
     return data;
 }
 
 bugsnag_event * loadSessionTestCase(jint num) {
     bugsnag_event *data = malloc(sizeof(bugsnag_event));
+    strcpy(data->session_id, "123");
+    strcpy(data->session_start, "2018-10-08T12:07:09Z");
+    data->handled_events = 2;
+    data->unhandled_events = 1;
     return data;
 }
 
 bugsnag_event * loadBreadcrumbsTestCase(jint num) {
     bugsnag_event *data = malloc(sizeof(bugsnag_event));
+    data->crumb_count = 1;
+    data->crumb_first_index = 0;
+    data->breadcrumbs[0].type = BSG_CRUMB_USER;
+    strcpy(data->breadcrumbs[0].name, "Jane");
+    strcpy(data->breadcrumbs[0].timestamp, "2018-10-08T12:07:09Z");
+    strcpy(data->breadcrumbs[0].metadata->key, "foo");
+    strcpy(data->breadcrumbs[0].metadata->value, "bar");
     return data;
 }
 
@@ -118,6 +152,11 @@ bsg_error * loadExceptionTestCase(jint num) {
     strcpy(data->errorMessage, "whoops something went wrong");
     strcpy(data->type, "c");
     data->frame_count = 1;
-    // TODO stacktrace
+    data->stacktrace[0].frame_address = 0x20000000;
+    data->stacktrace[0].symbol_address = 0x16000000;
+    data->stacktrace[0].load_address = 0x12000000;
+    data->stacktrace[0].line_number= 52;
+    strcpy(data->stacktrace[0].filename, "foo.c");
+    strcpy(data->stacktrace[0].method, "bar()");
     return data;
 }


### PR DESCRIPTION
## Goal

Fixes the native serialization tests using uninitialized values in their test data. This could lead to undefined behaviour and has resulted in flaky tests.

## Changeset

- Updated each function which loads a struct to populate a valid value for all fields on the struct
- Updated the expected JSON fixture to reflect the new values
- Improved test coverage generally for serialization of breadcrumbs/metadata/handledState by populating valid values
- Organised existing functions to populate fields in a struct in the order in which the struct is defined. This makes it easier to visually see when a field has been missed.
