### PR TITLE
Make errorReportingThread readonly

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -82,13 +82,6 @@ public class Thread implements JsonStream.Streamable {
     }
 
     /**
-     * Sets whether the thread was the thread that caused the event
-     */
-    public void setErrorReportingThread(boolean errorReportingThread) {
-        impl.setErrorReportingThread(errorReportingThread);
-    }
-
-    /**
      * Gets whether the thread was the thread that caused the event
      */
     public boolean getErrorReportingThread() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -6,7 +6,7 @@ class ThreadInternal internal constructor(
     var id: Long,
     var name: String,
     var type: ThreadType,
-    var isErrorReportingThread: Boolean,
+    val isErrorReportingThread: Boolean,
     stacktrace: Stacktrace
 ) : JsonStream.Streamable {
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -70,8 +70,6 @@ public class ThreadFacadeTest {
     @Test
     public void errorReportingThreadValid() {
         assertFalse(thread.getErrorReportingThread());
-        thread.setErrorReportingThread(true);
-        assertTrue(thread.getErrorReportingThread());
     }
 
     @Test


### PR DESCRIPTION
Makes the `errorReportingThread` property readonly. This prevents a user from setting the value to `true` on more than one thread, while allowing them to read the value in a callback.