### PR TITLE
Remove armeabi from default build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,13 @@ Files are generated into`<module>/build/outputs/aar`.
 
 ### Building with custom ABIs
 
+By default, the NDK module will be built with the following ABIs:
+
+- arm64-v8a
+- armeabi-v7a
+- x86
+- x86_64
+
 To build the NDK module with specific ABIs, use the `ABI_FILTERS` project
 option:
 
@@ -98,14 +105,7 @@ option:
 ./gradlew assembleRelease -PABI_FILTERS=x86,arm64-v8a
 ```
 
-To build for ARMv5 (`armeabi`):
-
-```shell
-./gradlew assembleRelease -PABI_FILTERS=armeabi
-```
-
-Note that `armeabi` has been removed in NDK r17 and requires the installation
-of an older NDK version.
+For release purposes, the Makefile's build command includes the "armeabi" ABI for compatibility with devices using r16 and below of the NDK.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,15 @@ option:
 ./gradlew assembleRelease -PABI_FILTERS=x86,arm64-v8a
 ```
 
+To build for ARMv5 (`armeabi`):
+
+```shell
+./gradlew assembleRelease -PABI_FILTERS=armeabi
+```
+
+Note that `armeabi` has been removed in NDK r17 and requires the installation
+of an older NDK version.
+
 ## Testing
 
 Full details of how to build and run tests can be found in [the testing guide](`TESTING.md`)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: build
 .PHONY: build test clean bump release
 
 build:
-	./gradlew build
+	./gradlew build -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64
 
 clean:
 	./gradlew clean

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,5 @@ endif
 	@git commit -m "Release v$(VERSION)"
 	@git tag v$(VERSION)
 	@git push origin master v$(VERSION)
-	@./gradlew assembleRelease publish bintrayUpload && ./gradlew assembleRelease publish bintrayUpload -PreleaseNdkArtefact=true
+	@./gradlew assembleRelease publish bintrayUpload -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64 \
+	 && ./gradlew assembleRelease publish bintrayUpload -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64 -PreleaseNdkArtefact=true

--- a/bugsnag-plugin-android-anr/build.gradle
+++ b/bugsnag-plugin-android-anr/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         externalNativeBuild.cmake.arguments "-DANDROID_CPP_FEATURES=exceptions", "-DANDROID_STL=c++_static"
         ndk.abiFilters = project.hasProperty("ABI_FILTERS") ? project.ABI_FILTERS.split(",") :
-            ["arm64-v8a", "armeabi-v7a", "armeabi", "x86", "x86_64"]
+            ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
     }
     externalNativeBuild.cmake.path = "CMakeLists.txt"
 }

--- a/bugsnag-plugin-android-ndk/build.gradle
+++ b/bugsnag-plugin-android-ndk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         externalNativeBuild.cmake.arguments "-DANDROID_CPP_FEATURES=exceptions", "-DANDROID_STL=c++_static"
         ndk.abiFilters = project.hasProperty("ABI_FILTERS") ? project.ABI_FILTERS.split(",") :
-            ["arm64-v8a", "armeabi-v7a", "armeabi", "x86", "x86_64"]
+            ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
     }
     externalNativeBuild.cmake.path = "CMakeLists.txt"
 }

--- a/dockerfiles/Dockerfile.android-builder
+++ b/dockerfiles/Dockerfile.android-builder
@@ -50,7 +50,7 @@ RUN echo "signing.secretKeyRingFile=/root/.gnupg/secring.gpg" >> ~/.gradle/gradl
 
 # Build and upload to the local maven as version 9.9.9
 RUN sed -i -e 's/VERSION_NAME=.*/VERSION_NAME=9.9.9/g' gradle.properties
-RUN ./gradlew assembleRelease publishToMavenLocal
+RUN ./gradlew assembleRelease publishToMavenLocal -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64
 
 COPY tests/features/ /app/features
 

--- a/dockerfiles/Dockerfile.android-builder
+++ b/dockerfiles/Dockerfile.android-builder
@@ -30,6 +30,8 @@ COPY scripts/ scripts/
 
 RUN scripts/install-ndk.sh
 
+ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk-bundle
+
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 
 RUN ./gradlew

--- a/dockerfiles/Dockerfile.android-instrumentation-tests
+++ b/dockerfiles/Dockerfile.android-instrumentation-tests
@@ -35,5 +35,4 @@ ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 RUN ./gradlew
 
 # Everything above this point should be derived from android-base
-RUN sed --in-place="" --expression='s/"armeabi",//' bugsnag-plugin-android-anr/build.gradle bugsnag-plugin-android-ndk/build.gradle
 CMD ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh

--- a/dockerfiles/Dockerfile.android-jvm
+++ b/dockerfiles/Dockerfile.android-jvm
@@ -39,8 +39,3 @@ RUN apt-get install -y cppcheck
 
 COPY examples/sdk-app-example/ examples/sdk-app-example/
 COPY config/ config/
-
-RUN sed --in-place="" --expression="s/'armeabi',//" bugsnag-plugin-android-anr/build.gradle \
-    bugsnag-plugin-android-ndk/build.gradle examples/sdk-app-example/build.gradle
-
-

--- a/dockerfiles/Dockerfile.android-sizer
+++ b/dockerfiles/Dockerfile.android-sizer
@@ -50,7 +50,7 @@ RUN echo "signing.secretKeyRingFile=/root/.gnupg/secring.gpg" >> ~/.gradle/gradl
 
 # Build and upload to the local maven as version 9.9.9
 RUN sed -i -e 's/VERSION_NAME=.*/VERSION_NAME=9.9.9/g' gradle.properties
-RUN ./gradlew assembleRelease publishToMavenLocal
+RUN ./gradlew assembleRelease publishToMavenLocal -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64
 
 COPY tests/features/ tests/features
 

--- a/dockerfiles/Dockerfile.android-sizer
+++ b/dockerfiles/Dockerfile.android-sizer
@@ -30,6 +30,8 @@ COPY scripts/ scripts/
 
 RUN scripts/install-ndk.sh
 
+ENV ANDROID_NDK_HOME=${ANDROID_HOME}/ndk-bundle
+
 ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
 
 RUN ./gradlew

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -52,9 +52,8 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.compileSdkVersion
         signingConfig signingConfigs.config
-        ndk {
-            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
-        }
+        ndk.abiFilters = project.hasProperty("ABI_FILTERS") ? project.ABI_FILTERS.split(",") :
+                ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
     }
     buildTypes {
         release {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -11,7 +11,7 @@ def expectedNdkVersion = "16" // Controls which NDK library major version should
 
 def expectedAbiLists = // Controls which combinations of ABIs are expected for release
 [
-    ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"] as Set,
+    ["arm64-v8a", "armeabi", "armeabi-v7a", "x86", "x86_64"] as Set,
     ["armeabi-v7a", "x86"] as Set
 ]
 
@@ -68,7 +68,7 @@ task validatePublishOptions() {
 }
 
 tasks.whenTaskAdded { task ->
-    if (task.name == 'assembleRelease') {
+    if ((task.name == 'assembleRelease') || (task.name == 'publish') || (task.name == 'bintrayUpload')) {
         task.dependsOn validatePublishOptions
     }
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -7,6 +7,14 @@ archivesBaseName = project.getProperties().get("artefactId")
 version = "${project.VERSION_NAME}"
 group = "${project.GROUP}"
 
+def expectedNdkVersion = "16" // Controls which NDK library major version should be used for release
+
+def expectedAbiLists = // Controls which combinations of ABIs are expected for release
+[
+    ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"] as Set,
+    ["armeabi-v7a", "x86"] as Set
+]
+
 // Disable doclint:
 // https://github.com/GPars/GPars/blob/312c5ae87605a0552bc72e22e3b2bd2fa1fdf98c/build.gradle#L208-L214
 if (JavaVersion.current().isJava8Compatible()) {
@@ -30,7 +38,43 @@ task sourceJar(type: Jar) {
     classifier "sources"
 }
 
+task validatePublishOptions() {
+    description = "Ensures assembleRelease is run with the correct NDK library version and ABI list"
+    doFirst {
+        def ndkVersion
+        try {
+            def props = new Properties()
+            file(System.getenv('ANDROID_NDK_HOME') + "/source.properties").withInputStream {
+                props.load(it)
+            }
+            ndkVersion = props.getProperty("Pkg.Revision")
+        } catch (Exception e) {
+            ndkVersion = "UNKNOWN"
+        }
+
+        if (!ndkVersion.startsWith("${expectedNdkVersion}.")) {
+            throw new GradleException("${project.name} must be released with ${expectedNdkVersion}.x of the NDK - found ${ndkVersion}")
+        }
+
+        if (project.android.defaultConfig.ndk.abiFilters != null) {
+            for (abiList in expectedAbiLists) {
+                if (abiList == project.android.defaultConfig.ndk.abiFilters as Set) {
+                    return
+                }
+            }
+            throw new GradleException("Unexpected list of ABIs for release: ${project.android.defaultConfig.ndk.abiFilters}")
+        }
+    }
+}
+
+tasks.whenTaskAdded { task ->
+    if (task.name == 'assembleRelease') {
+        task.dependsOn validatePublishOptions
+    }
+}
+
 publishing {
+
     repositories {
         maven {
             if (VERSION_NAME.contains("SNAPSHOT")) {
@@ -46,6 +90,7 @@ publishing {
     }
 
     publications {
+
         SDK(MavenPublication) {
             groupId "com.bugsnag"
             artifactId archivesBaseName


### PR DESCRIPTION
## Goal

As per #615 - removes the now unsupported "armeabi" ABI from the default build.

## Changeset

* bugsnag-plugin-android-anr/build.gradle - removed "armeabi" from default list of targets
* bugsnag-plugin-android-ndk/build.gradle - removed "armeabi" from default list of targets
* examples/sdk-app-example/build.gradle - removed "armeabi" from default list of targets and added ABI_FILTERS property for consistency with main build
* Makefile - added full list of ABIs for inclusion when making a release
* gradle/release.gradle - added check during before assembleRelease to throw exception if the NDK library version or ABI list is unexpected (supports both Android and Unity ABI lists). 

## Tests

Run locally to verify validation check, CI will show no difference without "armeabi".
