### PR TITLE
Ensure number of breadcrumbs is predictable

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -216,13 +216,15 @@ public class ClientTest {
 
     @Test
     public void testBreadcrumbStoreNotModified() {
-        client = generateClient();
+        config.setEnabledBreadcrumbTypes(Collections.singleton(BreadcrumbType.MANUAL));
+        client = generateClient(config);
+        client.leaveBreadcrumb("Manual breadcrumb");
         Collection<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
-        int breadcrumbCount = client.breadcrumbState.getStore().size();
 
         breadcrumbs.clear(); // only the copy should be cleared
         assertTrue(breadcrumbs.isEmpty());
-        assertEquals(breadcrumbCount, client.breadcrumbState.getStore().size());
+        assertEquals(1, client.breadcrumbState.getStore().size());
+        assertEquals("Manual breadcrumb", client.breadcrumbState.getStore().remove().getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Goal

Resolve potentially flaking instrumentation test.

## Design

Ensure that number of breadcrumbs expected is predictable by disabling all but manual breadcrumbs.

## Changeset

ClientTest.java

## Tests

Verified by peer review and passing CI run.
