### PR TITLE
Change enabledBreadcrumbTypes to affect automatic breadcrumb hooks only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ option:
 
 ## Testing
 
-Full details of how to build and run tests can be found in [the testing guide](`TESTING.md`)
+Full details of how to build and run tests can be found in [the testing guide](TESTING.md)
 
 ## Building the Example App
 
@@ -127,4 +127,4 @@ this version when you next run the app.
 
 # Releasing a New Version
 
-Full details of how to release can be found in [the release guide](`RELEASING.md`)
+Full details of how to release can be found in [the release guide](RELEASING.md)

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbFilterTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbFilterTest.kt
@@ -1,34 +1,46 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.BugsnagTestUtils.generateClient
-import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
-import org.junit.After
+import com.bugsnag.android.BreadcrumbType.MANUAL
 import org.junit.Assert.assertEquals
-import org.junit.Before
+
+import androidx.test.filters.SmallTest
+import com.bugsnag.android.BugsnagTestUtils.generateClient
+
+import org.junit.After
 import org.junit.Test
 
+@SmallTest
 class BreadcrumbFilterTest {
 
     private var client: Client? = null
 
-    @Before
-    fun setUp() {
-        val configuration = generateConfiguration()
-        configuration.enabledBreadcrumbTypes = setOf(BreadcrumbType.REQUEST)
-        client = generateClient(configuration)
-    }
-
     @After
     fun tearDown() {
-        client!!.close()
+        client?.close()
     }
 
     @Test
-    fun zeroBreadcrumbsReceived() {
-        client!!.leaveBreadcrumb("Hello")
-        assertEquals(0, client!!.breadcrumbState.store.size.toLong())
+    fun testManualBreadcrumbNotFiltered() {
+        val configuration = BugsnagTestUtils.generateConfiguration()
+        configuration.enabledBreadcrumbTypes = emptySet()
+        client = generateClient(configuration)
 
-        client!!.leaveBreadcrumb("Hello", BreadcrumbType.REQUEST, emptyMap())
-        assertEquals(1, client!!.breadcrumbState.store.size.toLong())
+        client?.leaveBreadcrumb("Hello World")
+
+        assertEquals(1, client!!.breadcrumbState.store.size)
     }
+
+    @Test
+    fun testManualBreadcrumbNotFilteredOnManual() {
+        val configuration = BugsnagTestUtils.generateConfiguration()
+        configuration.enabledBreadcrumbTypes = setOf(MANUAL)
+        client = generateClient(configuration)
+
+        client?.leaveBreadcrumb("Hello World")
+
+        assertEquals(1, client!!.breadcrumbState.store.size)
+    }
+
 }
+
+

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbFilterTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbFilterTest.kt
@@ -12,11 +12,11 @@ import org.junit.Test
 @SmallTest
 class BreadcrumbFilterTest {
 
-    private var client: Client? = null
+    lateinit var client: Client
 
     @After
     fun tearDown() {
-        client?.close()
+        client.close()
     }
 
     @Test
@@ -25,9 +25,9 @@ class BreadcrumbFilterTest {
         configuration.enabledBreadcrumbTypes = emptySet()
         client = generateClient(configuration)
 
-        client?.leaveBreadcrumb("Hello World")
+        client.leaveBreadcrumb("Hello World")
 
-        assertEquals(1, client!!.breadcrumbState.store.size)
+        assertEquals(1, client.breadcrumbState.store.size)
     }
 
     @Test
@@ -36,9 +36,9 @@ class BreadcrumbFilterTest {
         configuration.enabledBreadcrumbTypes = setOf(MANUAL)
         client = generateClient(configuration)
 
-        client?.leaveBreadcrumb("Hello World")
+        client.leaveBreadcrumb("Hello World")
 
-        assertEquals(1, client!!.breadcrumbState.store.size)
+        assertEquals(1, client.breadcrumbState.store.size)
     }
 
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 
 import androidx.test.filters.SmallTest
 import com.bugsnag.android.BugsnagTestUtils.generateClient
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 
 import org.junit.After
 import org.junit.Before
@@ -19,7 +20,6 @@ class BreadcrumbStateTest {
     @Before
     fun setUp() {
         breadcrumbState = BreadcrumbState(20, CallbackState(), NoopLogger)
-        client = generateClient()
     }
 
     @After
@@ -32,6 +32,7 @@ class BreadcrumbStateTest {
      */
     @Test
     fun testClientMethods() {
+        client = generateClient()
         client!!.leaveBreadcrumb("Hello World")
         val store = client!!.breadcrumbState.store
         var count = 0

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -72,9 +72,9 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
     final SessionTracker sessionTracker;
 
-    private SystemBroadcastReceiver systemBroadcastReceiver = null;
-    private ActivityBreadcrumbCollector activityBreadcrumbCollector = null;
-    private SessionLifecycleCallback sessionLifecycleCallback = null;
+    private final SystemBroadcastReceiver systemBroadcastReceiver;
+    private final ActivityBreadcrumbCollector activityBreadcrumbCollector;
+    private final SessionLifecycleCallback sessionLifecycleCallback;
 
     private final SharedPreferences sharedPrefs;
 
@@ -182,7 +182,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             application.registerActivityLifecycleCallbacks(sessionLifecycleCallback);
 
             if (immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.STATE)) {
-                activityBreadcrumbCollector = new ActivityBreadcrumbCollector(
+                this.activityBreadcrumbCollector = new ActivityBreadcrumbCollector(
                     new Function2<String, Map<String, ? extends Object>, Unit>() {
                         @SuppressWarnings("unchecked")
                         @Override
@@ -194,7 +194,12 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                     }
                 );
                 application.registerActivityLifecycleCallbacks(activityBreadcrumbCollector);
+            } else {
+                this.activityBreadcrumbCollector = null;
             }
+        } else {
+            this.activityBreadcrumbCollector = null;
+            this.sessionLifecycleCallback = null;
         }
 
         InternalReportDelegate delegate = new InternalReportDelegate(appContext, logger,
@@ -226,6 +231,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 logger.w("Failed to register for automatic breadcrumb broadcasts", ex);
             }
             this.systemBroadcastReceiver = systemBroadcastReceiver;
+        } else {
+            this.systemBroadcastReceiver = null;
         }
         connectivity.registerForNetworkChanges();
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -70,11 +70,12 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
     private final SessionStore sessionStore;
 
-    final SystemBroadcastReceiver systemBroadcastReceiver;
     final SessionTracker sessionTracker;
 
-    final ActivityBreadcrumbCollector activityBreadcrumbCollector;
-    final SessionLifecycleCallback sessionLifecycleCallback;
+    private SystemBroadcastReceiver systemBroadcastReceiver = null;
+    private ActivityBreadcrumbCollector activityBreadcrumbCollector = null;
+    private SessionLifecycleCallback sessionLifecycleCallback = null;
+
     private final SharedPreferences sharedPrefs;
 
     private final Connectivity connectivity;
@@ -121,8 +122,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 Map<String, Object> data = new HashMap<>();
                 data.put("hasConnection", hasConnection);
                 data.put("networkState", networkState);
-                leaveBreadcrumb("Connectivity change", BreadcrumbType.STATE, data);
-
+                leaveAutoBreadcrumb("Connectivity change", BreadcrumbType.STATE, data);
                 if (hasConnection) {
                     eventStore.flushAsync();
                 }
@@ -140,14 +140,6 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         int maxBreadcrumbs = immutableConfig.getMaxBreadcrumbs();
         breadcrumbState = new BreadcrumbState(maxBreadcrumbs, callbackState, logger);
 
-        // filter out any disabled breadcrumb types
-        addOnBreadcrumb(new OnBreadcrumbCallback() {
-            @Override
-            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
-                return immutableConfig.shouldRecordBreadcrumbType(breadcrumb.getType());
-            }
-        });
-
         storageManager = (StorageManager) appContext.getSystemService(Context.STORAGE_SERVICE);
 
         contextState = new ContextState();
@@ -156,7 +148,6 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         sessionStore = new SessionStore(appContext, logger, null);
         sessionTracker = new SessionTracker(immutableConfig, callbackState, this,
                 sessionStore, logger);
-        systemBroadcastReceiver = new SystemBroadcastReceiver(this, logger);
         metadataState = copyMetadataState(configuration);
 
         // Set up and collect constant app and device diagnostics
@@ -183,23 +174,27 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         deviceDataCollector = new DeviceDataCollector(connectivity, appContext, resources, id, info,
                 Environment.getDataDirectory(), logger);
 
-        activityBreadcrumbCollector = new ActivityBreadcrumbCollector(
-                new Function2<String, Map<String, ? extends Object>, Unit>() {
-                    @SuppressWarnings("unchecked")
-                    @Override
-                    public Unit invoke(String activity, Map<String, ?> metadata) {
-                        leaveBreadcrumb(activity, BreadcrumbType.STATE,
-                                (Map<String, Object>) metadata);
-                        return null;
-                    }
-                }
-        );
-        sessionLifecycleCallback = new SessionLifecycleCallback(sessionTracker);
 
         if (appContext instanceof Application) {
+
             Application application = (Application) appContext;
+            sessionLifecycleCallback = new SessionLifecycleCallback(sessionTracker);
             application.registerActivityLifecycleCallbacks(sessionLifecycleCallback);
-            application.registerActivityLifecycleCallbacks(activityBreadcrumbCollector);
+
+            if (immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.STATE)) {
+                activityBreadcrumbCollector = new ActivityBreadcrumbCollector(
+                    new Function2<String, Map<String, ? extends Object>, Unit>() {
+                        @SuppressWarnings("unchecked")
+                        @Override
+                        public Unit invoke(String activity, Map<String, ?> metadata) {
+                            leaveBreadcrumb(activity, BreadcrumbType.STATE,
+                                (Map<String, Object>) metadata);
+                            return null;
+                        }
+                    }
+                );
+                application.registerActivityLifecycleCallbacks(activityBreadcrumbCollector);
+            }
         }
 
         InternalReportDelegate delegate = new InternalReportDelegate(appContext, logger,
@@ -216,16 +211,20 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         }
 
         // register a receiver for automatic breadcrumbs
-        try {
-            Async.run(new Runnable() {
-                @Override
-                public void run() {
-                    IntentFilter intentFilter = SystemBroadcastReceiver.getIntentFilter();
-                    appContext.registerReceiver(systemBroadcastReceiver, intentFilter);
-                }
-            });
-        } catch (RejectedExecutionException ex) {
-            logger.w("Failed to register for automatic breadcrumb broadcasts", ex);
+        final SystemBroadcastReceiver systemBroadcastReceiver = new SystemBroadcastReceiver(this, logger);
+        if (systemBroadcastReceiver.getActions().size() > 0) {
+            try {
+                Async.run(new Runnable() {
+                    @Override
+                    public void run() {
+                        appContext.registerReceiver(systemBroadcastReceiver,
+                            systemBroadcastReceiver.getIntentFilter());
+                    }
+                });
+            } catch (RejectedExecutionException ex) {
+                logger.w("Failed to register for automatic breadcrumb broadcasts", ex);
+            }
+            this.systemBroadcastReceiver = systemBroadcastReceiver;
         }
         connectivity.registerForNetworkChanges();
 
@@ -234,7 +233,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         // Flush any on-disk errors
         eventStore.flushOnLaunch();
         Map<String, Object> data = Collections.emptyMap();
-        leaveBreadcrumb("Bugsnag loaded", BreadcrumbType.STATE, data);
+        leaveAutoBreadcrumb("Bugsnag loaded", BreadcrumbType.STATE, data);
 
         // finally, initialise plugins
         loadPlugins(configuration);
@@ -313,7 +312,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                         Map<String, Object> data = new HashMap<>();
                         data.put("from", oldOrientation);
                         data.put("to", newOrientation);
-                        leaveBreadcrumb("Orientation change", BreadcrumbType.STATE, data);
+                        leaveAutoBreadcrumb("Orientation change", BreadcrumbType.STATE, data);
                         clientObservable.postOrientationChange(newOrientation);
                         return null;
                     }
@@ -784,7 +783,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * Leave a "breadcrumb" log message representing an action or event which
      * occurred in your app, to aid with debugging
      *
-     * @param message     A short label
+     * @param message  A short label
      * @param type     A category for the breadcrumb
      * @param metadata Additional diagnostic information about the app environment
      */
@@ -795,6 +794,22 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date(), logger));
         } else {
             logNull("leaveBreadcrumb");
+        }
+    }
+
+    /**
+     * Intended for internal use only - leaves a breadcrumb if the type is enabled for automatic
+     * breadcrumbs.
+     *
+     * @param message  A short label
+     * @param type     A category for the breadcrumb
+     * @param metadata Additional diagnostic information about the app environment
+     */
+    void leaveAutoBreadcrumb(@NonNull String message,
+                             @NonNull BreadcrumbType type,
+                             @NonNull Map<String, Object> metadata) {
+        if (immutableConfig.shouldRecordBreadcrumbType(type)) {
+            breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date(), logger));
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -211,7 +211,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         }
 
         // register a receiver for automatic breadcrumbs
-        final SystemBroadcastReceiver systemBroadcastReceiver = new SystemBroadcastReceiver(this, logger);
+        final SystemBroadcastReceiver systemBroadcastReceiver =
+            new SystemBroadcastReceiver(this, logger);
         if (systemBroadcastReceiver.getActions().size() > 0) {
             try {
                 Async.run(new Runnable() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
@@ -20,15 +20,14 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
 
     private static final String INTENT_ACTION_KEY = "Intent Action";
 
-    @NonNull
-    private static final Map<String, BreadcrumbType> actions = buildActions();
-
     private final Client client;
     private final Logger logger;
+    private final Map<String, BreadcrumbType> actions;
 
     SystemBroadcastReceiver(@NonNull Client client, Logger logger) {
         this.client = client;
         this.logger = logger;
+        this.actions = buildActions();
     }
 
     @Override
@@ -88,47 +87,64 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
     }
 
     /**
-     * Builds a map of intent actions and their breadcrumb type.
+     * Builds a map of intent actions and their breadcrumb type (if enabled).
      *
-     * Noisy breadcrumbs are commented out, along with anything that involves a state change.
+     * Noisy breadcrumbs are omitted, along with anything that involves a state change.
      * @return the action map
      */
     @NonNull
-    private static Map<String, BreadcrumbType> buildActions() {
+    private Map<String, BreadcrumbType> buildActions() {
+
         Map<String, BreadcrumbType> actions = new HashMap<>();
-        actions.put("android.appwidget.action.APPWIDGET_DELETED", BreadcrumbType.USER);
-        actions.put("android.appwidget.action.APPWIDGET_DISABLED", BreadcrumbType.USER);
-        actions.put("android.appwidget.action.APPWIDGET_ENABLED", BreadcrumbType.USER);
-        actions.put("android.appwidget.action.APPWIDGET_HOST_RESTORED", BreadcrumbType.STATE);
-        actions.put("android.appwidget.action.APPWIDGET_RESTORED", BreadcrumbType.STATE);
-        actions.put("android.appwidget.action.APPWIDGET_UPDATE", BreadcrumbType.STATE);
-        actions.put("android.appwidget.action.APPWIDGET_UPDATE_OPTIONS", BreadcrumbType.STATE);
-        actions.put("android.intent.action.ACTION_POWER_CONNECTED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.ACTION_POWER_DISCONNECTED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.ACTION_SHUTDOWN", BreadcrumbType.STATE);
-        actions.put("android.intent.action.AIRPLANE_MODE", BreadcrumbType.STATE);
-        actions.put("android.intent.action.BATTERY_LOW", BreadcrumbType.STATE);
-        actions.put("android.intent.action.BATTERY_OKAY", BreadcrumbType.STATE);
-        actions.put("android.intent.action.BOOT_COMPLETED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.CAMERA_BUTTON", BreadcrumbType.USER);
-        actions.put("android.intent.action.CLOSE_SYSTEM_DIALOGS", BreadcrumbType.USER);
-        actions.put("android.intent.action.CONFIGURATION_CHANGED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.CONTENT_CHANGED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.DATE_CHANGED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.DEVICE_STORAGE_LOW", BreadcrumbType.STATE);
-        actions.put("android.intent.action.DEVICE_STORAGE_OK", BreadcrumbType.STATE);
-        actions.put("android.intent.action.DOCK_EVENT", BreadcrumbType.USER);
-        actions.put("android.intent.action.DREAMING_STARTED", BreadcrumbType.NAVIGATION);
-        actions.put("android.intent.action.DREAMING_STOPPED", BreadcrumbType.NAVIGATION);
-        actions.put("android.intent.action.INPUT_METHOD_CHANGED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.LOCALE_CHANGED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.REBOOT", BreadcrumbType.STATE);
-        actions.put("android.intent.action.SCREEN_OFF", BreadcrumbType.STATE);
-        actions.put("android.intent.action.SCREEN_ON", BreadcrumbType.STATE);
-        actions.put("android.intent.action.TIMEZONE_CHANGED", BreadcrumbType.STATE);
-        actions.put("android.intent.action.TIME_SET", BreadcrumbType.STATE);
-        actions.put("android.os.action.DEVICE_IDLE_MODE_CHANGED", BreadcrumbType.STATE);
-        actions.put("android.os.action.POWER_SAVE_MODE_CHANGED", BreadcrumbType.STATE);
+        if (client.getConfig().shouldRecordBreadcrumbType(BreadcrumbType.USER)) {
+            actions.put("android.appwidget.action.APPWIDGET_DELETED", BreadcrumbType.USER);
+            actions.put("android.appwidget.action.APPWIDGET_DISABLED", BreadcrumbType.USER);
+            actions.put("android.appwidget.action.APPWIDGET_ENABLED", BreadcrumbType.USER);
+            actions.put("android.intent.action.CAMERA_BUTTON", BreadcrumbType.USER);
+            actions.put("android.intent.action.CLOSE_SYSTEM_DIALOGS", BreadcrumbType.USER);
+            actions.put("android.intent.action.DOCK_EVENT", BreadcrumbType.USER);
+        }
+
+        if (client.getConfig().shouldRecordBreadcrumbType(BreadcrumbType.STATE)) {
+            actions.put("android.appwidget.action.APPWIDGET_HOST_RESTORED", BreadcrumbType.STATE);
+            actions.put("android.appwidget.action.APPWIDGET_RESTORED", BreadcrumbType.STATE);
+            actions.put("android.appwidget.action.APPWIDGET_UPDATE", BreadcrumbType.STATE);
+            actions.put("android.appwidget.action.APPWIDGET_UPDATE_OPTIONS", BreadcrumbType.STATE);
+            actions.put("android.intent.action.ACTION_POWER_CONNECTED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.ACTION_POWER_DISCONNECTED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.ACTION_SHUTDOWN", BreadcrumbType.STATE);
+            actions.put("android.intent.action.AIRPLANE_MODE", BreadcrumbType.STATE);
+            actions.put("android.intent.action.BATTERY_LOW", BreadcrumbType.STATE);
+            actions.put("android.intent.action.BATTERY_OKAY", BreadcrumbType.STATE);
+            actions.put("android.intent.action.BOOT_COMPLETED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.CONFIGURATION_CHANGED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.CONTENT_CHANGED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.DATE_CHANGED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.DEVICE_STORAGE_LOW", BreadcrumbType.STATE);
+            actions.put("android.intent.action.DEVICE_STORAGE_OK", BreadcrumbType.STATE);
+            actions.put("android.intent.action.INPUT_METHOD_CHANGED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.LOCALE_CHANGED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.REBOOT", BreadcrumbType.STATE);
+            actions.put("android.intent.action.SCREEN_OFF", BreadcrumbType.STATE);
+            actions.put("android.intent.action.SCREEN_ON", BreadcrumbType.STATE);
+            actions.put("android.intent.action.TIMEZONE_CHANGED", BreadcrumbType.STATE);
+            actions.put("android.intent.action.TIME_SET", BreadcrumbType.STATE);
+            actions.put("android.os.action.DEVICE_IDLE_MODE_CHANGED", BreadcrumbType.STATE);
+            actions.put("android.os.action.POWER_SAVE_MODE_CHANGED", BreadcrumbType.STATE);
+        }
+
+        if (client.getConfig().shouldRecordBreadcrumbType(BreadcrumbType.NAVIGATION)) {
+            actions.put("android.intent.action.DREAMING_STARTED", BreadcrumbType.NAVIGATION);
+            actions.put("android.intent.action.DREAMING_STOPPED", BreadcrumbType.NAVIGATION);
+        }
+
+        return actions;
+    }
+
+    /**
+     * @return the enabled actions
+     */
+    public Map<String, BreadcrumbType> getActions() {
         return actions;
     }
 
@@ -138,7 +154,7 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
      * @return The intent filter
      */
     @NonNull
-    static IntentFilter getIntentFilter() {
+    public IntentFilter getIntentFilter() {
         IntentFilter filter = new IntentFilter();
 
         for (String action : actions.keySet()) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
@@ -32,7 +32,6 @@ class SystemBroadcastReceiverTest {
         `when`(client.config).thenReturn(getConfig(emptySet()))
         `when`(intent.action).thenReturn("android.intent.action.AIRPLANE_MODE")
 
-
         val receiver = SystemBroadcastReceiver(client, NoopLogger)
         receiver.onReceive(context, intent)
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
@@ -29,6 +29,7 @@ class SystemBroadcastReceiverTest {
 
     @Test
     fun testBasicReceive() {
+        `when`(client.config).thenReturn(getConfig(emptySet()))
         `when`(intent.action).thenReturn("android.intent.action.AIRPLANE_MODE")
 
 
@@ -41,6 +42,7 @@ class SystemBroadcastReceiverTest {
 
     @Test
     fun testMetadataReceive() {
+        `when`(client.config).thenReturn(getConfig(emptySet()))
         `when`(intent.action).thenReturn("SomeTitle")
         `when`(intent.extras).thenReturn(bundle)
         `when`(bundle.keySet()).thenReturn(setOf("foo"))
@@ -51,6 +53,27 @@ class SystemBroadcastReceiverTest {
 
         val metadata = mapOf(Pair("Intent Action", "SomeTitle"), Pair("foo", "[bar]"))
         verify(client, times(1)).leaveBreadcrumb("SomeTitle", BreadcrumbType.STATE, metadata)
+    }
+
+    @Test
+    fun testBreadcrumbTypesUser() {
+        `when`(client.config).thenReturn(getConfig(setOf(BreadcrumbType.USER)))
+        val receiver = SystemBroadcastReceiver(client, NoopLogger)
+        assertEquals(6, receiver.actions.size)
+    }
+
+    @Test
+    fun testBreadcrumbTypesState() {
+        `when`(client.config).thenReturn(getConfig(setOf(BreadcrumbType.STATE)))
+        val receiver = SystemBroadcastReceiver(client, NoopLogger)
+        assertEquals(25, receiver.actions.size)
+    }
+
+    @Test
+    fun testBreadcrumbTypesNavigation() {
+        `when`(client.config).thenReturn(getConfig(setOf(BreadcrumbType.NAVIGATION)))
+        val receiver = SystemBroadcastReceiver(client, NoopLogger)
+        assertEquals(2, receiver.actions.size)
     }
 
     @Test
@@ -69,6 +92,12 @@ class SystemBroadcastReceiverTest {
             "NOT_ANDROID.net.wifi.p2p.CONNECTION_STATE_CHANGE",
             shortenActionNameIfNeeded("NOT_ANDROID.net.wifi.p2p.CONNECTION_STATE_CHANGE")
         )
+    }
+
+    private fun getConfig(breadcrumbTypes: Set<BreadcrumbType>) : ImmutableConfig {
+        var config = BugsnagTestUtils.generateConfiguration()
+        config.enabledBreadcrumbTypes = breadcrumbTypes
+        return BugsnagTestUtils.convert(config)
     }
 
 }

--- a/features/breadcrumb.feature
+++ b/features/breadcrumb.feature
@@ -22,9 +22,8 @@ Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs ar
     And the request is a valid for the error reporting API
     And the event has 1 breadcrumbs
 
-Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
+Scenario: An automatic breadcrumb is sent in report when the appropriate type is enabled
     When I run "BreadcrumbAutoScenario"
-    And I relauch the app
     Then I should receive a request
     And the request is a valid for the error reporting API
-    And the event has a "STATE" breadcrumb with message "Bugsnag loaded"
+    And the event has a "state" breadcrumb with the message "Bugsnag loaded"

--- a/features/breadcrumb.feature
+++ b/features/breadcrumb.feature
@@ -17,3 +17,16 @@ Scenario: Manually added breadcrumbs are sent in report
     And the event "breadcrumbs.0.type" equals "manual"
     And the event "breadcrumbs.0.metaData" is not null
     And the event "breadcrumbs.0.metaData.message" equals "Hello Breadcrumb!"
+
+Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
+    When I run "BreadcrumbDisabledScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the event has 1 breadcrumbs
+
+Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
+    When I run "BreadcrumbAutoScenario"
+    And I relauch the app
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the event has a "STATE" breadcrumb with message "Bugsnag loaded"

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbAutoScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbAutoScenario.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+
+import com.bugsnag.android.BreadcrumbType
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+import java.util.*
+
+/**
+ * Sends a handled exception to Bugsnag, which includes manual breadcrumbs.
+ */
+internal class BreadcrumbAutoScenario(config: Configuration,
+                                      context: Context) : Scenario(config, context) {
+    init {
+        config.autoTrackSessions = false
+        config.enabledBreadcrumbTypes = setOf(BreadcrumbType.STATE)
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.notify(generateException())
+    }
+
+}

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbDisabledScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbDisabledScenario.kt
@@ -1,0 +1,27 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+
+import com.bugsnag.android.BreadcrumbType
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+import java.util.*
+
+/**
+ * Sends a handled exception to Bugsnag, which includes manual breadcrumbs.
+ */
+internal class BreadcrumbDisabledScenario(config: Configuration,
+                                  context: Context) : Scenario(config, context) {
+    init {
+        config.autoTrackSessions = false
+        config.enabledBreadcrumbTypes = emptySet()
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.leaveBreadcrumb("Hello Breadcrumb!")
+        Bugsnag.notify(generateException())
+    }
+
+}

--- a/tests/features/breadcrumb.feature
+++ b/tests/features/breadcrumb.feature
@@ -17,3 +17,16 @@ Scenario: Manually added breadcrumbs are sent in report
     And the event "breadcrumbs.0.type" equals "manual"
     And the event "breadcrumbs.0.metaData" is not null
     And the event "breadcrumbs.0.metaData.message" equals "Hello Breadcrumb!"
+
+Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
+    When I run "BreadcrumbDisabledScenario"
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the event has 1 breadcrumbs
+
+Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
+    When I run "BreadcrumbAutoScenario"
+    And I relauch the app
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the event has a "STATE" breadcrumb with message "Bugsnag loaded"

--- a/tests/features/breadcrumb.feature
+++ b/tests/features/breadcrumb.feature
@@ -18,13 +18,12 @@ Scenario: Manually added breadcrumbs are sent in report
 
 Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
     When I run "BreadcrumbDisabledScenario"
-    Then I should receive a request
-    And the request is a valid for the error reporting API
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the event has 1 breadcrumbs
 
-Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
+Scenario: An automatic breadcrumb is sent in report when the appropriate type is enabled
     When I run "BreadcrumbAutoScenario"
-    And I relauch the app
-    Then I should receive a request
-    And the request is a valid for the error reporting API
-    And the event has a "STATE" breadcrumb with message "Bugsnag loaded"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the event has a "state" breadcrumb with the message "Bugsnag loaded"

--- a/tests/features/steps/android_steps.rb
+++ b/tests/features/steps/android_steps.rb
@@ -198,7 +198,7 @@ Then("the request is valid for the error reporting API version {string} for the 
   }
 end
 
-Then("the event has {[0-9]+} breadcrumbs") do |expected_count|
+Then("the event has {int} breadcrumbs") do |expected_count|
   value = Server.current_request[:body]["events"].first["breadcrumbs"]
   fail("Incorrect number of breadcrumbs found: #{value.length()}, expected: #{expected_count}") if value.length() != expected_count.to_i
 end

--- a/tests/features/steps/android_steps.rb
+++ b/tests/features/steps/android_steps.rb
@@ -197,3 +197,8 @@ Then("the request is valid for the error reporting API version {string} for the 
     And each element in payload field "events" has "exceptions"
   }
 end
+
+Then("the event has {[0-9]+} breadcrumbs") do |expected_count|
+  value = Server.current_request[:body]["events"].first["breadcrumbs"]
+  fail("Incorrect number of breadcrumbs found: #{value.length()}, expected: #{expected_count}") if value.length() != expected_count.to_i
+end


### PR DESCRIPTION
## Goal

The new `enabledBreadcrumbTypes` should only affect the automatically collected breadcrumbs and should disable the hooks to listen for the breadcrumbs to avoid unnecessary computations.

## Changeset

* Created `leaveAutoBreadcrumb` in `Client` for internally-left breadcrumbs to wrap the config check
* Wrapped the various hooks for listening to system events with a check of the config and didn't register the hook if it is disabled

## Tests

* Unit tests updated
* End-to-end tests for no breadcrumbs, manual and the loaded 'state' breadcrumb.