### PR TITLE
Amended ABI validation to be for publish and bintrayUpload only

### DIFF
--- a/dockerfiles/Dockerfile.android-builder
+++ b/dockerfiles/Dockerfile.android-builder
@@ -50,7 +50,7 @@ RUN echo "signing.secretKeyRingFile=/root/.gnupg/secring.gpg" >> ~/.gradle/gradl
 
 # Build and upload to the local maven as version 9.9.9
 RUN sed -i -e 's/VERSION_NAME=.*/VERSION_NAME=9.9.9/g' gradle.properties
-RUN ./gradlew assembleRelease publishToMavenLocal -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64
+RUN ./gradlew assembleRelease publishToMavenLocal
 
 COPY tests/features/ /app/features
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -68,7 +68,7 @@ task validatePublishOptions() {
 }
 
 tasks.whenTaskAdded { task ->
-    if ((task.name == 'assembleRelease') || (task.name == 'publish') || (task.name == 'bintrayUpload')) {
+    if ((task.name == 'publish') || (task.name == 'bintrayUpload')) {
         task.dependsOn validatePublishOptions
     }
 }


### PR DESCRIPTION
Reduced scope of the new ABI validation checks to be for the publish and bintrayUpload only - not assembleRelease as this requires extra switches unnecessarily in the e2e tests.