### PR TITLE
Update project gradle dependencies

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -2,29 +2,41 @@
 <SmellBaseline>
   <Blacklist></Blacklist>
   <Whitelist>
-    <ID>ComplexMethod:ObjectJsonStreamer.kt$ObjectJsonStreamer$// Write complex/nested values to a JsonStreamer @Throws(IOException::class) fun objectToStream(obj: Any?, writer: JsonStream, shouldRedactKeys: Boolean = false)</ID>
     <ID>EmptyFunctionBlock:SessionLifecycleCallback.kt$SessionLifecycleCallback${}</ID>
+    <ID>EmptyKtFile:Configuration.kt$.Configuration.kt</ID>
+    <ID>LongParameterList:App.kt$App$( /** * The architecture of the running application binary */ var binaryArch: String?, /** * The package name of the application */ var id: String?, /** * The release stage set in [Configuration.releaseStage] */ var releaseStage: String?, /** * The version of the application set in [Configuration.version] */ var version: String?, /** The revision ID from the manifest (React Native apps only) */ var codeBundleId: String?, /** * The unique identifier for the build of the application set in [Configuration.buildUuid] */ var buildUuid: String?, /** * The application type set in [Configuration#version] */ var type: String?, /** * The version code of the application set in [Configuration.versionCode] */ var versionCode: Number? )</ID>
+    <ID>LongParameterList:AppWithState.kt$AppWithState$( binaryArch: String?, id: String?, releaseStage: String?, version: String?, codeBundleId: String?, buildUuid: String?, type: String?, versionCode: Number?, /** * The number of milliseconds the application was running before the event occurred */ var duration: Number?, /** * The number of milliseconds the application was running in the foreground before the * event occurred */ var durationInForeground: Number?, /** * Whether the application was in the foreground when the event occurred */ var inForeground: Boolean? )</ID>
+    <ID>LongParameterList:AppWithState.kt$AppWithState$( config: ImmutableConfig, binaryArch: String?, id: String?, releaseStage: String?, version: String?, codeBundleId: String?, duration: Number?, durationInForeground: Number?, inForeground: Boolean? )</ID>
+    <ID>LongParameterList:DeviceBuildInfo.kt$DeviceBuildInfo$( val manufacturer: String?, val model: String?, val osVersion: String?, val apiLevel: Int?, val osBuild: String?, val fingerprint: String?, val tags: String?, val brand: String?, val cpuAbis: Array&lt;String&gt;? )</ID>
+    <ID>LongParameterList:DeviceDataCollector.kt$DeviceDataCollector$( private val connectivity: Connectivity, private val appContext: Context, private val resources: Resources?, private val installId: String, private val buildInfo: DeviceBuildInfo, private val dataDirectory: File, private val logger: Logger )</ID>
+    <ID>LongParameterList:DeviceWithState.kt$DeviceWithState$( buildInfo: DeviceBuildInfo, jailbroken: Boolean?, id: String?, locale: String?, totalMemory: Long?, /** * The number of free bytes of storage available on the device */ var freeDisk: Long?, /** * The number of free bytes of memory available on the device */ var freeMemory: Long?, /** * The orientation of the device when the event occurred: either portrait or landscape */ var orientation: String?, /** * The timestamp on the device when the event occurred */ var time: Date? )</ID>
+    <ID>LongParameterList:ThreadState.kt$ThreadState$( exc: Throwable?, isUnhandled: Boolean, sendThreads: ThreadSendPolicy, projectPackages: Collection&lt;String&gt;, logger: Logger, currentThread: java.lang.Thread = java.lang.Thread.currentThread(), stackTraces: MutableMap&lt;java.lang.Thread, Array&lt;StackTraceElement&gt;&gt; = java.lang.Thread.getAllStackTraces() )</ID>
+    <ID>LongParameterList:ThreadState.kt$ThreadState$( stackTraces: MutableMap&lt;java.lang.Thread, Array&lt;StackTraceElement&gt;&gt;, currentThread: java.lang.Thread, exc: Throwable?, isUnhandled: Boolean, projectPackages: Collection&lt;String&gt;, logger: Logger )</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$299</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$429</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>
-    <ID>MatchingDeclarationName:Breadcrumb.kt$com.bugsnag.android.Breadcrumb.kt</ID>
+    <ID>MatchingDeclarationName:Breadcrumb.kt$BreadcrumbInternal : Streamable</ID>
     <ID>MaxLineLength:ImmutableConfig.kt$val appInfo = runCatching { packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA ) }.getOrNull()</ID>
     <ID>MaxLineLength:InternalEventPayloadDelegateTest.kt$InternalEventPayloadDelegateTest$`when`(deviceDataCollector.generateDeviceWithState(ArgumentMatchers.anyLong())).thenReturn(generateDeviceWithState())</ID>
+    <ID>MaxLineLength:SessionTest.kt$SessionTest$assertFalse(Session(File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json"), Notifier(), NoopLogger).isV2Payload)</ID>
+    <ID>ProtectedMemberInFinalClass:ConfigInternal.kt$ConfigInternal$protected val plugins = mutableSetOf&lt;Plugin&gt;()</ID>
+    <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun shouldDiscardClass(): Boolean</ID>
+    <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>
+    <ID>ProtectedMemberInFinalClass:PluginClient.kt$PluginClient$protected val plugins: Set&lt;Plugin&gt;</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String&gt; ): DeliveryStatus</ID>
     <ID>ReturnCount:DeviceDataCollector.kt$DeviceDataCollector$ private fun isRooted(): Boolean</ID>
     <ID>TooGenericExceptionCaught:AppDataCollector.kt$AppDataCollector$exception: Exception</ID>
-    <ID>TooGenericExceptionCaught:BugsnagPluginInterface.kt$BugsnagPluginInterface$exc: Exception</ID>
     <ID>TooGenericExceptionCaught:CallbackState.kt$CallbackState$ex: Throwable</ID>
-    <ID>TooGenericExceptionCaught:ConfigInternal.kt$ConfigInternal$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:DefaultDelivery.kt$DefaultDelivery$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:DeviceDataCollector.kt$DeviceDataCollector$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:ManifestConfigLoader.kt$ManifestConfigLoader$exc: Exception</ID>
+    <ID>TooGenericExceptionCaught:PluginClient.kt$PluginClient$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:Stacktrace.kt$Stacktrace$lineEx: Exception</ID>
-    <ID>TooManyFunctions:ConfigInternal.kt$ConfigInternal : CallbackAwareMetadataAwareUserAware</ID>
-    <ID>TooManyFunctions:DeviceDataCollector.kt$DeviceDataCollector</ID>
-    <ID>TooManyFunctions:EventInternal.kt$EventInternal : StreamableMetadataAwareUserAware</ID>
-    <ID>TooManyFunctions:Metadata.kt$Metadata : StreamableMetadataAware</ID>
+    <ID>TooGenericExceptionThrown:BreadcrumbStateTest.kt$BreadcrumbStateTest$throw Exception("Oh no")</ID>
+    <ID>TooManyFunctions:ConfigInternal.kt$ConfigInternal$ConfigInternal</ID>
+    <ID>TooManyFunctions:DeviceDataCollector.kt$DeviceDataCollector$DeviceDataCollector</ID>
+    <ID>TooManyFunctions:EventInternal.kt$EventInternal$EventInternal</ID>
+    <ID>TooManyFunctions:Metadata.kt$Metadata$Metadata</ID>
     <ID>VariableNaming:EventInternal.kt$EventInternal$/** * @return user information associated with this Event */ internal var _user = User(null, null, null)</ID>
-    <ID>WildcardImport:EventInternal.kt$import com.bugsnag.android.Thread.ThreadSendPolicy.*</ID>
   </Whitelist>
 </SmellBaseline>

--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -2,15 +2,15 @@
 <SmellBaseline>
   <Blacklist></Blacklist>
   <Whitelist>
-    <ID>ComplexMethod:NativeBridge.kt$NativeBridge$override fun update(observable: Observable, arg: Any?)</ID>
+    <ID>ComplexMethod:NativeBridge.kt$NativeBridge$update</ID>
     <ID>LongParameterList:NativeBridge.kt$NativeBridge$( reportingDirectory: String, autoDetectNdkCrashes: Boolean, apiLevel: Int, is32bit: Boolean, appVersion: String, buildUuid: String, releaseStage: String )</ID>
     <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is AddBreadcrumb -&gt; addBreadcrumb(makeSafe(msg.message), makeSafe(msg.type.toString()), makeSafe(msg.timestamp), msg.metadata)</ID>
     <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is StartSession -&gt; startedSession(makeSafe(msg.id), makeSafe(msg.startedAt), msg.handledCount, msg.unhandledCount)</ID>
-    <ID>NestedBlockDepth:NativeBridge.kt$NativeBridge$private fun deliverPendingReports()</ID>
+    <ID>NestedBlockDepth:NativeBridge.kt$NativeBridge$deliverPendingReports</ID>
     <ID>NewLineAtEndOfFile:VerifyUtils.kt$com.bugsnag.android.ndk.VerifyUtils.kt</ID>
     <ID>ReturnCount:NativeBridge.kt$NativeBridge$private fun isInvalidMessage(msg: Any?): Boolean</ID>
     <ID>TooGenericExceptionCaught:NativeBridge.kt$NativeBridge$ex: Exception</ID>
-    <ID>TooManyFunctions:NativeBridge.kt$NativeBridge : Observer</ID>
+    <ID>TooManyFunctions:NativeBridge.kt$NativeBridge$NativeBridge</ID>
     <ID>WildcardImport:NativeBridge.kt$import com.bugsnag.android.StateEvent.*</ID>
   </Whitelist>
 </SmellBaseline>

--- a/bugsnag-plugin-react-native/detekt-baseline.xml
+++ b/bugsnag-plugin-react-native/detekt-baseline.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <Blacklist></Blacklist>
-  <Whitelist></Whitelist>
+  <Whitelist>
+    <ID>EmptyFunctionBlock:BugsnagReactNativePlugin.kt$BugsnagReactNativePlugin${}</ID>
+    <ID>TooManyFunctions:BugsnagReactNativePlugin.kt$BugsnagReactNativePlugin$BugsnagReactNativePlugin</ID>
+  </Whitelist>
 </SmellBaseline>

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:${agpVersion}"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.0"
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC16"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.9.1"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
     }
 }
@@ -80,10 +80,11 @@ ext {
     // Note minSdkVersion must be >=21 for 64 bit architectures
     compileSdkVersion = 28
     minSdkVersion = 14
+
     supportLibVersion = "1.1.0"
     supportTestVersion = "1.2.0"
     espressoVersion = "3.1.0"
     junitVersion = "4.12"
     mockitoVersion = "2.28.2"
-    bugsnagPluginVersion = "3.3.0"
+
 }

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -5,13 +5,12 @@ buildscript {
         mavenCentral()
         jcenter()
     }
-    ext.kotlin_version = "1.3.21"
-    ext.agpVersion = "3.4.2"
+    ext.kotlin_version = "1.3.61"
 
     dependencies {
-        classpath "com.android.tools.build:gradle:${agpVersion}"
+        classpath "com.android.tools.build:gradle:3.4.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.bugsnag:bugsnag-android-gradle-plugin:4.7.4"
+        classpath "com.bugsnag:bugsnag-android-gradle-plugin:4.7.5"
     }
 }
 
@@ -33,7 +32,6 @@ ext {
     minSdkVersion = 14
     supportLibVersion = "1.1.0"
     espressoVersion = "3.1.0"
-    bugsnagPluginVersion = "3.3.0"
 }
 
 

--- a/examples/sdk-app-example/gradle.properties
+++ b/examples/sdk-app-example/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,8 +14,4 @@ dependencies {
     androidTestImplementation "androidx.test:runner:$supportTestVersion"
     androidTestImplementation "androidx.test:rules:$supportTestVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
-
-    if (project.hasProperty("infer")) {
-        implementation "com.facebook.infer.annotation:infer-annotation:0.11.2"
-    }
 }

--- a/gradle/detekt.gradle
+++ b/gradle/detekt.gradle
@@ -1,6 +1,5 @@
 detekt {
     input = files("src/androidTest", "src/main/java", "src/test")
-    filters = ".*/resources/.*,.*/build/.*"
     baseline = file("detekt-baseline.xml")
 
     reports {

--- a/mazerunner-scenarios/detekt-baseline.xml
+++ b/mazerunner-scenarios/detekt-baseline.xml
@@ -2,16 +2,19 @@
 <SmellBaseline>
   <Blacklist></Blacklist>
   <Whitelist>
+    <ID>EmptyFunctionBlock:CustomPluginExample.kt$CustomPluginExample${}</ID>
     <ID>EmptyFunctionBlock:Scenario.kt$Scenario${}</ID>
     <ID>MagicNumber:AppNotRespondingDisabledNdkScenario.kt$AppNotRespondingDisabledNdkScenario$50000</ID>
     <ID>MagicNumber:AppNotRespondingDisabledScenario.kt$AppNotRespondingDisabledScenario$50000</ID>
     <ID>MagicNumber:AppNotRespondingScenario.kt$AppNotRespondingScenario$50000</ID>
     <ID>MagicNumber:BugsnagInitScenario.kt$BugsnagInitScenario$25</ID>
+    <ID>MagicNumber:LoadConfigurationKotlinScenario.kt$LoadConfigurationKotlinScenario$10000</ID>
+    <ID>MagicNumber:LoadConfigurationKotlinScenario.kt$LoadConfigurationKotlinScenario$98</ID>
     <ID>MagicNumber:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$6000</ID>
     <ID>MagicNumber:TestHarnessHooks.kt$&lt;no name provided&gt;$500</ID>
     <ID>MagicNumber:TrimmedStacktraceScenario.kt$TrimmedStacktraceScenario$100000</ID>
-    <ID>MatchingDeclarationName:ArrayNotifyReleaseStageScenario.kt$com.bugsnag.android.mazerunner.scenarios.ArrayNotifyReleaseStageScenario.kt</ID>
-    <ID>MatchingDeclarationName:HandledExceptionWithoutMessage.kt$com.bugsnag.android.mazerunner.scenarios.HandledExceptionWithoutMessage.kt</ID>
+    <ID>MatchingDeclarationName:ArrayNotifyReleaseStageScenario.kt$ArrayEnabledReleaseStageScenario : Scenario</ID>
+    <ID>MatchingDeclarationName:HandledExceptionWithoutMessage.kt$HandledExceptionWithoutMessageScenario : Scenario</ID>
     <ID>NewLineAtEndOfFile:TestHarnessHooks.kt$com.bugsnag.android.TestHarnessHooks.kt</ID>
     <ID>TooGenericExceptionThrown:CrashHandlerScenario.kt$CrashHandlerScenario$throw RuntimeException("CrashHandlerScenario")</ID>
     <ID>TooGenericExceptionThrown:CustomClientErrorFlushScenario.kt$CustomClientErrorFlushScenario$throw RuntimeException("ReportCacheScenario")</ID>
@@ -20,7 +23,7 @@
     <ID>TooGenericExceptionThrown:ReportCacheScenario.kt$ReportCacheScenario$throw RuntimeException("ReportCacheScenario")</ID>
     <ID>TooGenericExceptionThrown:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$throw RuntimeException("Regular crash")</ID>
     <ID>TooGenericExceptionThrown:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$throw RuntimeException("Startup crash")</ID>
-    <ID>TooManyFunctions:Scenario.kt$Scenario : ActivityLifecycleCallbacks</ID>
+    <ID>TooManyFunctions:Scenario.kt$Scenario$Scenario</ID>
     <ID>WildcardImport:AsyncErrorConnectivityScenario.kt$import com.bugsnag.android.*</ID>
     <ID>WildcardImport:AsyncErrorDoubleFlushScenario.kt$import com.bugsnag.android.*</ID>
     <ID>WildcardImport:AsyncErrorLaunchScenario.kt$import com.bugsnag.android.*</ID>

--- a/tests/features/fixtures/mazerunner/build.gradle
+++ b/tests/features/fixtures/mazerunner/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
-        classpath 'com.bugsnag:bugsnag-android-gradle-plugin:4.7.4'
+        classpath 'com.bugsnag:bugsnag-android-gradle-plugin:4.7.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/tests/features/fixtures/minimalapp/gradle.properties
+++ b/tests/features/fixtures/minimalapp/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
## Goal

Updates the project's Gradle dependencies in preparation for an AGP version update, and to avoid being stranded on legacy plugin versions.

## Changeset

- Updated detekt static analysis plugin to latest version and updated baseline to suppress existing warnings uncovered by new checks
- Bumped bugsnag gradle plugin + bintray publish plugin
- Removed obsolete check for previously removed infer static analysis dependency
- Added `android.useAndroidx` flag to apps, which is optional in AGP 3 but required for AGP 4
