### PR TITLE
Prevent duplicate notifier dependencies being added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 The following alterations have been made to support the React Native notifier:
 
+* Prevent duplicate notifier dependencies being added
+  [#911](https://github.com/bugsnag/bugsnag-android/pull/911)
+
 * Respect pre-populated fields on `Event` when notifying
   [#906](https://github.com/bugsnag/bugsnag-android/pull/906)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -11,7 +11,7 @@ class Notifier @JvmOverloads constructor(
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 
-    val dependencies = mutableListOf<Notifier>()
+    var dependencies = listOf<Notifier>()
 
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NotifierSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NotifierSerializationTest.kt
@@ -23,7 +23,7 @@ internal class NotifierSerializationTest {
             deps.version = "4.5.6"
             deps.name = "CustomNotifier"
             deps.url = "https://example.com"
-            deps.dependencies.add(notifier)
+            deps.dependencies = listOf(notifier)
             return generateSerializationTestCases("notifier", notifier, deps)
         }
     }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -51,7 +51,7 @@ class BugsnagReactNativePlugin : Plugin {
         notifier.name = "Bugsnag React Native"
         notifier.url = "https://github.com/bugsnag/bugsnag-js"
         notifier.version = jsVersion
-        notifier.dependencies.add(Notifier()) // depend on bugsnag-android
+        client.notifier.dependencies = listOf(Notifier()) // depend on bugsnag-android
     }
 
     private fun ignoreJavaScriptExceptions() {

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -51,7 +51,7 @@ class BugsnagReactNativePlugin : Plugin {
         notifier.name = "Bugsnag React Native"
         notifier.url = "https://github.com/bugsnag/bugsnag-js"
         notifier.version = jsVersion
-        client.notifier.dependencies = listOf(Notifier()) // depend on bugsnag-android
+        notifier.dependencies = listOf(Notifier()) // depend on bugsnag-android
     }
 
     private fun ignoreJavaScriptExceptions() {


### PR DESCRIPTION
## Goal

Prevents duplicate notifier dependencies being added when RN's JS layer is reloaded, by resetting the dependency list each time.

## Tests

Updated existing unit test coverage to ensure the notifier version information serializes correctly.
