### PR TITLE
Create observer before registering plugin

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -30,10 +30,10 @@ class BugsnagReactNativePlugin : Plugin {
         internalHooks = InternalHooks(client)
 
         // register a state observer immediately but only pass events on when JS callback set
-        client.registerObserver(observerBridge)
         observerBridge = BugsnagReactNativeBridge(client) {
             jsCallback?.invoke(it)
         }
+        client.registerObserver(observerBridge)
         client.logger.i("Initialized React Native Plugin")
     }
 


### PR DESCRIPTION
## Goal

Creates the observer before it is registered, otherwise this triggers an exception as the `lateinit var` will not have been initialised. This crashed the Bugsnag react native plugin

## Tests

Manually verified with a local artefact on the v7-react-native example app
