### PR TITLE
Fix version bump script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifeq ($(VERSION),)
 endif
 	@echo Bumping the version number to $(VERSION)
 	@sed -i '' "s/VERSION_NAME=.*/VERSION_NAME=$(VERSION)/" gradle.properties
-	@sed -i '' "s/NOTIFIER_VERSION = .*;/NOTIFIER_VERSION = \"$(VERSION)\";/"\
+	@sed -i '' "s/var version: String = .*/var version: String = \"$(VERSION)\",/"\
 	 bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
 	@sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,7 +7,7 @@ import java.io.IOException
  */
 class Notifier @JvmOverloads constructor(
     var name: String = "Android Bugsnag Notifier",
-    var version: String = "4.21.0",
+    var version: String = "5.0.0-rc.06-SNAPSHOT",
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 


### PR DESCRIPTION
Fixes the makefile script used to update the version reported in error/session payloads. This has changed as `Notifier` is now implemented as a Kotlin class rather than Java.