### PR TITLE
Add deserializers for error, thread, and stackframe

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
@@ -32,6 +32,14 @@ internal class Stacktrace : JsonStream.Streamable {
         this.logger = logger
     }
 
+    constructor(logger: Logger, frames: List<Stackframe>) {
+        trace = when {
+            frames.size >= STACKTRACE_TRIM_LENGTH -> frames.subList(0, STACKTRACE_TRIM_LENGTH)
+            else -> frames
+        }
+        this.logger = logger
+    }
+
     private fun mapToStackframe(it: Map<String, Any?>) =
         Stackframe(
             it["method"] as String?,

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
@@ -1,0 +1,36 @@
+package com.bugsnag.android;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+class ErrorDeserializer implements MapDeserializer<Error> {
+
+    private final StackframeDeserializer stackframeDeserializer;
+    private final Logger logger;
+
+    ErrorDeserializer(StackframeDeserializer stackframeDeserializer, Logger logger) {
+        this.stackframeDeserializer = stackframeDeserializer;
+        this.logger = logger;
+    }
+
+    @Override
+    public Error deserialize(Map<String, Object> map) {
+        String type = MapUtils.getOrThrow(map, "type");
+        List<Map<String, Object>> stacktrace = MapUtils.getOrThrow(map, "stacktrace");
+        List<Stackframe> frames = new ArrayList<>();
+
+        for (Map<String, Object> frame : stacktrace) {
+            frames.add(stackframeDeserializer.deserialize(frame));
+        }
+
+        ErrorInternal impl = new ErrorInternal(
+                MapUtils.<String>getOrThrow(map, "errorClass"),
+                MapUtils.<String>getOrNull(map, "errorMessage"),
+                frames,
+                ErrorType.valueOf(type.toUpperCase(Locale.US))
+        );
+        return new Error(impl, logger);
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapUtils.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapUtils.java
@@ -4,13 +4,19 @@ import java.util.Map;
 
 class MapUtils {
 
-    static String getString(Map<String, Object> map, String key) {
+    @SuppressWarnings("unchecked")
+    static <T> T getOrNull(Map<String, Object> map, String key) {
         Object id = map.get(key);
+        return id != null ? (T) id : null;
+    }
 
-        if (id instanceof String) {
-            return (String) id;
+    @SuppressWarnings("unchecked")
+    static <T> T getOrThrow(Map<String, Object> map, String key) {
+        Object id = map.get(key);
+        if (id != null) {
+            return (T) id;
         } else {
-            return null;
+            throw new IllegalArgumentException("Missing required parameter " + key);
         }
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/StackframeDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/StackframeDeserializer.java
@@ -1,0 +1,18 @@
+package com.bugsnag.android;
+
+import java.util.Collections;
+import java.util.Map;
+
+class StackframeDeserializer implements MapDeserializer<Stackframe> {
+
+    @Override
+    public Stackframe deserialize(Map<String, Object> map) {
+        return new Stackframe(
+                MapUtils.<String>getOrNull(map, "method"),
+                MapUtils.<String>getOrNull(map, "file"),
+                MapUtils.<Integer>getOrNull(map, "lineNumber"),
+                MapUtils.<Boolean>getOrNull(map, "inProject"),
+                Collections.<String, Object>emptyMap()
+        );
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -1,0 +1,37 @@
+package com.bugsnag.android;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+class ThreadDeserializer implements MapDeserializer<Thread> {
+
+    private final StackframeDeserializer stackframeDeserializer;
+    private final Logger logger;
+
+    ThreadDeserializer(StackframeDeserializer stackframeDeserializer, Logger logger) {
+        this.stackframeDeserializer = stackframeDeserializer;
+        this.logger = logger;
+    }
+
+    @Override
+    public Thread deserialize(Map<String, Object> map) {
+        String type = MapUtils.getOrThrow(map, "type");
+        List<Map<String, Object>> stacktrace = MapUtils.getOrThrow(map, "stacktrace");
+        List<Stackframe> frames = new ArrayList<>();
+
+        for (Map<String, Object> frame : stacktrace) {
+            frames.add(stackframeDeserializer.deserialize(frame));
+        }
+
+        return new Thread(
+                MapUtils.<Long>getOrThrow(map, "id"),
+                MapUtils.<String>getOrThrow(map, "name"),
+                ThreadType.valueOf(type.toUpperCase(Locale.US)),
+                MapUtils.<Boolean>getOrThrow(map, "errorReportingThread"),
+                new Stacktrace(logger, frames),
+                logger
+        );
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/UserDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/UserDeserializer.java
@@ -1,12 +1,14 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.MapUtils.getString;
-
 import java.util.Map;
 
 class UserDeserializer implements MapDeserializer<User> {
     @Override
     public User deserialize(Map<String, Object> map) {
-        return new User(getString(map, "id"), getString(map, "email"), getString(map, "name"));
+        return new User(
+                MapUtils.<String>getOrNull(map, "id"),
+                MapUtils.<String>getOrNull(map, "email"),
+                MapUtils.<String>getOrNull(map, "name")
+        );
     }
 }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ErrorDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ErrorDeserializerTest.kt
@@ -1,0 +1,42 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.HashMap
+
+class ErrorDeserializerTest {
+
+    private val map = HashMap<String, Any>()
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        val frame = HashMap<String, Any>()
+        frame["method"] = "foo()"
+        frame["file"] = "Bar.kt"
+        frame["lineNumber"] = 29
+        frame["inProject"] = true
+        map["stacktrace"] = listOf(frame)
+        map["errorClass"] = "BrowserException"
+        map["errorMessage"] = "whoops!"
+        map["type"] = "browser_js"
+    }
+
+    @Test
+    fun deserialize() {
+        val error = ErrorDeserializer(StackframeDeserializer(), object: Logger {}).deserialize(map)
+        assertEquals("BrowserException", error.errorClass)
+        assertEquals("whoops!", error.errorMessage)
+        assertEquals(ErrorType.BROWSER_JS, error.type)
+
+        val frame = error.stacktrace[0]
+        assertEquals("foo()", frame.method)
+        assertEquals("Bar.kt", frame.file)
+        assertEquals(29, frame.lineNumber)
+        assertTrue(frame.inProject as Boolean)
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/StackframeDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/StackframeDeserializerTest.kt
@@ -1,0 +1,33 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.HashMap
+
+class StackframeDeserializerTest {
+
+    private val map = HashMap<String, Any>()
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        map["method"] = "foo()"
+        map["file"] = "Bar.kt"
+        map["lineNumber"] = 29
+        map["inProject"] = true
+        map["customFields"] = emptyMap<String, Any>()
+    }
+
+    @Test
+    fun deserialize() {
+        val frame = StackframeDeserializer().deserialize(map)
+        assertEquals("foo()", frame.method)
+        assertEquals("Bar.kt", frame.file)
+        assertEquals(29, frame.lineNumber)
+        assertTrue(frame.inProject as Boolean)
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadDeserializerTest.kt
@@ -1,0 +1,46 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.HashMap
+
+class ThreadDeserializerTest {
+
+    private val map = HashMap<String, Any>()
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        val frame = HashMap<String, Any>()
+        frame["method"] = "foo()"
+        frame["file"] = "Bar.kt"
+        frame["lineNumber"] = 29
+        frame["inProject"] = true
+
+        map["stacktrace"] = listOf(frame)
+        map["id"] = 52L
+        map["type"] = "browser_js"
+        map["name"] = "thread-worker-02"
+        map["errorReportingThread"] = true
+        map["type"] = "browser_js"
+    }
+
+    @Test
+    fun deserialize() {
+        val thread = ThreadDeserializer(StackframeDeserializer(), object : Logger {}).deserialize(map)
+        assertEquals(52, thread.id)
+        assertEquals(ThreadType.BROWSER_JS, thread.type)
+        assertEquals("thread-worker-02", thread.name)
+        assertTrue(thread.errorReportingThread)
+
+        val frame = thread.stacktrace[0]
+        assertEquals("foo()", frame.method)
+        assertEquals("Bar.kt", frame.file)
+        assertEquals(29, frame.lineNumber)
+        assertTrue(frame.inProject as Boolean)
+    }
+}


### PR DESCRIPTION
## Goal

Adds deserializers which convert a `Map` into `Error`, `Thread`, and `Stackframe`. This is required by the React Native plugin when a JS error is sent over the React bridge for the native layer to deliver.

## Changeset

- Added deserializers for `Error/Thread/Stackframe`.
- Added `MapUtils` with convenience methods for retrieving values from a map with type safety, either returning null or throwing an exception
- Added additional constructor to `Stacktrace`
- Minor tweak of `UserDeserializer` implementation

## Tests

Added unit tests to cover each deserializer.
