### PR TITLE
Alter NDK event field sizes

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -167,7 +167,7 @@ typedef struct {
 } bsg_error;
 
 typedef struct {
-    char name[33];
+    char name[64];
     char timestamp[37];
     bugsnag_breadcrumb_type type;
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -21,7 +21,7 @@
 /**
  *  Max number of breadcrumbs in an event. Configures a default if not defined.
  */
-#define BUGSNAG_CRUMBS_MAX 30
+#define BUGSNAG_CRUMBS_MAX 25
 #endif
 #ifndef BUGSNAG_DEFAULT_EX_TYPE
 /**

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -3,6 +3,10 @@
 
 #include "event.h"
 
+#ifndef V1_BUGSNAG_CRUMBS_MAX
+#define V1_BUGSNAG_CRUMBS_MAX 30
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -118,7 +122,7 @@ typedef struct {
     // Breadcrumbs are a ring; the first index moves as the
     // structure is filled and replaced.
     int crumb_first_index;
-    bugsnag_breadcrumb_v1 breadcrumbs[BUGSNAG_CRUMBS_MAX];
+    bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
 
     char context[64];
     bugsnag_severity severity;
@@ -140,7 +144,7 @@ typedef struct {
     // Breadcrumbs are a ring; the first index moves as the
     // structure is filled and replaced.
     int crumb_first_index;
-    bugsnag_breadcrumb_v1 breadcrumbs[BUGSNAG_CRUMBS_MAX];
+    bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
 
     char context[64];
     bugsnag_severity severity;

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -153,10 +153,11 @@ bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2) {
 }
 
 void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2, bugsnag_event *event) {
-  for (int k = 0; k < report_v2->crumb_count; k++) {
-    int crumb_index = (report_v2->crumb_first_index + k) % BUGSNAG_CRUMBS_MAX;
+  for (int k = 0; k < event->crumb_count; k++) {
+    int crumb_index = (report_v2->crumb_first_index + k) % V1_BUGSNAG_CRUMBS_MAX;
+    int new_crumb_index = crumb_index % BUGSNAG_CRUMBS_MAX;
 
-    bugsnag_breadcrumb *new_crumb = &event->breadcrumbs[crumb_index];
+    bugsnag_breadcrumb *new_crumb = &event->breadcrumbs[new_crumb_index];
     bugsnag_breadcrumb_v1 *old_crumb = &report_v2->breadcrumbs[crumb_index];
     new_crumb->type = old_crumb->type;
     bsg_strncpy_safe(new_crumb->name, old_crumb->name, sizeof(new_crumb->name));
@@ -243,7 +244,7 @@ bugsnag_event *bsg_map_v1_to_report(bugsnag_report_v1 *report_v1) {
     event_v2->crumb_count = report_v1->crumb_count;
     event_v2->crumb_first_index = report_v1->crumb_first_index;
 
-    size_t breadcrumb_size = sizeof(bugsnag_breadcrumb) * BUGSNAG_CRUMBS_MAX;
+    size_t breadcrumb_size = sizeof(bugsnag_breadcrumb_v1) * V1_BUGSNAG_CRUMBS_MAX;
     memcpy(&event_v2->breadcrumbs, report_v1->breadcrumbs, breadcrumb_size);
 
     strcpy(event_v2->context, report_v1->context);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -31,6 +31,10 @@ void bsg_serialize_error(bsg_error exc, JSON_Object *exception, JSON_Array *stac
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 
+int bsg_calculate_total_crumbs(int old_count);
+int bsg_calculate_v1_start_index(int old_count);
+int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
@@ -1,6 +1,7 @@
 #include <greatest/greatest.h>
 #include <event.h>
 #include <time.h>
+#include <utils/serializer.h>
 
 bugsnag_breadcrumb *init_breadcrumb(const char *name, char *message, bugsnag_breadcrumb_type type) {
   bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
@@ -68,7 +69,54 @@ TEST test_add_breadcrumbs_over_max(void) {
   PASS();
 }
 
+TEST test_bsg_calculate_total_crumbs(void) {
+  ASSERT_EQ(0, bsg_calculate_total_crumbs(0));
+  ASSERT_EQ(5, bsg_calculate_total_crumbs(5));
+  ASSERT_EQ(22, bsg_calculate_total_crumbs(22));
+  ASSERT_EQ(25, bsg_calculate_total_crumbs(25));
+  ASSERT_EQ(25, bsg_calculate_total_crumbs(26));
+  ASSERT_EQ(25, bsg_calculate_total_crumbs(30));
+  PASS();
+}
+
+TEST test_bsg_calculate_start_index(void) {
+  ASSERT_EQ(0, bsg_calculate_v1_start_index(0));
+  ASSERT_EQ(0, bsg_calculate_v1_start_index(3));
+  ASSERT_EQ(0, bsg_calculate_v1_start_index(17));
+  ASSERT_EQ(0, bsg_calculate_v1_start_index(24));
+  ASSERT_EQ(0, bsg_calculate_v1_start_index(25));
+  ASSERT_EQ(1, bsg_calculate_v1_start_index(26));
+  ASSERT_EQ(3, bsg_calculate_v1_start_index(28));
+  ASSERT_EQ(5, bsg_calculate_v1_start_index(30));
+  PASS();
+}
+
+TEST test_bsg_calculate_crumb_index(void) {
+  ASSERT_EQ(0, bsg_calculate_v1_crumb_index(0, 0));
+
+  // zero offset
+  ASSERT_EQ(24, bsg_calculate_v1_crumb_index(24, 0));
+  ASSERT_EQ(25, bsg_calculate_v1_crumb_index(25, 0));
+  ASSERT_EQ(26, bsg_calculate_v1_crumb_index(26, 0));
+  ASSERT_EQ(0, bsg_calculate_v1_crumb_index(30, 0));
+
+  // offset
+  ASSERT_EQ(15, bsg_calculate_v1_crumb_index(0, 15));
+  ASSERT_EQ(15, bsg_calculate_v1_crumb_index(5, 10));
+  ASSERT_EQ(24, bsg_calculate_v1_crumb_index(10, 14));
+  ASSERT_EQ(25, bsg_calculate_v1_crumb_index(10, 15));
+  ASSERT_EQ(26, bsg_calculate_v1_crumb_index(11, 15));
+  ASSERT_EQ(29, bsg_calculate_v1_crumb_index(14, 15));
+  ASSERT_EQ(0, bsg_calculate_v1_crumb_index(20, 10));
+  ASSERT_EQ(1, bsg_calculate_v1_crumb_index(20, 11));
+  ASSERT_EQ(4, bsg_calculate_v1_crumb_index(23, 11));
+  PASS();
+}
+
 SUITE(breadcrumbs) {
   RUN_TEST(test_add_breadcrumb);
   RUN_TEST(test_add_breadcrumbs_over_max);
+  RUN_TEST(test_bsg_calculate_total_crumbs);
+  RUN_TEST(test_bsg_calculate_start_index);
+  RUN_TEST(test_bsg_calculate_crumb_index);
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
@@ -39,26 +39,31 @@ TEST test_add_breadcrumb(void) {
 
 TEST test_add_breadcrumbs_over_max(void) {
   bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
-  // HACK: assumes the max number of crumbs is 30
-  for (int i=0; i < 64; i++) {
-    char *format = malloc(sizeof(char) * 64);
-    memset(format, 0, sizeof(char) * 64);
+  int breadcrumb_count = 64;
+
+  for (int i=0; i < breadcrumb_count; i++) {
+    char *format = malloc(sizeof(char) * breadcrumb_count);
+    memset(format, 0, sizeof(char) * breadcrumb_count);
     sprintf(format, "crumb: %d", i);
     bugsnag_breadcrumb *crumb = init_breadcrumb(format, "go go go", BSG_CRUMB_USER);
     bugsnag_event_add_breadcrumb(event, crumb);
     free(crumb);
     free(format);
   }
-  ASSERT(strcmp("crumb: 60", event->breadcrumbs[0].name) == 0);
-  ASSERT(strcmp("crumb: 61", event->breadcrumbs[1].name) == 0);
-  ASSERT(strcmp("crumb: 62", event->breadcrumbs[2].name) == 0);
-  ASSERT(strcmp("crumb: 63", event->breadcrumbs[3].name) == 0);
-  ASSERT(strcmp("crumb: 34", event->breadcrumbs[4].name) == 0);
-  ASSERT(strcmp("crumb: 35", event->breadcrumbs[5].name) == 0);
-  ASSERT(strcmp("crumb: 58", event->breadcrumbs[28].name) == 0);
-  ASSERT(strcmp("crumb: 59", event->breadcrumbs[29].name) == 0);
+
+  // assertions assume that the crumb count is always 25
   ASSERT_EQ(BUGSNAG_CRUMBS_MAX, event->crumb_count);
-  ASSERT_EQ(4, event->crumb_first_index);
+  ASSERT_EQ(14, event->crumb_first_index);
+
+  ASSERT(strcmp("crumb: 50", event->breadcrumbs[0].name) == 0);
+  ASSERT(strcmp("crumb: 51", event->breadcrumbs[1].name) == 0);
+  ASSERT(strcmp("crumb: 52", event->breadcrumbs[2].name) == 0);
+  ASSERT(strcmp("crumb: 53", event->breadcrumbs[3].name) == 0);
+
+  ASSERT(strcmp("crumb: 63", event->breadcrumbs[13].name) == 0);
+  ASSERT(strcmp("crumb: 39", event->breadcrumbs[14].name) == 0);
+  ASSERT(strcmp("crumb: 40", event->breadcrumbs[15].name) == 0);
+  ASSERT(strcmp("crumb: 41", event->breadcrumbs[16].name) == 0);
   free(event);
   PASS();
 }


### PR DESCRIPTION
Alters the size of fields in the `bugsnag_event` struct to that specified in the notifier spec, and updates existing test coverage to ensure that the migration works as expected.

This alters the breadcrumb array length from 30 to 25, and the breadcrumb name field to 64 from 33.