### PR TITLE
Add deserializer interface for User

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppSerializer.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-internal class AppSerializer : WritableMapSerializer<AppWithState> {
+internal class AppSerializer : MapSerializer<AppWithState> {
     override fun serialize(map: MutableMap<String, Any?>, app: AppWithState) {
         map["appType"] = app.type
         map["binaryArch"] = app.binaryArch

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BreadcrumbSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BreadcrumbSerializer.kt
@@ -2,7 +2,7 @@ package com.bugsnag.android
 
 import java.util.Locale
 
-internal class BreadcrumbSerializer : WritableMapSerializer<Breadcrumb> {
+internal class BreadcrumbSerializer : MapSerializer<Breadcrumb> {
     override fun serialize(map: MutableMap<String, Any?>, crumb: Breadcrumb) {
         map["timestamp"] = DateUtils.toIso8601(crumb.timestamp)
         map["message"] = crumb.message

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-class ConfigSerializer implements WritableMapSerializer<ImmutableConfig> {
+class ConfigSerializer implements MapSerializer<ImmutableConfig> {
 
     @Override
     public void serialize(Map<String, Object> map, ImmutableConfig config) {

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceSerializer.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-internal class DeviceSerializer : WritableMapSerializer<DeviceWithState> {
+internal class DeviceSerializer : MapSerializer<DeviceWithState> {
     override fun serialize(map: MutableMap<String, Any?>, device: DeviceWithState) {
         map["cpuAbi"] = device.cpuAbi?.toList()
         map["jailbroken"] = device.jailbroken

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapDeserializer.java
@@ -1,0 +1,7 @@
+package com.bugsnag.android;
+
+import java.util.Map;
+
+interface MapDeserializer<T> {
+    T deserialize(Map<String, Object> map);
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapSerializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapSerializer.java
@@ -2,6 +2,6 @@ package com.bugsnag.android;
 
 import java.util.Map;
 
-interface WritableMapSerializer<T> {
+interface MapSerializer<T> {
     void serialize(Map<String, Object> map, T obj);
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapUtils.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapUtils.java
@@ -1,0 +1,16 @@
+package com.bugsnag.android;
+
+import java.util.Map;
+
+class MapUtils {
+
+    static String getString(Map<String, Object> map, String key) {
+        Object id = map.get(key);
+
+        if (id instanceof String) {
+            return (String) id;
+        } else {
+            return null;
+        }
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
@@ -2,7 +2,7 @@ package com.bugsnag.android
 
 import java.util.Locale
 
-internal class ThreadSerializer : WritableMapSerializer<Thread> {
+internal class ThreadSerializer : MapSerializer<Thread> {
     override fun serialize(map: MutableMap<String, Any?>, thread: Thread) {
         map["id"] = thread.id
         map["name"] = thread.name

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/UserDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/UserDeserializer.java
@@ -1,0 +1,12 @@
+package com.bugsnag.android;
+
+import static com.bugsnag.android.MapUtils.getString;
+
+import java.util.Map;
+
+class UserDeserializer implements MapDeserializer<User> {
+    @Override
+    public User deserialize(Map<String, Object> map) {
+        return new User(getString(map, "id"), getString(map, "email"), getString(map, "name"));
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/UserDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/UserDeserializerTest.kt
@@ -1,0 +1,29 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.HashMap
+
+class UserDeserializerTest {
+
+    private val map = HashMap<String, Any>()
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        map["id"] = "123"
+        map["email"] = "joe@example.com"
+        map["name"] = "Joe Bloggs"
+    }
+
+    @Test
+    fun deserialize() {
+        val user = UserDeserializer().deserialize(map)
+        assertEquals("123", user.id)
+        assertEquals("joe@example.com", user.email)
+        assertEquals("Joe Bloggs", user.name)
+    }
+}


### PR DESCRIPTION
## Goal

The `dispatch()` method on `BugsnagReactNativePlugin` accepts a map from the JS layer which contains information about a JS error. We need to deserialize this from a map into an `Event`.

This changeset adds an interface to do this and implements a deserializer for the `User` field. Other deserializers will be implemented in future PRs.

## Changeset

- Renamed `WritableMapSerializer` to `MapSerializer` to more accurately reflect responsibility
- Created `MapDeserializer` interface
- Implement deserializer for user information

## Tests

Added a unit test for the deserialization
