### PR TITLE
Add bugsnag-plugin-react-native as a module

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -8,6 +8,7 @@ import java.util.HashMap
 
 internal data class ImmutableConfig(
     val apiKey: String,
+    val autoDetectErrors: Boolean,
     val enabledErrorTypes: ErrorTypes,
     val autoTrackSessions: Boolean,
     val sendThreads: ThreadSendPolicy,
@@ -91,6 +92,7 @@ internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
 
     return ImmutableConfig(
         apiKey = config.apiKey,
+        autoDetectErrors = config.autoDetectErrors,
         enabledErrorTypes = errorTypes,
         autoTrackSessions = config.autoTrackSessions,
         sendThreads = config.sendThreads,

--- a/bugsnag-plugin-react-native/README.md
+++ b/bugsnag-plugin-react-native/README.md
@@ -1,7 +1,16 @@
-# bugsnag-plugin-android-anr
+# bugsnag-plugin-react-native
 
 This module detects errors in React Native apps and reports them to bugsnag.
 
 ## High-level Overview
 
-TBD
+This module depends on bugsnag-android-core, and implements a `BugsnagReactNativePlugin` which is
+added in the native layer using the `Plugin` interface. This class is intended to be the sole
+internal API which `BugsnagReactNative` in the `bugsnag-js` repository invokes.
+
+The responsibility of this module is to serialize information into a format that can be understood
+by the React Bridge, and to forward method calls onto the appropriate site from `bugsnag-js`.
+
+The responsibility of Android code in the `bugsnag-js` package is to implement any functionality
+that requires the React Native Android dependency. A minimal number of classes require this and
+ by default code should be implemented in this module.

--- a/bugsnag-plugin-react-native/README.md
+++ b/bugsnag-plugin-react-native/README.md
@@ -1,0 +1,7 @@
+# bugsnag-plugin-android-anr
+
+This module detects errors in React Native apps and reports them to bugsnag.
+
+## High-level Overview
+
+TBD

--- a/bugsnag-plugin-react-native/build.gradle
+++ b/bugsnag-plugin-react-native/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "com.github.hierynomus.license"
+}
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+apply plugin: "io.gitlab.arturbosch.detekt"
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    defaultConfig.minSdkVersion rootProject.ext.minSdkVersion
+}
+
+dependencies {
+    api project(':bugsnag-android-core')
+}
+
+apply from: "../gradle/dependencies.gradle"
+apply from: "../gradle/release.gradle"
+apply from: "../gradle/detekt.gradle"
+apply from: "../gradle/checkstyle.gradle"
+apply from: "../gradle/license-check.gradle"

--- a/bugsnag-plugin-react-native/detekt-baseline.xml
+++ b/bugsnag-plugin-react-native/detekt-baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <Blacklist></Blacklist>
+  <Whitelist></Whitelist>
+</SmellBaseline>

--- a/bugsnag-plugin-react-native/gradle.properties
+++ b/bugsnag-plugin-react-native/gradle.properties
@@ -1,0 +1,2 @@
+pomName=Bugsnag Android React Native
+artefactId=bugsnag-plugin-react-native

--- a/bugsnag-plugin-react-native/lint-baseline.xml
+++ b/bugsnag-plugin-react-native/lint-baseline.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="5" by="lint 3.4.2" client="gradle" variant="all" version="3.4.2">
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void serialize(Map&lt;String, Object> map, ImmutableConfig config) {"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/ConfigSerializer.java"
+            line="12"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public void serialize(Map&lt;String, Object> map, ImmutableConfig config) {"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/ConfigSerializer.java"
+            line="12"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public InternalHooks(Client client) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/InternalHooks.java"
+            line="11"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public ImmutableConfig getConfig() {"
+        errorLine2="           ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/InternalHooks.java"
+            line="15"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public AppWithState getAppWithState() {"
+        errorLine2="           ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/InternalHooks.java"
+            line="19"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public DeviceWithState getDeviceWithState() {"
+        errorLine2="           ~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/InternalHooks.java"
+            line="23"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public List&lt;Breadcrumb> getBreadcrumbs() {"
+        errorLine2="           ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/InternalHooks.java"
+            line="27"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="    public List&lt;Thread> getThreads() {"
+        errorLine2="           ~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/bugsnag/android/InternalHooks.java"
+            line="34"
+            column="12"/>
+    </issue>
+
+</issues>

--- a/bugsnag-plugin-react-native/proguard-rules.pro
+++ b/bugsnag-plugin-react-native/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keepattributes LineNumberTable,SourceFile

--- a/bugsnag-plugin-react-native/src/main/AndroidManifest.xml
+++ b/bugsnag-plugin-react-native/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.bugsnag.android.reactnative" />

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppSerializer.kt
@@ -1,0 +1,17 @@
+package com.bugsnag.android
+
+class AppSerializer : WritableMapSerializer<AppWithState> {
+    override fun serialize(map: MutableMap<String, Any?>, app: AppWithState) {
+        map["appType"] = app.type
+        map["binaryArch"] = app.binaryArch
+        map["buildUuid"] = app.buildUuid
+        map["codeBundleId"] = app.codeBundleId
+        map["duration"] = app.duration
+        map["durationInForeground"] = app.durationInForeground
+        map["id"] = app.id
+        map["inForeground"] = app.inForeground
+        map["releaseStage"] = app.releaseStage
+        map["version"] = app.version
+        map["versionCode"] = app.versionCode
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BreadcrumbSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BreadcrumbSerializer.kt
@@ -1,0 +1,12 @@
+package com.bugsnag.android
+
+import java.util.Locale
+
+class BreadcrumbSerializer : WritableMapSerializer<Breadcrumb> {
+    override fun serialize(map: MutableMap<String, Any?>, crumb: Breadcrumb) {
+        map["timestamp"] = DateUtils.toIso8601(crumb.timestamp)
+        map["message"] = crumb.message
+        map["type"] = crumb.type.toString().toLowerCase(Locale.US)
+        map["metadata"] = crumb.metadata
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.java
@@ -1,0 +1,16 @@
+package com.bugsnag.android;
+
+import org.jetbrains.annotations.NotNull;
+
+public class BugsnagReactNativePlugin implements Plugin {
+
+    @Override
+    public void load(@NotNull Client client) {
+        client.immutableConfig.getLogger().i("Initialized React Native Plugin");
+    }
+
+    @Override
+    public void unload() {
+
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
@@ -1,0 +1,63 @@
+package com.bugsnag.android;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class ConfigSerializer implements WritableMapSerializer<ImmutableConfig> {
+
+    @Override
+    public void serialize(Map<String, Object> map, ImmutableConfig config) {
+        map.put("apiKey", config.getApiKey());
+        map.put("autoDetectErrors", config.getAutoDetectErrors());
+        map.put("autoTrackSessions", config.getAutoTrackSessions());
+        map.put("sendThreads", config.getSendThreads().toString());
+        map.put("discardClasses", config.getDiscardClasses());
+        map.put("projectPackages", config.getProjectPackages());
+        map.put("enabledReleaseStages", config.getEnabledReleaseStages());
+        map.put("releaseStage", config.getReleaseStage());
+        map.put("buildUuid", config.getBuildUuid());
+        if (config.getAppVersion() != null) {
+            map.put("appVersion", config.getAppVersion());
+        }
+        map.put("versionCode", config.getVersionCode());
+        map.put("codeBundleId", config.getCodeBundleId());
+        map.put("type", config.getAppType());
+        map.put("persistUser", config.getPersistUser());
+        map.put("launchCrashThresholdMs", (int) config.getLaunchCrashThresholdMs());
+        map.put("maxBreadcrumbs", config.getMaxBreadcrumbs());
+        map.put("enabledBreadcrumbTypes", serializeBreadrumbTypes(config));
+        map.put("enabledErrorTypes", serializeErrorTypes(config));
+        map.put("endpoints", serializeEndpoints(config));
+    }
+
+    private Collection<String> serializeBreadrumbTypes(ImmutableConfig config) {
+        Collection<String> crumbTypes = new HashSet<>();
+        Set<BreadcrumbType> types = config.getEnabledBreadcrumbTypes();
+        if (types != null) {
+            for (BreadcrumbType type : types) {
+                crumbTypes.add(type.toString());
+            }
+        }
+        return crumbTypes;
+    }
+
+    private Map<String, Object> serializeErrorTypes(ImmutableConfig config) {
+        Map<String, Object> map = new HashMap<>();
+        ErrorTypes errorTypes = config.getEnabledErrorTypes();
+        map.put("anrs", errorTypes.getAnrs());
+        map.put("ndkCrashes", errorTypes.getNdkCrashes());
+        map.put("unhandledExceptions", errorTypes.getUnhandledExceptions());
+        return map;
+    }
+
+    private Map<String, Object> serializeEndpoints(ImmutableConfig config) {
+        Map<String, Object> map = new HashMap<>();
+        EndpointConfiguration endpoints = config.getEndpoints();
+        map.put("notify", endpoints.getNotify());
+        map.put("sessions", endpoints.getSessions());
+        return map;
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceSerializer.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android
+
+class DeviceSerializer : WritableMapSerializer<DeviceWithState> {
+    override fun serialize(map: MutableMap<String, Any?>, device: DeviceWithState) {
+        map["cpuAbi"] = device.cpuAbi?.toList()
+        map["jailbroken"] = device.jailbroken
+        map["id"] = device.id
+        map["locale"] = device.locale
+        map["manufacturer"] = device.manufacturer
+        map["model"] = device.model
+        map["osName"] = device.osName
+        map["osVersion"] = device.osVersion
+        map["totalMemory"] = device.totalMemory
+        map["freeDisk"] = device.freeDisk
+        map["freeMemory"] = device.freeMemory
+        map["orientation"] = device.orientation
+
+        if (device.time != null) {
+            map["time"] = DateUtils.toIso8601(device.time!!)
+        }
+        map["runtimeVersions"] = device.runtimeVersions
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -1,0 +1,37 @@
+package com.bugsnag.android;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+public class InternalHooks {
+
+    private final Client client;
+
+    public InternalHooks(Client client) {
+        this.client = client;
+    }
+
+    public ImmutableConfig getConfig() {
+        return client.getConfig();
+    }
+
+    public AppWithState getAppWithState() {
+        return client.appDataCollector.generateAppWithState();
+    }
+
+    public DeviceWithState getDeviceWithState() {
+        return client.deviceDataCollector.generateDeviceWithState(new Date().getTime());
+    }
+
+    public List<Breadcrumb> getBreadcrumbs() {
+        return client.getBreadcrumbs();
+    }
+
+    // TODO: need to return true values for threads, which requires extracting the
+    //  ThreadPolicy logic which determines whether to collect them or not from the Event
+    //  into the ThreadState constructor within bugsnag-android. Using a dummy value for now
+    public List<Thread> getThreads() {
+        return Collections.emptyList();
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android
+
+import java.util.Locale
+
+class ThreadSerializer : WritableMapSerializer<Thread> {
+    override fun serialize(map: MutableMap<String, Any?>, thread: Thread) {
+        map["id"] = thread.id
+        map["name"] = thread.name
+        map["type"] = thread.type.toString().toLowerCase(Locale.US)
+        map["errorReportingThread"] = thread.errorReportingThread
+
+        map["stacktrace"] = thread.stacktrace.map {
+            val frame = mutableMapOf<String, Any?>()
+            frame["method"] = it.method
+            frame["lineNumber"] = it.lineNumber
+            frame["file"] = it.file
+            frame["inProject"] = it.inProject
+            frame
+        }
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/WritableMapSerializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/WritableMapSerializer.java
@@ -1,0 +1,7 @@
+package com.bugsnag.android;
+
+import java.util.Map;
+
+interface WritableMapSerializer<T> {
+    void serialize(Map<String, Object> map, T obj);
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/AppSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/AppSerializerTest.java
@@ -1,0 +1,48 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+
+import com.bugsnag.android.AppWithState;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AppSerializerTest {
+
+    private AppWithState app;
+
+    /**
+     * Generates an AppWithState for verifying the serializer
+     */
+    @Before
+    public void setup() {
+        app = new AppWithState(TestData.generateConfig(),
+                "x86", "com.example.foo", "prod",
+                "1.5.3", 509, 23, true
+        );
+    }
+
+    @Test
+    public void serialize() {
+        Map<String, Object> map = new HashMap<>();
+        new AppSerializer().serialize(map, app);
+
+        assertEquals(509, map.get("duration"));
+        assertEquals(23, map.get("durationInForeground"));
+        assertEquals(true, map.get("inForeground"));
+        assertEquals("x86", map.get("binaryArch"));
+        assertEquals("builduuid-123", map.get("buildUuid"));
+        assertEquals("code-id-123", map.get("codeBundleId"));
+        assertEquals("com.example.foo", map.get("id"));
+        assertEquals("prod", map.get("releaseStage"));
+        assertEquals("android", map.get("appType"));
+        assertEquals("1.5.3", map.get("version"));
+        assertEquals(55, map.get("versionCode"));
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BreadcrumbSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BreadcrumbSerializerTest.java
@@ -1,0 +1,44 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+
+import com.bugsnag.android.Breadcrumb;
+import com.bugsnag.android.BreadcrumbType;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BreadcrumbSerializerTest {
+
+    private Breadcrumb crumb;
+    private Map<String, Object> metadata;
+
+    /**
+     * Generates a Breadcrumb for verifying the serializer
+     */
+    @Before
+    public void setup() {
+        Date timestamp = new Date(0);
+        metadata = new HashMap<>();
+        metadata.put("foo", "bar");
+        crumb = new Breadcrumb("Whoops", BreadcrumbType.STATE, metadata,
+                timestamp, NoopLogger.INSTANCE);
+    }
+
+    @Test
+    public void serialize() {
+        Map<String, Object> map = new HashMap<>();
+        new BreadcrumbSerializer().serialize(map, crumb);
+        assertEquals("1970-01-01T00:00:00Z", map.get("timestamp"));
+        assertEquals("Whoops", map.get("message"));
+        assertEquals("state", map.get("type"));
+        assertEquals(metadata, map.get("metadata"));
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
@@ -1,0 +1,62 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.bugsnag.android.ImmutableConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConfigSerializerTest {
+
+    private ImmutableConfig config;
+
+    /**
+     * Constructs an immutable config object
+     */
+    @Before
+    public void setUp() throws Exception {
+        config = TestData.generateConfig();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void serialize() {
+        ConfigSerializer serializer = new ConfigSerializer();
+        Map<String, Object> map = new HashMap<>();
+        serializer.serialize(map, config);
+
+        assertEquals("123456abcdeabcde", map.get("apiKey"));
+        assertTrue((Boolean) map.get("autoDetectErrors"));
+        assertTrue((Boolean) map.get("autoTrackSessions"));
+        assertEquals("ALWAYS", map.get("sendThreads"));
+        assertEquals(Collections.singleton("com.example.DiscardClass"), map.get("discardClasses"));
+        assertEquals(Collections.singleton("production"), map.get("enabledReleaseStages"));
+        assertEquals(Collections.singleton("com.example"), map.get("projectPackages"));
+        assertEquals("production", map.get("releaseStage"));
+        assertEquals("builduuid-123", map.get("buildUuid"));
+        assertEquals("1.4.3", map.get("appVersion"));
+        assertEquals(55, map.get("versionCode"));
+        assertEquals("code-id-123", map.get("codeBundleId"));
+        assertEquals("android", map.get("type"));
+        assertTrue((Boolean) map.get("persistUser"));
+        assertEquals(55, map.get("launchCrashThresholdMs"));
+        assertEquals(22, map.get("maxBreadcrumbs"));
+        assertEquals(Collections.singleton("manual"), map.get("enabledBreadcrumbTypes"));
+
+        Map<String, Object> errorTypes = (Map<String, Object>) map.get("enabledErrorTypes");
+        assertTrue((Boolean) errorTypes.get("anrs"));
+        assertFalse((Boolean) errorTypes.get("ndkCrashes"));
+        assertTrue((Boolean) errorTypes.get("unhandledExceptions"));
+
+        Map<String, Object> endpoints = (Map<String, Object>) map.get("endpoints");
+        assertEquals("https://notify.bugsnag.com", endpoints.get("notify"));
+        assertEquals("https://sessions.bugsnag.com", endpoints.get("sessions"));
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/DeviceSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/DeviceSerializerTest.java
@@ -1,0 +1,77 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+
+import com.bugsnag.android.DeviceBuildInfo;
+import com.bugsnag.android.DeviceWithState;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeviceSerializerTest {
+
+    private DeviceWithState device;
+
+    /**
+     * Generates a DeviceWithState for verifying the serializer
+     */
+    @Before
+    public void setup() {
+        device = new DeviceWithState(
+                new DeviceBuildInfo(
+                        "google",
+                        "pixel4",
+                        "8.0",
+                        27,
+                        "bulldog",
+                        "bulldog-3.6-android",
+                        "test-tag",
+                        "google pixel",
+                        new String[]{"x86"}
+                ),
+                new String[]{"x86"},
+                true,
+                "fa02",
+                "yue",
+                50923409234L,
+                20923423434L,
+                23409662345L,
+                "portrait",
+                new Date(0)
+        );
+    }
+
+    @Test
+    public void serialize() {
+        Map<String, Object> map = new HashMap<>();
+        new DeviceSerializer().serialize(map, device);
+
+        assertEquals(Arrays.asList("x86"), map.get("cpuAbi"));
+        assertEquals(true, map.get("jailbroken"));
+        assertEquals("fa02", map.get("id"));
+        assertEquals("yue", map.get("locale"));
+        assertEquals("google", map.get("manufacturer"));
+        assertEquals("pixel4", map.get("model"));
+        assertEquals("android", map.get("osName"));
+        assertEquals("8.0", map.get("osVersion"));
+        assertEquals(50923409234L, map.get("totalMemory"));
+        assertEquals(20923423434L, map.get("freeDisk"));
+        assertEquals(23409662345L, map.get("freeMemory"));
+        assertEquals("portrait", map.get("orientation"));
+        assertEquals("1970-01-01T00:00:00Z", map.get("time"));
+
+        Map<String, Object> runtimeVersions = new HashMap<>();
+        runtimeVersions.put("androidApiLevel", 27);
+        runtimeVersions.put("osBuild", "bulldog");
+        assertEquals(runtimeVersions, map.get("runtimeVersions"));
+
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
@@ -1,0 +1,32 @@
+package com.bugsnag.android;
+
+import java.util.Collections;
+import java.util.HashSet;
+
+class TestData {
+    static ImmutableConfig generateConfig() {
+        return new ImmutableConfig(
+                "123456abcdeabcde",
+                true,
+                new ErrorTypes(),
+                true,
+                ThreadSendPolicy.ALWAYS,
+                Collections.singleton("com.example.DiscardClass"),
+                Collections.singleton("production"),
+                Collections.singleton("com.example"),
+                new HashSet<>(Collections.singletonList(BreadcrumbType.MANUAL)),
+                "production",
+                "builduuid-123",
+                "1.4.3",
+                55,
+                "code-id-123",
+                "android",
+                new DefaultDelivery(null, NoopLogger.INSTANCE),
+                new EndpointConfiguration(),
+                true,
+                55,
+                NoopLogger.INSTANCE,
+                22
+        );
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
@@ -1,0 +1,59 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+
+import com.bugsnag.android.NoopLogger;
+import com.bugsnag.android.Stacktrace;
+import com.bugsnag.android.Thread;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ThreadSerializerTest {
+
+    private Thread thread;
+    private Map<String, Object> frame;
+
+    /**
+     * Generates a Thread for verifying the serializer
+     */
+    @Before
+    public void setup() {
+        frame = new HashMap<>();
+        frame.put("method", "foo()");
+        frame.put("file", "Bar.kt");
+        frame.put("lineNumber", 55);
+        frame.put("inProject", true);
+
+        List<Map<String, Object>> frames = Collections.singletonList(frame);
+        Stacktrace stacktrace = new Stacktrace(frames, NoopLogger.INSTANCE);
+        thread = new Thread(1, "fake-thread", ThreadType.ANDROID,
+                true, stacktrace, NoopLogger.INSTANCE);
+    }
+
+    @Test
+    public void serialize() {
+        Map<String, Object> map = new HashMap<>();
+        new ThreadSerializer().serialize(map, thread);
+
+        assertEquals(1L, map.get("id"));
+        assertEquals("fake-thread", map.get("name"));
+        assertEquals("android", map.get("type"));
+        assertEquals(true, map.get("errorReportingThread"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> frames = (List<Map<String, Object>>) map.get("stacktrace");
+        assertEquals(1, frames.size());
+
+        Map<String, Object> data = frames.get(0);
+        assertEquals(frame, data);
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/bugsnag-plugin-react-native/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/dockerfiles/Dockerfile.android-base
+++ b/dockerfiles/Dockerfile.android-base
@@ -23,6 +23,7 @@ COPY bugsnag-android-ndk/ bugsnag-android-ndk/
 COPY bugsnag-plugin-android-anr/ bugsnag-plugin-android-anr/
 COPY bugsnag-android-core/ bugsnag-android-core/
 COPY bugsnag-plugin-android-ndk/ bugsnag-plugin-android-ndk/
+COPY bugsnag-plugin-react-native/ bugsnag-plugin-react-native/
 COPY examples/ examples/
 COPY mazerunner-scenarios/ mazerunner-scenarios/
 COPY scripts/ scripts/

--- a/dockerfiles/Dockerfile.android-builder
+++ b/dockerfiles/Dockerfile.android-builder
@@ -23,6 +23,7 @@ COPY bugsnag-android-ndk/ bugsnag-android-ndk/
 COPY bugsnag-plugin-android-anr/ bugsnag-plugin-android-anr/
 COPY bugsnag-android-core/ bugsnag-android-core/
 COPY bugsnag-plugin-android-ndk/ bugsnag-plugin-android-ndk/
+COPY bugsnag-plugin-react-native/ bugsnag-plugin-react-native/
 COPY examples/ examples/
 COPY mazerunner-scenarios/ mazerunner-scenarios/
 COPY scripts/ scripts/

--- a/dockerfiles/Dockerfile.android-instrumentation-tests
+++ b/dockerfiles/Dockerfile.android-instrumentation-tests
@@ -23,6 +23,7 @@ COPY bugsnag-android-ndk/ bugsnag-android-ndk/
 COPY bugsnag-plugin-android-anr/ bugsnag-plugin-android-anr/
 COPY bugsnag-android-core/ bugsnag-android-core/
 COPY bugsnag-plugin-android-ndk/ bugsnag-plugin-android-ndk/
+COPY bugsnag-plugin-react-native/ bugsnag-plugin-react-native/
 COPY examples/ examples/
 COPY mazerunner-scenarios/ mazerunner-scenarios/
 COPY scripts/ scripts/

--- a/dockerfiles/Dockerfile.android-jvm
+++ b/dockerfiles/Dockerfile.android-jvm
@@ -23,6 +23,7 @@ COPY bugsnag-android-ndk/ bugsnag-android-ndk/
 COPY bugsnag-plugin-android-anr/ bugsnag-plugin-android-anr/
 COPY bugsnag-android-core/ bugsnag-android-core/
 COPY bugsnag-plugin-android-ndk/ bugsnag-plugin-android-ndk/
+COPY bugsnag-plugin-react-native/ bugsnag-plugin-react-native/
 COPY examples/ examples/
 COPY mazerunner-scenarios/ mazerunner-scenarios/
 COPY scripts/ scripts/

--- a/dockerfiles/Dockerfile.android-sizer
+++ b/dockerfiles/Dockerfile.android-sizer
@@ -23,6 +23,7 @@ COPY bugsnag-android-ndk/ bugsnag-android-ndk/
 COPY bugsnag-plugin-android-anr/ bugsnag-plugin-android-anr/
 COPY bugsnag-android-core/ bugsnag-android-core/
 COPY bugsnag-plugin-android-ndk/ bugsnag-plugin-android-ndk/
+COPY bugsnag-plugin-react-native/ bugsnag-plugin-react-native/
 COPY examples/ examples/
 COPY mazerunner-scenarios/ mazerunner-scenarios/
 COPY scripts/ scripts/

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,5 +4,6 @@ include(
     ':bugsnag-android-core',
     ':bugsnag-plugin-android-anr',
     ':bugsnag-plugin-android-ndk',
+    ':bugsnag-plugin-react-native',
     ":mazerunner-scenarios"
 )


### PR DESCRIPTION
## Goal

Adds `bugsnag-plugin-react-native` as a module to the project, rather than hosting a substantial amount of Android code in the bugsnag-js repo. This grants us several benefits:

- Less context-switching between bugsnag-android and bugsnag-react-native
- Less effort spent setting up static analysis for separate projects
- Easier to test native changes, as this would simply be a case of publishing to `mavenLocal` rather than altering vendored code in node_modules
- Greater clarity over whether the code should be owned by Android/JS custodians

For the equivalent JS changes, see https://github.com/bugsnag/bugsnag-js/pull/753

**Note**: the intended design for the module's interaction with bugsnag-js has been listed below, but this has not been implemented in full (as the bugsnag-react-native work is still in progress).

## Design

This change will result in a new artefact being published to mavenCentral with the artifactId `com.bugsnag:bugsnag-plugin-react-native`.  The `bugsnag-react-native` package will add a Gradle dependency on this artefact in addition to `com.bugsnag:bugsnag-android`.

The `BugsnagReactNativePlugin` will be registered as a plugin and loaded when `Bugsnag.start()` is invoked in the Android layer. The `BugsnagReactNative` class will remain in the bugsnag-js repository, and call onto the `BugsnagReactNativePlugin`, effectively using it as an internal API.

### Responsibility of remaining JS Android code

The remaining Android code in the bugsnag-js repository will be responsible for implementing code that requires a dependency on React Native. There are a minimal number of use-cases for this:

- Registering a react-native package
- Converting React Native's `WritableMap` and `ReadableMap` to `java.util.Map`
- Methods annotated with `@ReactMethod` to allow the JavaScript layer to call into the native layer

It is anticipated that this will result in a reasonably small amount of 'glue' code that is non-complex.

## Changeset

- Added a `bugsnag-plugin-react-native` module to the Gradle project
- Moved existing Android code from bugsnag-js to bugsnag-android
- Made minor alterations to existing Android code where required to compile the project (altering visibility of classes, nullability of types, rename of `ThreadSendPolicy`)
- Added `autoDetectErrors` to `ImmutableConfig` as this is read by the react-native layer
- Added baseline files for static analysis for this module
- Updated dockerfiles to copy module to build

**Note**: more code can be moved over from the bugsnag-js repository but this requires a more extensive refactor. This will be achieved in a separate PR later in the project.

## Tests

Manually verified that the dependency resolution and example app works in the bugsnag-js example project.
