### PR TITLE
Use 'name' field in manual breadcrumbs

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -37,8 +37,7 @@ class BreadcrumbStateTest {
         var count = 0
 
         for (breadcrumb in store) {
-            if (MANUAL == breadcrumb.type && "manual" == breadcrumb.message
-                && breadcrumb.metadata!!["message"] == "Hello World") {
+            if (MANUAL == breadcrumb.type && "Hello World" == breadcrumb.message) {
                 count++
             }
         }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -165,8 +165,7 @@ public class ClientTest {
 
         Breadcrumb poll = client.breadcrumbState.getStore().poll();
         assertEquals(BreadcrumbType.MANUAL, poll.getType());
-        assertEquals("manual", poll.getMessage());
-        assertEquals("another", poll.getMetadata().get("message"));
+        assertEquals("another", poll.getMessage());
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -4,6 +4,7 @@ import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import androidx.annotation.NonNull;
@@ -164,9 +165,8 @@ public class ObserverInterfaceTest {
         client.leaveBreadcrumb("Drift 4 units left");
         StateEvent.AddBreadcrumb crumb = findMessageInQueue(StateEvent.AddBreadcrumb.class);
         assertEquals(BreadcrumbType.MANUAL, crumb.getType());
-        assertEquals("manual", crumb.getMessage());
-        assertEquals(1, crumb.getMetadata().size());
-        assertEquals("Drift 4 units left", crumb.getMetadata().get("message"));
+        assertEquals("Drift 4 units left", crumb.getMessage());
+        assertTrue(crumb.getMetadata().isEmpty());
     }
 
     @Test
@@ -175,9 +175,8 @@ public class ObserverInterfaceTest {
         client.breadcrumbState.add(obj);
         StateEvent.AddBreadcrumb crumb = findMessageInQueue(StateEvent.AddBreadcrumb.class);
         assertEquals(BreadcrumbType.MANUAL, crumb.getType());
-        assertEquals("manual", crumb.getMessage());
-        assertEquals(1, crumb.getMetadata().size());
-        assertEquals("Drift 4 units left", crumb.getMetadata().get("message"));
+        assertEquals("Drift 4 units left", crumb.getMessage());
+        assertTrue(crumb.getMetadata().isEmpty());
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.kt
@@ -16,9 +16,9 @@ internal class BreadcrumbInternal internal constructor(
 ) : JsonStream.Streamable {
 
     internal constructor(message: String) : this(
-        "manual",
+        message,
         BreadcrumbType.MANUAL,
-        mutableMapOf(Pair("message", message)),
+        mutableMapOf(),
         Date()
     )
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -35,7 +35,7 @@ class BreadcrumbStateTest {
 
         val crumbs = breadcrumbState.store.toList()
         assertEquals(3, crumbs.size)
-        assertEquals(longStr, crumbs[2].metadata!!["message"])
+        assertEquals(longStr, crumbs[2].message)
     }
 
     /**
@@ -50,8 +50,8 @@ class BreadcrumbStateTest {
         }
 
         val crumbs = breadcrumbState.store.toList()
-        assertEquals("2", crumbs.first().metadata!!["message"])
-        assertEquals("6", crumbs.last().metadata!!["message"])
+        assertEquals("2", crumbs.first().message)
+        assertEquals("6", crumbs.last().message)
     }
 
     /**

--- a/features/breadcrumb.feature
+++ b/features/breadcrumb.feature
@@ -13,7 +13,5 @@ Scenario: Manually added breadcrumbs are sent in report
     And the event "breadcrumbs.1.metaData.Foo" equals "Bar"
 
     And the event "breadcrumbs.0.timestamp" is not null
-    And the event "breadcrumbs.0.name" equals "manual"
+    And the event "breadcrumbs.0.name" equals "Hello Breadcrumb!"
     And the event "breadcrumbs.0.type" equals "manual"
-    And the event "breadcrumbs.0.metaData" is not null
-    And the event "breadcrumbs.0.metaData.message" equals "Hello Breadcrumb!"

--- a/features/native_api.feature
+++ b/features/native_api.feature
@@ -105,7 +105,7 @@ Feature: Native API
         And the exception "errorClass" equals "SIGILL"
         And the event "severity" equals "error"
         And the event has a "log" breadcrumb named "Warm beer detected"
-        And the event has a "manual" breadcrumb with message "Reverse thrusters"
+        And the event has a "manual" breadcrumb with the message "Reverse thrusters"
         And the event "unhandled" is true
 
     Scenario: Leaving breadcrumbs in Java and followed by notifying in C
@@ -116,8 +116,8 @@ Feature: Native API
         And the exception "errorClass" equals "Failed instantiation"
         And the exception "message" equals "Could not allocate"
         And the event "severity" equals "error"
-        And the event has a "manual" breadcrumb with message "Initiate lift"
-        And the event has a "manual" breadcrumb with message "Disable lift"
+        And the event has a "manual" breadcrumb with the message "Initiate lift"
+        And the event has a "manual" breadcrumb with the message "Disable lift"
         And the event "unhandled" is false
 
     Scenario: Leaving breadcrumbs in Java followed by a C crash
@@ -128,7 +128,7 @@ Feature: Native API
         And the request payload contains a completed handled native report
         And the exception "errorClass" equals "SIGILL"
         And the event "severity" equals "error"
-        And the event has a "manual" breadcrumb with message "Bridge connector activated"
+        And the event has a "manual" breadcrumb with the message "Bridge connector activated"
         And the event "unhandled" is true
 
     Scenario: Leaving breadcrumbs in C followed by a Java crash

--- a/features/steps/build_steps.rb
+++ b/features/steps/build_steps.rb
@@ -202,3 +202,14 @@ Then(/^the payload field "(.+)" is greater than (\d+)(?: for request (\d+))?$/) 
   observed_value = read_key_path(find_request(request_index)[:body], field_path)
   assert(observed_value > int_value)
 end
+
+Then(/^the event has a "(.+)" breadcrumb with the message "(.+)"(?: for request (\d+))?$/) do |type, message, request_index|
+  value = read_key_path(find_request(get_request_index(request_index))[:body], "events.0.breadcrumbs")
+  found = false
+  value.each do |crumb|
+    if crumb["type"] == type and crumb["name"] == message then
+      found = true
+    end
+  end
+  fail("No breadcrumb matched: #{value}") unless found
+end

--- a/tests/features/breadcrumb.feature
+++ b/tests/features/breadcrumb.feature
@@ -13,7 +13,5 @@ Scenario: Manually added breadcrumbs are sent in report
     And the event "breadcrumbs.1.metaData.Foo" equals "Bar"
 
     And the event "breadcrumbs.0.timestamp" is not null
-    And the event "breadcrumbs.0.name" equals "manual"
+    And the event "breadcrumbs.0.name" equals "Hello Breadcrumb!"
     And the event "breadcrumbs.0.type" equals "manual"
-    And the event "breadcrumbs.0.metaData" is not null
-    And the event "breadcrumbs.0.metaData.message" equals "Hello Breadcrumb!"

--- a/tests/features/native_api.feature
+++ b/tests/features/native_api.feature
@@ -108,7 +108,7 @@ Feature: Native API
           | SIGTRAP |
         And the event "severity" equals "error"
         And the event has a "log" breadcrumb named "Warm beer detected"
-        And the event has a "manual" breadcrumb with message "Reverse thrusters"
+        And the event has a "manual" breadcrumb with the message "Reverse thrusters"
         And the event "unhandled" is true
 
     Scenario: Leaving breadcrumbs in Java and followed by notifying in C
@@ -118,8 +118,8 @@ Feature: Native API
         And the exception "errorClass" equals "Failed instantiation"
         And the exception "message" equals "Could not allocate"
         And the event "severity" equals "error"
-        And the event has a "manual" breadcrumb with message "Initiate lift"
-        And the event has a "manual" breadcrumb with message "Disable lift"
+        And the event has a "manual" breadcrumb with the message "Initiate lift"
+        And the event has a "manual" breadcrumb with the message "Disable lift"
         And the event "unhandled" is false
 
     Scenario: Leaving breadcrumbs in Java followed by a C crash
@@ -132,7 +132,7 @@ Feature: Native API
           | SIGILL |
           | SIGTRAP |
         And the event "severity" equals "error"
-        And the event has a "manual" breadcrumb with message "Bridge connector activated"
+        And the event has a "manual" breadcrumb with the message "Bridge connector activated"
         And the event "unhandled" is true
 
     Scenario: Leaving breadcrumbs in C followed by a Java crash

--- a/tests/features/steps/android_steps.rb
+++ b/tests/features/steps/android_steps.rb
@@ -197,3 +197,14 @@ Then("the request is valid for the error reporting API version {string} for the 
     And each element in payload field "events" has "exceptions"
   }
 end
+
+Then(/^the event has a "(.+)" breadcrumb with the message "(.+)"(?: for request (\d+))?$/) do |type, message, request_index|
+  value = read_key_path(Server.current_request[:body], "events.0.breadcrumbs")
+  found = false
+  value.each do |crumb|
+    if crumb["type"] == type and crumb["name"] == message then
+      found = true
+    end
+  end
+  fail("No breadcrumb matched: #{value}") unless found
+end


### PR DESCRIPTION
## Goal

Currently `Bugsnag.leaveBreadcrumb("Button tapped")` creates a breadcrumb with `type=manual`, `name="manual"` and a single metadata item with a key of "message" and a value of "Button tapped".

This should be changed to set the name to the provided text "Button tapped" and no metadata, to match the notifier spec.

## Changeset

Altered the `message` constructor parameter to serialize as the `name` field instead.

## Tests

Updated existing unit test coverage and E2E tests. Note that an existing mazerunner v1 step was added to the local build steps rather than updating it in the mazerunner repository - this is because the step has been removed from v2 as it was only used on Android.
