### PR TITLE
Gracefully fail if native library could not be loaded

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
@@ -1,0 +1,31 @@
+package com.bugsnag.android;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class LibraryLoader {
+
+    private AtomicBoolean attemptedLoad = new AtomicBoolean();
+
+    /**
+     * Attempts to load a native library, returning false if the load was unsuccessful.
+     * <p>
+     * If a load was attempted and failed, an error report will be sent using the supplied client
+     * and OnErrorCallback.
+     *
+     * @param name     the library name
+     * @param client   the bugsnag client
+     * @param callback an OnErrorCallback
+     * @return true if the library was loaded, false if not
+     */
+    boolean loadLibrary(String name, Client client, OnErrorCallback callback) {
+        if (!attemptedLoad.getAndSet(true)) {
+            try {
+                System.loadLibrary(name);
+                return true;
+            } catch (UnsatisfiedLinkError error) {
+                client.notify(error, callback);
+            }
+        }
+        return false;
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/LibraryLoaderTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/LibraryLoaderTest.kt
@@ -1,0 +1,37 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class LibraryLoaderTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Test
+    fun loadMissingLibrary() {
+        val libraryLoader = LibraryLoader()
+        val loaded = libraryLoader.loadLibrary("foo", client) { true }
+        assertFalse(loaded)
+        verify(client, times(1)).notify(any(), any())
+    }
+
+    @Test
+    fun loadCalledOnce() {
+        val libraryLoader = LibraryLoader()
+        var loaded = libraryLoader.loadLibrary("foo", client) { true }
+        assertFalse(loaded)
+
+        // duplicate calls only invoke System.loadLibrary once
+        loaded = libraryLoader.loadLibrary("foo", client) { true }
+        assertFalse(loaded)
+        verify(client, times(1)).notify(any(), any())
+    }
+}

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -5,6 +5,11 @@ import android.os.Looper
 
 internal class AnrPlugin : Plugin {
 
+    private companion object {
+        private const val LOAD_ERR_MSG = "Native library could not be linked. Bugsnag will " +
+                "not report ANRs. See https://docs.bugsnag.com/platforms/android/anr-link-errors"
+    }
+
     private val loader = LibraryLoader()
     private lateinit var client: Client
     private val collector = AnrDetailsCollector()
@@ -16,7 +21,7 @@ internal class AnrPlugin : Plugin {
         val loaded = loader.loadLibrary("bugsnag-plugin-android-anr", client) {
             val error = it.errors[0]
             error.errorClass = "AnrLinkError"
-            error.errorMessage = "Native library could not be linked. Bugsnag will not report ANRs."
+            error.errorMessage = LOAD_ERR_MSG
             true
         }
 
@@ -29,8 +34,7 @@ internal class AnrPlugin : Plugin {
                 client.logger.i("Initialised ANR Plugin")
             })
         } else {
-            client.logger.e("Native library could not be linked. Bugsnag will not report " +
-                    "ANRs. See https://docs.bugsnag.com/platforms/android/anr-link-errors")
+            client.logger.e(LOAD_ERR_MSG)
         }
     }
 

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -29,7 +29,8 @@ internal class AnrPlugin : Plugin {
                 client.logger.i("Initialised ANR Plugin")
             })
         } else {
-            client.logger.e("Native library could not be linked. Bugsnag will not report ANRs.")
+            client.logger.e("Native library could not be linked. Bugsnag will not report " +
+                    "ANRs. See https://docs.bugsnag.com/platforms/android/anr-link-errors")
         }
     }
 

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -26,8 +26,10 @@ internal class AnrPlugin : Plugin {
             Handler(Looper.getMainLooper()).post(Runnable {
                 this.client = client
                 enableAnrReporting(true)
-                client.logger.w("Initialised ANR Plugin")
+                client.logger.i("Initialised ANR Plugin")
             })
+        } else {
+            client.logger.e("Native library could not be linked. Bugsnag will not report ANRs.")
         }
     }
 

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -5,12 +5,7 @@ import android.os.Looper
 
 internal class AnrPlugin : Plugin {
 
-    companion object {
-        init {
-            System.loadLibrary("bugsnag-plugin-android-anr")
-        }
-    }
-
+    private val loader = LibraryLoader()
     private lateinit var client: Client
     private val collector = AnrDetailsCollector()
 
@@ -18,13 +13,22 @@ internal class AnrPlugin : Plugin {
     private external fun disableAnrReporting()
 
     override fun load(client: Client) {
-        // this must be run from the main thread as the SIGQUIT is sent to the main thread,
-        // and if the handler is installed on a background thread instead we receive no signal
-        Handler(Looper.getMainLooper()).post(Runnable {
-            this.client = client
-            enableAnrReporting(true)
-            client.logger.w("Initialised ANR Plugin")
-        })
+        val loaded = loader.loadLibrary("bugsnag-plugin-android-anr", client) {
+            val error = it.errors[0]
+            error.errorClass = "AnrLinkError"
+            error.errorMessage = "Native library could not be linked. Bugsnag will not report ANRs."
+            true
+        }
+
+        if (loaded) {
+            // this must be run from the main thread as the SIGQUIT is sent to the main thread,
+            // and if the handler is installed on a background thread instead we receive no signal
+            Handler(Looper.getMainLooper()).post(Runnable {
+                this.client = client
+                enableAnrReporting(true)
+                client.logger.w("Initialised ANR Plugin")
+            })
+        }
     }
 
     override fun unload() = disableAnrReporting()

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -4,6 +4,11 @@ import com.bugsnag.android.ndk.NativeBridge
 
 internal class NdkPlugin : Plugin {
 
+    private companion object {
+        private const val LOAD_ERR_MSG = "Native library could not be linked. Bugsnag will " +
+                "not report NDK errors. See https://docs.bugsnag.com/platforms/android/ndk-link-errors"
+    }
+
     private val loader = LibraryLoader()
 
     private external fun enableCrashReporting()
@@ -15,7 +20,7 @@ internal class NdkPlugin : Plugin {
         val loaded = loader.loadLibrary("bugsnag-ndk", client) {
             val error = it.errors[0]
             error.errorClass = "NdkLinkError"
-            error.errorMessage = "Native library could not be linked. Bugsnag will not report NDK errors."
+            error.errorMessage = LOAD_ERR_MSG
             true
         }
 
@@ -29,8 +34,7 @@ internal class NdkPlugin : Plugin {
             enableCrashReporting()
             client.logger.i("Initialised NDK Plugin")
         } else {
-            client.logger.e("Native library could not be linked. Bugsnag will not report NDK "
-                    + "errors. See https://docs.bugsnag.com/platforms/android/ndk-link-errors")
+            client.logger.e(LOAD_ERR_MSG)
         }
     }
 

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -29,7 +29,8 @@ internal class NdkPlugin : Plugin {
             enableCrashReporting()
             client.logger.i("Initialised NDK Plugin")
         } else {
-            client.logger.e("Native library could not be linked. Bugsnag will not report NDK errors.")
+            client.logger.e("Native library could not be linked. Bugsnag will not report NDK "
+                    + "errors. See https://docs.bugsnag.com/platforms/android/ndk-link-errors")
         }
     }
 

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -28,6 +28,8 @@ internal class NdkPlugin : Plugin {
             }
             enableCrashReporting()
             client.logger.i("Initialised NDK Plugin")
+        } else {
+            client.logger.e("Native library could not be linked. Bugsnag will not report NDK errors.")
         }
     }
 


### PR DESCRIPTION
## Goal

The ANR + NDK plugins load native libraries to detect errors. On some versions of Android these libraries cannot be loaded (e.g. due to PackageManager bugs) which results in an `UnsatisfiedLinkError` being thrown.

This error is now caught and reported to the Bugsnag dashboard, and the affected plugin(s) is disabled to allow graceful fallback.

## Changeset

- Moved native library loading to `LibraryLoader` class which attempts to load the library once, reporting any `UnsatisfiedLinkError` to bugsnag
- Updated ANR/NDK plugins to use `LibraryLoader` class and only continue loading if successful

Note: the error message format will need to be updated to link to documentation before this is merged. A documentation PR will be raised separately and in the meanwhile the rest of this PR can be reviewed.

## Tests

Added a unit test to verify the behaviour of the new `LibraryLoader` class.

Tested the error message format in the dashboard by running an example app where the library name supplied for loading was incorrect.
