### PR TITLE
Re-enabled BuildUUID test

### DIFF
--- a/tests/features/fixtures/mazerunner/build.gradle
+++ b/tests/features/fixtures/mazerunner/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
-        classpath 'com.bugsnag:bugsnag-android-gradle-plugin:4.7.3'
+        classpath 'com.bugsnag:bugsnag-android-gradle-plugin:4.7.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/tests/features/load_configuration.feature
+++ b/tests/features/load_configuration.feature
@@ -11,7 +11,7 @@ Scenario: Load configuration initialised from the Manifest
     And the event "metaData.test.foo" equals "bar"
     And the event "metaData.test.filter_me" equals "[REDACTED]"
     And the event "app.versionCode" equals 753
-    #And the event "app.buildUUID" equals "test-7.5.3"
+    And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.version" equals "7.5.3"
     And the event "app.type" equals "test"
     And the payload field "events.0.threads" is a non-empty array


### PR DESCRIPTION
## Goal

- Points the bugsnag-android-gradle-plugin version to the latest release
- Re-enables assertions that passes with the last release

## Tests

- Local run