### PR TITLE
[PLAT-4704] RN: Split updateMetadata method into two separate add/clear methods

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -113,7 +113,14 @@ class BugsnagReactNativePlugin : Plugin {
         client.codeBundleId = id
     }
 
-    fun updateMetadata(section: String, data: Map<String, Any?>?) {
+    fun clearMetadata(section: String, key: String?) {
+        when (key) {
+            null -> client.clearMetadata(section)
+            else -> client.clearMetadata(section, key)
+        }
+    }
+
+    fun addMetadata(section: String, data: Map<String, Any?>?) {
         when (data) {
             null -> client.clearMetadata(section)
             else -> client.addMetadata(section, data)

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/UpdateMetadataTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/UpdateMetadataTest.kt
@@ -26,7 +26,7 @@ class UpdateMetadataTest {
 
     @Test
     fun nullMetadataRemovesSection() {
-        plugin.updateMetadata("foo", null)
+        plugin.addMetadata("foo", null)
         verify(client, times(1)).clearMetadata("foo")
     }
 
@@ -38,7 +38,7 @@ class UpdateMetadataTest {
             "naughtyValue" to null
         )
 
-        plugin.updateMetadata("foo", data)
+        plugin.addMetadata("foo", data)
         verify(client, times(1)).addMetadata("foo", data)
     }
 }


### PR DESCRIPTION
Splits out the add/removal of metadata to facilitate more accurate synchronisation from the JS layer in RN.