### PR TITLE
Prevent ConcurrentModificationException thrown from Metadata class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Prevent ConcurrentModificationException thrown from Metadata class
+  [#935](https://github.com/bugsnag/bugsnag-android/pull/935)
+
 ## 5.1.0 (2020-09-08)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
@@ -3,7 +3,6 @@
 package com.bugsnag.android
 
 import java.io.IOException
-import java.util.HashMap
 import java.util.HashSet
 import java.util.concurrent.ConcurrentHashMap
 
@@ -14,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap
  * Diagnostic information is presented on your Bugsnag dashboard in tabs.
  */
 internal data class Metadata @JvmOverloads constructor(
-    internal val store: MutableMap<String, Any> = ConcurrentHashMap(),
+    internal val store: ConcurrentHashMap<String, Any> = ConcurrentHashMap(),
     val jsonStreamer: ObjectJsonStreamer = ObjectJsonStreamer(),
     val redactedKeys: Set<String> = jsonStreamer.redactedKeys
 ) : JsonStream.Streamable, MetadataAware {
@@ -79,8 +78,8 @@ internal data class Metadata @JvmOverloads constructor(
         }
     }
 
-    fun toMap(): Map<String, Any> {
-        val hashMap = HashMap(store)
+    fun toMap(): ConcurrentHashMap<String, Any> {
+        val hashMap = ConcurrentHashMap(store)
 
         // deep copy each section
         store.entries.forEach {
@@ -106,7 +105,7 @@ internal data class Metadata @JvmOverloads constructor(
             return newMeta
         }
 
-        internal fun mergeMaps(data: List<Map<String, Any>>): MutableMap<String, Any> {
+        internal fun mergeMaps(data: List<Map<String, Any>>): ConcurrentHashMap<String, Any> {
             val keys = data.flatMap { it.keys }.toSet()
             val result = ConcurrentHashMap<String, Any>()
 
@@ -144,7 +143,7 @@ internal data class Metadata @JvmOverloads constructor(
     }
 
     fun copy() = this.copy(
-        store = toMap().toMutableMap(),
+        store = toMap(),
         jsonStreamer = jsonStreamer,
         redactedKeys = redactedKeys
     )

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataConcurrentModificationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataConcurrentModificationTest.kt
@@ -1,0 +1,21 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.util.concurrent.Executors
+
+internal class MetadataConcurrentModificationTest {
+
+    @Test()
+    fun testHandlesConcurrentModification() {
+        val metadata = Metadata().copy()
+        val executor = Executors.newSingleThreadExecutor()
+
+        repeat(100) { count ->
+            assertNotNull(metadata.toMap())
+            executor.execute {
+                metadata.store["$count"] = count
+            }
+        }
+    }
+}

--- a/bugsnag-android-core/src/test/resources/event_redaction.json
+++ b/bugsnag-android-core/src/test/resources/event_redaction.json
@@ -3,10 +3,10 @@
     "app": {
       "password": "[REDACTED]"
     },
-    "device": {
+    "baz": {
       "password": "[REDACTED]"
     },
-    "baz": {
+    "device": {
       "password": "[REDACTED]"
     }
   },

--- a/bugsnag-android-core/src/test/resources/event_serialization_6.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_6.json
@@ -3,11 +3,11 @@
     "app": {
       "foo": 55
     },
-    "device": {
-      "bar": true
-    },
     "wham": {
       "some_key": "Avalue"
+    },
+    "device": {
+      "bar": true
     }
   },
   "severity": "warning",

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MetadataDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/MetadataDeserializer.java
@@ -1,10 +1,12 @@
 package com.bugsnag.android;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 class MetadataDeserializer implements MapDeserializer<Metadata> {
     @Override
     public Metadata deserialize(Map<String, Object> map) {
-        return new Metadata(map);
+        ConcurrentHashMap<String, Object> store = new ConcurrentHashMap<>(map);
+        return new Metadata(store);
     }
 }


### PR DESCRIPTION
## Goal

Prevents a `ConcurrentModificationException` from being thrown in the internally used `MetaData` class.

`MetaData` does correctly use a `ConcurrentHashMap` as the default value for the `store` property, but within the `copy()` method supplies a regular `HashMap`. Whenever `client.notify()` is invoked the global metadata state is copied, which can result in a `ConcurrentModificationException` being thrown in subsequent edits.

This changeset resolves the problem by enforcing that `store` must be a `ConcurrentHashMap`.

## Testing

Added a unit test which throws an exception without the changes, and confirmed that it no longer throws an exception.