### PR TITLE
Support changing Event's api key in OnErrorCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Bug fixes
+
+* Support changing Event's api key in OnErrorCallback
+  [#928](https://github.com/bugsnag/bugsnag-android/pull/928)
+
 ### Enhancements
 
 * Add accessor for breadcrumb list on Client

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -31,7 +31,7 @@ class DeliveryDelegate extends BaseObservable {
 
     void deliver(@NonNull Event event) {
         // Build the eventPayload
-        EventPayload eventPayload = new EventPayload(immutableConfig.getApiKey(), event, notifier);
+        EventPayload eventPayload = new EventPayload(event.getApiKey(), event, notifier);
         Session session = event.getSession();
 
         if (session != null) {
@@ -75,7 +75,8 @@ class DeliveryDelegate extends BaseObservable {
 
     @VisibleForTesting
     DeliveryStatus deliverPayloadInternal(@NonNull EventPayload payload, @NonNull Event event) {
-        DeliveryParams deliveryParams = immutableConfig.getErrorApiDeliveryParams();
+        String apiKey = payload.getApiKey();
+        DeliveryParams deliveryParams = immutableConfig.getErrorApiDeliveryParams(apiKey);
         Delivery delivery = immutableConfig.getDelivery();
         DeliveryStatus deliveryStatus = delivery.deliver(payload, deliveryParams);
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryHeaders.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryHeaders.kt
@@ -1,0 +1,30 @@
+package com.bugsnag.android
+
+import java.util.Date
+
+private const val HEADER_API_PAYLOAD_VERSION = "Bugsnag-Payload-Version"
+private const val HEADER_BUGSNAG_SENT_AT = "Bugsnag-Sent-At"
+internal const val HEADER_API_KEY = "Bugsnag-Api-Key"
+internal const val HEADER_INTERNAL_ERROR = "Bugsnag-Internal-Error"
+
+/**
+ * Supplies the headers which must be used in any request sent to the Error Reporting API.
+ *
+ * @return the HTTP headers
+ */
+internal fun errorApiHeaders(apiKey: String) = mapOf(
+    HEADER_API_PAYLOAD_VERSION to "4.0",
+    HEADER_API_KEY to apiKey,
+    HEADER_BUGSNAG_SENT_AT to DateUtils.toIso8601(Date())
+)
+
+/**
+ * Supplies the headers which must be used in any request sent to the Session Tracking API.
+ *
+ * @return the HTTP headers
+ */
+internal fun sessionApiHeaders(apiKey: String) = mapOf(
+    HEADER_API_PAYLOAD_VERSION to "1.0",
+    HEADER_API_KEY to apiKey,
+    HEADER_BUGSNAG_SENT_AT to DateUtils.toIso8601(Date())
+)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -29,13 +29,6 @@ internal data class ImmutableConfig(
     val maxBreadcrumbs: Int
 ) {
 
-    companion object {
-        private const val HEADER_API_PAYLOAD_VERSION = "Bugsnag-Payload-Version"
-        internal const val HEADER_API_KEY = "Bugsnag-Api-Key"
-        internal const val HEADER_INTERNAL_ERROR = "Bugsnag-Internal-Error"
-        private const val HEADER_BUGSNAG_SENT_AT = "Bugsnag-Sent-At"
-    }
-
     /**
      * Checks if the given release stage should be notified or not
      *
@@ -55,33 +48,7 @@ internal data class ImmutableConfig(
 
     @JvmName("getSessionApiDeliveryParams")
     internal fun getSessionApiDeliveryParams() =
-        DeliveryParams(endpoints.sessions, sessionApiHeaders())
-
-    /**
-     * Supplies the headers which must be used in any request sent to the Error Reporting API.
-     *
-     * @return the HTTP headers
-     */
-    private fun errorApiHeaders(apiKey: String): Map<String, String> {
-        val map = HashMap<String, String>()
-        map[HEADER_API_PAYLOAD_VERSION] = "4.0"
-        map[HEADER_API_KEY] = apiKey
-        map[HEADER_BUGSNAG_SENT_AT] = DateUtils.toIso8601(Date())
-        return map
-    }
-
-    /**
-     * Supplies the headers which must be used in any request sent to the Session Tracking API.
-     *
-     * @return the HTTP headers
-     */
-    private fun sessionApiHeaders(): Map<String, String> {
-        val map = HashMap<String, String>()
-        map[HEADER_API_PAYLOAD_VERSION] = "1.0"
-        map[HEADER_API_KEY] = apiKey
-        map[HEADER_BUGSNAG_SENT_AT] = DateUtils.toIso8601(Date())
-        return map
-    }
+        DeliveryParams(endpoints.sessions, sessionApiHeaders(apiKey))
 }
 
 internal fun convertToImmutableConfig(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -50,7 +50,8 @@ internal data class ImmutableConfig(
         enabledBreadcrumbTypes == null || enabledBreadcrumbTypes.contains(type)
 
     @JvmName("getErrorApiDeliveryParams")
-    internal fun getErrorApiDeliveryParams() = DeliveryParams(endpoints.notify, errorApiHeaders())
+    internal fun getErrorApiDeliveryParams(apiKey: String) =
+        DeliveryParams(endpoints.notify, errorApiHeaders(apiKey))
 
     @JvmName("getSessionApiDeliveryParams")
     internal fun getSessionApiDeliveryParams() =
@@ -61,7 +62,7 @@ internal data class ImmutableConfig(
      *
      * @return the HTTP headers
      */
-    private fun errorApiHeaders(): Map<String, String> {
+    private fun errorApiHeaders(apiKey: String): Map<String, String> {
         val map = HashMap<String, String>()
         map[HEADER_API_PAYLOAD_VERSION] = "4.0"
         map[HEADER_API_KEY] = apiKey

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -1,7 +1,7 @@
 package com.bugsnag.android;
 
-import static com.bugsnag.android.HandledState.REASON_UNHANDLED_EXCEPTION;
 import static com.bugsnag.android.DeliveryHeadersKt.HEADER_INTERNAL_ERROR;
+import static com.bugsnag.android.HandledState.REASON_UNHANDLED_EXCEPTION;
 
 import android.annotation.SuppressLint;
 import android.content.Context;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -105,7 +105,8 @@ class InternalReportDelegate implements EventStore.Delegate {
                 public void run() {
                     try {
                         Delivery delivery = immutableConfig.getDelivery();
-                        DeliveryParams params = immutableConfig.getErrorApiDeliveryParams();
+                        String apiKey = eventPayload.getApiKey();
+                        DeliveryParams params = immutableConfig.getErrorApiDeliveryParams(apiKey);
 
                         // can only modify headers if DefaultDelivery is in use
                         if (delivery instanceof DefaultDelivery) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -1,8 +1,7 @@
 package com.bugsnag.android;
 
 import static com.bugsnag.android.HandledState.REASON_UNHANDLED_EXCEPTION;
-import static com.bugsnag.android.ImmutableConfig.HEADER_API_KEY;
-import static com.bugsnag.android.ImmutableConfig.HEADER_INTERNAL_ERROR;
+import static com.bugsnag.android.DeliveryHeadersKt.HEADER_INTERNAL_ERROR;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -112,7 +111,7 @@ class InternalReportDelegate implements EventStore.Delegate {
                         if (delivery instanceof DefaultDelivery) {
                             Map<String, String> headers = params.getHeaders();
                             headers.put(HEADER_INTERNAL_ERROR, "true");
-                            headers.remove(HEADER_API_KEY);
+                            headers.remove(DeliveryHeadersKt.HEADER_API_KEY);
                             DefaultDelivery defaultDelivery = (DefaultDelivery) delivery;
                             defaultDelivery.deliver(params.getEndpoint(), eventPayload, headers);
                         }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -141,7 +141,7 @@ internal class ImmutableConfigTest {
     @Test
     fun verifyErrorApiHeaders() {
         val config = convertToImmutableConfig(seed)
-        val headers = config.getErrorApiDeliveryParams().headers
+        val headers = config.getErrorApiDeliveryParams(config.apiKey).headers
         assertEquals(config.apiKey, headers["Bugsnag-Api-Key"])
         assertNotNull(headers["Bugsnag-Sent-At"])
         assertNotNull(headers["Bugsnag-Payload-Version"])

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionApiKeyChangeScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionApiKeyChangeScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+import android.content.Context
+
+/**
+ * Sends a handled exception to Bugsnag where the API key is changed in a callback
+ */
+internal class HandledExceptionApiKeyChangeScenario(config: Configuration,
+                                                    context: Context) : Scenario(config, context) {
+    init {
+        config.autoTrackSessions = false
+    }
+
+    override fun run() {
+        super.run()
+        Bugsnag.notify(generateException()) { event ->
+            event.apiKey = "0000111122223333aaaabbbbcccc9999"
+            true
+        }
+    }
+}

--- a/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledExceptionApiKeyChangeScenario.kt
+++ b/mazerunner-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledExceptionApiKeyChangeScenario.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.OnErrorCallback
+
+/**
+ * Sends an unhandled exception to Bugsnag where the API key is changed in a callback
+ */
+internal class UnhandledExceptionApiKeyChangeScenario(config: Configuration,
+                                                      context: Context) : Scenario(config, context) {
+    init {
+        config.autoTrackSessions = false
+        config.addOnError(OnErrorCallback { event ->
+            event.apiKey = "0000111122223333aaaabbbbcccc9999"
+            true
+        })
+    }
+
+    override fun run() {
+        super.run()
+        throw generateException()
+    }
+
+}

--- a/tests/features/event_callback_alters_api_key.feature
+++ b/tests/features/event_callback_alters_api_key.feature
@@ -1,0 +1,18 @@
+Feature: When the api key is altered in an Event the JSON payload reflects this
+
+Scenario: Handled exception with altered API key
+    When I run "HandledExceptionApiKeyChangeScenario"
+    Then I wait to receive a request
+    And the payload field "events" is an array with 1 elements
+    And the exception "message" equals "HandledExceptionApiKeyChangeScenario"
+    And the payload field "apiKey" equals "0000111122223333aaaabbbbcccc9999"
+    And the "Bugsnag-Api-Key" header equals "0000111122223333aaaabbbbcccc9999"
+
+Scenario: Unhandled exception with altered API key
+    When I run "UnhandledExceptionApiKeyChangeScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledExceptionApiKeyChangeScenario"
+    And I wait to receive a request
+    And the payload field "events" is an array with 1 elements
+    And the exception "message" equals "UnhandledExceptionApiKeyChangeScenario"
+    And the payload field "apiKey" equals "0000111122223333aaaabbbbcccc9999"
+    And the "Bugsnag-Api-Key" header equals "0000111122223333aaaabbbbcccc9999"


### PR DESCRIPTION
## Goal

Supports changing the apiKey for an `Event` via an `OnErrorCallback`. This is achieved by encoding the apiKey in the filename if an event is cached on disk, and reading this apiKey from the filename at the point of delivery.

## Changeset

- `DeliveryDelegate` uses the apiKey set on `Event` rather than `Configuration`, which covers delivery of handled errors
- `errorApiHeaders()` now takes the `apiKey` as a parameter when generating HTTP headers so that `Bugsnag-Api-Key` is not always set to `config.apiKey`
- `flushEventFile()` reads the apiKey from the filename if present, and otherwise falls back to the `config.apiKey` value if the cached file is in the legacy format
- Fixed a minor bug where 'not-jvm' was always added to a filename if the report was not a startup crash. The presence of 'not-jvm' has no apparent consequence on the notifier's functionality and appears to be used only for debugging purposes
- Encoded the `apiKey` in the filename

This changeset does not address altering the API key for NDK errors, which will be handled separately.

## Testing

Added an E2E test for a handled error (which should be delivered without writing to disk) and an unhandled error (which requires writing to disk). Additionally unit tests have been added to cover filename generation for each event, and reading the apiKey from the filename.