### PR TITLE
feat(bugsnag-android-plugin-react-native): Dedupe JS crashes

### DIFF
--- a/bugsnag-plugin-react-native/proguard-rules.pro
+++ b/bugsnag-plugin-react-native/proguard-rules.pro
@@ -1,1 +1,2 @@
 -keepattributes LineNumberTable,SourceFile
+-keepnames class com.facebook.react.common.JavascriptException { *; }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -52,12 +52,24 @@ class BugsnagReactNativePlugin : Plugin {
         notifier.dependencies.add(Notifier()) // depend on bugsnag-android
     }
 
+    private fun ignoreJavaScriptExceptions() {
+        this.client.addOnError(OnErrorCallback { event ->
+            event.errors[0].errorClass != "com.facebook.react.common.JavascriptException"
+        })
+    }
+
     override fun unload() {}
 
     @Suppress("unused")
     fun configure(env: Map<String, Any?>?): Map<String, Any?> {
         requireNotNull(env)
         updateNotifierInfo(env)
+
+        // JS exceptions are caught by the JS layer and passed to the dispatch method
+        // in this plugin. When a JS exception crashes the app, we get a duplicate
+        // native exception for the same error so we ignore those once the JS layer
+        // has started.
+        ignoreJavaScriptExceptions()
 
         val map = HashMap<String, Any?>()
         configSerializer.serialize(map, internalHooks.config)

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -72,7 +72,7 @@ class BugsnagReactNativePlugin : Plugin {
         // in this plugin. When a JS exception crashes the app, we get a duplicate
         // native exception for the same error so we ignore those once the JS layer
         // has started.
-        if (!ignoreJsExceptionCallbackAdded) ignoreJavaScriptExceptions()
+        if (!ignoreJsExceptionCallbackAdded) { ignoreJavaScriptExceptions() }
 
         val map = HashMap<String, Any?>()
         configSerializer.serialize(map, internalHooks.config)

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -16,6 +16,8 @@ class BugsnagReactNativePlugin : Plugin {
     private val breadcrumbSerializer = BreadcrumbSerializer()
     private val threadSerializer = ThreadSerializer()
 
+    private var ignoreJsExceptionCallbackAdded = false
+
     internal lateinit var internalHooks: InternalHooks
     internal lateinit var client: Client
 
@@ -53,6 +55,7 @@ class BugsnagReactNativePlugin : Plugin {
     }
 
     private fun ignoreJavaScriptExceptions() {
+        ignoreJsExceptionCallbackAdded = true
         this.client.addOnError(OnErrorCallback { event ->
             event.errors[0].errorClass != "com.facebook.react.common.JavascriptException"
         })
@@ -69,7 +72,7 @@ class BugsnagReactNativePlugin : Plugin {
         // in this plugin. When a JS exception crashes the app, we get a duplicate
         // native exception for the same error so we ignore those once the JS layer
         // has started.
-        ignoreJavaScriptExceptions()
+        if (!ignoreJsExceptionCallbackAdded) ignoreJavaScriptExceptions()
 
         val map = HashMap<String, Any?>()
         configSerializer.serialize(map, internalHooks.config)


### PR DESCRIPTION
## Goal

When a JS exception crashes the app, the JS layer handles the offending error, routes it via the normal `onError` callbacks etc., and passes it to the `BugsnagReactNativePlugin` with all the usual metadata. In addition, the native layer receives a JVM exception – an instance of `com.facebook.react.common.JavascriptException` – which contains less information.

This resulted in duplicate events for the same error being delivered to the dashboard, so the aim of this PR is to dedupe such events.

## Design

I added an `onError` callback to the native notifier upon `Plugin.configure()` which filters out errors of this class. Previously this was done via the configuration option ignoreClasses but since configuration is now immutable doing it that way seemed off the cards.

## Changeset

- added `onError` callback when `configure()` is called on the plugin (when the JS layer has booted and started listening for errors
- added a rule to proguard config to ensure the name of the class is still intact at runtime after minification/obfuscation

## Tests

Tested manually. I looked at add unit tests for the plugin class but couldn't get it working.

I'm flying blind on the proguard rule addition – I'm not sure how to test that.
