### PR TITLE
Ensure frames are always trimmed by using Stacktrace class in Error

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
@@ -3,9 +3,11 @@ package com.bugsnag.android
 internal class ErrorInternal @JvmOverloads internal constructor(
     var errorClass: String,
     var errorMessage: String?,
-    val stacktrace: List<Stackframe>,
+    stacktrace: Stacktrace,
     var type: ErrorType = ErrorType.ANDROID
 ): JsonStream.Streamable {
+
+    val stacktrace: List<Stackframe> = stacktrace.trace
 
     internal companion object {
         fun createError(exc: Throwable, projectPackages: Collection<String>, logger: Logger): MutableList<Error> {
@@ -14,7 +16,7 @@ internal class ErrorInternal @JvmOverloads internal constructor(
             var currentEx: Throwable? = exc
             while (currentEx != null) {
                 val trace = Stacktrace(currentEx.stackTrace, projectPackages, logger)
-                errors.add(ErrorInternal(currentEx.javaClass.name, currentEx.localizedMessage, trace.trace))
+                errors.add(ErrorInternal(currentEx.javaClass.name, currentEx.localizedMessage, trace))
                 currentEx = currentEx.cause
             }
             return errors.map { Error(it, logger) }.toMutableList()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -25,7 +25,7 @@ public class ErrorFacadeTest {
         logger = new InterceptingLogger();
         trace = Collections.emptyList();
         ErrorInternal impl = new ErrorInternal("com.bar.CrashyClass",
-                "Whoops", trace, ErrorType.ANDROID);
+                "Whoops", new Stacktrace(logger, trace), ErrorType.ANDROID);
         error = new Error(impl, logger);
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
@@ -14,7 +14,7 @@ internal class ErrorSerializationTest {
         @Parameters
         fun testCases() = generateSerializationTestCases(
             "error",
-            Error(ErrorInternal("foo", "bar", listOf()), NoopLogger)
+            Error(ErrorInternal("foo", "bar", Stacktrace(NoopLogger, listOf())), NoopLogger)
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -53,7 +53,7 @@ internal class EventSerializationTest {
                     it.breadcrumbs = listOf(crumb)
 
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
-                    val err = Error(ErrorInternal("WhoopsException", "Whoops", stacktrace.trace), NoopLogger)
+                    val err = Error(ErrorInternal("WhoopsException", "Whoops", stacktrace), NoopLogger)
                     it.errors.clear()
                     it.errors.add(err)
                 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
@@ -46,7 +46,7 @@ public class NullMetadataTest {
         Stacktrace stacktrace = new Stacktrace(new StackTraceElement[]{}, projectPackages,
                 NoopLogger.INSTANCE);
         Error err = new Error(new ErrorInternal("RuntimeException", "Something broke",
-                stacktrace.getTrace()), NoopLogger.INSTANCE);
+                stacktrace), NoopLogger.INSTANCE);
         event.getErrors().clear();
         event.getErrors().add(err);
         validateDefaultMetadata(event);

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
@@ -28,7 +28,7 @@ class ErrorDeserializer implements MapDeserializer<Error> {
         ErrorInternal impl = new ErrorInternal(
                 MapUtils.<String>getOrThrow(map, "errorClass"),
                 MapUtils.<String>getOrNull(map, "errorMessage"),
-                frames,
+                new Stacktrace(logger, frames),
                 ErrorType.valueOf(type.toUpperCase(Locale.US))
         );
         return new Error(impl, logger);


### PR DESCRIPTION
Ensures that frames are always trimmed to a maximum of 200 by using Stacktrace class in the Error constructor.

This prevents the scenario where a user can supply a large stacktrace from React Native (e.g. 500 frames) which would not be trimmed, due to the `bugsnag-android-core` code assuming that the `List<Stackframe>` has already been sanitised.

Verified by existing unit test and E2E test coverage.
