### PR TITLE
Always set config.redactedKeys on Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+#### React Native
+
+* Always set config.redactedKeys on Event
+  [#913](https://github.com/bugsnag/bugsnag-android/pull/913)
+
 ## 5.0.1 (2020-07-23)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -671,6 +671,12 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             return;
         }
 
+        // set the redacted keys on the event as this
+        // will not have been set for RN/Unity events
+        Set<String> redactedKeys = metadataState.getMetadata().getRedactedKeys();
+        Metadata eventMetadata = event.impl.getMetadata();
+        eventMetadata.setRedactedKeys(redactedKeys);
+
         // get session for event
         Session currentSession = sessionTracker.getCurrentSession();
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -9,7 +9,7 @@ internal class EventInternal @JvmOverloads internal constructor(
     data: Metadata = Metadata()
 ) : JsonStream.Streamable, MetadataAware, UserAware {
 
-    internal val metadata: Metadata = data.copy()
+    val metadata: Metadata = data.copy()
     private val discardClasses: Set<String> = config.discardClasses.toSet()
 
     @JvmField


### PR DESCRIPTION
## Goal

Ensures that the `redactedKeys` is always set appropriately on `event.metadata`. For React Native the `redactedKeys` field was initialized to a default instead which led to the wrong fields being redacted for JS errors.

## Tests

Verified in an example app by installing a local artefact.
