### PR TITLE
feat(plugin-react-native): Pass device and app metadata to react native

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -152,6 +152,8 @@ class BugsnagReactNativePlugin : Plugin {
             threadSerializer.serialize(map, it)
             map
         }
+        info["appMetadata"] = internalHooks.getAppMetadata();
+        info["deviceMetadata"] = internalHooks.getDeviceMetadata();
         return info
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -20,9 +20,13 @@ class InternalHooks {
         return client.appDataCollector.generateAppWithState();
     }
 
-    public Map<String,Object> getAppMetadata() { return client.appDataCollector.getAppDataMetadata(); }
+    public Map<String,Object> getAppMetadata() {
+        return client.appDataCollector.getAppDataMetadata();
+    }
 
-    public Map<String,Object> getDeviceMetadata() { return client.deviceDataCollector.getDeviceMetadata(); }
+    public Map<String,Object> getDeviceMetadata() {
+        return client.deviceDataCollector.getDeviceMetadata();
+    }
 
     public DeviceWithState getDeviceWithState() {
         return client.deviceDataCollector.generateDeviceWithState(new Date().getTime());

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 class InternalHooks {
 
@@ -18,6 +19,10 @@ class InternalHooks {
     public AppWithState getAppWithState() {
         return client.appDataCollector.generateAppWithState();
     }
+
+    public Map<String,Object> getAppMetadata() { return client.appDataCollector.getAppDataMetadata(); }
+
+    public Map<String,Object> getDeviceMetadata() { return client.deviceDataCollector.getDeviceMetadata(); }
 
     public DeviceWithState getDeviceWithState() {
         return client.deviceDataCollector.generateDeviceWithState(new Date().getTime());


### PR DESCRIPTION
The app and device data that was captured at the last moment in `notifyInternal` is now not included in JS events (as of #906), and this also exposed the fact that they were not available to JS `onError` callbacks anyway.

This sends them across the bridge in `getPayloadInfo()` to fix both issues. A subsequent JS update is required to include them in the event payload that's sent back to the native layer.

I couldn't see a good way to test this.