### PR TITLE
Prevent logger from throwing NPE in Configuration

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -27,7 +27,10 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     var autoDetectErrors: Boolean = true
     var codeBundleId: String? = null
     var appType: String? = "android"
-    var logger: Logger? = null
+    var logger: Logger? = DebugLogger
+        set(value) {
+            field = value ?: NoopLogger
+        }
     var delivery: Delivery? = null
     var endpoints: EndpointConfiguration = EndpointConfiguration()
     var maxBreadcrumbs: Int = DEFAULT_MAX_SIZE

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -173,6 +173,7 @@ internal class ImmutableConfigTest {
         val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
         seed.logger = NoopLogger
         val config = sanitiseConfiguration(context, seed, connectivity)
+        assertEquals(NoopLogger, config.logger)
         assertEquals(setOf("com.example.foo"), config.projectPackages)
         assertEquals("production", config.releaseStage)
         assertEquals(55, config.versionCode)


### PR DESCRIPTION
## Goal

`config.logger` is null by default and is then set to a default value during the `Client` constructor. This can cause a NPE when an invalid option is supplied.

This alters the notifier to set the field to `DebugLogger` by default, and then if the `releaseStage` equals "production" in the `Client` constructor, sets the logger to a `NoopLogger`. This allows us to log error messages when a user has initialised configuration wrong but otherwise retain the default behaviour. It is still possible to disable logging entirely by setting a custom logger on `Configuration`.

This also fixes a bug caused by ordering, where the logger was set before the releaseStage in the Configuration sanitisation. `sanitiseConfiguration()` has therefore been moved as far up the `Client` constructor as possible.

## Tests

- Enhanced unit test to verify logger is set when sanitising config.
- Manually verified a message was logged by setting an invalid value on `config.maxBreadcrumbs`
