### PR TITLE
Avoid attempting to flush unhandled error reports in same session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Avoid attempting to flush unhandled error reports in same session
+  [#902](https://github.com/bugsnag/bugsnag-android/pull/902)
+
 ## 5.0.0 (2020-04-22)
 
 __This version contains many breaking changes__. It is part of an effort to unify our notifier

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -20,6 +20,7 @@
     <ID>MaxLineLength:InternalEventPayloadDelegateTest.kt$InternalEventPayloadDelegateTest$`when`(deviceDataCollector.generateDeviceWithState(ArgumentMatchers.anyLong())).thenReturn(generateDeviceWithState())</ID>
     <ID>MaxLineLength:SessionTest.kt$SessionTest$assertFalse(Session(File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json"), Notifier(), NoopLogger).isV2Payload)</ID>
     <ID>ProtectedMemberInFinalClass:ConfigInternal.kt$ConfigInternal$protected val plugins = mutableSetOf&lt;Plugin&gt;()</ID>
+    <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun isAnr(event: Event): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun shouldDiscardClass(): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>
     <ID>ProtectedMemberInFinalClass:PluginClient.kt$PluginClient$protected val plugins: Set&lt;Plugin&gt;</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -43,10 +43,22 @@ class DeliveryDelegate extends BaseObservable {
         }
 
         if (event.isUnhandled()) {
-            cacheEvent(event, true);
+            // should only send unhandled errors if they don't terminate the process (i.e. ANRs)
+            cacheEvent(event, isAnr(event));
         } else {
             deliverPayloadAsync(event, eventPayload);
         }
+    }
+
+    boolean isAnr(@NonNull Event event) {
+        List<Error> errors = event.getErrors();
+        String errorClass = null;
+
+        if (!errors.isEmpty()) {
+            Error error = errors.get(0);
+            errorClass = error.getErrorClass();
+        }
+        return "ANR".equals(errorClass);
     }
 
     private void deliverPayloadAsync(@NonNull Event event, EventPayload eventPayload) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -44,21 +44,10 @@ class DeliveryDelegate extends BaseObservable {
 
         if (event.isUnhandled()) {
             // should only send unhandled errors if they don't terminate the process (i.e. ANRs)
-            cacheEvent(event, isAnr(event));
+            cacheEvent(event, event.impl.isAnr(event));
         } else {
             deliverPayloadAsync(event, eventPayload);
         }
-    }
-
-    boolean isAnr(@NonNull Event event) {
-        List<Error> errors = event.getErrors();
-        String errorClass = null;
-
-        if (!errors.isEmpty()) {
-            Error error = errors.get(0);
-            errorClass = error.getErrorClass();
-        }
-        return "ANR".equals(errorClass);
     }
 
     private void deliverPayloadAsync(@NonNull Event event, EventPayload eventPayload) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -48,6 +48,16 @@ internal class EventInternal @JvmOverloads internal constructor(
         }
     }
 
+    protected fun isAnr(event: Event): Boolean {
+        val errors = event.errors
+        var errorClass: String? = null
+        if (errors.isNotEmpty()) {
+            val error = errors[0]
+            errorClass = error.errorClass
+        }
+        return "ANR" == errorClass
+    }
+
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {
         // Write error basics

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -2,8 +2,10 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -97,6 +99,21 @@ internal class DeliveryDelegateTest {
         assertEquals("Whoops!", breadcrumb.metadata!!["message"])
         assertEquals("true", breadcrumb.metadata!!["unhandled"])
         assertEquals("ERROR", breadcrumb.metadata!!["severity"])
+    }
+
+    @Test
+    fun isAnr() {
+        val state = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
+        val event = Event(RuntimeException("Whoops!"), config, state, NoopLogger)
+        assertFalse(deliveryDelegate.isAnr(event))
+
+        // simulate ANR
+        event.errors[0].errorClass = "ANR"
+        assertTrue(deliveryDelegate.isAnr(event))
+
+        // clear all errors
+        event.errors.clear()
+        assertFalse(deliveryDelegate.isAnr(event))
     }
 
     private class InterceptingLogger : Logger {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -101,21 +101,6 @@ internal class DeliveryDelegateTest {
         assertEquals("ERROR", breadcrumb.metadata!!["severity"])
     }
 
-    @Test
-    fun isAnr() {
-        val state = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION)
-        val event = Event(RuntimeException("Whoops!"), config, state, NoopLogger)
-        assertFalse(deliveryDelegate.isAnr(event))
-
-        // simulate ANR
-        event.errors[0].errorClass = "ANR"
-        assertTrue(deliveryDelegate.isAnr(event))
-
-        // clear all errors
-        event.errors.clear()
-        assertFalse(deliveryDelegate.isAnr(event))
-    }
-
     private class InterceptingLogger : Logger {
         var msg: String? = null
         override fun i(msg: String) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
@@ -160,4 +160,19 @@ public class EventTest {
         assertEquals(testRuntimeException.getClass().getName(), errors.get(0).getErrorClass());
         assertEquals(testRuntimeException.getMessage(), errors.get(0).getErrorMessage());
     }
+
+    @Test
+    public void testIsAnr() {
+        RuntimeException exc = new RuntimeException("Something went wrong");
+        Event event = new Event(exc, config, handledState, NoopLogger.INSTANCE);
+        assertFalse(event.impl.isAnr(event));
+
+        // simulate ANR
+        event.getErrors().get(0).setErrorClass("ANR");
+        assertTrue(event.impl.isAnr(event));
+
+        // clear all errors
+        event.getErrors().clear();
+        assertFalse(event.impl.isAnr(event));
+    }
 }

--- a/tests/features/stackoverflow.feature
+++ b/tests/features/stackoverflow.feature
@@ -1,7 +1,8 @@
 Feature: Reporting Stack overflow
 
 Scenario: Stack Overflow sends
-    When I run "StackOverflowScenario"
+    When I run "StackOverflowScenario" and relaunch the app
+    And I configure Bugsnag for "StackOverflowScenario"
     And I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the payload field "events" is an array with 1 elements


### PR DESCRIPTION
## Goal

When an unhandled error is captured the process is usually about to terminate. Currently bugsnag attempts to send the request which can lead to a condition where a request is successfully sent but the process is terminated before the SDK can act on the response. This can lead to duplicate error reports on the relaunch of the app (and is theorised to cause flakes in the E2E tests).

Disabling this behaviour for unhandled errors will reduce the likelihood of these duplicate requests being sent. This excludes the following ANRs, because the process will not directly terminate and there's a good chance the request will be delivered in the same session.

## Tests

Added unit tests to cover ANR calculations.
