### PR TITLE
Enable logging in mazerunner

### DIFF
--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -9,6 +9,7 @@ import android.widget.EditText
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
+import com.bugsnag.android.Logger
 import com.bugsnag.android.mazerunner.scenarios.Scenario
 
 class MainActivity : Activity() {
@@ -78,6 +79,41 @@ class MainActivity : Activity() {
         config.endpoints = EndpointConfiguration("http://bs-local.com:9339", "http://bs-local.com:9339")
         config.enabledErrorTypes.ndkCrashes = true
         config.enabledErrorTypes.anrs = true
+        config.logger = object: Logger {
+            private val TAG = "Bugsnag"
+
+            override fun e(msg: String) {
+                Log.e(TAG, msg)
+            }
+
+            override fun e(msg: String, throwable: Throwable) {
+                Log.e(TAG, msg, throwable)
+            }
+
+            override fun w(msg: String) {
+                Log.w(TAG, msg)
+            }
+
+            override fun w(msg: String, throwable: Throwable) {
+                Log.w(TAG, msg, throwable)
+            }
+
+            override fun i(msg: String) {
+                Log.i(TAG, msg)
+            }
+
+            override fun i(msg: String, throwable: Throwable) {
+                Log.i(TAG, msg, throwable)
+            }
+
+            override fun d(msg: String) {
+                Log.d(TAG, msg)
+            }
+
+            override fun d(msg: String, throwable: Throwable) {
+                Log.d(TAG, msg, throwable)
+            }
+        }
         return config
     }
 


### PR DESCRIPTION
## Goal

Enables debug logging in mazerunner. Logging is disabled by default in release mode - this alters configuration to log everything to logcat, which should aid debugging failing mazerunner scenarios.
