### PR TITLE
[PLAT-4713] RN: Retain unhandled value when parsing a JS event

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/HandledState.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/HandledState.java
@@ -36,7 +36,7 @@ final class HandledState implements JsonStream.Streamable {
 
     private final Severity defaultSeverity;
     private Severity currentSeverity;
-    private final boolean unhandled;
+    private boolean unhandled;
 
     static HandledState newInstance(@SeverityReason String severityReasonType) {
         return newInstance(severityReasonType, null, null);
@@ -94,6 +94,10 @@ final class HandledState implements JsonStream.Streamable {
 
     public boolean isUnhandled() {
         return unhandled;
+    }
+
+    void setUnhandled(boolean isUnhandled) {
+        unhandled = isUnhandled;
     }
 
     @Nullable

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -18,6 +18,8 @@ internal class EventDeserializer(
         val severityReason = map["severityReason"] as Map<String, Any>
         val type = severityReason["type"] as String
         val handledState: HandledState = HandledState.newInstance(type)
+        val unhandled = map["unhandled"] as Boolean
+        handledState.isUnhandled = unhandled
 
         // construct event
         val event = NativeInterface.createEvent(null, client, handledState)


### PR DESCRIPTION
When the severity is modified in a JS `onError` callback, the original value for `unhandled` was lost. This update takes and applies the `unhandled` value from the JS event payload.