### PR TITLE
Sync initial state with observers

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -1,9 +1,10 @@
 package com.bugsnag.android;
 
 import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
@@ -41,6 +42,7 @@ public class ObserverInterfaceTest {
         breadcrumbTypes.add(BreadcrumbType.LOG);
         breadcrumbTypes.add(BreadcrumbType.MANUAL);
         config.setEnabledBreadcrumbTypes(breadcrumbTypes);
+        config.addMetadata("foo", "bar", true);
         client = new Client(ApplicationProvider.getApplicationContext(), config);
         observer = new BugsnagTestObserver();
         client.registerObserver(observer);
@@ -49,6 +51,31 @@ public class ObserverInterfaceTest {
     @After
     public void tearDown() {
         client.close();
+    }
+
+    @SuppressWarnings("EmptyCatchBlock")
+    @Test
+    public void testSyncInitialState() {
+        try {
+            assertNull(findMessageInQueue(StateEvent.UpdateUser.class));
+            fail("UpdateUser message not expected");
+        } catch (Throwable ignored) {
+        }
+        try {
+            assertNull(findMessageInQueue(StateEvent.AddMetadata.class));
+            fail("AddMetadata message not expected");
+        } catch (Throwable ignored) {
+        }
+        try {
+            assertNull(findMessageInQueue(StateEvent.UpdateContext.class));
+            fail("UpdateContext message not expected");
+        } catch (Throwable ignored) {
+        }
+
+        client.syncInitialState();
+        assertNotNull(findMessageInQueue(StateEvent.UpdateUser.class));
+        assertNotNull(findMessageInQueue(StateEvent.AddMetadata.class));
+        assertNotNull(findMessageInQueue(StateEvent.UpdateContext.class));
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -324,7 +324,6 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
     void sendNativeSetupNotification() {
         clientObservable.postNdkInstall(immutableConfig);
-        metadataState.initObservableMessages();
         try {
             Async.run(new Runnable() {
                 @Override
@@ -345,6 +344,15 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         userState.addObserver(observer);
         contextState.addObserver(observer);
         deliveryDelegate.addObserver(observer);
+    }
+
+    /**
+     * Sends initial state values for Metadata/User/Context to any registered observers.
+     */
+    void syncInitialState() {
+        metadataState.emitObservableEvent();
+        contextState.emitObservableEvent();
+        userState.emitObservableEvent();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ContextState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ContextState.kt
@@ -4,8 +4,10 @@ internal class ContextState(context: String? = null) : BaseObservable() {
     var context = context
         set(value) {
             field = value
-            notifyObservers(StateEvent.UpdateContext(context))
+            emitObservableEvent()
         }
+
+    fun emitObservableEvent() = notifyObservers(StateEvent.UpdateContext(context))
 
     fun copy() = ContextState(context)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -37,7 +37,7 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) : BaseObs
      * Fires the initial observable messages for all the metadata which has been added before an
      * Observer was added. This is used initially to populate the NDK with data.
      */
-    fun initObservableMessages() {
+    fun emitObservableEvent() {
         val sections = metadata.store.keys
 
         for (section in sections) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserState.kt
@@ -8,7 +8,9 @@ internal class UserState(private val userRepository: UserRepository) : BaseObser
     fun setUser(id: String?, email: String?, name: String?) {
         user = User(id, email, name)
         userRepository.save(user)
-        notifyObservers(StateEvent.UpdateUser(user))
+        emitObservableEvent()
     }
+
+    fun emitObservableEvent() = notifyObservers(StateEvent.UpdateUser(user))
 
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
@@ -55,7 +55,7 @@ internal class MetadataStateTest {
             data.add(msg.section)
         }
 
-        state.initObservableMessages()
+        state.emitObservableEvent()
         assertEquals(setOf("foo", "bar"), data)
     }
 }

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -20,6 +20,7 @@ internal class NdkPlugin : Plugin {
             nativeBridge = NativeBridge()
             client.registerObserver(nativeBridge)
             client.sendNativeSetupNotification()
+            client.syncInitialState()
         }
         enableCrashReporting()
         client.logger.i("Initialised NDK Plugin")

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -48,6 +48,7 @@ class BugsnagReactNativePlugin : Plugin {
 
     fun registerForMessageEvents(cb: (MessageEvent) -> Unit) {
         client.registerObserver(BugsnagReactNativeBridge(client, cb))
+        client.syncInitialState()
     }
 
     fun leaveBreadcrumb(map: Map<String, Any?>?) {


### PR DESCRIPTION
## Goal

Syncs the initial state with any observers for the Metadata, User, and Context values. This alters the implementation so that the initial state is synced in both the NDK and React Native plugins.

## Changeset

- Created `syncInitialState()` which sends observable messages that describe the user/context/metadata to the NDK + RN observers
- Altered the RN + NDK plugins to call `syncInitialState()` after they have registered observers so that the message is always received

## Tests

Added an instrumentation test to verify that the user/context/metadata message is sent when a `Client` is initialised and `syncInitialState()` is invoked.
