### PR TITLE
Attempt delivery of promise rejections immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 #### React Native
 
+The following alterations have been made to support the React Native notifier:
+
+* Attempt delivery of promise rejections immediately
+  [#912](https://github.com/bugsnag/bugsnag-android/pull/912)
+
 * Always set config.redactedKeys on Event
   [#913](https://github.com/bugsnag/bugsnag-android/pull/913)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import static com.bugsnag.android.HandledState.REASON_PROMISE_REJECTION;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
@@ -44,7 +46,10 @@ class DeliveryDelegate extends BaseObservable {
 
         if (event.isUnhandled()) {
             // should only send unhandled errors if they don't terminate the process (i.e. ANRs)
-            cacheEvent(event, event.impl.isAnr(event));
+            String severityReasonType = event.impl.getSeverityReasonType();
+            boolean promiseRejection = REASON_PROMISE_REJECTION.equals(severityReasonType);
+            boolean anr = event.impl.isAnr(event);
+            cacheEvent(event, anr || promiseRejection);
         } else {
             deliverPayloadAsync(event, eventPayload);
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -110,6 +110,7 @@ internal class EventInternal @JvmOverloads internal constructor(
         this.severity = severity
     }
 
+    fun getSeverityReasonType(): String = handledState.severityReasonType
 
     override fun setUser(id: String?, email: String?, name: String?) {
         _user = User(id, email, name)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
@@ -175,4 +175,11 @@ public class EventTest {
         event.getErrors().clear();
         assertFalse(event.impl.isAnr(event));
     }
+
+    @Test
+    public void testSeverityReasonType() {
+        RuntimeException exc = new RuntimeException("Something went wrong");
+        Event event = new Event(exc, config, handledState, NoopLogger.INSTANCE);
+        assertEquals(HandledState.REASON_HANDLED_EXCEPTION, event.impl.getSeverityReasonType());
+    }
 }


### PR DESCRIPTION
## Goal

Attempts to deliver promise rejections immediately. This is required for the React Native notifier where promise rejections are set as unhandled but do not terminate the process.

The logic in Android is now that unhandled events should only be delivered in the same process if they are an ANR or Promise Rejection.
