### PR TITLE
Use proper 2.0.0 release of Maze Runner

### DIFF
--- a/dockerfiles/Dockerfile.android-maze-runner
+++ b/dockerfiles/Dockerfile.android-maze-runner
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:v2-cli as android-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:v2.0.0-cli as android-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 
 COPY tests/features features


### PR DESCRIPTION
## Goal

Use the 2.0.0 release of Maze Runner.

## Design

Maze Runner has now moved to a proper release-based versioning strategy and the `v2` branch of development has ceased.  The Maze Runner image should now be referenced either by full release number or `latest-cli` to roll with the latest release available.

## Changeset

Maze Runner Dockerfile only.

## Tests

Standard CI pipeline.