### PR TITLE
Implement react native dispatch method

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -846,6 +846,10 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         connectivity.unregisterForNetworkChanges();
     }
 
+    Logger getLogger() {
+        return logger;
+    }
+
     /**
      * Retrieves an instantiated plugin of the given type, or null if none has been created
      */

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Device.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Device.kt
@@ -57,11 +57,14 @@ open class Device internal constructor(
      * A collection of names and their versions of the primary languages, frameworks or
      * runtimes that the application is running on
      */
-    var runtimeVersions: MutableMap<String, Any>? = mutableMapOf(
-        Pair("androidApiLevel", buildInfo.apiLevel),
-        Pair("osBuild", buildInfo.osBuild)
-    )
+    var runtimeVersions: MutableMap<String, Any>?
 
+    init {
+        val map = mutableMapOf<String, Any>()
+        buildInfo.apiLevel?.let { map["androidApiLevel"] = it }
+        buildInfo.osBuild?.let { map["osBuild"] = it }
+        runtimeVersions = map
+    }
 
     internal open fun serializeFields(writer: JsonStream) {
         writer.name("cpuAbi").value(cpuAbi)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceBuildInfo.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceBuildInfo.kt
@@ -3,15 +3,15 @@ package com.bugsnag.android
 import android.os.Build
 
 internal class DeviceBuildInfo(
-    val manufacturer: String,
-    val model: String,
-    val osVersion: String,
-    val apiLevel: Int,
-    val osBuild: String,
-    val fingerprint: String,
-    val tags: String,
-    val brand: String,
-    val cpuAbis: Array<String>
+    val manufacturer: String?,
+    val model: String?,
+    val osVersion: String?,
+    val apiLevel: Int?,
+    val osBuild: String?,
+    val fingerprint: String?,
+    val tags: String?,
+    val brand: String?,
+    val cpuAbis: Array<String>?
 ) {
     companion object {
         fun defaultInfo(): DeviceBuildInfo {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
@@ -74,7 +74,8 @@ internal class DeviceDataCollector(
      * Check if the current Android device is rooted
      */
     private fun isRooted(): Boolean {
-        if (buildInfo.tags.contains("test-keys")) {
+        val tags = buildInfo.tags
+        if (tags != null && tags.contains("test-keys")) {
             return true
         }
 
@@ -96,7 +97,7 @@ internal class DeviceDataCollector(
     private// genymotion
     fun isEmulator(): Boolean {
         val fingerprint = buildInfo.fingerprint
-        return (fingerprint.startsWith("unknown")
+        return fingerprint != null && (fingerprint.startsWith("unknown")
                 || fingerprint.contains("generic")
                 || fingerprint.contains("vbox"))
     }
@@ -188,7 +189,7 @@ internal class DeviceDataCollector(
     /**
      * Gets information about the CPU / API
      */
-    fun getCpuAbi(): Array<String> = buildInfo.cpuAbis
+    fun getCpuAbi(): Array<String> = buildInfo.cpuAbis ?: emptyArray()
 
     /**
      * Get the usable disk space on internal storage's data directory

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -375,7 +375,7 @@ public class NativeInterface {
     }
 
     @NonNull
-    public static Event createEvent(@NonNull Throwable exc,
+    public static Event createEvent(@Nullable Throwable exc,
                                     @NonNull Client client,
                                     @NonNull HandledState handledState) {
         return new Event(exc, client.getConfig(), handledState, client.logger);

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -39,8 +39,6 @@ class BugsnagReactNativePlugin : Plugin {
             logger.d("React native event: $it")
         })
 
-        // TODO: I think we also want to return values for state here too:
-        // i.e of user, context and metadata
         val map = HashMap<String, Any?>()
         configSerializer.serialize(map, internalHooks.config)
         return map
@@ -83,8 +81,10 @@ class BugsnagReactNativePlugin : Plugin {
     }
 
     @Suppress("unused")
-    fun dispatch(@Suppress("UNUSED_PARAMETER") payload: Map<String, Any?>?) {
-        // TODO implement
+    fun dispatch(payload: MutableMap<String, Any?>?) {
+        requireNotNull(payload)
+        val event = EventDeserializer(client).deserialize(payload)
+        client.notifyInternal(event, null)
     }
 
     @Suppress("unused")

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
@@ -8,15 +8,15 @@ class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
     @Override
     public DeviceWithState deserialize(Map<String, Object> map) {
         DeviceBuildInfo buildInfo = new DeviceBuildInfo(
-                MapUtils.<String>getOrThrow(map, "manufacturer"),
-                MapUtils.<String>getOrThrow(map, "model"),
-                MapUtils.<String>getOrThrow(map, "osVersion"),
-                MapUtils.<Integer>getOrThrow(map, "apiLevel"),
-                MapUtils.<String>getOrThrow(map, "osBuild"),
-                MapUtils.<String>getOrThrow(map, "fingerprint"),
-                MapUtils.<String>getOrThrow(map, "tags"),
-                MapUtils.<String>getOrThrow(map, "brand"),
-                MapUtils.<String[]>getOrThrow(map, "cpuAbis")
+                MapUtils.<String>getOrNull(map, "manufacturer"),
+                MapUtils.<String>getOrNull(map, "model"),
+                MapUtils.<String>getOrNull(map, "osVersion"),
+                MapUtils.<Integer>getOrNull(map, "apiLevel"),
+                MapUtils.<String>getOrNull(map, "osBuild"),
+                MapUtils.<String>getOrNull(map, "fingerprint"),
+                MapUtils.<String>getOrNull(map, "tags"),
+                MapUtils.<String>getOrNull(map, "brand"),
+                MapUtils.<String[]>getOrNull(map, "cpuAbis")
         );
 
         String time = MapUtils.getOrNull(map, "time");

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -1,0 +1,59 @@
+package com.bugsnag.android
+
+import java.util.Locale
+
+internal class EventDeserializer(
+    private val client: Client
+) : MapDeserializer<Event> {
+
+    private val appDeserializer = AppDeserializer()
+    private val deviceDeserializer = DeviceDeserializer()
+    private val stackframeDeserializer = StackframeDeserializer()
+    private val errorDeserializer = ErrorDeserializer(stackframeDeserializer, client.getLogger())
+    private val threadDeserializer = ThreadDeserializer(stackframeDeserializer, client.getLogger())
+    private val breadcrumbDeserializer = BreadcrumbDeserializer(client.getLogger())
+
+    @Suppress("UNCHECKED_CAST")
+    override fun deserialize(map: MutableMap<String, Any?>): Event {
+        val severityReason = map["severityReason"] as Map<String, Any>
+        val type = severityReason["type"] as String
+        val handledState: HandledState = HandledState.newInstance(type)
+
+        // construct event
+        val event = NativeInterface.createEvent(null, client, handledState)
+        event.context = map["context"] as String?
+        event.groupingHash = map["groupingHash"] as String?
+        val severity = map["severity"] as String
+        event.updateSeverityInternal(Severity.valueOf(severity.toUpperCase(Locale.US)))
+
+        // app/device
+        event.app = appDeserializer.deserialize(map["app"] as MutableMap<String, Any>)
+        event.device = deviceDeserializer.deserialize(map["device"] as MutableMap<String, Any>)
+
+        // user
+        val user = UserDeserializer().deserialize(map["user"] as MutableMap<String, Any>)
+        event.setUser(user.id, user.email, user.name)
+
+        // errors
+        val errors = map["errors"] as List<Map<String, Any?>>
+        event.errors.clear()
+        event.errors.addAll(errors.map(errorDeserializer::deserialize))
+
+        // threads
+        val threads = map["threads"] as List<Map<String, Any?>>
+        event.threads.clear()
+        event.threads.addAll(threads.map(threadDeserializer::deserialize))
+
+        // breadcrumbs
+        val breadcrumbs = map["breadcrumbs"] as List<Map<String, Any?>>
+        event.breadcrumbs.clear()
+        event.breadcrumbs.addAll(breadcrumbs.map(breadcrumbDeserializer::deserialize))
+
+        // metadata
+        val metadata = map["metadata"] as Map<String, Any?>
+        metadata.forEach {
+            event.addMetadata(it.key, it.value as Map<String, Any>)
+        }
+        return event
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -25,11 +25,13 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
             frames.add(stackframeDeserializer.deserialize(frame));
         }
 
+        Boolean errorReportingThread = MapUtils.<Boolean>getOrNull(map, "errorReportingThread");
+        errorReportingThread = errorReportingThread == null ? false : errorReportingThread;
         return new Thread(
                 MapUtils.<Long>getOrThrow(map, "id"),
                 MapUtils.<String>getOrThrow(map, "name"),
                 ThreadType.valueOf(type.toUpperCase(Locale.US)),
-                MapUtils.<Boolean>getOrThrow(map, "errorReportingThread"),
+                errorReportingThread,
                 new Stacktrace(logger, frames),
                 logger
         );

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -1,0 +1,89 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import java.util.Date
+
+@RunWith(MockitoJUnitRunner::class)
+class EventDeserializerTest {
+
+    @Mock
+    lateinit var client: Client
+
+    private val map = mutableMapOf<String, Any?>()
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        map["severity"] = "info"
+        map["unhandled"] = false
+        map["context"] = "Foo"
+        map["groupingHash"] = "SomeHash"
+        map["severityReason"] = mapOf(Pair("type", HandledState.REASON_HANDLED_EXCEPTION))
+        map["user"] = mapOf(Pair("id", "123"))
+        map["breadcrumbs"] = listOf(breadcrumbMap())
+        map["threads"] = listOf(threadMap())
+        map["errors"] = listOf(errorMap())
+        map["metadata"] = metadataMap()
+        map["app"] = mapOf(Pair("id", "app-id"))
+        map["device"] = mapOf(Pair("id", "device-id"))
+
+        `when`(client.config).thenReturn(TestData.generateConfig())
+        `when`(client.getLogger()).thenReturn(object : Logger {})
+    }
+
+    private fun breadcrumbMap() = hashMapOf(
+        "message" to "Whoops",
+        "type" to "navigation",
+        "timestamp" to DateUtils.toIso8601(Date(0))
+    )
+
+    private fun threadMap() = hashMapOf(
+        "stacktrace" to listOf<Any>(),
+        "id" to 52L,
+        "type" to "browser_js",
+        "name" to "thread-worker-02",
+        "errorReportingThread" to true,
+        "type" to "browser_js"
+    )
+
+    private fun errorMap() = hashMapOf(
+        "stacktrace" to emptyList<Any>(),
+        "errorClass" to "BrowserException",
+        "errorMessage" to "whoops!",
+        "type" to "browser_js"
+    )
+
+    private fun metadataMap() = hashMapOf(
+        "custom" to hashMapOf(
+            "id" to "123"
+        )
+    )
+
+    @Test
+    fun deserialize() {
+        val event = EventDeserializer(client).deserialize(map)
+        assertNotNull(event)
+        assertEquals(Severity.INFO, event.severity)
+        assertFalse(event.isUnhandled)
+        assertEquals("Foo", event.context)
+        assertEquals("SomeHash", event.groupingHash)
+        assertEquals("123", event.getUser().id)
+        assertTrue(event.breadcrumbs.isNotEmpty())
+        assertTrue(event.threads.isNotEmpty())
+        assertTrue(event.errors.isNotEmpty())
+        assertEquals("app-id", event.app.id)
+        assertEquals("device-id", event.device.id)
+        assertEquals("123", event.getMetadata("custom", "id"))
+    }
+}


### PR DESCRIPTION
## Goal

Implements the `dispatch()` method on React Native, which sends an error from the JS layer to the native layer.

## Changeset

- Added a `getLogger()` method to `Client` to allow mocking rather than using direct field access
- Updated `DeviceBuildInfo` and related code to take nullable fields, as these values may have been set to null in a JS `OnError` callback
- Fixed wrong nullability annotation on `NativeInterface`
- Added `EventDeserializer` which deserializes a `Map` into an `Event`

## Tests

Added a unit test for deserialization.
