### PR TITLE
Respect pre-populated fields on Event when notifying

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -613,7 +613,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             HandledState handledState = HandledState.newInstance(REASON_HANDLED_EXCEPTION);
             Metadata metadata = metadataState.getMetadata();
             Event event = new Event(exc, immutableConfig, handledState, metadata, logger);
-            notifyInternal(event, onError);
+            populateAndNotifyAndroidEvent(event, onError);
         } else {
             logNull("notify");
         }
@@ -631,28 +631,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 = HandledState.newInstance(severityReason, Severity.ERROR, attributeValue);
         Metadata data = Metadata.Companion.merge(metadataState.getMetadata(), metadata);
         Event event = new Event(exc, immutableConfig, handledState, data, logger);
-        notifyInternal(event, null);
+        populateAndNotifyAndroidEvent(event, null);
     }
 
-    void notifyInternal(@NonNull Event event,
-                        @Nullable OnErrorCallback onError) {
-        // Don't notify if this event class should be ignored
-        if (event.shouldDiscardClass()) {
-            return;
-        }
-
-        if (!immutableConfig.shouldNotifyForReleaseStage()) {
-            return;
-        }
-
-        // get session for event
-        Session currentSession = sessionTracker.getCurrentSession();
-
-        if (currentSession != null
-                && (immutableConfig.getAutoTrackSessions() || !currentSession.isAutoCaptured())) {
-            event.setSession(currentSession);
-        }
-
+    void populateAndNotifyAndroidEvent(@NonNull Event event,
+                                       @Nullable OnErrorCallback onError) {
         // Capture the state of the app and device and attach diagnostics to the event
         event.setDevice(deviceDataCollector.generateDeviceWithState(new Date().getTime()));
         event.addMetadata("device", deviceDataCollector.getDeviceMetadata());
@@ -673,6 +656,27 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         if (Intrinsics.isEmpty(event.getContext())) {
             String context = contextState.getContext();
             event.setContext(context != null ? context : appDataCollector.getActiveScreenClass());
+        }
+        notifyInternal(event, onError);
+    }
+
+    void notifyInternal(@NonNull Event event,
+                        @Nullable OnErrorCallback onError) {
+        // Don't notify if this event class should be ignored
+        if (event.shouldDiscardClass()) {
+            return;
+        }
+
+        if (!immutableConfig.shouldNotifyForReleaseStage()) {
+            return;
+        }
+
+        // get session for event
+        Session currentSession = sessionTracker.getCurrentSession();
+
+        if (currentSession != null
+                && (immutableConfig.getAutoTrackSessions() || !currentSession.isAutoCaptured())) {
+            event.setSession(currentSession);
         }
 
         // Run on error tasks, don't notify if any return false

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrDetailsCollector.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrDetailsCollector.kt
@@ -68,7 +68,7 @@ internal class AnrDetailsCollector {
                     }
                 } else {
                     addErrorStateInfo(event, anrDetails)
-                    client.notifyInternal(event, null)
+                    client.populateAndNotifyAndroidEvent(event, null)
                 }
             }
         })


### PR DESCRIPTION
## Goal

Respects pre-populated fields on Event when notifying. This prevents the case where an event is populated on React Native and its custom app/device/user etc being overridden by the Android values.

## Changeset

Created `populateAndNotifyAndroidEvent` method which populates the event for errors captured within bugsnag-android. `notifyInternal` does not populate any information. This is in line with how bugsnag-cocoa works.
