### PR TITLE
Move thread serialization logic into ThreadState

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
@@ -10,14 +10,22 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.lang.Thread
+import java.util.Collections
 
 @SmallTest
 class ThreadStateTest {
 
     private val configuration = generateImmutableConfig()
     private val trace: Throwable? = null
-    private val threadState = ThreadState(configuration,
-        null, Thread.currentThread(), Thread.getAllStackTraces(), NoopLogger)
+    private val threadState = ThreadState(
+        null,
+        true,
+        ThreadSendPolicy.ALWAYS,
+        Collections.emptyList(),
+        NoopLogger,
+        Thread.currentThread(),
+        Thread.getAllStackTraces()
+    )
     private val json = streamableToJsonArray(threadState)
 
     /**
@@ -40,7 +48,15 @@ class ThreadStateTest {
             .map { it.key }
             .first()
 
-        val state = ThreadState(configuration, trace, otherThread, Thread.getAllStackTraces(), NoopLogger)
+        val state = ThreadState(
+            trace,
+            true,
+            ThreadSendPolicy.ALWAYS,
+            Collections.emptyList(),
+            NoopLogger,
+            otherThread,
+            Thread.getAllStackTraces()
+        )
         val json = streamableToJsonArray(state)
         verifyCurrentThreadStructure(json, otherThread.id)
     }
@@ -55,7 +71,15 @@ class ThreadStateTest {
         val missingTraces = Thread.getAllStackTraces()
         missingTraces.remove(currentThread)
 
-        val state = ThreadState(configuration, trace, currentThread, missingTraces, NoopLogger)
+        val state = ThreadState(
+            trace,
+            true,
+            ThreadSendPolicy.ALWAYS,
+            Collections.emptyList(),
+            NoopLogger,
+            currentThread,
+            missingTraces
+        )
         val json = streamableToJsonArray(state)
 
         verifyCurrentThreadStructure(json, currentThread.id) {
@@ -70,7 +94,15 @@ class ThreadStateTest {
     fun testHandledStacktrace() {
         val currentThread = Thread.currentThread()
         val allStackTraces = Thread.getAllStackTraces()
-        val state = ThreadState(configuration, trace, currentThread, allStackTraces, NoopLogger)
+        val state = ThreadState(
+            trace,
+            true,
+            ThreadSendPolicy.ALWAYS,
+            Collections.emptyList(),
+            NoopLogger,
+            currentThread,
+            allStackTraces
+        )
         val json = streamableToJsonArray(state)
 
         // find the stack trace for the current thread that was passed as a parameter
@@ -105,7 +137,15 @@ class ThreadStateTest {
         val exc: Throwable = RuntimeException("Whoops")
         val expectedTrace = exc.stackTrace
 
-        val state = ThreadState(configuration, exc, currentThread, allStackTraces, NoopLogger)
+        val state = ThreadState(
+            exc,
+            true,
+            ThreadSendPolicy.ALWAYS,
+            Collections.emptyList(),
+            NoopLogger,
+            currentThread,
+            allStackTraces
+        )
         val json = streamableToJsonArray(state)
 
         verifyCurrentThreadStructure(json, currentThread.id) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.ThreadSendPolicy.*
 import java.io.IOException
 
 internal class EventInternal @JvmOverloads internal constructor(
@@ -33,17 +32,7 @@ internal class EventInternal @JvmOverloads internal constructor(
         else -> Error.createError(originalError, config.projectPackages, config.logger)
     }
 
-    var threads: MutableList<Thread>
-
-    init {
-        val recordThreads = config.sendThreads == ALWAYS || (config.sendThreads == UNHANDLED_ONLY && isUnhandled)
-
-        threads = when {
-            recordThreads -> ThreadState(config, if (isUnhandled) originalError else null).threads
-            else -> mutableListOf()
-        }
-    }
-
+    var threads: MutableList<Thread> = ThreadState(originalError, isUnhandled, config).threads
     var groupingHash: String? = null
     var context: String? = null
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -5,33 +5,61 @@ import java.io.IOException
 /**
  * Capture and serialize the state of all threads at the time of an exception.
  */
-internal class ThreadState @JvmOverloads constructor
-    (
-    config: ImmutableConfig,
+internal class ThreadState @JvmOverloads constructor(
     exc: Throwable?,
+    isUnhandled: Boolean,
+    sendThreads: ThreadSendPolicy,
+    projectPackages: Collection<String>,
+    logger: Logger,
     currentThread: java.lang.Thread = java.lang.Thread.currentThread(),
-    stackTraces: MutableMap<java.lang.Thread, Array<StackTraceElement>> = java.lang.Thread.getAllStackTraces(),
-    logger: Logger = config.logger
+    stackTraces: MutableMap<java.lang.Thread, Array<StackTraceElement>> = java.lang.Thread.getAllStackTraces()
 ) : JsonStream.Streamable {
 
-    internal val threads: MutableList<Thread>
+    internal constructor(
+        exc: Throwable?,
+        isUnhandled: Boolean,
+        config: ImmutableConfig
+    ) : this(exc, isUnhandled, config.sendThreads, config.projectPackages, config.logger)
+
+    val threads: MutableList<Thread>
 
     init {
+        val recordThreads = sendThreads == ThreadSendPolicy.ALWAYS
+                || (sendThreads == ThreadSendPolicy.UNHANDLED_ONLY && isUnhandled)
+
+        threads = when {
+            recordThreads -> captureThreadTrace(
+                stackTraces, currentThread, exc,
+                isUnhandled, projectPackages, logger
+            )
+            else -> mutableListOf()
+        }
+    }
+
+    private fun captureThreadTrace(
+        stackTraces: MutableMap<java.lang.Thread, Array<StackTraceElement>>,
+        currentThread: java.lang.Thread,
+        exc: Throwable?,
+        isUnhandled: Boolean,
+        projectPackages: Collection<String>,
+        logger: Logger
+    ): MutableList<Thread> {
         // API 24/25 don't record the currentThread, add it in manually
         // https://issuetracker.google.com/issues/64122757
         if (!stackTraces.containsKey(currentThread)) {
             stackTraces[currentThread] = currentThread.stackTrace
         }
-        if (exc != null) { // unhandled errors use the exception trace for thread traces
+        if (exc != null && isUnhandled) { // unhandled errors use the exception trace for thread traces
             stackTraces[currentThread] = exc.stackTrace
         }
 
         val currentThreadId = currentThread.id
-        threads = stackTraces.keys
+        return stackTraces.keys
             .sortedBy { it.id }
             .map {
-                val stacktrace = Stacktrace(stackTraces[it]!!, config.projectPackages, logger)
-                Thread(it.id, it.name, ThreadType.ANDROID, it.id == currentThreadId, stacktrace, logger)
+                val stacktrace = Stacktrace(stackTraces[it]!!, projectPackages, logger)
+                val errorThread = it.id == currentThreadId
+                Thread(it.id, it.name, ThreadType.ANDROID, errorThread, stacktrace, logger)
             }.toMutableList()
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -128,6 +128,7 @@ public class ClientFacadeTest {
         // required fields for generating an event
         when(metadataState.getMetadata()).thenReturn(new Metadata());
         when(immutableConfig.getLogger()).thenReturn(logger);
+        when(immutableConfig.getSendThreads()).thenReturn(ThreadSendPolicy.ALWAYS);
         when(immutableConfig.shouldNotifyForReleaseStage()).thenReturn(true);
 
         when(deviceDataCollector.generateDeviceWithState(anyLong())).thenReturn(device);

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -88,7 +88,7 @@ class BugsnagReactNativePlugin : Plugin {
     }
 
     @Suppress("unused")
-    fun getPayloadInfo(): Map<String, Any?> {
+    fun getPayloadInfo(unhandled: Boolean): Map<String, Any?> {
         val info = mutableMapOf<String, Any?>()
         val app = mutableMapOf<String, Any?>()
         appSerializer.serialize(app, internalHooks.appWithState)
@@ -103,7 +103,7 @@ class BugsnagReactNativePlugin : Plugin {
             breadcrumbSerializer.serialize(map, it)
             map
         }
-        info["threads"] = internalHooks.threads.map {
+        info["threads"] = internalHooks.getThreads(unhandled).map {
             val map = mutableMapOf<String, Any?>()
             threadSerializer.serialize(map, it)
             map

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -1,6 +1,5 @@
 package com.bugsnag.android;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -28,10 +27,7 @@ class InternalHooks {
         return client.getBreadcrumbs();
     }
 
-    // TODO: need to return true values for threads, which requires extracting the
-    //  ThreadPolicy logic which determines whether to collect them or not from the Event
-    //  into the ThreadState constructor within bugsnag-android. Using a dummy value for now
-    public List<Thread> getThreads() {
-        return Collections.emptyList();
+    public List<Thread> getThreads(boolean unhandled) {
+        return new ThreadState(null, unhandled, getConfig()).getThreads();
     }
 }


### PR DESCRIPTION
## Goal

Moves the logic for determining whether to collect a thread trace from `Event` into `ThreadState`. This allows for the React Native implementation to return an empty list of threads if `config.sendThreads` is not enabled for the given error.

## Changeset

- Moved logic for collecting thread trace from `Event` to `ThreadState` constructor
- Updated `getPayloadInfo()` to accept a boolean value which holds the unhandled state

## Tests

Updated existing test coverage to handle new `ThreadState` constructor
