### PR TITLE
Add unhandledRejections to enabledErrorTypes

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
@@ -22,9 +22,17 @@ class ErrorTypes(
      * Sets whether Bugsnag should automatically capture and report unhandled errors.
      * By default, this value is true.
      */
-    var unhandledExceptions: Boolean = true
-) {
-    internal constructor(detectErrors: Boolean) : this(detectErrors, detectErrors, detectErrors)
+    var unhandledExceptions: Boolean = true,
 
-    internal fun copy() = ErrorTypes(anrs, ndkCrashes, unhandledExceptions)
+
+    /**
+     * Sets whether Bugsnag should automatically capture and report unhandled promise rejections.
+     * This only applies to React Native apps.
+     * By default, this value is true.
+     */
+    var unhandledRejections: Boolean = true
+) {
+    internal constructor(detectErrors: Boolean) : this(detectErrors, detectErrors, detectErrors, detectErrors)
+
+    internal fun copy() = ErrorTypes(anrs, ndkCrashes, unhandledExceptions, unhandledRejections)
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
@@ -15,6 +15,7 @@ class EnabledErrorTypesTest {
         assertTrue(config.enabledErrorTypes.anrs)
         assertFalse(config.enabledErrorTypes.ndkCrashes)
         assertTrue(config.enabledErrorTypes.unhandledExceptions)
+        assertTrue(config.enabledErrorTypes.unhandledRejections)
     }
 
     @Test
@@ -25,6 +26,7 @@ class EnabledErrorTypesTest {
             assertTrue(anrs)
             assertFalse(ndkCrashes)
             assertTrue(unhandledExceptions)
+            assertTrue(unhandledRejections)
         }
     }
 
@@ -36,6 +38,7 @@ class EnabledErrorTypesTest {
             assertFalse(anrs)
             assertFalse(ndkCrashes)
             assertFalse(unhandledExceptions)
+            assertFalse(unhandledRejections)
         }
     }
 
@@ -45,6 +48,7 @@ class EnabledErrorTypesTest {
             assertFalse(anrs)
             assertFalse(ndkCrashes)
             assertFalse(unhandledExceptions)
+            assertFalse(unhandledRejections)
         }
     }
 }


### PR DESCRIPTION
Adds the `unhandledRejections` reason to `enabledErrorTypes` to allow it to be accessed from the JS layer. This is required by the JS project.