### PR TITLE
Capture state events relevant to react native

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -64,7 +64,7 @@ public class ObserverInterfaceTest {
     public void testAddNullMetadataSendsMessage() {
         client.addMetadata("foo", "bar", "baz");
         client.addMetadata("foo", "bar", null);
-        StateEvent.RemoveMetadata msg = findMessageInQueue(StateEvent.RemoveMetadata.class);
+        StateEvent.ClearMetadataValue msg = findMessageInQueue(StateEvent.ClearMetadataValue.class);
         assertEquals("foo", msg.getSection());
         assertEquals("bar", msg.getKey());
     }
@@ -72,14 +72,16 @@ public class ObserverInterfaceTest {
     @Test
     public void testClearTopLevelTabSendsMessage() {
         client.clearMetadata("axis");
-        StateEvent.ClearMetadataTab value = findMessageInQueue(StateEvent.ClearMetadataTab.class);
+        StateEvent.ClearMetadataSection value
+                = findMessageInQueue(StateEvent.ClearMetadataSection.class);
         assertEquals("axis", value.getSection());
     }
 
     @Test
     public void testClearTabSendsMessage() {
         client.clearMetadata("axis", "foo");
-        StateEvent.RemoveMetadata value = findMessageInQueue(StateEvent.RemoveMetadata.class);
+        StateEvent.ClearMetadataValue value
+                = findMessageInQueue(StateEvent.ClearMetadataValue.class);
         assertEquals("axis", value.getSection());
         assertEquals("foo", value.getKey());
     }
@@ -124,14 +126,10 @@ public class ObserverInterfaceTest {
     @Test
     public void testClientSetUserId() {
         client.setUser("personX", "bip@example.com", "Loblaw");
-        StateEvent.UpdateUserId idMsg = findMessageInQueue(StateEvent.UpdateUserId.class);
-        assertEquals("personX", idMsg.getId());
-
-        StateEvent.UpdateUserEmail emailMsg = findMessageInQueue(StateEvent.UpdateUserEmail.class);
-        assertEquals("bip@example.com", emailMsg.getEmail());
-
-        StateEvent.UpdateUserName nameMsg = findMessageInQueue(StateEvent.UpdateUserName.class);
-        assertEquals("Loblaw", nameMsg.getName());
+        StateEvent.UpdateUser idMsg = findMessageInQueue(StateEvent.UpdateUser.class);
+        assertEquals("personX", idMsg.getUser().getId());
+        assertEquals("bip@example.com", idMsg.getUser().getEmail());
+        assertEquals("Loblaw", idMsg.getUser().getName());
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -25,8 +25,8 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) : BaseObs
 
     private fun notifyClear(section: String, key: String?) {
         when (key) {
-            null -> notifyObservers(StateEvent.ClearMetadataTab(section))
-            else -> notifyObservers(StateEvent.RemoveMetadata(section, key))
+            null -> notifyObservers(StateEvent.ClearMetadataSection(section))
+            else -> notifyObservers(StateEvent.ClearMetadataValue(section, key))
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
@@ -12,8 +12,8 @@ sealed class StateEvent {
 
     class AddMetadata(val section: String, val key: String?, val value: Any?) : StateEvent()
     object ClearBreadcrumbs : StateEvent()
-    class ClearMetadataTab(val section: String) : StateEvent()
-    class RemoveMetadata(val section: String, val key: String?) : StateEvent()
+    class ClearMetadataSection(val section: String) : StateEvent()
+    class ClearMetadataValue(val section: String, val key: String?) : StateEvent()
 
     class AddBreadcrumb(
         val message: String,
@@ -37,7 +37,5 @@ sealed class StateEvent {
     class UpdateInForeground(val inForeground: Boolean, val contextActivity: String?) : StateEvent()
     class UpdateOrientation(val orientation: String?) : StateEvent()
 
-    class UpdateUserEmail(val email: String?) : StateEvent()
-    class UpdateUserName(val name: String?) : StateEvent()
-    class UpdateUserId(val id: String?) : StateEvent()
+    class UpdateUser(val user: User) : StateEvent()
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserState.kt
@@ -6,27 +6,9 @@ internal class UserState(private val userRepository: UserRepository) : BaseObser
         private set
 
     fun setUser(id: String?, email: String?, name: String?) {
-        setUserId(id)
-        setUserEmail(email)
-        setUserName(name)
-    }
-
-    fun setUserId(id: String?) {
-        user = User(id, user.email, user.name)
+        user = User(id, email, name)
         userRepository.save(user)
-        notifyObservers(StateEvent.UpdateUserId(id))
-    }
-
-    fun setUserEmail(email: String?) {
-        user = User(user.id, email, user.name)
-        userRepository.save(user)
-        notifyObservers(StateEvent.UpdateUserEmail(email))
-    }
-
-    fun setUserName(name: String?) {
-        user = User(user.id, user.email, name)
-        userRepository.save(user)
-        notifyObservers(StateEvent.UpdateUserName(name))
+        notifyObservers(StateEvent.UpdateUser(user))
     }
 
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/UserStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/UserStateTest.kt
@@ -28,39 +28,6 @@ internal class UserStateTest {
     }
 
     @Test
-    fun setUserId() {
-        val state = UserState(repository)
-        var msg: StateEvent.UpdateUserId? = null
-        state.addObserver { _, arg ->
-            msg = arg as StateEvent.UpdateUserId
-        }
-        state.setUserId("55")
-        assertEquals("55", msg!!.id)
-    }
-
-    @Test
-    fun setUserEmail() {
-        val state = UserState(repository)
-        var msg: StateEvent.UpdateUserEmail? = null
-        state.addObserver { _, arg ->
-            msg = arg as StateEvent.UpdateUserEmail
-        }
-        state.setUserEmail("woop@example.com")
-        assertEquals("woop@example.com", msg!!.email)
-    }
-
-    @Test
-    fun setUserName() {
-        val state = UserState(repository)
-        var msg: StateEvent.UpdateUserName? = null
-        state.addObserver { _, arg ->
-            msg = arg as StateEvent.UpdateUserName
-        }
-        state.setUserName("Foo")
-        assertEquals("Foo", msg!!.name)
-    }
-
-    @Test
     fun setUser() {
         val state = UserState(repository)
         val msgs = mutableListOf<StateEvent>()
@@ -70,8 +37,9 @@ internal class UserStateTest {
 
         state.setUser("99", "tc@example.com", "Tobias")
 
-        assertEquals("99", (msgs[0] as StateEvent.UpdateUserId).id)
-        assertEquals("tc@example.com", (msgs[1] as StateEvent.UpdateUserEmail).email)
-        assertEquals("Tobias", (msgs[2] as StateEvent.UpdateUserName).name)
+        val msg = msgs[0] as StateEvent.UpdateUser
+        assertEquals("99", msg.user.id)
+        assertEquals("tc@example.com", msg.user.email)
+        assertEquals("Tobias", msg.user.name)
     }
 }

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -85,8 +85,8 @@ class NativeBridge : Observer {
             DeliverPending -> deliverPendingReports()
             is AddMetadata -> handleAddMetadata(msg)
             ClearBreadcrumbs -> clearBreadcrumbs()
-            is ClearMetadataTab -> clearMetadataTab(makeSafe(msg.section))
-            is RemoveMetadata -> removeMetadata(makeSafe(msg.section), makeSafe(msg.key ?: ""))
+            is ClearMetadataSection -> clearMetadataTab(makeSafe(msg.section))
+            is ClearMetadataValue -> removeMetadata(makeSafe(msg.section), makeSafe(msg.key ?: ""))
             is AddBreadcrumb -> addBreadcrumb(makeSafe(msg.message), makeSafe(msg.type.toString()), makeSafe(msg.timestamp), msg.metadata)
             NotifyHandled -> addHandledEvent()
             NotifyUnhandled -> addUnhandledEvent()
@@ -95,9 +95,11 @@ class NativeBridge : Observer {
             is UpdateContext -> updateContext(makeSafe(msg.context ?: ""))
             is UpdateInForeground -> updateInForeground(msg.inForeground, makeSafe(msg.contextActivity ?: ""))
             is UpdateOrientation -> updateOrientation(msg.orientation ?: "")
-            is UpdateUserEmail -> updateUserEmail(makeSafe(msg.email ?: ""))
-            is UpdateUserName -> updateUserName(makeSafe(msg.name ?: ""))
-            is UpdateUserId -> updateUserId(makeSafe(msg.id ?: ""))
+            is UpdateUser -> {
+                updateUserId(makeSafe(msg.user.id ?: ""))
+                updateUserName(makeSafe(msg.user.name ?: ""))
+                updateUserEmail(makeSafe(msg.user.email ?: ""))
+            }
         }
     }
 

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativeBridge.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativeBridge.kt
@@ -1,0 +1,44 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.StateEvent.AddMetadata
+import com.bugsnag.android.StateEvent.ClearMetadataSection
+import com.bugsnag.android.StateEvent.ClearMetadataValue
+import com.bugsnag.android.StateEvent.UpdateContext
+import com.bugsnag.android.StateEvent.UpdateUser
+import java.util.Observable
+import java.util.Observer
+
+/**
+ * Listens for changes in the user, context, and metadata, then informs the JS layer
+ * of any state alterations.
+ */
+internal class BugsnagReactNativeBridge(
+    private val client: Client,
+    private val cb: (event: MessageEvent) -> Unit
+) : Observer {
+
+    override fun update(observable: Observable, arg: Any?) {
+        if (arg is StateEvent) {
+            val event: MessageEvent? = when (arg) {
+                is UpdateContext -> {
+                    MessageEvent("ContextUpdate", arg.context)
+                }
+                is AddMetadata, is ClearMetadataSection, is ClearMetadataValue -> {
+                    MessageEvent("MetadataUpdate", client.metadata)
+                }
+                is UpdateUser -> {
+                    MessageEvent("UserUpdate", mapOf(
+                        Pair("id", arg.user.id),
+                        Pair("email", arg.user.email),
+                        Pair("name", arg.user.name)
+                    ))
+                }
+                else -> null
+            }
+
+            if (event != null) {
+                cb(event)
+            }
+        }
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -31,8 +31,13 @@ class BugsnagReactNativePlugin : Plugin {
     fun configure(): Map<String, Any?> {
         // see if bugsnag-android is already initialised
         client = Bugsnag.getClient()
-        internalHooks = InternalHooks(client)
         logger = client.logger
+        internalHooks = InternalHooks(client)
+
+        client.registerObserver(BugsnagReactNativeBridge(client) {
+            // TODO future: serialize event to JS layer
+            logger.d("React native event: $it")
+        })
 
         // TODO: I think we also want to return values for state here too:
         // i.e of user, context and metadata

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MessageEvent.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MessageEvent.kt
@@ -1,6 +1,19 @@
 package com.bugsnag.android
 
+/**
+ * Holds information about a state change event which is serialized by the BugsnagReactNative
+ * class and emitted to the JS layer.
+ */
 class MessageEvent(
+
+    /**
+     * The type of the event. E.g. `UpdateContext`
+     */
     val type: String,
+
+    /**
+     * The data which underwent a state change. For instance, if a user called
+     * `Bugsnag.setContext()`, the new context value would be present in this field.
+     */
     val data: Any?
 )

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MessageEvent.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MessageEvent.kt
@@ -1,0 +1,6 @@
+package com.bugsnag.android
+
+class MessageEvent(
+    val type: String,
+    val data: Any?
+)

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativeBridgeTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativeBridgeTest.java
@@ -1,0 +1,111 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Observable;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BugsnagReactNativeBridgeTest {
+
+    private Map<String, Object> metadata;
+
+    @Mock
+    Client client;
+
+    /**
+     * Constructs a client which returns a dummy metadata value
+     */
+    @Before
+    public void setUp() {
+        Map<String, Boolean> bar = Collections.singletonMap("Bar", true);
+        metadata = Collections.<String, Object>singletonMap("foo", bar);
+        Mockito.when(client.getMetadata()).thenReturn(metadata);
+    }
+
+    @Test
+    public void userUpdate() {
+        MessageEventCb cb = new MessageEventCb();
+        BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
+
+        User user = new User("123", "joe@example.com", "Joe Bloggs");
+        bridge.update(new Observable(), new StateEvent.UpdateUser(user));
+        assertNotNull(cb.event);
+        assertEquals("UserUpdate", cb.event.getType());
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) cb.event.getData();
+        assertEquals("123", data.get("id"));
+        assertEquals("joe@example.com", data.get("email"));
+        assertEquals("Joe Bloggs", data.get("name"));
+    }
+
+    @Test
+    public void contextUpdate() {
+        MessageEventCb cb = new MessageEventCb();
+        BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
+
+        bridge.update(new Observable(), new StateEvent.UpdateContext("Foo"));
+        assertNotNull(cb.event);
+        assertEquals("ContextUpdate", cb.event.getType());
+        assertEquals("Foo", cb.event.getData());
+    }
+
+    @Test
+    public void addMetadataUpdate() {
+        MessageEventCb cb = new MessageEventCb();
+        BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
+
+        StateEvent.AddMetadata arg = new StateEvent.AddMetadata("foo", "bar", true);
+        bridge.update(new Observable(), arg);
+        assertNotNull(cb.event);
+        assertEquals("MetadataUpdate", cb.event.getType());
+        assertEquals(metadata, cb.event.getData());
+    }
+
+    @Test
+    public void clearMetadataSectionUpdate() {
+        MessageEventCb cb = new MessageEventCb();
+        BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
+
+        StateEvent.ClearMetadataSection arg = new StateEvent.ClearMetadataSection("baz");
+        bridge.update(new Observable(), arg);
+        assertNotNull(cb.event);
+        assertEquals("MetadataUpdate", cb.event.getType());
+        assertEquals(metadata, cb.event.getData());
+    }
+
+    @Test
+    public void clearMetadataValueUpdate() {
+        MessageEventCb cb = new MessageEventCb();
+        BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
+
+        StateEvent.ClearMetadataValue arg = new StateEvent.ClearMetadataValue("baz", "wham");
+        bridge.update(new Observable(), arg);
+        assertNotNull(cb.event);
+        assertEquals("MetadataUpdate", cb.event.getType());
+        assertEquals(metadata, cb.event.getData());
+    }
+
+    static class MessageEventCb implements Function1<MessageEvent, Unit> {
+        MessageEvent event;
+
+        @Override
+        public Unit invoke(MessageEvent messageEvent) {
+            this.event = messageEvent;
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Captures state events relevant to React Native and converts them to a `MessageEvent` class, which will be sent across the React Native bridge. The JS layer needs to be informed of 3 changes on the native layer: context, user, and metadata. This changeset subscribes to these events and converts them to an agreed interface the JS layer can understand.

**Note**: the actual emission of the event data across the React Native bridge has not been included and will be implemented in a separate PR.

## Changeset

- Added `BugsnagReactNativeBridge` which converts state events to `MessageEvent` then invokes a callback
- Subscribed the plugin to events for context/user/metadata
- Converted separate user StateEvent types into one, `UpdateUser`
- Renamed old `StateEvent` types to `ClearMetadataSection` and `ClearMetadataValue` to keep in line with current terminology

## Tests

Added unit tests to verify that each state event message is converted correctly. Updated existing test coverage where necessary.
