### PR TITLE
Ensure device ID is set separately to the user ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Ensure device ID is set separately to the user ID
+  [#939](https://github.com/bugsnag/bugsnag-android/pull/939)
+
 ## 5.2.0 (2020-09-22)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -6,6 +6,7 @@ import static com.bugsnag.android.BugsnagTestUtils.getSharedPrefs;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -326,5 +327,13 @@ public class ClientTest {
         assertNotNull(user.getId()); // use an auto-generated-id
         assertNull(user.getName());
         assertNull(user.getEmail());
+    }
+
+    @Test
+    public void testDeviceIdNotUserId() {
+        config.setUser("123", "test@example.com", "Tess Derby");
+        client = new Client(context, config);
+        assertEquals("123", client.getUser().getId());
+        assertNotEquals("123", client.getDeviceDataCollector().generateDevice().getId());
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -336,4 +336,12 @@ public class ClientTest {
         assertEquals("123", client.getUser().getId());
         assertNotEquals("123", client.getDeviceDataCollector().generateDevice().getId());
     }
+
+    @Test
+    public void testDeviceIdEqualsUserId() {
+        client = new Client(context, config);
+        String userId = client.getUser().getId();
+        String deviceId = client.getDeviceDataCollector().generateDevice().getId();
+        assertEquals(userId, deviceId);
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -168,9 +168,9 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             userState.setUser(user.getId(), user.getEmail(), user.getName());
         }
 
-        String id = userState.getUser().getId();
         DeviceBuildInfo info = DeviceBuildInfo.Companion.defaultInfo();
         Resources resources = appContext.getResources();
+        String id = userRepository.getDeviceId();
         deviceDataCollector = new DeviceDataCollector(connectivity, appContext, resources, id, info,
                 Environment.getDataDirectory(), logger);
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserRepository.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserRepository.kt
@@ -13,13 +13,7 @@ internal class UserRepository(private val prefs: SharedPreferences, private val 
     }
 
     fun load(): User {
-        var installId = prefs.getString(INSTALL_ID_KEY, null)
-
-        if (installId == null) {
-            installId = UUID.randomUUID().toString()
-            prefs.edit().putString(INSTALL_ID_KEY, installId).apply()
-        }
-
+        val installId = getDeviceId()
         return when {
             persist -> // Check to see if a user was stored in the SharedPreferences
                 User(
@@ -45,5 +39,14 @@ internal class UserRepository(private val prefs: SharedPreferences, private val 
                 .remove(USER_EMAIL_KEY)
         }
         editor.apply()
+    }
+
+    fun getDeviceId(): String {
+        var installId = prefs.getString(INSTALL_ID_KEY, null)
+        if (installId == null) {
+            installId = UUID.randomUUID().toString()
+            prefs.edit().putString(INSTALL_ID_KEY, installId).apply()
+        }
+        return installId
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserRepository.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserRepository.kt
@@ -41,6 +41,10 @@ internal class UserRepository(private val prefs: SharedPreferences, private val 
         editor.apply()
     }
 
+    /**
+     * Retrieves the device ID. This is a UUID which is generated per installation
+     * and persisted in SharedPreferences.
+     */
     fun getDeviceId(): String {
         var installId = prefs.getString(INSTALL_ID_KEY, null)
         if (installId == null) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/UserRepositoryTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/UserRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import android.content.SharedPreferences
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -69,5 +70,22 @@ class UserRepositoryTest {
         verify(editor, times(1)).remove("user.email")
         verify(editor, times(1)).remove("user.name")
         verify(editor, times(1)).apply()
+    }
+
+    @Test
+    fun getDeviceIdFirstTime() {
+        `when`(prefs.getString(contains("install.iud"), any())).thenReturn(null)
+        val repository = UserRepository(prefs, false)
+        val deviceId = repository.getDeviceId()
+        assertNotNull(deviceId)
+        verify(editor, times(1)).putString(matches("install.iud"), any())
+    }
+
+    @Test
+    fun getDeviceIdExistingValue() {
+        `when`(prefs.getString(contains("install.iud"), any())).thenReturn("4a09cbe2")
+        val repository = UserRepository(prefs, false)
+        val deviceId = repository.getDeviceId()
+        assertEquals("4a09cbe2", deviceId)
     }
 }


### PR DESCRIPTION
## Goal

Ensures that the device ID is set separately to the user ID. Previously if the user ID was set on `Configuration` then the device ID would be incorrectly overridden.

This fix alters the `Client` to load the device ID separately on initialization from the `UserRepository` class.

## Testing

Added unit and integration tests to verify that the `UserRepository` can read the device ID and that the Client value is set appropriately.