### PR TITLE
Increase max breadcrumbs

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class Configuration implements CallbackAware, MetadataAware, UserAware {
 
     private static final int MIN_BREADCRUMBS = 0;
-    private static final int MAX_BREADCRUMBS = 100;
+    private static final int MAX_BREADCRUMBS = 1000;
     private static final String API_KEY_REGEX = "[A-Fa-f0-9]{32}";
     private static final long MIN_LAUNCH_CRASH_THRESHOLD_MS = 0;
 


### PR DESCRIPTION
This doesn't change the default behavior but allows users to change the max breadcrumbs to 1000.

Fixes #891

## Goal

Square uses 400 breadcrumbs in reports, the current max is 100.

