### PR TITLE
Add deserializers for Breadcrumb and Metadata

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DateUtils.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DateUtils.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import androidx.annotation.NonNull;
 
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -28,5 +29,14 @@ class DateUtils {
             throw new IllegalStateException("Unable to find valid dateformatter");
         }
         return dateFormat.format(date);
+    }
+
+    @NonNull
+    static Date fromIso8601(@NonNull String date) {
+        try {
+            return iso8601Holder.get().parse(date);
+        } catch (ParseException exc) {
+            throw new IllegalArgumentException("Failed to parse timestamp", exc);
+        }
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BreadcrumbDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BreadcrumbDeserializer.java
@@ -1,0 +1,27 @@
+package com.bugsnag.android;
+
+import java.util.Locale;
+import java.util.Map;
+
+class BreadcrumbDeserializer implements MapDeserializer<Breadcrumb> {
+
+    private final Logger logger;
+
+    BreadcrumbDeserializer(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public Breadcrumb deserialize(Map<String, Object> map) {
+        String type = MapUtils.getOrThrow(map, "type");
+        String timestamp = MapUtils.getOrThrow(map, "timestamp");
+
+        return new Breadcrumb(
+                MapUtils.<String>getOrThrow(map, "message"),
+                BreadcrumbType.valueOf(type.toUpperCase(Locale.US)),
+                MapUtils.<Map<String, Object>>getOrNull(map, "metadata"),
+                DateUtils.fromIso8601(timestamp),
+                logger
+        );
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MetadataDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MetadataDeserializer.java
@@ -1,0 +1,10 @@
+package com.bugsnag.android;
+
+import java.util.Map;
+
+class MetadataDeserializer implements MapDeserializer<Metadata> {
+    @Override
+    public Metadata deserialize(Map<String, Object> map) {
+        return new Metadata(map);
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BreadcrumbDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BreadcrumbDeserializerTest.kt
@@ -1,0 +1,40 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.BreadcrumbType.NAVIGATION
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Collections
+import java.util.Date
+import java.util.HashMap
+
+class BreadcrumbDeserializerTest {
+
+    private val map = HashMap<String, Any>()
+    private val metadata = HashMap<String, Any>()
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        metadata["custom"] = hashMapOf(
+            "id" to 123,
+            "surname" to "Bloggs"
+        )
+        metadata["data"] = Collections.singletonMap("optIn", true)
+        map["metadata"] = metadata
+        map["message"] = "Whoops"
+        map["type"] = "navigation"
+        map["timestamp"] = DateUtils.toIso8601(Date(0))
+    }
+
+    @Test
+    fun deserialize() {
+        val crumb = BreadcrumbDeserializer(object : Logger {}).deserialize(map)
+        assertEquals("Whoops", crumb.message)
+        assertEquals(NAVIGATION, crumb.type)
+        assertEquals(Date(0).time, crumb.timestamp.time)
+        assertEquals(metadata, crumb.metadata)
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/MetadataDeserializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/MetadataDeserializerTest.java
@@ -1,0 +1,37 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MetadataDeserializerTest {
+
+    private Map<String, Object> map = new HashMap<>();
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    public void setup() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("id", 123);
+        data.put("surname", "Bloggs");
+
+        map.put("custom", data);
+        map.put("data", Collections.singletonMap("optIn", true));
+    }
+
+    @Test
+    public void deserialize() {
+        Metadata metadata = new MetadataDeserializer().deserialize(map);
+        assertEquals(123, metadata.getMetadata("custom", "id"));
+        assertEquals("Bloggs", metadata.getMetadata("custom", "surname"));
+        assertTrue((Boolean) metadata.getMetadata("data", "optIn"));
+    }
+}


### PR DESCRIPTION
## Goal

Adds deserializers which convert a `Map` into `Breadcrumb` and `Metadata`. This is required by the React Native plugin when a JS error is sent over the React bridge for the native layer to deliver.

## Changeset

- Added deserializers for `Breadcrumb/Metadata`.
- Added `MapUtils` with convenience methods for retrieving values from a map with type safety, either returning null or throwing an exception
- Minor tweak of `UserDeserializer` implementation

## Tests

Added unit tests to cover each deserializer.
