### PR TITLE
Add accessor for breadcrumb list on Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Add accessor for breadcrumb list on Client
+  [#924](https://github.com/bugsnag/bugsnag-android/pull/924)
+
 ## 5.0.2 (2020-08-17)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## TBD
 
+### Enhancements
+
 * Add accessor for breadcrumb list on Client
   [#924](https://github.com/bugsnag/bugsnag-android/pull/924)
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -207,7 +207,7 @@ public class ClientTest {
     @Test
     public void testBreadcrumbGetter() {
         client = generateClient();
-        Collection<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
+        List<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
 
         int breadcrumbCount = breadcrumbs.size();
         client.leaveBreadcrumb("Foo");
@@ -219,7 +219,7 @@ public class ClientTest {
         config.setEnabledBreadcrumbTypes(Collections.singleton(BreadcrumbType.MANUAL));
         client = generateClient(config);
         client.leaveBreadcrumb("Manual breadcrumb");
-        Collection<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
+        List<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
 
         breadcrumbs.clear(); // only the copy should be cleared
         assertTrue(breadcrumbs.isEmpty());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import static com.bugsnag.android.BugsnagTestUtils.generateClient;
 import static com.bugsnag.android.BugsnagTestUtils.generateConfiguration;
 import static com.bugsnag.android.BugsnagTestUtils.getSharedPrefs;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -21,6 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -28,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 @SuppressWarnings("unchecked")
 @SmallTest
@@ -202,6 +205,16 @@ public class ClientTest {
         client = generateClient();
         assertNotNull(client.getUser());
         assertNotNull(client.getUser().getId());
+    }
+
+    @Test
+    public void testClientBreadcrumbRetrieval() {
+        client = generateClient();
+        client.leaveBreadcrumb("Hello World");
+        List<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
+        List<Breadcrumb> store = new ArrayList<>(client.breadcrumbState.getStore());
+        assertEquals(store, breadcrumbs);
+        assertNotSame(store, breadcrumbs);
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -370,7 +370,9 @@ public final class Bugsnag {
      * use {@link Configuration#setEnabledBreadcrumbTypes(Set)} and
      * {@link Configuration#addOnBreadcrumb(OnBreadcrumbCallback)} instead.
      *
-     * @return a list of collected breadcrumbs
+     * Returns the current buffer of breadcrumbs that will be sent with captured events. This
+     * ordered list represents the most recent breadcrumbs to be captured up to the limit
+     * set in {@link Configuration#getMaxBreadcrumbs()}.
      */
     @NonNull
     public static List<Breadcrumb> getBreadcrumbs() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -363,16 +363,16 @@ public final class Bugsnag {
     }
 
     /**
-     * Returns a readonly List of breadcrumbs in the order which they were captured by the Client.
+     * Returns the current buffer of breadcrumbs that will be sent with captured events. This
+     * ordered list represents the most recent breadcrumbs to be captured up to the limit
+     * set in {@link Configuration#getMaxBreadcrumbs()}.
      *
      * The returned collection is readonly and mutating the list will cause no effect on the
      * Client's state. If you wish to alter the breadcrumbs collected by the Client then you should
      * use {@link Configuration#setEnabledBreadcrumbTypes(Set)} and
      * {@link Configuration#addOnBreadcrumb(OnBreadcrumbCallback)} instead.
      *
-     * Returns the current buffer of breadcrumbs that will be sent with captured events. This
-     * ordered list represents the most recent breadcrumbs to be captured up to the limit
-     * set in {@link Configuration#getMaxBreadcrumbs()}.
+     * @return a list of collected breadcrumbs
      */
     @NonNull
     public static List<Breadcrumb> getBreadcrumbs() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -6,7 +6,10 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Static access to a Bugsnag Client, the easiest way to use Bugsnag in your Android app.
@@ -357,6 +360,21 @@ public final class Bugsnag {
      */
     public static void pauseSession() {
         getClient().pauseSession();
+    }
+
+    /**
+     * Returns a readonly List of breadcrumbs in the order which they were captured by the Client.
+     *
+     * The returned collection is readonly and mutating the list will cause no effect on the
+     * Client's state. If you wish to alter the breadcrumbs collected by the Client then you should
+     * use {@link Configuration#setEnabledBreadcrumbTypes(Set)} and
+     * {@link Configuration#addOnBreadcrumb(OnBreadcrumbCallback)} instead.
+     *
+     * @return a list of collected breadcrumbs
+     */
+    @NonNull
+    public static List<Breadcrumb> getBreadcrumbs() {
+        return getClient().getBreadcrumbs();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -703,7 +703,9 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      * use {@link Configuration#setEnabledBreadcrumbTypes(Set)} and
      * {@link Configuration#addOnBreadcrumb(OnBreadcrumbCallback)} instead.
      *
-     * @return a list of collected breadcrumbs
+     * Returns the current buffer of breadcrumbs that will be sent with captured events. This
+     * ordered list represents the most recent breadcrumbs to be captured up to the limit
+     * set in {@link Configuration#getMaxBreadcrumbs()}.
      */
     @NonNull
     public List<Breadcrumb> getBreadcrumbs() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -696,16 +696,16 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     }
 
     /**
-     * Returns a readonly List of breadcrumbs in the order which they were captured by the Client.
+     * Returns the current buffer of breadcrumbs that will be sent with captured events. This
+     * ordered list represents the most recent breadcrumbs to be captured up to the limit
+     * set in {@link Configuration#getMaxBreadcrumbs()}.
      *
      * The returned collection is readonly and mutating the list will cause no effect on the
      * Client's state. If you wish to alter the breadcrumbs collected by the Client then you should
      * use {@link Configuration#setEnabledBreadcrumbTypes(Set)} and
      * {@link Configuration#addOnBreadcrumb(OnBreadcrumbCallback)} instead.
      *
-     * Returns the current buffer of breadcrumbs that will be sent with captured events. This
-     * ordered list represents the most recent breadcrumbs to be captured up to the limit
-     * set in {@link Configuration#getMaxBreadcrumbs()}.
+     * @return a list of collected breadcrumbs
      */
     @NonNull
     public List<Breadcrumb> getBreadcrumbs() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -695,8 +695,18 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         deliveryDelegate.deliver(event);
     }
 
+    /**
+     * Returns a readonly List of breadcrumbs in the order which they were captured by the Client.
+     *
+     * The returned collection is readonly and mutating the list will cause no effect on the
+     * Client's state. If you wish to alter the breadcrumbs collected by the Client then you should
+     * use {@link Configuration#setEnabledBreadcrumbTypes(Set)} and
+     * {@link Configuration#addOnBreadcrumb(OnBreadcrumbCallback)} instead.
+     *
+     * @return a list of collected breadcrumbs
+     */
     @NonNull
-    List<Breadcrumb> getBreadcrumbs() {
+    public List<Breadcrumb> getBreadcrumbs() {
         return new ArrayList<>(breadcrumbState.getStore());
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -173,6 +173,12 @@ class BugsnagApiTest {
         verify(client, times(1)).pauseSession()
     }
 
+    @Test
+    fun getBreadcrumbs() {
+        Bugsnag.getBreadcrumbs()
+        verify(client, times(1)).breadcrumbs
+    }
+
     @Test(expected = IllegalStateException::class)
     fun nullClient() {
         Bugsnag.client = null

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -149,7 +149,7 @@ class BugsnagReactNativePlugin : Plugin {
         deviceSerializer.serialize(device, internalHooks.deviceWithState)
         info["device"] = device
 
-        info["breadcrumbs"] = internalHooks.breadcrumbs.map {
+        info["breadcrumbs"] = client.breadcrumbs.map {
             val map = mutableMapOf<String, Any?>()
             breadcrumbSerializer.serialize(map, it)
             map

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -32,10 +32,6 @@ class InternalHooks {
         return client.deviceDataCollector.generateDeviceWithState(new Date().getTime());
     }
 
-    public List<Breadcrumb> getBreadcrumbs() {
-        return client.getBreadcrumbs();
-    }
-
     public List<Thread> getThreads(boolean unhandled) {
         return new ThreadState(null, unhandled, getConfig()).getThreads();
     }


### PR DESCRIPTION
## Goal

Adds an accessor for a list of breadcrumbs collected by `Client`. This allows users to access a readonly copy of the collection and resolves #892 

## Changeset

- Altered existing getter on `Client` to be public, and added equivalent method to `Bugsnag` facade
- Removed redundant method from `InternalHooks`
- Updated existing unit test coverage to verify a `List` rather than a `Collection` is used as the breadcrumbs need to be ordered by capture time
- Added unit test to verify `Bugsnag` facade method
