### PR TITLE
Update example app and test fixture dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,17 +111,6 @@ For release purposes, the Makefile's build command includes the "armeabi" ABI fo
 
 Full details of how to build and run tests can be found in [the testing guide](TESTING.md)
 
-## Building the Example App
-
-You can build and install the example app as follows:
-
-```shell
-./gradlew installDebug
-```
-
-This builds the latest version of the library and installs an app onto your
-device/emulator.
-
 ## Installing/testing against a local maven repository
 
 Change `VERSION_NAME` in `gradle.properties` to a version higher than the currently

--- a/dockerfiles/Dockerfile.android-sizer
+++ b/dockerfiles/Dockerfile.android-sizer
@@ -12,8 +12,8 @@ COPY tests/features/ tests/features
 RUN apt-get install -y ruby-full
 
 WORKDIR /app/tests/features/fixtures/minimalapp
-RUN curl -LJO https://github.com/google/bundletool/releases/download/0.10.3/bundletool-all-0.10.3.jar
-RUN mv bundletool-all-0.10.3.jar bundletool.jar
+RUN curl -LJO https://github.com/google/bundletool/releases/download/1.0.0/bundletool-all-1.0.0.jar
+RUN mv bundletool-all-1.0.0.jar bundletool.jar
 
 RUN gem install bundler
 RUN bundle install

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -5,10 +5,10 @@ buildscript {
         mavenCentral()
         jcenter()
     }
-    ext.kotlin_version = "1.3.61"
+    ext.kotlin_version = "1.3.72"
 
     dependencies {
-        classpath "com.android.tools.build:gradle:3.4.2"
+        classpath "com.android.tools.build:gradle:4.0.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.bugsnag:bugsnag-android-gradle-plugin:4.7.5"
     }
@@ -28,12 +28,11 @@ allprojects {
 
 ext {
     // Note minSdkVersion must be >=21 for 64 bit architectures
-    compileSdkVersion = 28
+    compileSdkVersion = 29
     minSdkVersion = 14
     supportLibVersion = "1.1.0"
     espressoVersion = "3.1.0"
 }
-
 
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.kotlin_version = "1.3.72"
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.0"
+        classpath "com.android.tools.build:gradle:3.6.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.bugsnag:bugsnag-android-gradle-plugin:4.7.5"
     }

--- a/examples/sdk-app-example/src/main/java/com.bugsnag.android/example/ExampleApplication.kt
+++ b/examples/sdk-app-example/src/main/java/com.bugsnag.android/example/ExampleApplication.kt
@@ -9,6 +9,13 @@ class ExampleApplication : Application() {
 
     companion object {
         init {
+//            if you support API <= 17 you should uncomment this to load the bugsnag library
+//            before any libraries that link to it
+//            https://docs.bugsnag.com/platforms/android/#initialize-the-bugsnag-client
+//
+//            System.loadLibrary("bugsnag-ndk")
+//            System.loadLibrary("bugsnag-plugin-android-anr")
+
             System.loadLibrary("entrypoint")
         }
     }

--- a/gradle/detekt.gradle
+++ b/gradle/detekt.gradle
@@ -1,10 +1,4 @@
 detekt {
     input = files("src/androidTest", "src/main/java", "src/test")
     baseline = file("detekt-baseline.xml")
-
-    reports {
-        html {
-            enabled = true
-        }
-    }
 }

--- a/tests/features/fixtures/mazerunner/build.gradle
+++ b/tests/features/fixtures/mazerunner/build.gradle
@@ -22,10 +22,10 @@ buildscript {
         mavenCentral()
         jcenter()
     }
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.3.72'
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.bugsnag:bugsnag-android-gradle-plugin:4.7.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -33,11 +33,11 @@ buildscript {
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 29
         versionCode 34
         versionName "1.1.14"
         manifestPlaceholders = [
@@ -86,6 +86,10 @@ android {
         main {
             jniLibs.srcDirs = ['libs']
         }
+    }
+    // adding custom jniLibs results in dupe SO files, ignore
+    packagingOptions {
+        pickFirst '**/*.so'
     }
     lintOptions {
         tasks.lint.enabled = false

--- a/tests/features/fixtures/mazerunner/gradle.properties
+++ b/tests/features/fixtures/mazerunner/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/tests/features/fixtures/mazerunner/src/main/AndroidManifest.xml
+++ b/tests/features/fixtures/mazerunner/src/main/AndroidManifest.xml
@@ -3,7 +3,9 @@
     package="com.bugsnag.android.mazerunner">
 
     <application
-        android:label="MazeRunner">
+        android:label="MazeRunner"
+        android:networkSecurityConfig="@xml/network_security_config"
+        >
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -9,6 +9,7 @@ import android.widget.EditText
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
+import com.bugsnag.android.Logger
 import com.bugsnag.android.mazerunner.scenarios.Scenario
 
 class MainActivity : Activity() {
@@ -78,6 +79,39 @@ class MainActivity : Activity() {
         config.endpoints = EndpointConfiguration("http://bs-local.com:9339", "http://bs-local.com:9339")
         config.enabledErrorTypes.ndkCrashes = true
         config.enabledErrorTypes.anrs = true
+        config.logger = object: Logger {
+            override fun d(msg: String) {
+                Log.d("Bugsnag", msg)
+            }
+
+            override fun d(msg: String, throwable: Throwable) {
+                Log.d("Bugsnag", msg, throwable)
+            }
+
+            override fun e(msg: String) {
+                Log.e("Bugsnag", msg)
+            }
+
+            override fun e(msg: String, throwable: Throwable) {
+                Log.e("Bugsnag", msg, throwable)
+            }
+
+            override fun i(msg: String) {
+                Log.i("Bugsnag", msg)
+            }
+
+            override fun i(msg: String, throwable: Throwable) {
+                Log.i("Bugsnag", msg, throwable)
+            }
+
+            override fun w(msg: String) {
+                Log.w("Bugsnag", msg)
+            }
+
+            override fun w(msg: String, throwable: Throwable) {
+                Log.w("Bugsnag", msg, throwable)
+            }
+        }
         return config
     }
 

--- a/tests/features/fixtures/mazerunner/src/main/res/xml/network_security_config.xml
+++ b/tests/features/fixtures/mazerunner/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">bs-local.com</domain>
+    </domain-config>
+</network-security-config>

--- a/tests/features/fixtures/minimalapp/Dangerfile
+++ b/tests/features/fixtures/minimalapp/Dangerfile
@@ -3,8 +3,8 @@ require 'fileutils'
 RELEASE_APK = "app/build/outputs/apk/release/app-release-unsigned.apk"
 
 BUNDLE_DIR = "app/build/outputs/bundle/release/"
-RELEASE_BUNDLE = "app.aab"
-UNBUNDLED_RELEASE = "app.apks"
+RELEASE_BUNDLE = "app-release.aab"
+UNBUNDLED_RELEASE = "app-release.apks"
 
 STANDALONE_DIR = BUNDLE_DIR + "standalones/"
 STANDALONE_HDPI_BASE = "standalone-hdpi.apk"

--- a/tests/features/fixtures/minimalapp/app/build.gradle
+++ b/tests/features/fixtures/minimalapp/app/build.gradle
@@ -11,15 +11,14 @@ repositories {
 }
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "29.0.0"
+    compileSdkVersion 29
+
     defaultConfig {
         applicationId "com.bugsnag.android.minimalapp"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -30,12 +29,7 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
 if (project.hasProperty("withBugsnag")) {

--- a/tests/features/fixtures/minimalapp/app/src/main/AndroidManifest.xml
+++ b/tests/features/fixtures/minimalapp/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <application android:allowBackup="true"
         android:label="minimal_app"
+        android:name=".CustomApp"
         android:supportsRtl="true">
         <meta-data android:name="com.bugsnag.android.API_KEY"
                    android:value="12312312312312312312312312312312"/>

--- a/tests/features/fixtures/minimalapp/app/src/main/java/com/bugsnag/android/minimalapp/CustomApp.java
+++ b/tests/features/fixtures/minimalapp/app/src/main/java/com/bugsnag/android/minimalapp/CustomApp.java
@@ -1,0 +1,10 @@
+package com.bugsnag.android.minimalapp;
+
+import android.app.Application;
+
+class CustomApp extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+}

--- a/tests/features/fixtures/minimalapp/build.gradle
+++ b/tests/features/fixtures/minimalapp/build.gradle
@@ -1,16 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.3.72'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         if (project.hasProperty("withBugsnag")) {
-            classpath 'com.bugsnag:bugsnag-android-gradle-plugin:4.+'
+            classpath 'com.bugsnag:bugsnag-android-gradle-plugin:4.7.5'
         }
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Goal

Updates the example app and test fixtures to use the latest AGP version (4.0.0), and updates their dependencies to ensure they are not left abandoned on an obsolete version.

This is part of the groundwork of preparing the entire project to use AGP 4.0.0.

## Changeset

- Updated android sizer task to use 1.0.0 of bundletool
- Updated apps to use latest compileSdkVersion of 29, AGP 4.0.0, Kotlin 1.3.72
- Added one Java file to `minimalapp` fixture to prevent Android Bundle failing to generate APKs with AGP 4.0.0 due to no code being present
- Removed unneeded test dependencies from minimalapp
- Updated android sizer script to get APKs/AABs from new generated location
- Updated test fixture to allow clear text traffic required by bs-local.com, which was failing the scenarios on Android 9 after upgrading the compileSdkVersion