### PR TITLE
Removed old settings from manifest in example

### DIFF
--- a/examples/sdk-app-example/src/main/AndroidManifest.xml
+++ b/examples/sdk-app-example/src/main/AndroidManifest.xml
@@ -34,14 +34,6 @@
       android:name="com.bugsnag.android.API_KEY"
       android:value="your-api-key" />
 
-    <meta-data
-      android:name="com.bugsnag.android.AUTO_DETECT_ANRS"
-      android:value="true" />
-
-    <meta-data
-      android:name="com.bugsnag.android.AUTO_DETECT_NDK_CRASHES"
-      android:value="true" />
-
   </application>
 
 </manifest>

--- a/examples/sdk-app-example/src/main/AndroidManifest.xml
+++ b/examples/sdk-app-example/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
 
     <meta-data
       android:name="com.bugsnag.android.API_KEY"
-      android:value="your-api-key" />
+      android:value="0abcdef000000abcdef000000abcdef0" />
 
   </application>
 


### PR DESCRIPTION
AUTO_DETECT_ANRS and AUTO_DETECT_NDK_CRASHES are now set in `enabledErrorTypes` not through manifest.