### PR TITLE
Fix instrumentation tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,101 +60,101 @@ steps:
 
   # End-to-end tests take the longest to run, so start as soon as possible.
 
-#  - label: ':android: Android 5 end-to-end tests'
-#    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_5_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: Android 6 end-to-end tests'
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_6_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: Android 7 end-to-end tests'
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_7_1"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: Android 8.0 end-to-end tests'
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_8_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: Android 8.1 end-to-end tests'
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_8_1"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#    soft_fail:
-#      - exit_status: "*"
-#
-#  - label: ':android: Android 9 end-to-end tests'
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_9_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: Android 10 end-to-end tests'
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_10_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#    soft_fail:
-#      - exit_status: "*"
+  - label: ':android: Android 5 end-to-end tests'
+    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_5_0"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 6 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_6_0"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 7 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_7_1"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 8.0 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_8_0"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 8.1 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_8_1"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
+
+  - label: ':android: Android 9 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_9_0"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 10 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_10_0"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android size reporting'
     timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -183,7 +183,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -195,7 +194,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -207,7 +205,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -219,7 +216,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -231,7 +227,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -243,7 +238,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -255,7 +249,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -267,7 +260,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -279,7 +271,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -291,7 +282,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'
@@ -303,7 +293,6 @@ steps:
       - docker-compose#v3.3.0:
           run: android-ci
     env:
-      APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
     concurrency: 10
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,101 +60,101 @@ steps:
 
   # End-to-end tests take the longest to run, so start as soon as possible.
 
-  - label: ':android: Android 5 end-to-end tests'
-    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_5_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: Android 6 end-to-end tests'
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_6_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: Android 7 end-to-end tests'
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_7_1"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: Android 8.0 end-to-end tests'
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_8_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: Android 8.1 end-to-end tests'
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_8_1"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
-
-  - label: ':android: Android 9 end-to-end tests'
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_9_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: Android 10 end-to-end tests'
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_10_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
+#  - label: ':android: Android 5 end-to-end tests'
+#    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_5_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: Android 6 end-to-end tests'
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_6_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: Android 7 end-to-end tests'
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_7_1"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: Android 8.0 end-to-end tests'
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_8_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: Android 8.1 end-to-end tests'
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_8_1"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#    soft_fail:
+#      - exit_status: "*"
+#
+#  - label: ':android: Android 9 end-to-end tests'
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_9_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: Android 10 end-to-end tests'
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_10_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#    soft_fail:
+#      - exit_status: "*"
 
   - label: ':android: Android size reporting'
     timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -184,6 +184,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r12b
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -195,6 +196,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r12b
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -206,6 +208,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r12b
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -217,6 +220,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r16b
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -228,6 +232,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r16b
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -239,6 +244,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r16b
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -250,6 +256,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r16b
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -261,6 +268,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r19
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -272,6 +280,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r19
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -283,6 +292,7 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r19
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -294,5 +304,6 @@ steps:
           run: android-ci
     env:
       INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
+      NDK_VERSION: r21
     concurrency: 10
     concurrency_group: 'browserstack-app'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       BROWSER_STACK_USERNAME:
       BROWSER_STACK_ACCESS_KEY:
       INSTRUMENTATION_DEVICES:
-      APP_LOCATION:
       NDK_VERSION:
 
   android-jvm:
@@ -58,7 +57,7 @@ services:
       BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}
       DEVICE_TYPE:
       APP_LOCATION:
-    command: --tags ~@ignore --fail-fast 
+    command: --tags ~@ignore --fail-fast
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output

--- a/dockerfiles/Dockerfile.android-ci-base
+++ b/dockerfiles/Dockerfile.android-ci-base
@@ -28,6 +28,10 @@ RUN echo "signing.secretKeyRingFile=/root/.gnupg/secring.gpg" >> ~/.gradle/gradl
 # Copy remaining Gradle files
 COPY build.gradle settings.gradle /app/
 
+# Build the example app - needed for Espresso tests
+COPY examples/ examples/
+RUN ./gradlew -p examples/sdk-app-example assembleRelease
+
 # Branch specifics
 COPY bugsnag-android/ bugsnag-android/
 COPY bugsnag-android-ndk/ bugsnag-android-ndk/
@@ -35,7 +39,6 @@ COPY bugsnag-plugin-android-anr/ bugsnag-plugin-android-anr/
 COPY bugsnag-android-core/ bugsnag-android-core/
 COPY bugsnag-plugin-android-ndk/ bugsnag-plugin-android-ndk/
 COPY bugsnag-plugin-react-native/ bugsnag-plugin-react-native/
-COPY examples/ examples/
 COPY mazerunner-scenarios/ mazerunner-scenarios/
 COPY scripts/ scripts/
 

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -69,7 +69,7 @@ android {
 }
 
 dependencies {
-    implementation "com.bugsnag:bugsnag-android:5.0.0-rc.07-SNAPSHOT"
+    implementation "com.bugsnag:bugsnag-android:5.0.0"
     implementation "androidx.appcompat:appcompat:$supportLibVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/scripts/build-instrumentation-tests.sh
+++ b/scripts/build-instrumentation-tests.sh
@@ -1,4 +1,7 @@
 echo Switching to NDK $NDK_VERSION
-mv android-ndk-$NDK_VERSION $ANDROID_HOME/ndk-bundle
 
+export ANDROID_NDK_HOME="${ANDROID_HOME}/android-ndk-${NDK_VERSION}"
+export PATH="${ANDROID_NDK_HOME}:${PATH}"
+
+# Build the Espresso Test App
 ./gradlew assembleAndroidTest --stacktrace

--- a/scripts/run-instrumentation-test.sh
+++ b/scripts/run-instrumentation-test.sh
@@ -7,11 +7,11 @@ timestamp() {
 echo "Android Tests [$(timestamp)]: Starting instrumentation test run against devices: $INSTRUMENTATION_DEVICES"
 echo "Android Tests [$(timestamp)]: Uploading first test app from $APP_LOCATION to BrowserStack"
 app_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@$APP_LOCATION")
-app_url=$(echo $app_response | jq -r ".app_url")
+app_url=$(echo "$app_response" | jq -r ".app_url")
 
-if [ -z $app_url ]; then
+if [ -z "$app_url" ]; then
     echo "Android Tests [$(timestamp)]: First app upload failed, exiting"
-    echo $app_response
+    echo "$app_response"
     exit 1
 fi
 
@@ -19,11 +19,11 @@ echo "Android Tests [$(timestamp)]: First app upload successful, url: $app_url"
 
 echo "Android Tests [$(timestamp)]: Uploading second test app from $APP_LOCATION to BrowserStack"
 test_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/espresso/test-suite" -F "file=@$APP_LOCATION")
-test_url=$(echo $test_response | jq -r ".test_url")
+test_url=$(echo "$test_response" | jq -r ".test_url")
 
-if [ -z $test_url ]; then
+if [ -z "$test_url" ]; then
     echo "Android Tests [$(timestamp)]: Second app upload failed, exiting"
-    echo $test_response
+    echo "$test_response"
     exit 1
 fi
 
@@ -31,11 +31,11 @@ echo "Android Tests [$(timestamp)]: Second app upload successful, url: $test_url
 
 echo "Android Tests [$(timestamp)]: Starting test run"
 build_response=$(curl -X POST "https://api-cloud.browserstack.com/app-automate/espresso/build" -d \ "{\"devices\": $INSTRUMENTATION_DEVICES, \"app\": \"$app_url\", \"deviceLogs\" : true, \"testSuite\": \"$test_url\"}" -H "Content-Type: application/json" -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY")
-build_id=$(echo $build_response | jq -r ".build_id")
+build_id=$(echo "$build_response" | jq -r ".build_id")
 
-if [ -z $build_id ]; then
+if [ -z "$build_id" ]; then
     echo "Android Tests [$(timestamp)]: Test start failed, exiting"
-    echo $build_response
+    echo "$build_response"
     exit 1
 fi
 
@@ -44,32 +44,32 @@ echo "Android Tests [$(timestamp)]: Test run creation successful, id: $build_id"
 echo "Android Tests [$(timestamp)]: Waiting for test run to begin"
 sleep 10 # Allow the tests to kick off
 
-status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/$build_id)
-status=$(echo $status_response | jq -r ".status")
+status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+status=$(echo "$status_response" | jq -r ".status")
 
 WAIT_COUNT=0
-until [ $status == "\"done\"" ] || [ $WAIT_COUNT -eq 50 ]; do
+until [ "$status" == "\"done\"" ] || [ $WAIT_COUNT -eq 6 ]; do
     echo "Android Tests [$(timestamp)]: Current test status: $status, Time waited: $((WAIT_COUNT * 30))"
     ((WAIT_COUNT++))
     sleep 30
-    status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/$build_id)
-    status=$(echo $status_response | jq ".status")
+    status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+    status=$(echo "$status_response" | jq ".status")
 done
 
 echo "Android Tests [$(timestamp)]: Tests complete"
 
-NUMBER_OF_DEVICES=$(awk -F "," '{print NF}' <<< $INSTRUMENTATION_DEVICES)
+NUMBER_OF_DEVICES=$(awk -F "," '{print NF}' <<< "$INSTRUMENTATION_DEVICES")
 device_count=0
 total_succeeded=0
 total_failed=0
-until [ $device_count -eq $NUMBER_OF_DEVICES ]; do
-    device=$(echo $status_response | jq -r --arg dc $device_count '.input_capabilities.devices[$dc|tonumber]')
-    device_status=$(echo $status_response | jq --arg dev "$device" '.devices[$dev]')
-    failed=$(echo $device_status | jq '.test_status.FAILED')
+until [ $device_count -eq "$NUMBER_OF_DEVICES" ]; do
+    device=$(echo "$status_response" | jq -r --arg dc $device_count '.input_capabilities.devices[$dc|tonumber]')
+    device_status=$(echo "$status_response" | jq --arg dev "$device" '.devices[$dev]')
+    failed=$(echo "$device_status" | jq '.test_status.FAILED')
     total_failed=$((total_failed + failed))
-    succeeded=$(echo $device_status | jq '.test_status.SUCCESS')
+    succeeded=$(echo "$device_status" | jq '.test_status.SUCCESS')
     total_succeeded=$((total_succeeded + succeeded))
-    if [ $failed -ne 0 ]; then
+    if [ "$failed" -ne 0 ]; then
         echo "Android Tests [$(timestamp)]: $device had test failures, visit https://app-automate.browserstack.com/builds/$build_id for details"
     fi
     ((device_count++))
@@ -78,5 +78,9 @@ done
 echo "Android Tests [$(timestamp)]: Total succeeded: $total_succeeded"
 echo "Android Tests [$(timestamp)]: Total failed: $total_failed"
 if [ $total_failed -ne 0 ];  then
+  exit 1
+fi
+if [ $total_failed -eq 0 ];  then
+  echo "No successful tests detected, this should not happen."
   exit 1
 fi

--- a/scripts/run-instrumentation-test.sh
+++ b/scripts/run-instrumentation-test.sh
@@ -31,8 +31,13 @@ echo "Android Tests [$(timestamp)]: Second app upload successful, url: $test_url
 
 echo "Android Tests [$(timestamp)]: Starting test run"
 build_response=$(curl -X POST "https://api-cloud.browserstack.com/app-automate/espresso/build" -d \ "{\"devices\": $INSTRUMENTATION_DEVICES, \"app\": \"$app_url\", \"deviceLogs\" : true, \"testSuite\": \"$test_url\"}" -H "Content-Type: application/json" -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY")
+
+printf "$build_response: %s", "$build_response"
+
+
 build_id=$(echo "$build_response" | jq -r ".build_id")
 
+# TODO Also check if build_id is "null"
 if [ -z "$build_id" ]; then
     echo "Android Tests [$(timestamp)]: Test start failed, exiting"
     echo "$build_response"
@@ -53,6 +58,7 @@ until [ "$status" == "\"done\"" ] || [ $WAIT_COUNT -eq 6 ]; do
     ((WAIT_COUNT++))
     sleep 30
     status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+    printf "status_response: %s\n", "$status_response"
     status=$(echo "$status_response" | jq ".status")
 done
 

--- a/scripts/run-instrumentation-test.sh
+++ b/scripts/run-instrumentation-test.sh
@@ -54,16 +54,15 @@ status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X
 status=$(echo "$status_response" | jq -r ".status")
 
 WAIT_COUNT=0
-until [ "$status" == "\"done\"" ] || [ $WAIT_COUNT -eq 60 ]; do
-    echo "Android Tests [$(timestamp)]: Current test status: $status, Time waited: $((WAIT_COUNT * 10))"
+until [ "$status" == "\"done\"" ] || [ $WAIT_COUNT -eq 100 ]; do
+    echo "Android Tests [$(timestamp)]: Current test status: $status, Time waited: $((WAIT_COUNT * 15))"
     ((WAIT_COUNT++))
-    sleep 10
+    sleep 15
     status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
-    printf "status_response: %s\n", "$status_response"
     status=$(echo "$status_response" | jq ".status")
 done
 
-if [ "$status" != "\"done\"" ] then;
+if [ "$status" != "\"done\"" ]; then
     echo "Timed out waiting for tests to complete"
     exit 1
 fi

--- a/scripts/run-instrumentation-test.sh
+++ b/scripts/run-instrumentation-test.sh
@@ -21,7 +21,7 @@ fi
 
 echo "Android Tests [$(timestamp)]: First app upload successful, url: $app_url"
 
-# Aecond app - the tests.
+# Second app - the tests.
 echo "Android Tests [$(timestamp)]: Uploading second test app from $TEST_LOCATION to BrowserStack"
 test_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/espresso/test-suite" -F "file=@$TEST_LOCATION")
 test_url=$(echo "$test_response" | jq -r ".test_url")
@@ -50,7 +50,7 @@ echo "Android Tests [$(timestamp)]: Test run creation successful, id: $build_id"
 echo "Android Tests [$(timestamp)]: Waiting for test run to begin"
 sleep 10 # Allow the tests to kick off
 
-status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+status_response=$(curl -s -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
 status=$(echo "$status_response" | jq -r ".status")
 
 WAIT_COUNT=0
@@ -58,7 +58,7 @@ until [ "$status" == "\"done\"" ] || [ $WAIT_COUNT -eq 100 ]; do
     echo "Android Tests [$(timestamp)]: Current test status: $status, Time waited: $((WAIT_COUNT * 15))"
     ((WAIT_COUNT++))
     sleep 15
-    status_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+    status_response=$(curl -s -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
     status=$(echo "$status_response" | jq ".status")
 done
 
@@ -92,7 +92,7 @@ echo "Android Tests [$(timestamp)]: Total failed: $total_failed"
 if [ $total_failed -ne 0 ];  then
   exit 1
 fi
-if [ $total_failed -eq 0 ];  then
+if [ $total_succeeded -eq 0 ];  then
   echo "No successful tests detected, this should not happen."
   exit 1
 fi

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,5 @@ include(
     ':bugsnag-android-core',
     ':bugsnag-plugin-android-anr',
     ':bugsnag-plugin-android-ndk',
-    ':bugsnag-plugin-react-native',
-    ":mazerunner-scenarios"
+    ':bugsnag-plugin-react-native'
 )


### PR DESCRIPTION
## Goal

This changes fixes two main issues:
- Instrumentation tests were not building against the correct NDK version because the environment variable was not being passed to the container.
- BrowserStack have added a check against the two apps needed to run Espresso tests, meaning that they now have to have different bundle Ids.  Because we don't actually need the first uploaded app, we were uploading the same apk twice, which now causes a failure (although we did not detect that).

## Design

Any apk would suffice to use as the first Espresso app, but I have chosen the example as this has the added benefit of verifying that the example builds as part of CI.

As well as fixing the underlying failure, I've added a number of checks to `run-instrumentation-test.sh` in order that any such failures should be detected in future, as well as giving it a general tidy-up to resolve warnings generated by my IDE style checker.

## Tests

Tested by carefully inspecting the log output for instrumentation tests and a successful CI run.