### PR TITLE
Setup dokka for generating documentation

### DIFF
--- a/bugsnag-android-core/build.gradle
+++ b/bugsnag-android-core/build.gradle
@@ -16,3 +16,10 @@ apply from: "../gradle/release.gradle"
 apply from: "../gradle/detekt.gradle"
 apply from: "../gradle/checkstyle.gradle"
 apply from: "../gradle/license-check.gradle"
+
+apply plugin: 'org.jetbrains.dokka'
+
+dokka {
+    outputFormat = 'html'
+    outputDirectory = "$buildDir/dokka"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC16"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
     }
 }
 plugins {


### PR DESCRIPTION
## Goal

Sets up the [Dokka](https://github.com/Kotlin/dokka) plugin for generating documentation, which is necessary now that we use Kotlin + Java files in the project.

Eventually we will want to automate this process to push to the `gh-pages` branch - for now this must be done manually.
