### PR TITLE
Improve stack traces and grouping for promise rejections on React Native < 0.63.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Ensure device ID is set separately to the user ID
   [#939](https://github.com/bugsnag/bugsnag-android/pull/939)
+  
+* Improve stack traces and grouping for promise rejections on React Native < 0.63.2
+  [#940](https://github.com/bugsnag/bugsnag-android/pull/940)
 
 ## 5.2.0 (2020-09-22)
 

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeErrorDeserializer.java
@@ -51,16 +51,21 @@ class NativeErrorDeserializer implements MapDeserializer<Error> {
     private Stackframe deserializeStackframe(Map<String, Object> map,
                                              Collection<String> projectPackages) {
         String methodName = MapUtils.getOrNull(map, "methodName");
-        String clz = MapUtils.getOrNull(map, "class");
-
         if (methodName == null) {
             methodName = "";
         }
+
+        String clz = MapUtils.getOrNull(map, "class");
+        String method = String.format("%s.%s", clz, methodName);
+
+        // RN <0.63.2 doesn't add class, gracefully fallback by only reporting
+        // method name. see https://github.com/facebook/react-native/pull/25014
         if (clz == null) {
             clz = "";
+            method = methodName;
         }
         return new Stackframe(
-                String.format("%s.%s", clz, methodName),
+                method,
                 MapUtils.<String>getOrNull(map, "file"),
                 MapUtils.<Integer>getOrNull(map, "lineNumber"),
                 Stacktrace.Companion.inProject(clz, projectPackages)

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/NativeErrorDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/NativeErrorDeserializerTest.kt
@@ -44,6 +44,11 @@ class NativeErrorDeserializerTest {
                 "lineNumber" to 57,
                 "file" to "Foo.kt",
                 "class" to "com.example.Foo"
+            ),
+            mapOf(
+                "methodName" to "invokeWham",
+                "lineNumber" to 159,
+                "file" to "Wham.kt"
             )
         )
         map = mapOf(
@@ -60,7 +65,7 @@ class NativeErrorDeserializerTest {
         assertEquals("BrowserException", error.errorClass)
         assertEquals("whoops!", error.errorMessage)
         assertEquals(ErrorType.ANDROID, error.type)
-        assertEquals(2, error.stacktrace.count())
+        assertEquals(3, error.stacktrace.count())
 
         val firstFrame = error.stacktrace[0]
         assertEquals("com.reactnativetest.BenCrash.asyncReject", firstFrame.method)
@@ -72,6 +77,12 @@ class NativeErrorDeserializerTest {
         assertEquals("com.example.Foo.invokeFoo", secondFrame.method)
         assertEquals("Foo.kt", secondFrame.file)
         assertEquals(57, secondFrame.lineNumber)
+        assertNull(secondFrame.inProject)
+
+        val thirdFrame = error.stacktrace[2]
+        assertEquals("invokeWham", thirdFrame.method)
+        assertEquals("Wham.kt", thirdFrame.file)
+        assertEquals(159, thirdFrame.lineNumber)
         assertNull(secondFrame.inProject)
     }
 }


### PR DESCRIPTION
## Goal

React Native 0.63.2 does not include the 'class' value in stacktraces for Android, and only records 10 frames. As a fallback bugsnag will record the method name only. While this does not allow deobfuscation if an app is obfuscated, it grants more information than would otherwise be available.

## Testing

Added a unit test to cover deserialization and verified manually in an example app.