### PR TITLE
Dismiss system dialogs in e2e test scenarios

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -112,6 +112,8 @@ steps:
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 10
     concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 8.1 end-to-end tests'
     timeout_in_minutes: 60
@@ -125,8 +127,6 @@ steps:
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 10
     concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 9 end-to-end tests'
     timeout_in_minutes: 60

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.mazerunner
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -22,6 +23,10 @@ class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // Attempt to dismiss any system dialogs (such as "MazeRunner crashed")
+        val closeDialog = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
+        sendBroadcast(closeDialog)
 
         val bugsnagStarter = findViewById<Button>(R.id.startBugsnagButton)
 


### PR DESCRIPTION
## Goal

Dismiss any system dialogs (but specifically the buttonless "MazeRunner crashed dialog)when the test fiture app (re)launches.

## Design

Viewing the video of a previous CI run, it was evident that Android 8.1 scenarios were failing due to the dialog hogging focus and blocking text entry by Appium.  This change appears to have fied that now (2/2 successful runs) and so I have moved the soft fail onto the problematic 8.0 tests (which fail due to a known infrastructure proxy issue).

## Changeset

e2e scenario test fixture and build pipeline.

## Testing

This is part of a continuing journey, but the Android 8.1 tests now seem to pass and nothing else is worse than it was.