### PR TITLE
fix(metadata): Ensure metadata updates set with a map notify observers

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -5,8 +5,10 @@ import com.bugsnag.android.StateEvent.AddMetadata
 internal data class MetadataState(val metadata: Metadata = Metadata()) : BaseObservable(),
     MetadataAware {
 
-    override fun addMetadata(section: String, value: Map<String, Any?>) =
+    override fun addMetadata(section: String, value: Map<String, Any?>) {
         metadata.addMetadata(section, value)
+        notifyMetadataAdded(section, value)
+    }
 
     override fun addMetadata(section: String, key: String, value: Any?) {
         metadata.addMetadata(section, key, value)
@@ -53,6 +55,12 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) : BaseObs
         when (value) {
             null -> notifyClear(section, key)
             else -> notifyObservers(AddMetadata(section, key, metadata.getMetadata(section, key)))
+        }
+    }
+
+    private fun notifyMetadataAdded(section: String, value: Map<String,Any?>) {
+        value.entries.forEach {
+            notifyObservers(AddMetadata(section, it.key, metadata.getMetadata(it.key)))
         }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
@@ -58,4 +58,25 @@ internal class MetadataStateTest {
         state.emitObservableEvent()
         assertEquals(setOf("foo", "bar"), data)
     }
+
+    @Test
+    fun initObservableMessagesWithMap() {
+        state.addMetadata("foo", hashMapOf(
+            "key1" to "1",
+            "key2" to "2",
+            "key3" to 3)
+        )
+
+        val sections = mutableSetOf<String>()
+        val keys = mutableSetOf<String?>()
+        state.addObserver { _, arg ->
+            val msg = arg as StateEvent.AddMetadata
+            sections.add(msg.section)
+            keys.add(msg.key)
+        }
+
+        state.emitObservableEvent()
+        assertEquals(setOf("foo"), sections)
+        assertEquals(setOf("key1", "key2", "key3"), keys)
+    }
 }


### PR DESCRIPTION
Metadata updates with a map did not trigger any updates for observers. This fix ensures the observers are notified for each tab that changed.