### PR TITLE
Rearrange leaveBreadcrumb param

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -181,7 +181,7 @@ public class ObserverInterfaceTest {
 
     @Test
     public void testLeaveBreadcrumbSendsMessage() {
-        client.leaveBreadcrumb("Rollback", BreadcrumbType.LOG, new HashMap<String, Object>());
+        client.leaveBreadcrumb("Rollback", new HashMap<String, Object>(), BreadcrumbType.LOG);
         StateEvent.AddBreadcrumb crumb = findMessageInQueue(StateEvent.AddBreadcrumb.class);
         assertEquals(BreadcrumbType.LOG, crumb.getType());
         assertEquals("Rollback", crumb.getMessage());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbCallbackStateTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbCallbackStateTest.java
@@ -12,7 +12,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -110,7 +109,7 @@ public class OnBreadcrumbCallbackStateTest {
         });
 
         client.leaveBreadcrumb("Foo");
-        client.leaveBreadcrumb("Hello", BreadcrumbType.USER, new HashMap<String, Object>());
+        client.leaveBreadcrumb("Hello", new HashMap<String, Object>(), BreadcrumbType.USER);
         assertEquals(5, count[0]);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -284,15 +284,14 @@ public final class Bugsnag {
     /**
      * Leave a "breadcrumb" log message representing an action or event which
      * occurred in your app, to aid with debugging
-     *
      * @param message     A short label
-     * @param type     A category for the breadcrumb
      * @param metadata Additional diagnostic information about the app environment
+     * @param type     A category for the breadcrumb
      */
     public static void leaveBreadcrumb(@NonNull String message,
-                                       @NonNull BreadcrumbType type,
-                                       @NonNull Map<String, Object> metadata) {
-        getClient().leaveBreadcrumb(message, type, metadata);
+                                       @NonNull Map<String, Object> metadata,
+                                       @NonNull BreadcrumbType type) {
+        getClient().leaveBreadcrumb(message, metadata, type);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -187,8 +187,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                         @SuppressWarnings("unchecked")
                         @Override
                         public Unit invoke(String activity, Map<String, ?> metadata) {
-                            leaveBreadcrumb(activity, BreadcrumbType.STATE,
-                                (Map<String, Object>) metadata);
+                            leaveBreadcrumb(activity, (Map<String, Object>) metadata,
+                                    BreadcrumbType.STATE);
                             return null;
                         }
                     }
@@ -798,14 +798,13 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     /**
      * Leave a "breadcrumb" log message representing an action or event which
      * occurred in your app, to aid with debugging
-     *
      * @param message  A short label
-     * @param type     A category for the breadcrumb
      * @param metadata Additional diagnostic information about the app environment
+     * @param type     A category for the breadcrumb
      */
     public void leaveBreadcrumb(@NonNull String message,
-                                @NonNull BreadcrumbType type,
-                                @NonNull Map<String, Object> metadata) {
+                                @NonNull Map<String, Object> metadata,
+                                @NonNull BreadcrumbType type) {
         if (message != null && type != null && metadata != null) {
             breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date(), logger));
         } else {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Used as the entry point for native code to allow proguard to obfuscate other areas if needed
@@ -181,7 +180,7 @@ public class NativeInterface {
         if (name == null) {
             return;
         }
-        getClient().leaveBreadcrumb(name, type, new HashMap<String, Object>());
+        getClient().leaveBreadcrumb(name, new HashMap<String, Object>(), type);
     }
 
     /**
@@ -193,7 +192,7 @@ public class NativeInterface {
             return;
         }
         String name = new String(nameBytes, UTF8Charset);
-        getClient().leaveBreadcrumb(name, type, new HashMap<String, Object>());
+        getClient().leaveBreadcrumb(name, new HashMap<String, Object>(), type);
     }
 
     /**
@@ -203,7 +202,7 @@ public class NativeInterface {
                                        @NonNull String type,
                                        @NonNull Map<String, Object> metadata) {
         String typeName = type.toUpperCase(Locale.US);
-        getClient().leaveBreadcrumb(message, BreadcrumbType.valueOf(typeName), metadata);
+        getClient().leaveBreadcrumb(message, metadata, BreadcrumbType.valueOf(typeName));
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
@@ -65,7 +65,7 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
             if (type == null) {
                 type = BreadcrumbType.STATE;
             }
-            client.leaveBreadcrumb(shortAction, type, meta);
+            client.leaveBreadcrumb(shortAction, meta, type);
 
         } catch (Exception ex) {
             logger.w("Failed to leave breadcrumb in SystemBroadcastReceiver: "

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -151,8 +151,8 @@ class BugsnagApiTest {
 
     @Test
     fun leaveBreadcrumb1() {
-        Bugsnag.leaveBreadcrumb("whoops", BreadcrumbType.LOG, mapOf())
-        verify(client, times(1)).leaveBreadcrumb("whoops", BreadcrumbType.LOG, mapOf())
+        Bugsnag.leaveBreadcrumb("whoops", mapOf(), BreadcrumbType.LOG)
+        verify(client, times(1)).leaveBreadcrumb("whoops", mapOf(), BreadcrumbType.LOG)
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -20,9 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -439,27 +437,27 @@ public class ClientFacadeTest {
     @Test
     public void leaveComplexBreadcrumbValid() {
         HashMap<String, Object> metadata = new HashMap<>();
-        client.leaveBreadcrumb("foo", BreadcrumbType.NAVIGATION, metadata);
+        client.leaveBreadcrumb("foo", metadata, BreadcrumbType.NAVIGATION);
         verify(breadcrumbState, times(1)).add(any(Breadcrumb.class));
     }
 
     @Test
     public void leaveComplexBreadcrumbInvalid1() {
         HashMap<String, Object> metadata = new HashMap<>();
-        client.leaveBreadcrumb(null, BreadcrumbType.NAVIGATION, metadata);
+        client.leaveBreadcrumb(null, metadata, BreadcrumbType.NAVIGATION);
         verify(breadcrumbState, times(0)).add(any(Breadcrumb.class));
     }
 
     @Test
     public void leaveComplexBreadcrumbInvalid2() {
         HashMap<String, Object> metadata = new HashMap<>();
-        client.leaveBreadcrumb("foo", null, metadata);
+        client.leaveBreadcrumb("foo", metadata, null);
         verify(breadcrumbState, times(0)).add(any(Breadcrumb.class));
     }
 
     @Test
     public void leaveComplexBreadcrumbInvalid3() {
-        client.leaveBreadcrumb("foo", BreadcrumbType.NAVIGATION, null);
+        client.leaveBreadcrumb("foo", null, BreadcrumbType.NAVIGATION);
         verify(breadcrumbState, times(0)).add(any(Breadcrumb.class));
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -163,7 +163,7 @@ internal class NativeInterfaceApiTest {
     @Test
     fun leaveBreadcrumb() {
         NativeInterface.leaveBreadcrumb("wow", BreadcrumbType.LOG)
-        verify(client, times(1)).leaveBreadcrumb("wow", BreadcrumbType.LOG, emptyMap())
+        verify(client, times(1)).leaveBreadcrumb("wow", emptyMap(), BreadcrumbType.LOG)
     }
 
     @Test
@@ -171,8 +171,8 @@ internal class NativeInterfaceApiTest {
         NativeInterface.leaveBreadcrumb("wow", "log", mapOf(Pair("foo", "bar")))
         verify(client, times(1)).leaveBreadcrumb(
             "wow",
-            BreadcrumbType.LOG,
-            mapOf(Pair("foo", "bar"))
+            mapOf(Pair("foo", "bar")),
+            BreadcrumbType.LOG
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
@@ -36,7 +36,7 @@ class SystemBroadcastReceiverTest {
         receiver.onReceive(context, intent)
 
         val metadata = mapOf(Pair("Intent Action", "android.intent.action.AIRPLANE_MODE"))
-        verify(client, times(1)).leaveBreadcrumb("AIRPLANE_MODE", BreadcrumbType.STATE, metadata)
+        verify(client, times(1)).leaveBreadcrumb("AIRPLANE_MODE", metadata, BreadcrumbType.STATE)
     }
 
     @Test
@@ -51,7 +51,7 @@ class SystemBroadcastReceiverTest {
         receiver.onReceive(context, intent)
 
         val metadata = mapOf(Pair("Intent Action", "SomeTitle"), Pair("foo", "[bar]"))
-        verify(client, times(1)).leaveBreadcrumb("SomeTitle", BreadcrumbType.STATE, metadata)
+        verify(client, times(1)).leaveBreadcrumb("SomeTitle", metadata, BreadcrumbType.STATE)
     }
 
     @Test

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -57,7 +57,7 @@ class BugsnagReactNativePlugin : Plugin {
         val type = BreadcrumbType.valueOf((map["type"] as String).toUpperCase(Locale.US))
         val obj = map["metadata"] ?: emptyMap<String, Any>()
         @Suppress("UNCHECKED_CAST")
-        client.leaveBreadcrumb(msg, type, obj as Map<String, Any>)
+        client.leaveBreadcrumb(msg, obj as Map<String, Any>, type)
     }
 
     fun startSession() {

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/LeaveBreadcrumbTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/LeaveBreadcrumbTest.kt
@@ -42,8 +42,8 @@ class LeaveBreadcrumbTest {
 
         verify(client, times(1)).leaveBreadcrumb(
             eq("JS: invoked API"),
-            eq(BreadcrumbType.REQUEST),
-            eq(metadata)
+            eq(metadata),
+            eq(BreadcrumbType.REQUEST)
         )
     }
 
@@ -57,8 +57,8 @@ class LeaveBreadcrumbTest {
 
         verify(client, times(1)).leaveBreadcrumb(
             eq("JS: invoked API"),
-            eq(BreadcrumbType.REQUEST),
-            eq(emptyMap())
+            eq(emptyMap()),
+            eq(BreadcrumbType.REQUEST)
         )
     }
 }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
@@ -22,7 +22,7 @@ internal class BreadcrumbScenario(config: Configuration,
         super.run()
         Bugsnag.leaveBreadcrumb("Hello Breadcrumb!")
         val data = Collections.singletonMap("Foo", "Bar" as Any)
-        Bugsnag.leaveBreadcrumb("Another Breadcrumb", BreadcrumbType.USER, data)
+        Bugsnag.leaveBreadcrumb("Another Breadcrumb", data, BreadcrumbType.USER)
         Bugsnag.notify(generateException())
     }
 


### PR DESCRIPTION
Rearranges the `leaveBreadcrumb` parameter to match the notifier spec.