### PR TITLE
Allow registering for callbacks on the react native plugin

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -32,14 +32,13 @@ class BugsnagReactNativePlugin : Plugin {
 
     @Suppress("unused")
     fun configure(): Map<String, Any?> {
-        client.registerObserver(BugsnagReactNativeBridge(client) {
-            // TODO future: serialize event to JS layer
-            logger.d("React native event: $it")
-        })
-
         val map = HashMap<String, Any?>()
         configSerializer.serialize(map, internalHooks.config)
         return map
+    }
+
+    fun registerForMessageEvents(cb: (MessageEvent) -> Unit) {
+        client.registerObserver(BugsnagReactNativeBridge(client, cb))
     }
 
     fun leaveBreadcrumb(map: Map<String, Any?>?) {

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativePluginTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativePluginTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -25,6 +26,12 @@ internal class BugsnagReactNativePluginTest {
         plugin.client = client
         plugin.internalHooks = internalHooks
         plugin.logger = object : Logger {}
+    }
+
+    @Test
+    fun registerForMessageEvents() {
+        plugin.registerForMessageEvents {  }
+        verify(client, times(1)).registerObserver(any())
     }
 
     @Test


### PR DESCRIPTION
Exposes an internal API for registering a callback on the react native plugin which is invoked when a state change occurs. This allows the `BugsnagReactNative` class in the JS repo to emit the event across the React Native bridge by calling `registerForMessageEvents()` during initialisation. This aspect of the change will be raised in a separate PR in the bugsnag-js repo.