### PR TITLE
fix(plugin-react-native): Use the correct keys for runtime version data

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -41,10 +41,10 @@ class BugsnagReactNativePlugin : Plugin {
 
     private fun updateNotifierInfo(env: Map<String, Any?>) {
         val reactNativeVersion = env["reactNativeVersion"] as String?
-        reactNativeVersion?.let { client.addRuntimeVersionInfo("reactNativeVersion", it) }
+        reactNativeVersion?.let { client.addRuntimeVersionInfo("reactNative", it) }
 
         val engine = env["engine"] as String?
-        engine?.let { client.addRuntimeVersionInfo("engine", it) }
+        engine?.let { client.addRuntimeVersionInfo("reactNativeJsEngine", it) }
 
         val jsVersion = env["notifierVersion"] as String
         val notifier = client.notifier


### PR DESCRIPTION
As per the docs for the [Error Reporting API](https://bugsnagerrorreportingapi.docs.apiary.io/#reference/0/notify), the correct keys for the RN runtime version data are:

- `reactNative` and
- `reactNativeJsEngine`