### PR TITLE
[PLAT-4921] fix(plugin-react-native): Keep name of class for use in reflection

### DIFF
--- a/bugsnag-plugin-react-native/proguard-rules.pro
+++ b/bugsnag-plugin-react-native/proguard-rules.pro
@@ -1,2 +1,3 @@
 -keepattributes LineNumberTable,SourceFile
 -keepnames class com.facebook.react.common.JavascriptException { *; }
+-keepnames class com.bugsnag.android.BugsnagReactNativePlugin { *; }


### PR DESCRIPTION
## Goal

Enabling the flag `enableProguardInReleaseBuilds` on a React Native project with Bugsnag causes the app to crash. This is because the [`BugsnagReactNativePlugin` instance is obtained by reflection](https://github.com/bugsnag/bugsnag-js/blob/2de4bc0251d9d56c6f7c4a68908dfbff38812ff7/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt#L55) and when proguard is enabled this class name is obfuscated, so the reflection fails.

## Design

An additional proguard rule to keep the name of this class enables the reflection to work.

## Changeset

Rule added to `proguard-rules.pro`.

## Testing

This was tested manually on a React Native project. Additionally the end to end React Native CI tests will be run against an app with proguard enabled, to prevent regressions in this area.