### PR TITLE
Improve stack traces and grouping for React Native promise rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@
 
 * Prevent ConcurrentModificationException thrown from Metadata class
   [#935](https://github.com/bugsnag/bugsnag-android/pull/935)
-
+  
 * Prevent incorrect merge of nested maps in metadata
   [#936](https://github.com/bugsnag/bugsnag-android/pull/936)
+
+#### React Native
+
+* Improve stack traces and grouping for React Native promise rejections
+  [#937](https://github.com/bugsnag/bugsnag-android/pull/937)
 
 ## 5.1.0 (2020-09-08)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
@@ -11,6 +11,14 @@ internal class Stacktrace : JsonStream.Streamable {
     companion object {
         private const val STACKTRACE_TRIM_LENGTH = 200
 
+        /**
+         * Calculates whether a stackframe is 'in project' or not by checking its class against
+         * [Configuration.getProjectPackages].
+         *
+         * For example if the projectPackages included 'com.example', then
+         * the `com.example.Foo` class would be considered in project, but `org.example.Bar` would
+         * not.
+         */
         fun inProject(className: String, projectPackages: Collection<String>): Boolean? {
             for (packageName in projectPackages) {
                 if (className.startsWith(packageName)) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
@@ -10,6 +10,15 @@ internal class Stacktrace : JsonStream.Streamable {
 
     companion object {
         private const val STACKTRACE_TRIM_LENGTH = 200
+
+        fun inProject(className: String, projectPackages: Collection<String>): Boolean? {
+            for (packageName in projectPackages) {
+                if (className.startsWith(packageName)) {
+                    return true
+                }
+            }
+            return null
+        }
     }
 
     val trace: List<Stackframe>
@@ -63,14 +72,5 @@ internal class Stacktrace : JsonStream.Streamable {
             logger.w("Failed to serialize stacktrace", lineEx)
             return null
         }
-    }
-
-    private fun inProject(className: String, projectPackages: Collection<String>): Boolean? {
-        for (packageName in projectPackages) {
-            if (className.startsWith(packageName)) {
-                return true
-            }
-        }
-        return null
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -134,7 +134,8 @@ class BugsnagReactNativePlugin : Plugin {
     @Suppress("unused")
     fun dispatch(payload: MutableMap<String, Any?>?) {
         requireNotNull(payload)
-        val event = EventDeserializer(client).deserialize(payload)
+        val projectPackages = internalHooks.getProjectPackages(client.config)
+        val event = EventDeserializer(client, projectPackages).deserialize(payload)
         client.notifyInternal(event, null)
     }
 

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -45,6 +45,9 @@ internal class EventDeserializer(
         event.errors.clear()
         event.errors.addAll(errors.map(errorDeserializer::deserialize))
 
+        // if the JS payload has passed down a native stacktrace,
+        // construct a second error object from it and append it to the event
+        // so both stacktraces are visible to the user
         if (map.containsKey("nativeStack") && event.errors.isNotEmpty()) {
             runCatching {
                 val jsError = event.errors.first()

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -34,5 +35,9 @@ class InternalHooks {
 
     public List<Thread> getThreads(boolean unhandled) {
         return new ThreadState(null, unhandled, getConfig()).getThreads();
+    }
+
+    public Collection<String> getProjectPackages(ImmutableConfig config) {
+        return config.getProjectPackages();
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeErrorDeserializer.java
@@ -1,0 +1,60 @@
+package com.bugsnag.android;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Deserializes an error from the 'nativeStack' property supplied by React Native
+ */
+class NativeErrorDeserializer implements MapDeserializer<Error> {
+
+    private final Error jsError;
+    private final Logger logger;
+    private final Collection<String> projectPackages;
+
+    NativeErrorDeserializer(Error jsError, Collection<String> projectPackages, Logger logger) {
+        this.jsError = jsError;
+        this.projectPackages = projectPackages;
+        this.logger = logger;
+    }
+
+    @Override
+    public Error deserialize(Map<String, Object> map) {
+        List<Map<String, Object>> nativeStack = MapUtils.getOrThrow(map, "nativeStack");
+        List<Stackframe> frames = new ArrayList<>();
+
+        for (Map<String, Object> frame : nativeStack) {
+            frames.add(deserializeStackframe(frame, projectPackages));
+        }
+
+        Stacktrace trace = new Stacktrace(frames, logger);
+        ErrorInternal impl = new ErrorInternal(
+                jsError.getErrorClass(),
+                jsError.getErrorMessage(),
+                trace,
+                ErrorType.ANDROID
+        );
+        return new Error(impl, logger);
+    }
+
+    private Stackframe deserializeStackframe(Map<String, Object> map,
+                                             Collection<String> projectPackages) {
+        String methodName = MapUtils.getOrNull(map, "methodName");
+        String clz = MapUtils.getOrNull(map, "class");
+
+        if (methodName == null) {
+            methodName = "";
+        }
+        if (clz == null) {
+            clz = "";
+        }
+        return new Stackframe(
+                String.format("%s.%s", clz, methodName),
+                MapUtils.<String>getOrNull(map, "file"),
+                MapUtils.<Integer>getOrNull(map, "lineNumber"),
+                Stacktrace.Companion.inProject(clz, projectPackages)
+        );
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeErrorDeserializer.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 /**
  * Deserializes an error from the 'nativeStack' property supplied by React Native
+ *
+ * This requires the original JS error, whose error message/class is used by the native error.
  */
 class NativeErrorDeserializer implements MapDeserializer<Error> {
 
@@ -20,6 +22,13 @@ class NativeErrorDeserializer implements MapDeserializer<Error> {
         this.logger = logger;
     }
 
+    /**
+     * Constructs a native error from the given payload. This assumes that 'nativeStack' contains
+     * a list of stackframes containing the methodName, class, file, and lineNumber.
+     *
+     * @param map the JSON payload passed from the JS layer
+     * @return a representation of a native error
+     */
     @Override
     public Error deserialize(Map<String, Object> map) {
         List<Map<String, Object>> nativeStack = MapUtils.getOrThrow(map, "nativeStack");

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -71,7 +71,7 @@ class EventDeserializerTest {
 
     @Test
     fun deserialize() {
-        val event = EventDeserializer(client).deserialize(map)
+        val event = EventDeserializer(client, emptyList()).deserialize(map)
         assertNotNull(event)
         assertEquals(Severity.INFO, event.severity)
         assertFalse(event.isUnhandled)

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/NativeErrorDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/NativeErrorDeserializerTest.kt
@@ -1,0 +1,77 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.TestData.generateError
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NativeErrorDeserializerTest {
+
+    private lateinit var map: Map<String, Any>
+
+    /**
+     * Generates a map for verifying the serializer
+     */
+    @Before
+    fun setup() {
+        val errorStacktrace = listOf(
+            mapOf(
+                "method" to "foo()",
+                "file" to "Bar.kt",
+                "lineNumber" to 29,
+                "inProject" to true
+            )
+        )
+        val error = mapOf(
+            "stacktrace" to errorStacktrace,
+            "errorClass" to "BrowserException",
+            "errorMessage" to "whoops!",
+            "type" to "reactnativejs"
+        )
+
+        val nativeStack = listOf(
+            mapOf(
+                "methodName" to "asyncReject",
+                "lineNumber" to 42,
+                "file" to "BenCrash.java",
+                "class" to "com.reactnativetest.BenCrash"
+            ),
+            mapOf(
+                "methodName" to "invokeFoo",
+                "lineNumber" to 57,
+                "file" to "Foo.kt",
+                "class" to "com.example.Foo"
+            )
+        )
+        map = mapOf(
+            "errors" to listOf(error),
+            "nativeStack" to nativeStack
+        )
+    }
+
+    @Test
+    fun deserialize() {
+        val logger = object : Logger {}
+        val packages = listOf("com.reactnativetest")
+        val error = NativeErrorDeserializer(generateError(), packages, logger).deserialize(map)
+        assertEquals("BrowserException", error.errorClass)
+        assertEquals("whoops!", error.errorMessage)
+        assertEquals(ErrorType.ANDROID, error.type)
+        assertEquals(2, error.stacktrace.count())
+
+        val firstFrame = error.stacktrace[0]
+        assertEquals("com.reactnativetest.BenCrash.asyncReject", firstFrame.method)
+        assertEquals("BenCrash.java", firstFrame.file)
+        assertEquals(42, firstFrame.lineNumber)
+        assertTrue(firstFrame.inProject!!)
+
+        val secondFrame = error.stacktrace[1]
+        assertEquals("com.example.Foo.invokeFoo", secondFrame.method)
+        assertEquals("Foo.kt", secondFrame.file)
+        assertEquals(57, secondFrame.lineNumber)
+        assertNull(secondFrame.inProject)
+    }
+}

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 class TestData {
     static ImmutableConfig generateConfig() {
@@ -27,5 +28,22 @@ class TestData {
                 NoopLogger.INSTANCE,
                 22
         );
+    }
+
+    static Error generateError() {
+        List<Stackframe> frames = Collections.singletonList(new Stackframe(
+                "foo",
+                "Bar.kt",
+                5,
+                true
+        ));
+
+        ErrorInternal impl = new ErrorInternal(
+                "BrowserException",
+                "whoops!",
+                new Stacktrace(frames, NoopLogger.INSTANCE),
+                ErrorType.REACTNATIVEJS
+        );
+        return new Error(impl, NoopLogger.INSTANCE);
     }
 }


### PR DESCRIPTION
## Goal

Improves the stack traces reported for React Native promise rejections by including the native stack trace in the reported error.

## Changeset

- Added `NativeErrorDeserializer` class which grabs the `nativeStack` property if set by the JS layer and creates an `Error` object, which is appended as a separate stacktrace
- Passed the JS error to the `NativeErrorDeserializer` and used its error message/class as the default values for the native error
- Moved `inProject` to Stacktrace's [companion object](https://kotlinlang.org/docs/tutorials/kotlin-for-py/objects-and-companion-objects.html) for accessibility from the `NativeErrorDeserializer`

## Testing

In addition to unit testing of deserialization logic, relied on E2E scenarios from https://github.com/bugsnag/bugsnag-js/pull/1047 and manually verified that the stacktrace appeared as expected in the dashboard:

<img width="974" alt="Screenshot 2020-09-18 at 14 38 46" src="https://user-images.githubusercontent.com/11800640/93605510-c0162280-f9be-11ea-9f8b-416b816feeb4.png">

https://github.com/bugsnag/bugsnag-js/compare/bengourley/rn-native-stack...PLAT-5001/native-stack

The RN changes can be trialled in an example app on the following branch: https://github.com/bugsnag/bugsnag-js/tree/PLAT-5001/native-stack