### PR TITLE
[PLAT-4713] RN: Refactor event deserialiser to ensure unhandled value is retained

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/HandledState.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/HandledState.java
@@ -96,10 +96,6 @@ final class HandledState implements JsonStream.Streamable {
         return unhandled;
     }
 
-    void setUnhandled(boolean isUnhandled) {
-        unhandled = isUnhandled;
-    }
-
     @Nullable
     String getAttributeValue() {
         return attributeValue;

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -19,7 +19,12 @@ internal class EventDeserializer(
         val severityReasonType = severityReason["type"] as String
         val severity = map["severity"] as String
         val unhandled = map["unhandled"] as Boolean
-        val handledState = HandledState(severityReasonType, Severity.valueOf(severity.toUpperCase(Locale.US)), unhandled, null)
+        val handledState = HandledState(
+            severityReasonType,
+            Severity.valueOf(severity.toUpperCase(Locale.US)),
+            unhandled,
+            null
+        )
 
         // construct event
         val event = NativeInterface.createEvent(null, client, handledState)

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -16,17 +16,15 @@ internal class EventDeserializer(
     @Suppress("UNCHECKED_CAST")
     override fun deserialize(map: MutableMap<String, Any?>): Event {
         val severityReason = map["severityReason"] as Map<String, Any>
-        val type = severityReason["type"] as String
-        val handledState: HandledState = HandledState.newInstance(type)
+        val severityReasonType = severityReason["type"] as String
+        val severity = map["severity"] as String
         val unhandled = map["unhandled"] as Boolean
-        handledState.isUnhandled = unhandled
+        val handledState = HandledState(severityReasonType, Severity.valueOf(severity.toUpperCase(Locale.US)), unhandled, null)
 
         // construct event
         val event = NativeInterface.createEvent(null, client, handledState)
         event.context = map["context"] as String?
         event.groupingHash = map["groupingHash"] as String?
-        val severity = map["severity"] as String
-        event.updateSeverityInternal(Severity.valueOf(severity.toUpperCase(Locale.US)))
 
         // app/device
         event.app = appDeserializer.deserialize(map["app"] as MutableMap<String, Any>)


### PR DESCRIPTION
The previous PR (#914) didn't completely fix this problem, as when `severity` was parsed and set on the event, the value for `unhandled` was lost again. This refactors the way the `HandledState` object is constructed to avoid further such issues.