### PR TITLE
Amend internal use of Configuration to ConfigInternal

### DIFF
--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -100,24 +100,6 @@ class BreadcrumbStateTest {
     }
 
     /**
-     * Verifies that the max breadcrumb accessors only allow positive numbers
-     */
-    @Test
-    fun testMaxBreadcrumbAccessors() {
-        val config = generateConfiguration()
-        assertEquals(25, config.maxBreadcrumbs)
-
-        config.maxBreadcrumbs = 50
-        assertEquals(50, config.maxBreadcrumbs)
-
-        config.maxBreadcrumbs = Int.MAX_VALUE
-        assertEquals(50, config.maxBreadcrumbs)
-
-        config.maxBreadcrumbs = -5
-        assertEquals(50, config.maxBreadcrumbs)
-    }
-
-    /**
      * Verifies that an [OnBreadcrumbCallback] callback is run when specified in [BreadcrumbState]
      */
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -6,8 +6,8 @@ import java.util.Date;
 
 final class BugsnagTestUtils {
 
-    static Configuration generateConfiguration() {
-        Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
+    static ConfigInternal generateConfiguration() {
+        ConfigInternal configuration = new ConfigInternal("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());
         configuration.setLogger(NoopLogger.INSTANCE);
         return configuration;
@@ -18,7 +18,7 @@ final class BugsnagTestUtils {
     }
 
 
-    static ImmutableConfig convert(Configuration config) {
+    static ImmutableConfig convert(ConfigInternal config) {
         return ImmutableConfigKt.convertToImmutableConfig(config);
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigApiTest.kt
@@ -17,15 +17,15 @@ import org.mockito.junit.MockitoJUnitRunner
 @RunWith(MockitoJUnitRunner::class)
 internal class ConfigApiTest {
 
-    lateinit var config: Configuration
+    lateinit var config: ConfigInternal
     private lateinit var callbackState: CallbackState
     private lateinit var metadataState: MetadataState
 
     @Before
     fun setUp() {
         config = generateConfiguration()
-        callbackState = config.impl.callbackState
-        metadataState = config.impl.metadataState
+        callbackState = config.callbackState
+        metadataState = config.metadataState
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
@@ -100,6 +100,9 @@ public class ConfigurationFacadeTest {
     public void launchCrashThresholdMsValid() {
         config.setLaunchCrashThresholdMs(123456);
         assertEquals(123456, config.impl.getLaunchCrashThresholdMs());
+
+        config.setLaunchCrashThresholdMs(-5);
+        assertEquals(123456, config.impl.getLaunchCrashThresholdMs());
     }
 
     @Test
@@ -188,6 +191,22 @@ public class ConfigurationFacadeTest {
         assertEquals(66, config.impl.getMaxBreadcrumbs());
     }
 
+    /**
+     * Verifies that the max breadcrumb accessors only allow positive numbers
+     */
+    @Test
+    public void testMaxBreadcrumbAccessors() {
+        assertEquals(25, config.getMaxBreadcrumbs());
+
+        config.setMaxBreadcrumbs(50);
+        assertEquals(50, config.impl.getMaxBreadcrumbs());
+
+        config.setMaxBreadcrumbs(Integer.MAX_VALUE);
+        assertEquals(50, config.impl.getMaxBreadcrumbs());
+
+        config.setMaxBreadcrumbs(-5);
+        assertEquals(50, config.impl.getMaxBreadcrumbs());
+    }
     @Test
     public void contextValid() {
         config.setContext("Whoops");

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 public class ConfigurationTest {
 
-    private Configuration config;
+    private ConfigInternal config;
 
     @Before
     public void setUp() {
@@ -85,7 +85,7 @@ public class ConfigurationTest {
         assertFalse(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
     }
 
-    private ImmutableConfig createConfigWithReleaseStages(Configuration config,
+    private ImmutableConfig createConfigWithReleaseStages(ConfigInternal config,
                                                           Set<String> releaseStages,
                                                           String releaseStage) {
         config.setEnabledReleaseStages(releaseStages);
@@ -95,11 +95,6 @@ public class ConfigurationTest {
 
     @Test
     public void testLaunchThreshold() {
-        assertEquals(5000L, config.getLaunchCrashThresholdMs());
-
-        config.setLaunchCrashThresholdMs(-5);
-        assertEquals(5000, config.getLaunchCrashThresholdMs());
-
         int expected = 1500;
         config.setLaunchCrashThresholdMs(expected);
         assertEquals(expected, config.getLaunchCrashThresholdMs());
@@ -175,9 +170,10 @@ public class ConfigurationTest {
 
     @Test
     public void testVersionCode() {
-        Configuration configuration = generateConfiguration();
+        ConfigInternal configuration = generateConfiguration();
         assertEquals(0, (int) configuration.getVersionCode()); // populated in client ctor if null
         configuration.setVersionCode(577);
         assertEquals(577, (int) configuration.getVersionCode());
     }
+
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStateTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStateTest.java
@@ -22,7 +22,7 @@ public class EventStateTest {
      */
     @Before
     public void setUp() {
-        Configuration configuration = BugsnagTestUtils.generateConfiguration();
+        ConfigInternal configuration = BugsnagTestUtils.generateConfiguration();
         ImmutableConfig config = convert(configuration);
         RuntimeException exception = new RuntimeException("Example message");
         event = new Event(exception, config, handledState, NoopLogger.INSTANCE);
@@ -30,7 +30,7 @@ public class EventStateTest {
 
     @Test
     public void shouldIgnoreMatches() {
-        Configuration configuration = BugsnagTestUtils.generateConfiguration();
+        ConfigInternal configuration = BugsnagTestUtils.generateConfiguration();
         configuration.setDiscardClasses(Collections.singleton("java.io.IOException"));
 
         ImmutableConfig conig = convert(configuration);
@@ -40,7 +40,7 @@ public class EventStateTest {
 
     @Test
     public void shouldIgnoreMatchesMultiple() {
-        Configuration configuration = BugsnagTestUtils.generateConfiguration();
+        ConfigInternal configuration = BugsnagTestUtils.generateConfiguration();
         configuration.setDiscardClasses(Collections.singleton("java.io.IOException"));
 
         RuntimeException exc = new RuntimeException(new IOException());
@@ -51,7 +51,7 @@ public class EventStateTest {
 
     @Test
     public void shouldIgnoreDoesNotMatch() {
-        Configuration configuration = BugsnagTestUtils.generateConfiguration();
+        ConfigInternal configuration = BugsnagTestUtils.generateConfiguration();
         configuration.setDiscardClasses(Collections.<String>emptySet());
         ImmutableConfig config = convert(configuration);
         event = new Event(new IOException(), config, handledState, NoopLogger.INSTANCE);
@@ -60,7 +60,7 @@ public class EventStateTest {
 
     @Test
     public void shouldIgnoreDoesNotMatchMultiple() {
-        Configuration configuration = BugsnagTestUtils.generateConfiguration();
+        ConfigInternal configuration = BugsnagTestUtils.generateConfiguration();
         configuration.setDiscardClasses(Collections.<String>emptySet());
         RuntimeException exc = new RuntimeException(new IllegalStateException());
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -170,7 +170,7 @@ internal class ImmutableConfigTest {
         packageInfo.versionCode = 55
         `when`(packageManager.getPackageInfo("com.example.foo", 0)).thenReturn(packageInfo)
 
-        val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        val seed = ConfigInternal("5d1ec5bd39a74caa1267142706a7fb21")
         seed.logger = NoopLogger
         val config = sanitiseConfiguration(context, seed, connectivity)
         assertEquals(setOf("com.example.foo"), config.projectPackages)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
@@ -56,7 +56,7 @@ internal class SessionTrackerPauseResumeTest {
         `when`(context.getSystemService("activity")).thenReturn(activityManager)
         tracker = SessionTracker(
             BugsnagTestUtils.generateImmutableConfig(),
-            configuration.impl.callbackState, client, sessionStore, NoopLogger
+            configuration.callbackState, client, sessionStore, NoopLogger
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
@@ -26,7 +26,7 @@ public class SessionTrackerTest {
 
     private SessionTracker sessionTracker;
     private User user;
-    private Configuration configuration;
+    private ConfigInternal configuration;
     private ImmutableConfig immutableConfig;
 
     @Mock
@@ -66,7 +66,7 @@ public class SessionTrackerTest {
         configuration.setDelivery(BugsnagTestUtils.generateDelivery());
         immutableConfig = BugsnagTestUtils.generateImmutableConfig();
         sessionTracker = new SessionTracker(immutableConfig,
-                configuration.impl.callbackState, client, sessionStore, NoopLogger.INSTANCE);
+                configuration.callbackState, client, sessionStore, NoopLogger.INSTANCE);
         configuration.setAutoTrackSessions(true);
         user = new User(null, null, null);
     }
@@ -153,7 +153,7 @@ public class SessionTrackerTest {
 
     @Test
     public void testZeroSessionTimeout() {
-        CallbackState callbackState = configuration.impl.callbackState;
+        CallbackState callbackState = configuration.callbackState;
         sessionTracker = new SessionTracker(immutableConfig, callbackState, client,
             0, sessionStore, NoopLogger.INSTANCE);
 
@@ -169,7 +169,7 @@ public class SessionTrackerTest {
 
     @Test
     public void testSessionTimeout() {
-        CallbackState callbackState = configuration.impl.callbackState;
+        CallbackState callbackState = configuration.callbackState;
         sessionTracker = new SessionTracker(immutableConfig, callbackState, client,
             100, sessionStore, NoopLogger.INSTANCE);
 

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -7,8 +7,8 @@ final class BugsnagTestUtils {
     private BugsnagTestUtils() {
     }
 
-    static Configuration generateConfiguration() {
-        Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
+    static ConfigInternal generateConfiguration() {
+        ConfigInternal configuration = new ConfigInternal("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());
         configuration.setLogger(NoopLogger.INSTANCE);
         return configuration;
@@ -19,7 +19,7 @@ final class BugsnagTestUtils {
     }
 
 
-    static ImmutableConfig convert(Configuration config) {
+    static ImmutableConfig convert(ConfigInternal config) {
         return ImmutableConfigKt.convertToImmutableConfig(config);
     }
 

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
@@ -41,8 +41,8 @@ public class JavaHooks {
      * Generates fake Configuration
      */
     @NonNull
-    public static Configuration generateConfiguration() {
-        Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
+    public static ConfigInternal generateConfiguration() {
+        ConfigInternal configuration = new ConfigInternal("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());
         configuration.setLogger(NoopLogger.INSTANCE);
         return configuration;


### PR DESCRIPTION
I think we should use ConfigInternal everywhere inside the library to benefit from it being a Kotlin class. Therefore Client should convert it and santitise it to give defaults early on and nothing else should access it.

TODO - the tests probably need looking at to ensure they are testing the right thing. I wanted to get opinion on this before spending too much time on this.