### PR TITLE
Enable ndk detection by default

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -8,7 +8,7 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     private var user = User()
 
     @JvmField
-    internal val callbackState: CallbackState
+    internal val callbackState: CallbackState = CallbackState()
 
     @JvmField
     internal val metadataState: MetadataState = MetadataState()
@@ -40,20 +40,6 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
             metadataState.metadata.setRedactedKeys(value)
             field = value
         }
-
-    init {
-        this.callbackState = CallbackState()
-
-        enabledErrorTypes.ndkCrashes = try {
-            // check if AUTO_DETECT_NDK_CRASHES has been set in bugsnag-android
-            // or bugsnag-android-ndk
-            val clz = Class.forName("com.bugsnag.android.BuildConfig")
-            val field = clz.getDeclaredField("AUTO_DETECT_NDK_CRASHES")
-            field.getBoolean(null)
-        } catch (exc: Throwable) {
-            false
-        }
-    }
 
     var discardClasses: Set<String> = emptySet()
     var enabledReleaseStages: Set<String>? = null

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorTypes.kt
@@ -13,10 +13,9 @@ class ErrorTypes(
     /**
      * Determines whether NDK crashes such as signals and exceptions should be reported by bugsnag.
      *
-     * If you are using bugsnag-android this flag is false by default; if you are using
-     * bugsnag-android-ndk this flag is true by default.
+     * This flag is true by default.
      */
-    var ndkCrashes: Boolean = false,
+    var ndkCrashes: Boolean = true,
 
     /**
      * Sets whether Bugsnag should automatically capture and report unhandled errors.

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
@@ -13,7 +13,7 @@ class EnabledErrorTypesTest {
     fun testDetectAnrDefault() {
         assertTrue(config.autoDetectErrors)
         assertTrue(config.enabledErrorTypes.anrs)
-        assertFalse(config.enabledErrorTypes.ndkCrashes)
+        assertTrue(config.enabledErrorTypes.ndkCrashes)
         assertTrue(config.enabledErrorTypes.unhandledExceptions)
         assertTrue(config.enabledErrorTypes.unhandledRejections)
     }
@@ -24,7 +24,7 @@ class EnabledErrorTypesTest {
 
         with(convertToImmutableConfig(config).enabledErrorTypes) {
             assertTrue(anrs)
-            assertFalse(ndkCrashes)
+            assertTrue(ndkCrashes)
             assertTrue(unhandledExceptions)
             assertTrue(unhandledRejections)
         }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -51,7 +51,7 @@ internal class ImmutableConfigTest {
             assertTrue(autoTrackSessions)
             assertTrue(enabledErrorTypes.unhandledExceptions)
             assertTrue(enabledErrorTypes.anrs)
-            assertFalse(enabledErrorTypes.ndkCrashes)
+            assertTrue(enabledErrorTypes.ndkCrashes)
             assertEquals(ThreadSendPolicy.ALWAYS, sendThreads)
 
             // release stages
@@ -83,7 +83,7 @@ internal class ImmutableConfigTest {
         seed.autoTrackSessions = false
         seed.enabledErrorTypes.unhandledExceptions = false
         seed.enabledErrorTypes.anrs = false
-        seed.enabledErrorTypes.ndkCrashes = true
+        seed.enabledErrorTypes.ndkCrashes = false
         seed.sendThreads = ThreadSendPolicy.UNHANDLED_ONLY
 
         seed.discardClasses = setOf("foo")
@@ -111,7 +111,7 @@ internal class ImmutableConfigTest {
             assertNotSame(seed.enabledErrorTypes, enabledErrorTypes)
             assertFalse(enabledErrorTypes.unhandledExceptions)
             assertFalse(enabledErrorTypes.anrs)
-            assertTrue(enabledErrorTypes.ndkCrashes)
+            assertFalse(enabledErrorTypes.ndkCrashes)
             assertEquals(ThreadSendPolicy.UNHANDLED_ONLY, sendThreads)
 
             // release stages

--- a/bugsnag-android-ndk/build.gradle
+++ b/bugsnag-android-ndk/build.gradle
@@ -6,10 +6,6 @@ apply plugin: "com.android.library"
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig.minSdkVersion rootProject.ext.minSdkVersion
-
-    buildTypes.each { buildType ->
-        buildType.buildConfigField("boolean", "AUTO_DETECT_NDK_CRASHES", "true")
-    }
 }
 
 dependencies {

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
@@ -51,7 +51,7 @@ public class ConfigSerializerTest {
 
         Map<String, Object> errorTypes = (Map<String, Object>) map.get("enabledErrorTypes");
         assertTrue((Boolean) errorTypes.get("anrs"));
-        assertFalse((Boolean) errorTypes.get("ndkCrashes"));
+        assertTrue((Boolean) errorTypes.get("ndkCrashes"));
         assertTrue((Boolean) errorTypes.get("unhandledExceptions"));
         assertTrue((Boolean) errorTypes.get("unhandledRejections"));
 


### PR DESCRIPTION
## Goal

Enables NDK detection by default as requested by product to give users more insight into NDK errors that may be happening in their apps.

## Changeset

- Flipped `detectNdkCrashes` to true
- Removed `BuildConfig.AUTO_DETECT_NDK_CRASHES` which was used to enable detection when consuming the `bugsnag-android-ndk` artefact, and disable detection when consuming the `bugsnag-android` artefact

## Tests

Relied on existing test coverage
