### PR TITLE
Add code and columnNumber properties to Stackframe class

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
@@ -5,7 +5,7 @@ import java.io.IOException
 /**
  * Represents a single stackframe from a [Throwable]
  */
-class Stackframe internal constructor(
+class Stackframe @JvmOverloads internal constructor(
 
     /**
      * The name of the method that was being executed
@@ -28,8 +28,17 @@ class Stackframe internal constructor(
      * [Configuration.projectPackages]
      */
     var inProject: Boolean?,
-    private var customFields: Map<String, Any?>
-): JsonStream.Streamable {
+
+    /**
+     * Lines of the code surrounding the frame, where the lineNumber is the key (React Native only)
+     */
+    var code: Map<String, String?>? = null,
+
+    /**
+     * The column number of the frame (React Native only)
+     */
+    var columnNumber: Number? = null
+) : JsonStream.Streamable {
 
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {
@@ -38,9 +47,17 @@ class Stackframe internal constructor(
         writer.name("file").value(file)
         writer.name("lineNumber").value(lineNumber)
         writer.name("inProject").value(inProject)
-        customFields.forEach {
-            writer.name(it.key)
-            writer.value(it.value)
+        writer.name("columnNumber").value(columnNumber)
+
+        code?.let { map: Map<String, String?> ->
+            writer.name("code")
+
+            map.forEach {
+                writer.beginObject()
+                writer.name(it.key)
+                writer.value(it.value)
+                writer.endObject()
+            }
         }
         writer.endObject()
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -25,7 +25,7 @@ public class ErrorFacadeTest {
         logger = new InterceptingLogger();
         trace = Collections.emptyList();
         ErrorInternal impl = new ErrorInternal("com.bar.CrashyClass",
-                "Whoops", new Stacktrace(logger, trace), ErrorType.ANDROID);
+                "Whoops", new Stacktrace(trace, logger), ErrorType.ANDROID);
         error = new Error(impl, logger);
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
@@ -14,7 +14,7 @@ internal class ErrorSerializationTest {
         @Parameters
         fun testCases() = generateSerializationTestCases(
             "error",
-            Error(ErrorInternal("foo", "bar", Stacktrace(NoopLogger, listOf())), NoopLogger)
+            Error(ErrorInternal("foo", "bar", Stacktrace(listOf(), NoopLogger)), NoopLogger)
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StackframeSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StackframeSerializationTest.kt
@@ -15,7 +15,7 @@ internal class StackframeSerializationTest {
         fun testCases() =
             generateSerializationTestCases(
                 "stackframe",
-                Stackframe("foo", "Bar", 55, true, mapOf(Pair("loadAddress", "0x520923409")))
+                Stackframe("foo", "Bar", 55, true)
             )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceSerializationTest.kt
@@ -12,15 +12,16 @@ internal class StacktraceSerializationTest {
     companion object {
         @JvmStatic
         @Parameters
-        fun testCases() =
-            generateSerializationTestCases(
+        fun testCases(): Collection<Pair<Stacktrace, String>> {
+            val frame = Stackframe("foo()", "Bar.kt", 55, true, mapOf(Pair("54", "invoke()")), 99)
+            return generateSerializationTestCases(
                 "stacktrace",
 
                 // empty stacktrace element ctor
                 Stacktrace(arrayOf(), emptySet(), NoopLogger),
 
                 // empty custom frames ctor
-                Stacktrace(listOf(mapOf(Pair("columnNumber", "55"))), NoopLogger),
+                Stacktrace(listOf(frame), NoopLogger),
 
                 // basic
                 basic(),
@@ -32,6 +33,7 @@ internal class StacktraceSerializationTest {
                 trimStacktrace(),
                 trimStacktraceListCtor()
             )
+        }
 
         private fun basic() =
             Stacktrace(
@@ -55,7 +57,7 @@ internal class StacktraceSerializationTest {
 
         private fun trimStacktraceListCtor(): Stacktrace {
             val elements = (0..999).map {
-                mapOf(Pair("Foo", it))
+                Stackframe("Foo", "Bar.kt", it, true)
             }
             return Stacktrace(elements, NoopLogger)
         }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -25,7 +25,7 @@ public class ThreadFacadeTest {
     @Before
     public void setUp() {
         logger = new InterceptingLogger();
-        List<Map<String, Object>> frames = Collections.emptyList();
+        List<Stackframe> frames = Collections.emptyList();
         stacktrace = new Stacktrace(frames, logger);
         thread = new Thread(1, "thread-2", ThreadType.ANDROID, false, stacktrace, logger);
     }
@@ -77,7 +77,7 @@ public class ThreadFacadeTest {
     @Test
     public void stacktraceValid() {
         assertEquals(stacktrace.getTrace(), thread.getStacktrace());
-        List<Map<String, Object>> frames = Collections.emptyList();
+        List<Stackframe> frames = Collections.emptyList();
         Stacktrace other = new Stacktrace(frames, logger);
         thread.setStacktrace(other.getTrace());
         assertEquals(other.getTrace(), thread.getStacktrace());

--- a/bugsnag-android-core/src/test/resources/stackframe_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/stackframe_serialization_0.json
@@ -2,6 +2,5 @@
   "method": "foo",
   "file": "Bar",
   "lineNumber": 55,
-  "inProject": true,
-  "loadAddress": "0x520923409"
+  "inProject": true
 }

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_1.json
@@ -1,5 +1,12 @@
 [
   {
-    "columnNumber": "55"
+    "method": "foo()",
+    "file": "Bar.kt",
+    "lineNumber": 55,
+    "inProject": true,
+    "columnNumber": 99,
+    "code": {
+      "54": "invoke()"
+    }
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_2.json
@@ -2,11 +2,11 @@
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.basic",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": 38
+    "lineNumber": 40
   },
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": 26
+    "lineNumber": 27
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_3.json
@@ -2,13 +2,13 @@
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.inProject",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": 44,
+    "lineNumber": 46,
     "inProject": true
   },
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": 29,
+    "lineNumber": 30,
     "inProject": true
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_5.json
@@ -1,602 +1,1202 @@
 [
   {
-    "Foo": 0
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 0,
+    "inProject": true
   },
   {
-    "Foo": 1
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 1,
+    "inProject": true
   },
   {
-    "Foo": 2
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 2,
+    "inProject": true
   },
   {
-    "Foo": 3
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 3,
+    "inProject": true
   },
   {
-    "Foo": 4
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 4,
+    "inProject": true
   },
   {
-    "Foo": 5
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 5,
+    "inProject": true
   },
   {
-    "Foo": 6
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 6,
+    "inProject": true
   },
   {
-    "Foo": 7
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 7,
+    "inProject": true
   },
   {
-    "Foo": 8
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 8,
+    "inProject": true
   },
   {
-    "Foo": 9
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 9,
+    "inProject": true
   },
   {
-    "Foo": 10
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 10,
+    "inProject": true
   },
   {
-    "Foo": 11
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 11,
+    "inProject": true
   },
   {
-    "Foo": 12
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 12,
+    "inProject": true
   },
   {
-    "Foo": 13
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 13,
+    "inProject": true
   },
   {
-    "Foo": 14
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 14,
+    "inProject": true
   },
   {
-    "Foo": 15
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 15,
+    "inProject": true
   },
   {
-    "Foo": 16
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 16,
+    "inProject": true
   },
   {
-    "Foo": 17
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 17,
+    "inProject": true
   },
   {
-    "Foo": 18
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 18,
+    "inProject": true
   },
   {
-    "Foo": 19
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 19,
+    "inProject": true
   },
   {
-    "Foo": 20
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 20,
+    "inProject": true
   },
   {
-    "Foo": 21
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 21,
+    "inProject": true
   },
   {
-    "Foo": 22
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 22,
+    "inProject": true
   },
   {
-    "Foo": 23
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 23,
+    "inProject": true
   },
   {
-    "Foo": 24
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 24,
+    "inProject": true
   },
   {
-    "Foo": 25
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 25,
+    "inProject": true
   },
   {
-    "Foo": 26
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 26,
+    "inProject": true
   },
   {
-    "Foo": 27
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 27,
+    "inProject": true
   },
   {
-    "Foo": 28
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 28,
+    "inProject": true
   },
   {
-    "Foo": 29
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 29,
+    "inProject": true
   },
   {
-    "Foo": 30
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 30,
+    "inProject": true
   },
   {
-    "Foo": 31
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 31,
+    "inProject": true
   },
   {
-    "Foo": 32
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 32,
+    "inProject": true
   },
   {
-    "Foo": 33
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 33,
+    "inProject": true
   },
   {
-    "Foo": 34
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 34,
+    "inProject": true
   },
   {
-    "Foo": 35
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 35,
+    "inProject": true
   },
   {
-    "Foo": 36
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 36,
+    "inProject": true
   },
   {
-    "Foo": 37
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 37,
+    "inProject": true
   },
   {
-    "Foo": 38
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 38,
+    "inProject": true
   },
   {
-    "Foo": 39
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 39,
+    "inProject": true
   },
   {
-    "Foo": 40
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 40,
+    "inProject": true
   },
   {
-    "Foo": 41
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 41,
+    "inProject": true
   },
   {
-    "Foo": 42
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 42,
+    "inProject": true
   },
   {
-    "Foo": 43
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 43,
+    "inProject": true
   },
   {
-    "Foo": 44
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 44,
+    "inProject": true
   },
   {
-    "Foo": 45
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 45,
+    "inProject": true
   },
   {
-    "Foo": 46
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 46,
+    "inProject": true
   },
   {
-    "Foo": 47
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 47,
+    "inProject": true
   },
   {
-    "Foo": 48
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 48,
+    "inProject": true
   },
   {
-    "Foo": 49
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 49,
+    "inProject": true
   },
   {
-    "Foo": 50
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 50,
+    "inProject": true
   },
   {
-    "Foo": 51
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 51,
+    "inProject": true
   },
   {
-    "Foo": 52
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 52,
+    "inProject": true
   },
   {
-    "Foo": 53
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 53,
+    "inProject": true
   },
   {
-    "Foo": 54
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 54,
+    "inProject": true
   },
   {
-    "Foo": 55
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 55,
+    "inProject": true
   },
   {
-    "Foo": 56
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 56,
+    "inProject": true
   },
   {
-    "Foo": 57
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 57,
+    "inProject": true
   },
   {
-    "Foo": 58
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 58,
+    "inProject": true
   },
   {
-    "Foo": 59
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 59,
+    "inProject": true
   },
   {
-    "Foo": 60
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 60,
+    "inProject": true
   },
   {
-    "Foo": 61
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 61,
+    "inProject": true
   },
   {
-    "Foo": 62
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 62,
+    "inProject": true
   },
   {
-    "Foo": 63
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 63,
+    "inProject": true
   },
   {
-    "Foo": 64
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 64,
+    "inProject": true
   },
   {
-    "Foo": 65
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 65,
+    "inProject": true
   },
   {
-    "Foo": 66
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 66,
+    "inProject": true
   },
   {
-    "Foo": 67
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 67,
+    "inProject": true
   },
   {
-    "Foo": 68
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 68,
+    "inProject": true
   },
   {
-    "Foo": 69
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 69,
+    "inProject": true
   },
   {
-    "Foo": 70
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 70,
+    "inProject": true
   },
   {
-    "Foo": 71
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 71,
+    "inProject": true
   },
   {
-    "Foo": 72
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 72,
+    "inProject": true
   },
   {
-    "Foo": 73
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 73,
+    "inProject": true
   },
   {
-    "Foo": 74
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 74,
+    "inProject": true
   },
   {
-    "Foo": 75
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 75,
+    "inProject": true
   },
   {
-    "Foo": 76
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 76,
+    "inProject": true
   },
   {
-    "Foo": 77
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 77,
+    "inProject": true
   },
   {
-    "Foo": 78
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 78,
+    "inProject": true
   },
   {
-    "Foo": 79
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 79,
+    "inProject": true
   },
   {
-    "Foo": 80
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 80,
+    "inProject": true
   },
   {
-    "Foo": 81
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 81,
+    "inProject": true
   },
   {
-    "Foo": 82
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 82,
+    "inProject": true
   },
   {
-    "Foo": 83
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 83,
+    "inProject": true
   },
   {
-    "Foo": 84
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 84,
+    "inProject": true
   },
   {
-    "Foo": 85
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 85,
+    "inProject": true
   },
   {
-    "Foo": 86
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 86,
+    "inProject": true
   },
   {
-    "Foo": 87
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 87,
+    "inProject": true
   },
   {
-    "Foo": 88
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 88,
+    "inProject": true
   },
   {
-    "Foo": 89
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 89,
+    "inProject": true
   },
   {
-    "Foo": 90
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 90,
+    "inProject": true
   },
   {
-    "Foo": 91
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 91,
+    "inProject": true
   },
   {
-    "Foo": 92
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 92,
+    "inProject": true
   },
   {
-    "Foo": 93
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 93,
+    "inProject": true
   },
   {
-    "Foo": 94
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 94,
+    "inProject": true
   },
   {
-    "Foo": 95
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 95,
+    "inProject": true
   },
   {
-    "Foo": 96
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 96,
+    "inProject": true
   },
   {
-    "Foo": 97
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 97,
+    "inProject": true
   },
   {
-    "Foo": 98
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 98,
+    "inProject": true
   },
   {
-    "Foo": 99
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 99,
+    "inProject": true
   },
   {
-    "Foo": 100
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 100,
+    "inProject": true
   },
   {
-    "Foo": 101
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 101,
+    "inProject": true
   },
   {
-    "Foo": 102
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 102,
+    "inProject": true
   },
   {
-    "Foo": 103
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 103,
+    "inProject": true
   },
   {
-    "Foo": 104
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 104,
+    "inProject": true
   },
   {
-    "Foo": 105
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 105,
+    "inProject": true
   },
   {
-    "Foo": 106
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 106,
+    "inProject": true
   },
   {
-    "Foo": 107
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 107,
+    "inProject": true
   },
   {
-    "Foo": 108
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 108,
+    "inProject": true
   },
   {
-    "Foo": 109
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 109,
+    "inProject": true
   },
   {
-    "Foo": 110
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 110,
+    "inProject": true
   },
   {
-    "Foo": 111
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 111,
+    "inProject": true
   },
   {
-    "Foo": 112
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 112,
+    "inProject": true
   },
   {
-    "Foo": 113
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 113,
+    "inProject": true
   },
   {
-    "Foo": 114
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 114,
+    "inProject": true
   },
   {
-    "Foo": 115
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 115,
+    "inProject": true
   },
   {
-    "Foo": 116
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 116,
+    "inProject": true
   },
   {
-    "Foo": 117
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 117,
+    "inProject": true
   },
   {
-    "Foo": 118
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 118,
+    "inProject": true
   },
   {
-    "Foo": 119
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 119,
+    "inProject": true
   },
   {
-    "Foo": 120
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 120,
+    "inProject": true
   },
   {
-    "Foo": 121
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 121,
+    "inProject": true
   },
   {
-    "Foo": 122
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 122,
+    "inProject": true
   },
   {
-    "Foo": 123
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 123,
+    "inProject": true
   },
   {
-    "Foo": 124
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 124,
+    "inProject": true
   },
   {
-    "Foo": 125
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 125,
+    "inProject": true
   },
   {
-    "Foo": 126
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 126,
+    "inProject": true
   },
   {
-    "Foo": 127
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 127,
+    "inProject": true
   },
   {
-    "Foo": 128
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 128,
+    "inProject": true
   },
   {
-    "Foo": 129
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 129,
+    "inProject": true
   },
   {
-    "Foo": 130
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 130,
+    "inProject": true
   },
   {
-    "Foo": 131
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 131,
+    "inProject": true
   },
   {
-    "Foo": 132
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 132,
+    "inProject": true
   },
   {
-    "Foo": 133
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 133,
+    "inProject": true
   },
   {
-    "Foo": 134
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 134,
+    "inProject": true
   },
   {
-    "Foo": 135
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 135,
+    "inProject": true
   },
   {
-    "Foo": 136
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 136,
+    "inProject": true
   },
   {
-    "Foo": 137
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 137,
+    "inProject": true
   },
   {
-    "Foo": 138
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 138,
+    "inProject": true
   },
   {
-    "Foo": 139
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 139,
+    "inProject": true
   },
   {
-    "Foo": 140
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 140,
+    "inProject": true
   },
   {
-    "Foo": 141
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 141,
+    "inProject": true
   },
   {
-    "Foo": 142
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 142,
+    "inProject": true
   },
   {
-    "Foo": 143
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 143,
+    "inProject": true
   },
   {
-    "Foo": 144
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 144,
+    "inProject": true
   },
   {
-    "Foo": 145
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 145,
+    "inProject": true
   },
   {
-    "Foo": 146
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 146,
+    "inProject": true
   },
   {
-    "Foo": 147
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 147,
+    "inProject": true
   },
   {
-    "Foo": 148
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 148,
+    "inProject": true
   },
   {
-    "Foo": 149
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 149,
+    "inProject": true
   },
   {
-    "Foo": 150
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 150,
+    "inProject": true
   },
   {
-    "Foo": 151
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 151,
+    "inProject": true
   },
   {
-    "Foo": 152
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 152,
+    "inProject": true
   },
   {
-    "Foo": 153
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 153,
+    "inProject": true
   },
   {
-    "Foo": 154
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 154,
+    "inProject": true
   },
   {
-    "Foo": 155
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 155,
+    "inProject": true
   },
   {
-    "Foo": 156
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 156,
+    "inProject": true
   },
   {
-    "Foo": 157
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 157,
+    "inProject": true
   },
   {
-    "Foo": 158
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 158,
+    "inProject": true
   },
   {
-    "Foo": 159
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 159,
+    "inProject": true
   },
   {
-    "Foo": 160
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 160,
+    "inProject": true
   },
   {
-    "Foo": 161
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 161,
+    "inProject": true
   },
   {
-    "Foo": 162
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 162,
+    "inProject": true
   },
   {
-    "Foo": 163
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 163,
+    "inProject": true
   },
   {
-    "Foo": 164
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 164,
+    "inProject": true
   },
   {
-    "Foo": 165
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 165,
+    "inProject": true
   },
   {
-    "Foo": 166
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 166,
+    "inProject": true
   },
   {
-    "Foo": 167
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 167,
+    "inProject": true
   },
   {
-    "Foo": 168
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 168,
+    "inProject": true
   },
   {
-    "Foo": 169
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 169,
+    "inProject": true
   },
   {
-    "Foo": 170
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 170,
+    "inProject": true
   },
   {
-    "Foo": 171
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 171,
+    "inProject": true
   },
   {
-    "Foo": 172
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 172,
+    "inProject": true
   },
   {
-    "Foo": 173
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 173,
+    "inProject": true
   },
   {
-    "Foo": 174
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 174,
+    "inProject": true
   },
   {
-    "Foo": 175
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 175,
+    "inProject": true
   },
   {
-    "Foo": 176
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 176,
+    "inProject": true
   },
   {
-    "Foo": 177
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 177,
+    "inProject": true
   },
   {
-    "Foo": 178
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 178,
+    "inProject": true
   },
   {
-    "Foo": 179
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 179,
+    "inProject": true
   },
   {
-    "Foo": 180
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 180,
+    "inProject": true
   },
   {
-    "Foo": 181
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 181,
+    "inProject": true
   },
   {
-    "Foo": 182
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 182,
+    "inProject": true
   },
   {
-    "Foo": 183
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 183,
+    "inProject": true
   },
   {
-    "Foo": 184
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 184,
+    "inProject": true
   },
   {
-    "Foo": 185
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 185,
+    "inProject": true
   },
   {
-    "Foo": 186
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 186,
+    "inProject": true
   },
   {
-    "Foo": 187
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 187,
+    "inProject": true
   },
   {
-    "Foo": 188
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 188,
+    "inProject": true
   },
   {
-    "Foo": 189
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 189,
+    "inProject": true
   },
   {
-    "Foo": 190
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 190,
+    "inProject": true
   },
   {
-    "Foo": 191
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 191,
+    "inProject": true
   },
   {
-    "Foo": 192
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 192,
+    "inProject": true
   },
   {
-    "Foo": 193
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 193,
+    "inProject": true
   },
   {
-    "Foo": 194
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 194,
+    "inProject": true
   },
   {
-    "Foo": 195
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 195,
+    "inProject": true
   },
   {
-    "Foo": 196
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 196,
+    "inProject": true
   },
   {
-    "Foo": 197
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 197,
+    "inProject": true
   },
   {
-    "Foo": 198
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 198,
+    "inProject": true
   },
   {
-    "Foo": 199
+    "method": "Foo",
+    "file": "Bar.kt",
+    "lineNumber": 199,
+    "inProject": true
   }
 ]

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
@@ -28,7 +28,7 @@ class ErrorDeserializer implements MapDeserializer<Error> {
         ErrorInternal impl = new ErrorInternal(
                 MapUtils.<String>getOrThrow(map, "errorClass"),
                 MapUtils.<String>getOrNull(map, "errorMessage"),
-                new Stacktrace(logger, frames),
+                new Stacktrace(frames, logger),
                 ErrorType.valueOf(type.toUpperCase(Locale.US))
         );
         return new Error(impl, logger);

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/StackframeDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/StackframeDeserializer.java
@@ -1,6 +1,5 @@
 package com.bugsnag.android;
 
-import java.util.Collections;
 import java.util.Map;
 
 class StackframeDeserializer implements MapDeserializer<Stackframe> {
@@ -11,7 +10,9 @@ class StackframeDeserializer implements MapDeserializer<Stackframe> {
                 MapUtils.<String>getOrNull(map, "method"),
                 MapUtils.<String>getOrNull(map, "file"),
                 MapUtils.<Integer>getOrNull(map, "lineNumber"),
-                MapUtils.<Boolean>getOrNull(map, "inProject")
+                MapUtils.<Boolean>getOrNull(map, "inProject"),
+                MapUtils.<Map<String, String>>getOrNull(map, "code"),
+                MapUtils.<Integer>getOrNull(map, "columnNumber")
         );
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/StackframeDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/StackframeDeserializer.java
@@ -11,8 +11,7 @@ class StackframeDeserializer implements MapDeserializer<Stackframe> {
                 MapUtils.<String>getOrNull(map, "method"),
                 MapUtils.<String>getOrNull(map, "file"),
                 MapUtils.<Integer>getOrNull(map, "lineNumber"),
-                MapUtils.<Boolean>getOrNull(map, "inProject"),
-                Collections.<String, Object>emptyMap()
+                MapUtils.<Boolean>getOrNull(map, "inProject")
         );
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -32,7 +32,7 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
                 MapUtils.<String>getOrThrow(map, "name"),
                 ThreadType.valueOf(type.toUpperCase(Locale.US)),
                 errorReportingThread,
-                new Stacktrace(logger, frames),
+                new Stacktrace(frames, logger),
                 logger
         );
     }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/StackframeDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/StackframeDeserializerTest.kt
@@ -19,7 +19,11 @@ class StackframeDeserializerTest {
         map["file"] = "Bar.kt"
         map["lineNumber"] = 29
         map["inProject"] = true
-        map["customFields"] = emptyMap<String, Any>()
+        map["columnNumber"] = 52
+        map["code"] = hashMapOf(
+            "55" to "foo(bar)",
+            "56" to "var x = 5;"
+        )
     }
 
     @Test
@@ -28,6 +32,9 @@ class StackframeDeserializerTest {
         assertEquals("foo()", frame.method)
         assertEquals("Bar.kt", frame.file)
         assertEquals(29, frame.lineNumber)
+        assertEquals(52, frame.columnNumber)
+        assertEquals("foo(bar)", frame.code!!["55"])
+        assertEquals("var x = 5;", frame.code!!["56"])
         assertTrue(frame.inProject as Boolean)
     }
 }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
@@ -33,7 +33,8 @@ public class ThreadSerializerTest {
         frame.put("lineNumber", 55);
         frame.put("inProject", true);
 
-        List<Map<String, Object>> frames = Collections.singletonList(frame);
+        Stackframe stackframe = new Stackframe("foo()", "Bar.kt", 55, true);
+        List<Stackframe> frames = Collections.singletonList(stackframe);
         Stacktrace stacktrace = new Stacktrace(frames, NoopLogger.INSTANCE);
         thread = new Thread(1, "fake-thread", ThreadType.ANDROID,
                 true, stacktrace, NoopLogger.INSTANCE);


### PR DESCRIPTION
## Goal

Adds the code and columnNumber properties to the Stackframe class. These are used by JavaScript but are not present in the React Native layer.

## Changeset

- Added `code` and `columnNumber` fields to the `Stackframe` interface as per the notifier spec
- Updated serializer to write new fields to JSON
- Updated `bugsnag-plugin-react-native` deserializer to grab `code` + `columNumber` from Map passed over the React bridge
- Reduced duplication in how the stacktrace length is trimmed by extracting generic function
- Converted the 2nd `Stacktrace` constructor to take a `List<Stackframe>` instead. Previously it took `List<Map>`, but this is unused outside of test code so has been replaced to gain more type safety

## Tests

Relied on existing test coverage and expanded serialization tests.
