### PR TITLE
V5 app device deserialize

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -92,7 +92,7 @@ final class BugsnagTestUtils {
 
     static DeviceWithState generateDeviceWithState() {
         DeviceBuildInfo buildInfo = DeviceBuildInfo.Companion.defaultInfo();
-        return new DeviceWithState(buildInfo, new String[]{}, null, null, null,
+        return new DeviceWithState(buildInfo, null, null, null,
                 109230923452L, 22234423124L, 92340255592L, "portrait", new Date(0));
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/App.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/App.kt
@@ -7,8 +7,6 @@ import java.io.IOException
  * can be accessed and amended if necessary.
  */
 open class App internal constructor(
-    config: ImmutableConfig,
-
     /**
      * The architecture of the running application binary
      */
@@ -27,28 +25,45 @@ open class App internal constructor(
     /**
      * The version of the application set in [Configuration.version]
      */
-    var version: String?
-) : JsonStream.Streamable {
+    var version: String?,
 
     /**
      * The unique identifier for the build of the application set in [Configuration.buildUuid]
      */
-    var buildUuid: String? = config.buildUuid
+    var buildUuid: String?,
 
     /**
      * The revision ID from the manifest (React Native apps only)
      */
-    var codeBundleId: String? = config.codeBundleId
+    var codeBundleId: String?,
 
     /**
      * The application type set in [Configuration#version]
      */
-    var type: String? = config.appType
+    var type: String?,
 
     /**
      * The version code of the application set in [Configuration.versionCode]
      */
-    var versionCode: Number? = config.versionCode
+    var versionCode: Number?
+) : JsonStream.Streamable {
+
+    internal constructor(
+        config: ImmutableConfig,
+        binaryArch: String?,
+        id: String?,
+        releaseStage: String?,
+        version: String?
+    ) : this(
+        binaryArch,
+        id,
+        releaseStage,
+        version,
+        config.buildUuid,
+        config.codeBundleId,
+        config.appType,
+        config.versionCode
+    )
 
     internal open fun serialiseFields(writer: JsonStream) {
         writer.name("binaryArch").value(binaryArch)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppWithState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppWithState.kt
@@ -4,12 +4,15 @@ package com.bugsnag.android
  * Stateful information set by the notifier about your app can be found on this class. These values
  * can be accessed and amended if necessary.
  */
-class AppWithState internal constructor(
-    config: ImmutableConfig,
+class AppWithState(
     binaryArch: String?,
     id: String?,
     releaseStage: String?,
     version: String?,
+    buildUuid: String?,
+    codeBundleId: String?,
+    type: String?,
+    versionCode: Number?,
 
     /**
      * The number of milliseconds the application was running before the event occurred
@@ -26,7 +29,30 @@ class AppWithState internal constructor(
      * Whether the application was in the foreground when the event occurred
      */
     var inForeground: Boolean?
-) : App(config, binaryArch, id, releaseStage, version) {
+) : App(binaryArch, id, releaseStage, version, buildUuid, codeBundleId, type, versionCode) {
+
+    internal constructor(
+        config: ImmutableConfig,
+        binaryArch: String?,
+        id: String?,
+        releaseStage: String?,
+        version: String?,
+        duration: Number?,
+        durationInForeground: Number?,
+        inForeground: Boolean?
+    ) : this(
+        binaryArch,
+        id,
+        releaseStage,
+        version,
+        config.buildUuid,
+        config.codeBundleId,
+        config.appType,
+        config.versionCode,
+        duration,
+        durationInForeground,
+        inForeground
+    )
 
     override fun serialiseFields(writer: JsonStream) {
         super.serialiseFields(writer)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DateUtils.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DateUtils.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import androidx.annotation.NonNull;
 
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -28,5 +29,14 @@ class DateUtils {
             throw new IllegalStateException("Unable to find valid dateformatter");
         }
         return dateFormat.format(date);
+    }
+
+    @NonNull
+    static Date fromIso8601(@NonNull String date) {
+        try {
+            return iso8601Holder.get().parse(date);
+        } catch (ParseException exc) {
+            throw new IllegalArgumentException("Failed to parse timestamp", exc);
+        }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
@@ -46,7 +46,6 @@ internal class DeviceDataCollector(
 
     fun generateDeviceWithState(now: Long) = DeviceWithState(
         buildInfo,
-        cpuAbi,
         rooted,
         installId,
         locale,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceWithState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceWithState.kt
@@ -8,7 +8,6 @@ import java.util.Date
  */
 class DeviceWithState internal constructor(
     buildInfo: DeviceBuildInfo,
-    cpuAbi: Array<String>,
     jailbroken: Boolean?,
     id: String?,
     locale: String?,
@@ -33,7 +32,7 @@ class DeviceWithState internal constructor(
      * The timestamp on the device when the event occurred
      */
     var time: Date?
-) : Device(buildInfo, cpuAbi, jailbroken, id, locale, totalMemory) {
+) : Device(buildInfo, buildInfo.cpuAbis, jailbroken, id, locale, totalMemory) {
 
     override fun serializeFields(writer: JsonStream) {
         super.serializeFields(writer)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -36,7 +36,7 @@ final class BugsnagTestUtils {
 
     static DeviceWithState generateDeviceWithState() {
         DeviceBuildInfo buildInfo = generateDeviceBuildInfo();
-        return new DeviceWithState(buildInfo, new String[]{}, null, null, null,
+        return new DeviceWithState(buildInfo,null, null, null,
                 109230923452L, 22234423124L, 92340255592L, "portrait", new Date(0));
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventRedactionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventRedactionTest.kt
@@ -26,6 +26,7 @@ internal class EventRedactionTest {
         val metadata = mutableMapOf<String, Any?>(Pair("password", "whoops"))
         event.breadcrumbs = listOf(Breadcrumb("Whoops", BreadcrumbType.LOG, metadata, Date(0), NoopLogger))
         event.threads.clear()
+        event.device.cpuAbi = emptyArray()
 
         val writer = StringWriter()
         val stream = JsonStream(writer)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -70,6 +70,7 @@ internal class EventSerializationTest {
             event.threads.clear()
             event.app = generateAppWithState()
             event.device = generateDeviceWithState()
+            event.device.cpuAbi = emptyArray()
             cb(event)
             return event
         }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppDeserializer.java
@@ -1,0 +1,23 @@
+package com.bugsnag.android;
+
+import java.util.Map;
+
+class AppDeserializer implements MapDeserializer<AppWithState> {
+
+    @Override
+    public AppWithState deserialize(Map<String, Object> map) {
+        return new AppWithState(
+                MapUtils.<String>getOrNull(map, "binaryArch"),
+                MapUtils.<String>getOrNull(map, "id"),
+                MapUtils.<String>getOrNull(map, "releaseStage"),
+                MapUtils.<String>getOrNull(map, "version"),
+                MapUtils.<String>getOrNull(map, "buildUuid"),
+                MapUtils.<String>getOrNull(map, "codeBundleId"),
+                MapUtils.<String>getOrNull(map, "type"),
+                MapUtils.<Number>getOrNull(map, "versionCode"),
+                MapUtils.<Number>getOrNull(map, "duration"),
+                MapUtils.<Number>getOrNull(map, "durationInForeground"),
+                MapUtils.<Boolean>getOrNull(map, "inForeground")
+        );
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import java.util.Date;
 import java.util.Map;
 
 class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
@@ -19,9 +20,13 @@ class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
         );
 
         String time = MapUtils.getOrNull(map, "time");
+        Date date = null;
+
+        if (time != null) {
+            date = DateUtils.fromIso8601(time);
+        }
         return new DeviceWithState(
                 buildInfo,
-                buildInfo.getCpuAbis(),
                 MapUtils.<Boolean>getOrNull(map, "jailbroken"),
                 MapUtils.<String>getOrNull(map, "id"),
                 MapUtils.<String>getOrNull(map, "locale"),
@@ -29,7 +34,7 @@ class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
                 MapUtils.<Long>getOrNull(map, "freeDisk"),
                 MapUtils.<Long>getOrNull(map, "freeMemory"),
                 MapUtils.<String>getOrNull(map, "orientation"),
-                DateUtils.fromIso8601(time)
+                date
         );
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
@@ -1,0 +1,35 @@
+package com.bugsnag.android;
+
+import java.util.Map;
+
+class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
+
+    @Override
+    public DeviceWithState deserialize(Map<String, Object> map) {
+        DeviceBuildInfo buildInfo = new DeviceBuildInfo(
+                MapUtils.<String>getOrThrow(map, "manufacturer"),
+                MapUtils.<String>getOrThrow(map, "model"),
+                MapUtils.<String>getOrThrow(map, "osVersion"),
+                MapUtils.<Integer>getOrThrow(map, "apiLevel"),
+                MapUtils.<String>getOrThrow(map, "osBuild"),
+                MapUtils.<String>getOrThrow(map, "fingerprint"),
+                MapUtils.<String>getOrThrow(map, "tags"),
+                MapUtils.<String>getOrThrow(map, "brand"),
+                MapUtils.<String[]>getOrThrow(map, "cpuAbis")
+        );
+
+        String time = MapUtils.getOrNull(map, "time");
+        return new DeviceWithState(
+                buildInfo,
+                buildInfo.getCpuAbis(),
+                MapUtils.<Boolean>getOrNull(map, "jailbroken"),
+                MapUtils.<String>getOrNull(map, "id"),
+                MapUtils.<String>getOrNull(map, "locale"),
+                MapUtils.<Long>getOrNull(map, "totalMemory"),
+                MapUtils.<Long>getOrNull(map, "freeDisk"),
+                MapUtils.<Long>getOrNull(map, "freeMemory"),
+                MapUtils.<String>getOrNull(map, "orientation"),
+                DateUtils.fromIso8601(time)
+        );
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/AppDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/AppDeserializerTest.kt
@@ -1,0 +1,46 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.HashMap
+
+class AppDeserializerTest {
+
+    private val map = HashMap<String, Any>()
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        map["binaryArch"] = "x86"
+        map["id"] = "com.example.foo"
+        map["releaseStage"] = "prod"
+        map["version"] = "1.5.3"
+        map["buildUuid"] = "build-uuid-123"
+        map["codeBundleId"] = "code-id-123"
+        map["type"] = "android"
+        map["versionCode"] = 55
+        map["duration"] = 2094
+        map["durationInForeground"] = 1095
+        map["inForeground"] = true
+    }
+
+    @Test
+    fun deserialize() {
+        val app = AppDeserializer().deserialize(map)
+        assertEquals("x86", app.binaryArch)
+        assertEquals("com.example.foo", app.id)
+        assertEquals("prod", app.releaseStage)
+        assertEquals("1.5.3", app.version)
+        assertEquals("build-uuid-123", app.buildUuid)
+        assertEquals("code-id-123", app.codeBundleId)
+        assertEquals("android", app.type)
+        assertEquals(55, app.versionCode)
+        assertEquals(2094, app.duration)
+        assertEquals(1095, app.durationInForeground)
+        assertTrue(app.inForeground!!)
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/DeviceDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/DeviceDeserializerTest.kt
@@ -1,0 +1,60 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+import java.util.HashMap
+
+class DeviceDeserializerTest {
+
+    private val map = HashMap<String, Any>()
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        map["cpuAbi"] = arrayOf("x86")
+        map["jailbroken"] = true
+        map["id"] = "509a0f934"
+        map["locale"] = "en-US"
+        map["totalMemory"] = 490209823402
+        map["manufacturer"] = "google"
+        map["model"] = "pixel 3a"
+        map["osName"] = "android"
+        map["osBuild"] = "bulldog"
+        map["fingerprint"] = "foo"
+        map["cpuAbis"] = arrayOf("x86")
+        map["tags"] = "enabled"
+        map["brand"] = "pixel"
+        map["osVersion"] = "8.1"
+        map["apiLevel"] = 27
+        map["runtimeVersions"] = mapOf(Pair("apiLevel", 27))
+        map["freeDisk"] = 4092340985
+        map["freeMemory"] = 50923422234
+        map["orientation"] = "portrait"
+        map["time"] = DateUtils.toIso8601(Date(0))
+    }
+
+    @Test
+    fun deserialize() {
+        val device = DeviceDeserializer().deserialize(map)
+        assertArrayEquals(arrayOf("x86"), device.cpuAbi)
+        assertTrue(device.jailbroken!!)
+        assertEquals("509a0f934", device.id)
+        assertEquals("en-US", device.locale)
+        assertEquals(490209823402, device.totalMemory)
+        assertEquals("google", device.manufacturer)
+        assertEquals("pixel 3a", device.model)
+        assertEquals("android", device.osName)
+        assertEquals("8.1", device.osVersion)
+        assertEquals(mapOf(Pair("androidApiLevel", 27), Pair("osBuild", "bulldog")), device.runtimeVersions)
+        assertEquals(4092340985, device.freeDisk)
+        assertEquals(50923422234, device.freeMemory)
+        assertEquals("portrait", device.orientation)
+        assertEquals(0, device.time!!.time)
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/DeviceSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/DeviceSerializerTest.java
@@ -37,7 +37,6 @@ public class DeviceSerializerTest {
                         "google pixel",
                         new String[]{"x86"}
                 ),
-                new String[]{"x86"},
                 true,
                 "fa02",
                 "yue",

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
@@ -24,7 +24,7 @@ public class JavaHooks {
     @NonNull
     public static DeviceWithState generateDeviceWithState() {
         DeviceBuildInfo buildInfo = DeviceBuildInfo.Companion.defaultInfo();
-        return new DeviceWithState(buildInfo, new String[]{}, null, null, null,
+        return new DeviceWithState(buildInfo, null, null, null,
                 109230923452L, 22234423124L, 92340255592L, "portrait", new Date(0));
     }
 


### PR DESCRIPTION
## Goal

Adds deserializers which convert a `Map` into `AppWithState` and `DeviceWithState`. This is required by the React Native plugin when a JS error is sent over the React bridge for the native layer to deliver.

## Changeset

- Added deserializers for `AppWithState/DeviceWithState`.
- Altered `App/AppWithState` constructors to allow passing in buildUuid and other fields without a `ImmutableConfig` object
- Added `MapUtils` with convenience methods for retrieving values from a map with type safety, either returning null or throwing an exception
- Minor tweak of `UserDeserializer` implementation

## Tests

Added unit tests to cover each deserializer.
