### PR TITLE
Remove buildUuid from Configuration

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,7 +60,7 @@ The full list of altered methods and their intended replacements can be found be
 | `Client#notifyBlocking(Throwable, Severity, MetaData)`                                 | `Bugsnag#notify(Throwable, OnErrorCallback)` |
 | `Client#setAppVersion` or <br />`Bugsnag#setAppVersion`                                | `Configuration#setAppVersion` |
 | `Client#setAutoCaptureSessions` or <br />`Bugsnag#setAutoCaptureSessions`              | `Configuration#setAutoTrackSessions` |
-| `Client#setBuildUUID` or <br />`Bugsnag#setBuildUUID`                                  | `Configuration#setBuildUuid` |
+| `Client#setBuildUUID` or <br />`Bugsnag#setBuildUUID`                                  | Method removed. Set as an AndroidManifest <meta-data> element instead using `com.bugsnag.android.BUILD_UUID` as the key |
 | `Client#setEndpoint` or <br />`Bugsnag#setEndpoint`                                    | `Configuration#setEndpoints` |
 | `Client#setErrorReportApiClient` or <br />`Bugsnag#setErrorReportApiClient`            | `Configuration#setDelivery` |
 | `Client#setFilters` or <br />`Bugsnag#setFilters`                                      | `Configuration#setRedactedKeys` |
@@ -112,7 +112,7 @@ Several methods on `Configuration` have been renamed for greater API consistency
 | `Configuration#setAutomaticallyCollectBreadcrumbs` | `Configuration#setEnabledBreadcrumbTypes` |
 | `Configuration#setAnrThresholdMs`                  | Method no longer required. |
 | `Configuration#setAutoCaptureSessions`             | `Configuration#setAutoTrackSessions` |
-| `Configuration#setBuildUUID`                       | `Configuration#setBuildUuid` |
+| `Configuration#setBuildUUID`                       | Method removed. Set as an AndroidManifest <meta-data> element instead using `com.bugsnag.android.BUILD_UUID` as the key |
 | `Configuration#setDetectAnrs`                      | `Configuration#setAutoDetectErrors` or <br />`Configuration#setEnabledErrorTypes` |
 | `Configuration#setDetectNdkCrashes`                | `Configuration#setAutoDetectErrors` or <br />`Configuration#setEnabledErrorTypes` |
 | `Configuration#setEnableExceptionHandler`          | `Configuration#setAutoDetectErrors` or <br />`Configuration#setEnabledErrorTypes` |

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -72,7 +72,7 @@ final class BugsnagTestUtils {
 
 
     static ImmutableConfig convert(Configuration config) {
-        return ImmutableConfigKt.convertToImmutableConfig(config);
+        return ImmutableConfigKt.convertToImmutableConfig(config, null);
     }
 
     static SessionTracker generateSessionTracker() {

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -24,7 +24,6 @@ class ManifestConfigLoaderTest {
 
         with(config) {
             assertEquals(apiKey, "5d1ec5bd39a74caa1267142706a7fb21")
-            assertNull(buildUuid)
 
             // detection
             assertTrue(autoDetectErrors)
@@ -89,7 +88,6 @@ class ManifestConfigLoaderTest {
 
         with(config) {
             assertEquals("5d1ec5bd39a74caa1267142706a7fb21", apiKey)
-            assertEquals("fgh123456", buildUuid)
 
             // detection
             assertFalse(autoDetectErrors)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -13,7 +13,6 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     @JvmField
     internal val metadataState: MetadataState = MetadataState()
 
-    var buildUuid: String? = null
     var appVersion: String? = null
     var versionCode: Int? = 0
     var releaseStage: String? = null

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -77,31 +77,6 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
     }
 
     /**
-     * Sets a unique identifier for the app build to be included in all events sent to Bugsnag.
-     *
-     * This is used to identify proguard
-     * mapping files in the case that you publish multiple different apps with
-     * the same appId and versionCode. The default value is read from the
-     * com.bugsnag.android.BUILD_UUID meta-data field in your app manifest.
-     */
-    @Nullable
-    public String getBuildUuid() {
-        return impl.getBuildUuid();
-    }
-
-    /**
-     * Sets a unique identifier for the app build to be included in all events sent to Bugsnag.
-     *
-     * This is used to identify proguard
-     * mapping files in the case that you publish multiple different apps with
-     * the same appId and versionCode. The default value is read from the
-     * com.bugsnag.android.BUILD_UUID meta-data field in your app manifest.
-     */
-    public void setBuildUuid(@Nullable String buildUuid) {
-        impl.setBuildUuid(buildUuid);
-    }
-
-    /**
      * Set the application version sent to Bugsnag. We'll automatically pull your app version
      * from the versionName field in your AndroidManifest.xml file.
      */

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -83,7 +83,10 @@ internal data class ImmutableConfig(
     }
 }
 
-internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
+internal fun convertToImmutableConfig(
+    config: Configuration,
+    buildUuid: String? = null
+): ImmutableConfig {
     val errorTypes = when {
         config.autoDetectErrors -> config.enabledErrorTypes.copy()
         else -> ErrorTypes(false)
@@ -99,7 +102,7 @@ internal fun convertToImmutableConfig(config: Configuration): ImmutableConfig {
         enabledReleaseStages = config.enabledReleaseStages?.toSet(),
         projectPackages = config.projectPackages.toSet(),
         releaseStage = config.releaseStage,
-        buildUuid = config.buildUuid,
+        buildUuid = buildUuid,
         appVersion = config.appVersion,
         versionCode = config.versionCode,
         appType = config.appType,
@@ -152,17 +155,14 @@ internal fun sanitiseConfiguration(
         configuration.projectPackages = setOf<String>(packageName)
     }
 
-    // populate from manifest (in the case where the constructor was called directly by the
-    // User or no UUID was supplied)
-    if (configuration.buildUuid == null) {
-        configuration.buildUuid = appInfo?.metaData?.getString(ManifestConfigLoader.BUILD_UUID)
-    }
+    // populate buildUUID from manifest
+    val buildUuid = appInfo?.metaData?.getString(ManifestConfigLoader.BUILD_UUID)
 
     @Suppress("SENSELESS_COMPARISON")
     if (configuration.delivery == null) {
         configuration.delivery = DefaultDelivery(connectivity, configuration.logger!!)
     }
-    return convertToImmutableConfig(configuration)
+    return convertToImmutableConfig(configuration, buildUuid)
 }
 
 internal const val RELEASE_STAGE_DEVELOPMENT = "development"

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -71,7 +71,6 @@ internal class ManifestConfigLoader {
 
         // misc config
         with(config) {
-            buildUuid = data.getString(BUILD_UUID)
             maxBreadcrumbs = data.getInt(MAX_BREADCRUMBS, maxBreadcrumbs)
             launchCrashThresholdMs =
                 data.getInt(LAUNCH_CRASH_THRESHOLD_MS, launchCrashThresholdMs.toInt()).toLong()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/AppDataCollectorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/AppDataCollectorSerializationTest.kt
@@ -33,7 +33,6 @@ internal class AppDataCollectorSerializationTest {
 
             // populate regular fields
             `when`(context.packageName).thenReturn("com.example.foo")
-            config.buildUuid = "123456"
 
             // populate metadata fields
             `when`(sessionTracker.contextActivity).thenReturn("MyActivity")

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/AppMetadataSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/AppMetadataSerializationTest.kt
@@ -33,7 +33,6 @@ internal class AppMetadataSerializationTest {
 
             // populate regular fields
             `when`(context.packageName).thenReturn("com.example.foo")
-            config.buildUuid = "123456"
 
             // populate metadata fields
             `when`(sessionTracker.contextActivity).thenReturn("MyActivity")

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -19,7 +19,7 @@ final class BugsnagTestUtils {
 
 
     static ImmutableConfig convert(Configuration config) {
-        return ImmutableConfigKt.convertToImmutableConfig(config);
+        return ImmutableConfigKt.convertToImmutableConfig(config, null);
     }
 
     static DeviceBuildInfo generateDeviceBuildInfo() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
@@ -46,14 +46,6 @@ public class ConfigurationFacadeTest {
     }
 
     @Test
-    public void buildUuidValid() {
-        config.setBuildUuid("123");
-        assertEquals("123", config.impl.getBuildUuid());
-        config.setBuildUuid(null);
-        assertNull(config.impl.getBuildUuid());
-    }
-
-    @Test
     public void appVersionValid() {
         config.setAppVersion("1.23");
         assertEquals("1.23", config.impl.getAppVersion());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -62,7 +62,7 @@ internal class ImmutableConfigTest {
 
             // identifiers
             assertEquals(seed.appVersion, appVersion)
-            assertEquals(seed.buildUuid, buildUuid)
+            assertNull(buildUuid)
             assertEquals(seed.appType, appType)
 
             // network config
@@ -92,7 +92,6 @@ internal class ImmutableConfigTest {
         seed.releaseStage = "wham"
 
         seed.appVersion = "1.2.3"
-        seed.buildUuid = "f7ab"
         seed.appType = "custom"
 
         val endpoints = EndpointConfiguration("http://example.com:1234", "http://example.com:1235")
@@ -103,7 +102,7 @@ internal class ImmutableConfigTest {
         seed.enabledBreadcrumbTypes = emptySet()
 
         // verify overrides are copied across
-        with(convertToImmutableConfig(seed)) {
+        with(convertToImmutableConfig(seed, "f7ab")) {
             assertEquals("5d1ec5bd39a74caa1267142706a7fb21", apiKey)
 
             // detection
@@ -122,7 +121,7 @@ internal class ImmutableConfigTest {
 
             // identifiers
             assertEquals("1.2.3", seed.appVersion)
-            assertEquals("f7ab", seed.buildUuid)
+            assertEquals("f7ab", buildUuid)
             assertEquals("custom", seed.appType)
 
             // network config

--- a/bugsnag-android-core/src/test/resources/app_data_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/app_data_serialization_0.json
@@ -1,6 +1,5 @@
 {
   "binaryArch": "x86",
-  "buildUUID": "123456",
   "codeBundleId": "foo-99",
   "id": "com.example.foo",
   "releaseStage": "test-stage",

--- a/bugsnag-android-core/src/test/resources/app_data_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/app_data_serialization_1.json
@@ -1,6 +1,5 @@
 {
   "binaryArch": "x86",
-  "buildUUID": "123456",
   "codeBundleId": "foo-99",
   "id": "com.example.foo",
   "releaseStage": "test-stage",

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -20,7 +20,7 @@ final class BugsnagTestUtils {
 
 
     static ImmutableConfig convert(Configuration config) {
-        return ImmutableConfigKt.convertToImmutableConfig(config);
+        return ImmutableConfigKt.convertToImmutableConfig(config, null);
     }
 
     public static Delivery generateDelivery() {

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
@@ -75,6 +75,6 @@ public class JavaHooks {
      */
     @NonNull
     public static ImmutableConfig generateImmutableConfig() {
-        return ImmutableConfigKt.convertToImmutableConfig(generateConfiguration());
+        return ImmutableConfigKt.convertToImmutableConfig(generateConfiguration(), null);
     }
 }

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
@@ -27,7 +27,6 @@ internal class LoadConfigurationKotlinScenario(
         testConfig.appType = "kotlin"
         testConfig.autoDetectErrors = true
         testConfig.autoTrackSessions = false
-        testConfig.buildUuid = "kotlin-0.9.8"
         testConfig.enabledReleaseStages = setOf("production", "development", "kotlin")
         testConfig.endpoints = EndpointConfiguration("http://bs-local.com:9339", "http://bs-local.com:9339")
         testConfig.projectPackages = setOf("com.company.package1", "com.company.package2")

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationNullsScenario.java
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationNullsScenario.java
@@ -35,7 +35,6 @@ public class LoadConfigurationNullsScenario extends Scenario {
         // Nullable options
         testConfig.setAppType(null);
         testConfig.setAppVersion(null);
-        testConfig.setBuildUuid(null);
         testConfig.setContext(null);
         testConfig.setDelivery(null);
         testConfig.setDiscardClasses(null);

--- a/tests/features/load_configuration.feature
+++ b/tests/features/load_configuration.feature
@@ -27,7 +27,7 @@ Scenario: Load configuration initialised with Kotlin
     And the event "metaData.test.filter_me" equals "bar"
     And the event "metaData.test.filter_me_two" equals "[REDACTED]"
     And the event "app.versionCode" equals 98
-    And the event "app.buildUUID" equals "kotlin-0.9.8"
+    And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.version" equals "0.9.8"
     And the event "app.type" equals "kotlin"
     And the payload field "events.0.threads" is an array with 0 elements


### PR DESCRIPTION
## Goal

The `buildUuid` field should not be settable in Configuration and should be read via the manifest only to prevent the value getting out of date with the value generated by the gradle plugin.

## Changeset

- Removed `buildUuid` accessors from `Configuration` and `ManifestConfigLoader`
- Updated `ImmutableConfig` to load `buildUuid` from manifest only
- Updated upgrading guide

## Tests
- Removed `buildUuid` accessor/loading tests as appropriate
- Updated `event.app` serialization tests to avoid checking `buildUuid`, as the property cannot currently be mocked or faked for test
- Tested changes in example app and verified that the `buildUuid` is still reported