### PR TITLE
React Native fixes after integration testing in example app

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorType.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorType.kt
@@ -13,7 +13,7 @@ enum class ErrorType(internal val desc: String) {
     /**
      * An error captured from JavaScript
      */
-    BROWSER_JS("browserjs"),
+    REACTNATIVEJS("reactnativejs"),
 
     /**
      * An error captured from Android's C layer

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadType.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadType.kt
@@ -13,5 +13,5 @@ enum class ThreadType(internal val desc: String) {
     /**
      * A thread captured from JavaScript
      */
-    BROWSER_JS("browserjs")
+    REACTNATIVEJS("reactnativejs")
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -57,8 +57,8 @@ public class ErrorFacadeTest {
     @Test
     public void typeValid() {
         assertEquals(ErrorType.ANDROID, error.getType());
-        error.setType(ErrorType.BROWSER_JS);
-        assertEquals(ErrorType.BROWSER_JS, error.getType());
+        error.setType(ErrorType.REACTNATIVEJS);
+        assertEquals(ErrorType.REACTNATIVEJS, error.getType());
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -55,8 +55,8 @@ public class ThreadFacadeTest {
     @Test
     public void typeValid() {
         assertEquals(ThreadType.ANDROID, thread.getType());
-        thread.setType(ThreadType.BROWSER_JS);
-        assertEquals(ThreadType.BROWSER_JS, thread.getType());
+        thread.setType(ThreadType.REACTNATIVEJS);
+        assertEquals(ThreadType.REACTNATIVEJS, thread.getType());
     }
 
     @Test

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
@@ -7,14 +7,11 @@ class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
 
     @Override
     public DeviceWithState deserialize(Map<String, Object> map) {
-        Number num = MapUtils.getOrNull(map, "apiLevel");
-        Integer apiLevel = num != null ? num.intValue() : null;
-
         DeviceBuildInfo buildInfo = new DeviceBuildInfo(
                 MapUtils.<String>getOrNull(map, "manufacturer"),
                 MapUtils.<String>getOrNull(map, "model"),
                 MapUtils.<String>getOrNull(map, "osVersion"),
-                apiLevel,
+                MapUtils.getInt(map, "apiLevel"),
                 MapUtils.<String>getOrNull(map, "osBuild"),
                 MapUtils.<String>getOrNull(map, "fingerprint"),
                 MapUtils.<String>getOrNull(map, "tags"),
@@ -33,16 +30,11 @@ class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
                 MapUtils.<Boolean>getOrNull(map, "jailbroken"),
                 MapUtils.<String>getOrNull(map, "id"),
                 MapUtils.<String>getOrNull(map, "locale"),
-                getLong(map, "totalMemory"),
-                getLong(map, "freeDisk"),
-                getLong(map, "freeMemory"),
+                MapUtils.getLong(map, "totalMemory"),
+                MapUtils.getLong(map, "freeDisk"),
+                MapUtils.getLong(map, "freeMemory"),
                 MapUtils.<String>getOrNull(map, "orientation"),
                 date
         );
-    }
-
-    private Long getLong(Map<String, Object> map, String key) {
-        Number num = MapUtils.getOrNull(map, key);
-        return num != null ? num.longValue() : null;
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceDeserializer.java
@@ -7,11 +7,14 @@ class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
 
     @Override
     public DeviceWithState deserialize(Map<String, Object> map) {
+        Number num = MapUtils.getOrNull(map, "apiLevel");
+        Integer apiLevel = num != null ? num.intValue() : null;
+
         DeviceBuildInfo buildInfo = new DeviceBuildInfo(
                 MapUtils.<String>getOrNull(map, "manufacturer"),
                 MapUtils.<String>getOrNull(map, "model"),
                 MapUtils.<String>getOrNull(map, "osVersion"),
-                MapUtils.<Integer>getOrNull(map, "apiLevel"),
+                apiLevel,
                 MapUtils.<String>getOrNull(map, "osBuild"),
                 MapUtils.<String>getOrNull(map, "fingerprint"),
                 MapUtils.<String>getOrNull(map, "tags"),
@@ -30,11 +33,16 @@ class DeviceDeserializer implements MapDeserializer<DeviceWithState> {
                 MapUtils.<Boolean>getOrNull(map, "jailbroken"),
                 MapUtils.<String>getOrNull(map, "id"),
                 MapUtils.<String>getOrNull(map, "locale"),
-                MapUtils.<Long>getOrNull(map, "totalMemory"),
-                MapUtils.<Long>getOrNull(map, "freeDisk"),
-                MapUtils.<Long>getOrNull(map, "freeMemory"),
+                getLong(map, "totalMemory"),
+                getLong(map, "freeDisk"),
+                getLong(map, "freeMemory"),
                 MapUtils.<String>getOrNull(map, "orientation"),
                 date
         );
+    }
+
+    private Long getLong(Map<String, Object> map, String key) {
+        Number num = MapUtils.getOrNull(map, key);
+        return num != null ? num.longValue() : null;
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapUtils.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MapUtils.java
@@ -19,4 +19,14 @@ class MapUtils {
             throw new IllegalArgumentException("Missing required parameter " + key);
         }
     }
+
+    static Long getLong(Map<String, Object> map, String key) {
+        Number num = MapUtils.getOrNull(map, key);
+        return num != null ? num.longValue() : null;
+    }
+
+    static Integer getInt(Map<String, Object> map, String key) {
+        Number num = MapUtils.getOrNull(map, key);
+        return num != null ? num.intValue() : null;
+    }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -28,7 +28,7 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
         Boolean errorReportingThread = MapUtils.<Boolean>getOrNull(map, "errorReportingThread");
         errorReportingThread = errorReportingThread == null ? false : errorReportingThread;
         return new Thread(
-                MapUtils.<Long>getOrThrow(map, "id"),
+                MapUtils.<Number>getOrThrow(map, "id").longValue(),
                 MapUtils.<String>getOrThrow(map, "name"),
                 ThreadType.valueOf(type.toUpperCase(Locale.US)),
                 errorReportingThread,

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ErrorDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ErrorDeserializerTest.kt
@@ -23,7 +23,7 @@ class ErrorDeserializerTest {
         map["stacktrace"] = listOf(frame)
         map["errorClass"] = "BrowserException"
         map["errorMessage"] = "whoops!"
-        map["type"] = "browser_js"
+        map["type"] = "reactnativejs"
     }
 
     @Test
@@ -31,7 +31,7 @@ class ErrorDeserializerTest {
         val error = ErrorDeserializer(StackframeDeserializer(), object: Logger {}).deserialize(map)
         assertEquals("BrowserException", error.errorClass)
         assertEquals("whoops!", error.errorMessage)
-        assertEquals(ErrorType.BROWSER_JS, error.type)
+        assertEquals(ErrorType.REACTNATIVEJS, error.type)
 
         val frame = error.stacktrace[0]
         assertEquals("foo()", frame.method)

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -51,17 +51,16 @@ class EventDeserializerTest {
     private fun threadMap() = hashMapOf(
         "stacktrace" to listOf<Any>(),
         "id" to 52L,
-        "type" to "browser_js",
+        "type" to "reactnativejs",
         "name" to "thread-worker-02",
-        "errorReportingThread" to true,
-        "type" to "browser_js"
+        "errorReportingThread" to true
     )
 
     private fun errorMap() = hashMapOf(
         "stacktrace" to emptyList<Any>(),
         "errorClass" to "BrowserException",
         "errorMessage" to "whoops!",
-        "type" to "browser_js"
+        "type" to "reactnativejs"
     )
 
     private fun metadataMap() = hashMapOf(

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadDeserializerTest.kt
@@ -23,17 +23,16 @@ class ThreadDeserializerTest {
 
         map["stacktrace"] = listOf(frame)
         map["id"] = 52L
-        map["type"] = "browser_js"
+        map["type"] = "reactnativejs"
         map["name"] = "thread-worker-02"
         map["errorReportingThread"] = true
-        map["type"] = "browser_js"
     }
 
     @Test
     fun deserialize() {
         val thread = ThreadDeserializer(StackframeDeserializer(), object : Logger {}).deserialize(map)
         assertEquals(52, thread.id)
-        assertEquals(ThreadType.BROWSER_JS, thread.type)
+        assertEquals(ThreadType.REACTNATIVEJS, thread.type)
         assertEquals("thread-worker-02", thread.name)
         assertTrue(thread.errorReportingThread)
 


### PR DESCRIPTION
## Goal

Fixes bugs in the RN module implementation which prevented the example app from receiving errors during integration testing.

## Changeset

- Altered error/thread types 'browser_js' to 'reactnativejs'
- Coerce int/long/double values into `Number` rather than casting directly to Int/Long, as this led to a crash since the JS layer could serialize these values as doubles.

## Tests

Relied on existing test coverage and manual testing within a RN example app.
