### PR TITLE
Migrate NDK breadcrumb metadata to use new struct

### DIFF
--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/breadcrumbs_serialization_0.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/breadcrumbs_serialization_0.json
@@ -1,1 +1,1 @@
-[{"name":"Jane","timestamp":"2018-10-08T12:07:09Z","type":"user","metaData":{"foo":"bar"}}]
+[{"name":"Jane","timestamp":"2018-10-08T12:07:09Z","type":"user","metaData":{"str":"Foo","bool":true,"num":55}}]

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/breadcrumbs_serialization_0.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/breadcrumbs_serialization_0.json
@@ -1,1 +1,1 @@
-[{"name":"Jane","timestamp":"2018-10-08T12:07:09Z","type":"user","metaData":{"str":"Foo","bool":true,"num":55}}]
+[{"name":"Jane","timestamp":"2018-10-08T12:07:09Z","type":"user","metaData":{"str":"Foo"}},{"name":"Something went wrong","timestamp":"2018-10-08T12:07:11Z","type":"manual","metaData":{"bool":true}},{"name":"MainActivity","timestamp":"2018-10-08T12:07:15Z","type":"navigation"},{"name":"Updated store","timestamp":"2018-10-08T12:07:16Z","type":"state"}]

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -519,7 +519,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateMetadata(
   if (bsg_global_env == NULL)
     return;
   bsg_request_env_write_lock();
-  bsg_populate_metadata(env, &bsg_global_env->next_event, metadata);
+  bsg_populate_metadata(env, &bsg_global_env->next_event.metadata, metadata);
   bsg_release_env_write_lock();
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -15,7 +15,7 @@ int bsg_find_next_free_metadata_index(bugsnag_metadata *const metadata) {
   return -1;
 }
 
-int bsg_add_metadata_value(bugsnag_metadata *metadata, char *section, char *name) {
+int bsg_allocate_metadata_index(bugsnag_metadata *metadata, char *section, char *name) {
   int index = bsg_find_next_free_metadata_index(metadata);
   if (index < 0) {
     return index;
@@ -32,7 +32,7 @@ int bsg_add_metadata_value(bugsnag_metadata *metadata, char *section, char *name
 
 void bsg_add_metadata_value_double(bugsnag_metadata *metadata, char *section,
                                    char *name, double value) {
-  int index = bsg_add_metadata_value(metadata, section, name);
+  int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_NUMBER_VALUE;
     metadata->values[index].double_value = value;
@@ -41,7 +41,7 @@ void bsg_add_metadata_value_double(bugsnag_metadata *metadata, char *section,
 
 void bsg_add_metadata_value_str(bugsnag_metadata *metadata, char *section,
                                 char *name, char *value) {
-  int index = bsg_add_metadata_value(metadata, section, name);
+  int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_CHAR_VALUE;
     bsg_strncpy_safe(metadata->values[index].char_value, value,
@@ -51,7 +51,7 @@ void bsg_add_metadata_value_str(bugsnag_metadata *metadata, char *section,
 
 void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, char *section,
                                  char *name, bool value) {
-  int index = bsg_add_metadata_value(metadata, section, name);
+  int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_BOOL_VALUE;
     metadata->values[index].bool_value = value;

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -167,11 +167,6 @@ typedef struct {
 } bsg_error;
 
 typedef struct {
-    char key[64];
-    char value[64];
-} bsg_char_metadata_pair;
-
-typedef struct {
     char name[33];
     char timestamp[37];
     bugsnag_breadcrumb_type type;
@@ -179,7 +174,7 @@ typedef struct {
     /**
      * Key/value pairs of related information for debugging
      */
-    bsg_char_metadata_pair metadata[8];
+    bugsnag_metadata metadata;
 } bugsnag_breadcrumb;
 
 typedef struct {
@@ -219,6 +214,13 @@ void bugsnag_event_clear_breadcrumbs(bugsnag_event *event);
 void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
                                  char *started_at, int handled_count, int unhandled_count);
 bool bugsnag_event_has_session(bugsnag_event *event);
+
+void bsg_add_metadata_value_double(bugsnag_metadata *metadata, char *section,
+                                   char *name, double value);
+void bsg_add_metadata_value_str(bugsnag_metadata *metadata, char *section,
+                                char *name, char *value);
+void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, char *section,
+                                 char *name, bool value);
 
 /*********************************
  * (end) NDK-SPECIFIC BITS

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -189,9 +189,8 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
       (*env)->CallObjectMethod(env, metadata, jni_cache->map_key_set);
   jobject keylist = (*env)->NewObject(
       env, jni_cache->arraylist, jni_cache->arraylist_init_with_obj, keyset);
-  size_t metadata_size = sizeof(crumb->metadata) / BUGSNAG_METADATA_MAX;
 
-  for (int i = 0; i < map_size && i < metadata_size; i++) {
+  for (int i = 0; i < map_size; i++) {
     jstring _key = (*env)->CallObjectMethod(env, keylist,
                                             jni_cache->arraylist_get, (jint)i);
     jobject _value = (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
@@ -12,7 +12,7 @@ void bsg_populate_event(JNIEnv *env, bugsnag_event *event);
  * Load custom metadata from NativeInterface into a event, optionally from an object.
  * If metadata is not provided, load from NativeInterface
  */
-void bsg_populate_metadata(JNIEnv *env, bugsnag_event *event, jobject metadata);
+void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst, jobject metadata);
 
 /**
  * Parse as java.util.Map<String, String> to populate crumb metadata

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
@@ -9,7 +9,7 @@
  */
 void bsg_populate_event(JNIEnv *env, bugsnag_event *event);
 /**
- * Load custom metadata from NativeInterface into a event, optionally from an object.
+ * Load custom metadata from NativeInterface into a native metadata struct, optionally from an object.
  * If metadata is not provided, load from NativeInterface
  */
 void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst, jobject metadata);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -46,6 +46,22 @@ typedef struct {
 } bsg_exception;
 
 typedef struct {
+    char key[64];
+    char value[64];
+} bsg_char_metadata_pair;
+
+typedef struct {
+    char name[33];
+    char timestamp[37];
+    bugsnag_breadcrumb_type type;
+
+    /**
+     * Key/value pairs of related information for debugging
+     */
+    bsg_char_metadata_pair metadata[8];
+} bugsnag_breadcrumb_v1;
+
+typedef struct {
     char name[64];
     char id[64];
     char package_name[64];
@@ -102,7 +118,7 @@ typedef struct {
     // Breadcrumbs are a ring; the first index moves as the
     // structure is filled and replaced.
     int crumb_first_index;
-    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+    bugsnag_breadcrumb_v1 breadcrumbs[BUGSNAG_CRUMBS_MAX];
 
     char context[64];
     bugsnag_severity severity;
@@ -124,7 +140,7 @@ typedef struct {
     // Breadcrumbs are a ring; the first index moves as the
     // structure is filled and replaced.
     int crumb_first_index;
-    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+    bugsnag_breadcrumb_v1 breadcrumbs[BUGSNAG_CRUMBS_MAX];
 
     char context[64];
     bugsnag_severity severity;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
@@ -2,14 +2,12 @@
 #include <event.h>
 #include <time.h>
 
-bugsnag_breadcrumb *init_breadcrumb(const char *name, const char *message, bugsnag_breadcrumb_type type) {
+bugsnag_breadcrumb *init_breadcrumb(const char *name, char *message, bugsnag_breadcrumb_type type) {
   bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
   crumb->type = type;
   strcpy(crumb->name, name);
   strcpy(crumb->timestamp, "2018-08-29T21:41:39Z");
-  strcpy(crumb->metadata[0].key, "message");
-  strcpy(crumb->metadata[0].value, message);
-
+  bsg_add_metadata_value_str(&crumb->metadata, "metaData", "message", message);
   return crumb;
 }
 
@@ -20,19 +18,19 @@ TEST test_add_breadcrumb(void) {
   ASSERT_EQ(1, event->crumb_count);
   ASSERT_EQ(0, event->crumb_first_index);
   ASSERT(strcmp("stroll", event->breadcrumbs[0].name) == 0);
-  ASSERT(strcmp("message", event->breadcrumbs[0].metadata[0].key) == 0);
-  ASSERT(strcmp("this is a drill.", event->breadcrumbs[0].metadata[0].value) == 0);
+  ASSERT(strcmp("message", event->breadcrumbs[0].metadata.values[0].name) == 0);
+  ASSERT(strcmp("this is a drill.", event->breadcrumbs[0].metadata.values[0].char_value) == 0);
   free(crumb);
   bugsnag_breadcrumb *crumb2 = init_breadcrumb("walking...", "this is not a drill.", BSG_CRUMB_USER);
   bugsnag_event_add_breadcrumb(event, crumb2);
   ASSERT_EQ(2, event->crumb_count);
   ASSERT_EQ(0, event->crumb_first_index);
   ASSERT(strcmp("stroll", event->breadcrumbs[0].name) == 0);
-  ASSERT(strcmp("message", event->breadcrumbs[0].metadata[0].key) == 0);
-  ASSERT(strcmp("this is a drill.", event->breadcrumbs[0].metadata[0].value) == 0);
+  ASSERT(strcmp("message", event->breadcrumbs[0].metadata.values[0].name) == 0);
+  ASSERT(strcmp("this is a drill.", event->breadcrumbs[0].metadata.values[0].char_value) == 0);
   ASSERT(strcmp("walking...", event->breadcrumbs[1].name) == 0);
-  ASSERT(strcmp("message", event->breadcrumbs[1].metadata[0].key) == 0);
-  ASSERT(strcmp("this is not a drill.", event->breadcrumbs[1].metadata[0].value) == 0);
+  ASSERT(strcmp("message", event->breadcrumbs[1].metadata.values[0].name) == 0);
+  ASSERT(strcmp("this is not a drill.", event->breadcrumbs[1].metadata.values[0].char_value) == 0);
 
   free(event);
   free(crumb2);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -125,33 +125,63 @@ bugsnag_event * loadSessionTestCase(jint num) {
 
 bugsnag_event * loadBreadcrumbsTestCase(jint num) {
     bugsnag_event *event = malloc(sizeof(bugsnag_event));
-    event->crumb_count = 1;
-    event->crumb_first_index = 0;
-    event->breadcrumbs[0].type = BSG_CRUMB_USER;
-    strcpy(event->breadcrumbs[0].name, "Jane");
-    strcpy(event->breadcrumbs[0].timestamp, "2018-10-08T12:07:09Z");
 
-    bugsnag_metadata *data = &event->breadcrumbs[0].metadata;
-    data->value_count = 4;
+    // ensure that serialization loop is covered by test
+    event->crumb_count = 4;
+    event->crumb_first_index = BUGSNAG_CRUMBS_MAX - 2;
 
+    // first breadcrumb
+    bugsnag_breadcrumb *crumb = &event->breadcrumbs[BUGSNAG_CRUMBS_MAX - 2];
+    crumb->type = BSG_CRUMB_USER;
+    strcpy(crumb->name, "Jane");
+    strcpy(crumb->timestamp, "2018-10-08T12:07:09Z");
+
+    // metadata
+    bugsnag_metadata *data = &crumb->metadata;
+    data->value_count = 1;
     data->values[0].type = BSG_METADATA_CHAR_VALUE;
     strcpy(data->values[0].section, "custom");
     strcpy(data->values[0].name, "str");
     strcpy(data->values[0].char_value, "Foo");
 
-    data->values[1].type = BSG_METADATA_BOOL_VALUE;
-    strcpy(data->values[1].section, "custom");
-    strcpy(data->values[1].name, "bool");
-    data->values[1].bool_value = true;
+    // second breadcrumb
+    crumb = &event->breadcrumbs[BUGSNAG_CRUMBS_MAX - 1];
+    crumb->type = BSG_CRUMB_MANUAL;
+    strcpy(crumb->name, "Something went wrong");
+    strcpy(crumb->timestamp, "2018-10-08T12:07:11Z");
 
-    data->values[2].type = BSG_METADATA_NUMBER_VALUE;
-    strcpy(data->values[2].section, "custom");
-    strcpy(data->values[2].name, "num");
-    data->values[2].double_value = 55;
+    // metadata
+    data = &crumb->metadata;
+    data->value_count = 1;
+    data->values[0].type = BSG_METADATA_BOOL_VALUE;
+    strcpy(data->values[0].section, "custom");
+    strcpy(data->values[0].name, "bool");
+    data->values[0].bool_value = true;
 
-    data->values[3].type = BSG_METADATA_NONE_VALUE;
-    strcpy(data->values[3].section, "custom");
-    strcpy(data->values[3].name, "none");
+    // third breadcrumb
+    crumb = &event->breadcrumbs[0];
+    crumb->type = BSG_CRUMB_NAVIGATION;
+    strcpy(crumb->name, "MainActivity");
+    strcpy(crumb->timestamp, "2018-10-08T12:07:15Z");
+
+    // metadata
+    data = &crumb->metadata;
+    data->values[0].type = BSG_METADATA_NUMBER_VALUE;
+    strcpy(data->values[0].section, "custom");
+    strcpy(data->values[0].name, "num");
+    data->values[0].double_value = 55;
+
+    // fourth breadcrumb
+    crumb = &event->breadcrumbs[1];
+    crumb->type = BSG_CRUMB_STATE;
+    strcpy(crumb->name, "Updated store");
+    strcpy(crumb->timestamp, "2018-10-08T12:07:16Z");
+
+    // metadata
+    data = &crumb->metadata;
+    data->values[0].type = BSG_METADATA_NONE_VALUE;
+    strcpy(data->values[0].section, "custom");
+    strcpy(data->values[0].name, "none");
     return event;
 }
 

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -124,15 +124,35 @@ bugsnag_event * loadSessionTestCase(jint num) {
 }
 
 bugsnag_event * loadBreadcrumbsTestCase(jint num) {
-    bugsnag_event *data = malloc(sizeof(bugsnag_event));
-    data->crumb_count = 1;
-    data->crumb_first_index = 0;
-    data->breadcrumbs[0].type = BSG_CRUMB_USER;
-    strcpy(data->breadcrumbs[0].name, "Jane");
-    strcpy(data->breadcrumbs[0].timestamp, "2018-10-08T12:07:09Z");
-    strcpy(data->breadcrumbs[0].metadata->key, "foo");
-    strcpy(data->breadcrumbs[0].metadata->value, "bar");
-    return data;
+    bugsnag_event *event = malloc(sizeof(bugsnag_event));
+    event->crumb_count = 1;
+    event->crumb_first_index = 0;
+    event->breadcrumbs[0].type = BSG_CRUMB_USER;
+    strcpy(event->breadcrumbs[0].name, "Jane");
+    strcpy(event->breadcrumbs[0].timestamp, "2018-10-08T12:07:09Z");
+
+    bugsnag_metadata *data = &event->breadcrumbs[0].metadata;
+    data->value_count = 4;
+
+    data->values[0].type = BSG_METADATA_CHAR_VALUE;
+    strcpy(data->values[0].section, "custom");
+    strcpy(data->values[0].name, "str");
+    strcpy(data->values[0].char_value, "Foo");
+
+    data->values[1].type = BSG_METADATA_BOOL_VALUE;
+    strcpy(data->values[1].section, "custom");
+    strcpy(data->values[1].name, "bool");
+    data->values[1].bool_value = true;
+
+    data->values[2].type = BSG_METADATA_NUMBER_VALUE;
+    strcpy(data->values[2].section, "custom");
+    strcpy(data->values[2].name, "num");
+    data->values[2].double_value = 55;
+
+    data->values[3].type = BSG_METADATA_NONE_VALUE;
+    strcpy(data->values[3].section, "custom");
+    strcpy(data->values[3].name, "none");
+    return event;
 }
 
 bugsnag_stackframe * loadStackframeTestCase(jint num) {


### PR DESCRIPTION
## Goal

Migrates the NDK layer to use the new `bugsnag_metadata` struct. This allows for numeric/boolean values to be added as metadata in breadcrumbs, and simplifies the implementation by keeping the same sort of metadata for both fields.

## Changeset

- Replaced `bsg_char_metadata_pair` with `bugsnag_metadata` on the event interface
- Added a migration to handle previously serialized structs
- Altered non-public methods for manipulating metadata to take a `metadata` parameter, rather than just a `bugsnag_event`, to allow code reuse between event/breadcrumb metadata manipulation
- Supported setting boolean and numeric values on breadcrumb metadata

## Tests

- Manually verified that a boolean metadata value can be added to a breadcrumb from Java, and that it is displayed in fatal NDK errors.
- Updated existing test assertions to account for new metadata structure and expanded coverage for serialization tests for breadcrumb metadata
