### PR TITLE
fix(plugin-react-native): appType -> app.type event serialisation differs from config

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppSerializer.kt
@@ -2,7 +2,7 @@ package com.bugsnag.android
 
 internal class AppSerializer : MapSerializer<AppWithState> {
     override fun serialize(map: MutableMap<String, Any?>, app: AppWithState) {
-        map["appType"] = app.type
+        map["type"] = app.type
         map["binaryArch"] = app.binaryArch
         map["buildUuid"] = app.buildUuid
         map["codeBundleId"] = app.codeBundleId

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/AppSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/AppSerializerTest.java
@@ -41,7 +41,7 @@ public class AppSerializerTest {
         assertEquals("code-id-123", map.get("codeBundleId"));
         assertEquals("com.example.foo", map.get("id"));
         assertEquals("prod", map.get("releaseStage"));
-        assertEquals("android", map.get("appType"));
+        assertEquals("android", map.get("type"));
         assertEquals("1.5.3", map.get("version"));
         assertEquals(55, map.get("versionCode"));
     }


### PR DESCRIPTION
This was a preexisting bug that was exaserbated by #906.
Ensures that `app.type` is populated for events created in JS land.