### PR TITLE
Register react native observer once only

### DIFF
--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativePluginTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativePluginTest.kt
@@ -31,7 +31,7 @@ internal class BugsnagReactNativePluginTest {
     @Test
     fun registerForMessageEvents() {
         plugin.registerForMessageEvents {  }
-        verify(client, times(1)).registerObserver(any())
+        verify(client, times(1)).syncInitialState()
     }
 
     @Test


### PR DESCRIPTION
## Goal

Alters the react native plugin so that an observer for native events is only registered once.

This is required because the JS layer can be hot reloaded at runtime, and therefore `registerForMessageEvents` can be called multiple times. Previously this registered multiple callbacks which would be sent to a destroyed React bridge, causing a warning to be logged.

## Changeset

Added a native state observer when `Plugin#load()` is called. When `registerForMessageEvents()` is called, a JS callback is stored in a field, and invoked on any subsequent state changes.

If the JS layer undergoes a hot reload, the JS callback will be reassigned when `registerForMessageEvents()` is invoked again.


## Tests

Relied on existing unit test coverage.
