### PR TITLE
Ensure plugins are loaded before flushing errors

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -241,8 +241,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         loadPlugins(configuration);
 
         // Flush any on-disk errors
-        eventStore.flushOnLaunch();
         connectivity.registerForNetworkChanges();
+        eventStore.flushOnLaunch();
 
         // leave auto breadcrumb
         Map<String, Object> data = Collections.emptyMap();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -234,17 +234,19 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         } else {
             this.systemBroadcastReceiver = null;
         }
-        connectivity.registerForNetworkChanges();
 
         registerOrientationChangeListener();
 
+        // initialise plugins before attempting to flush any errors
+        loadPlugins(configuration);
+
         // Flush any on-disk errors
         eventStore.flushOnLaunch();
+        connectivity.registerForNetworkChanges();
+
+        // leave auto breadcrumb
         Map<String, Object> data = Collections.emptyMap();
         leaveAutoBreadcrumb("Bugsnag loaded", BreadcrumbType.STATE, data);
-
-        // finally, initialise plugins
-        loadPlugins(configuration);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Goal

Ensures that plugins are loaded before flushing errors. This avoids the potential for a race condition where a plugin sets a callback that filters out a particular error class.

## Tests

Relied on existing test coverage.
