### PR TITLE
Add null check when loading data from manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Add null check when loading data from manifest
+  [#878](https://github.com/bugsnag/bugsnag-android/pull/878)
+
 ## 5.0.0 (2020-04-21)
 
 __This version contains many breaking changes__. It is part of an effort to unify our notifier

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -59,21 +59,23 @@ internal class ManifestConfigLoader {
      * @param data   the manifest bundle
      */
     @VisibleForTesting
-    internal fun load(data: Bundle, userSuppliedApiKey: String?): Configuration {
+    internal fun load(data: Bundle?, userSuppliedApiKey: String?): Configuration {
         // get the api key from the JVM call, or lookup in the manifest if null
-        val apiKey = (userSuppliedApiKey ?: data.getString(API_KEY))
+        val apiKey = (userSuppliedApiKey ?: data?.getString(API_KEY))
             ?: throw IllegalArgumentException("No Bugsnag API key set")
         val config = Configuration(apiKey)
 
-        loadDetectionConfig(config, data)
-        loadEndpointsConfig(config, data)
-        loadAppConfig(config, data)
+        if (data != null) {
+            loadDetectionConfig(config, data)
+            loadEndpointsConfig(config, data)
+            loadAppConfig(config, data)
 
-        // misc config
-        with(config) {
-            maxBreadcrumbs = data.getInt(MAX_BREADCRUMBS, maxBreadcrumbs)
-            launchCrashThresholdMs =
-                data.getInt(LAUNCH_CRASH_THRESHOLD_MS, launchCrashThresholdMs.toInt()).toLong()
+            // misc config
+            with(config) {
+                maxBreadcrumbs = data.getInt(MAX_BREADCRUMBS, maxBreadcrumbs)
+                launchCrashThresholdMs =
+                    data.getInt(LAUNCH_CRASH_THRESHOLD_MS, launchCrashThresholdMs.toInt()).toLong()
+            }
         }
         return config
     }


### PR DESCRIPTION
## Goal

Adds a null check when loading meta-data from the manifest. In a React Native 0.55 example app with no `meta-data` elements present in the manifest, `applicationInfo.metadata` was returned as null by the `PackageManager`.

It's hypothesised that this was caused by a very old targetSdkVersion/compileSdkVersion, and can be demonstrated to be caused by the lack of any `meta-data` elements in the manifest, making this a relatively rare scenario. A null check has been added regardless.
