### PR TITLE
Serialize enabledErrorTypes.unhandledRejections for React Native

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
@@ -49,6 +49,7 @@ class ConfigSerializer implements MapSerializer<ImmutableConfig> {
         map.put("anrs", errorTypes.getAnrs());
         map.put("ndkCrashes", errorTypes.getNdkCrashes());
         map.put("unhandledExceptions", errorTypes.getUnhandledExceptions());
+        map.put("unhandledRejections", errorTypes.getUnhandledRejections());
         return map;
     }
 

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
@@ -53,6 +53,7 @@ public class ConfigSerializerTest {
         assertTrue((Boolean) errorTypes.get("anrs"));
         assertFalse((Boolean) errorTypes.get("ndkCrashes"));
         assertTrue((Boolean) errorTypes.get("unhandledExceptions"));
+        assertTrue((Boolean) errorTypes.get("unhandledRejections"));
 
         Map<String, Object> endpoints = (Map<String, Object>) map.get("endpoints");
         assertEquals("https://notify.bugsnag.com", endpoints.get("notify"));


### PR DESCRIPTION
## Goal

Serializes the `unhandledRejections` flag in the React Native plugin, which is required information for the JS notifier to configure.

## Changeset

Serialized `enabledErrorTypes.unhandledRejections` as a boolean field that is passed to react-native.

## Tests

Added a unit test to verify the serializer.
