### PR TITLE
Add testing against Android 11

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -311,6 +311,18 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
+  - label: ':android: NDK 21 SDK 11.0 Instrumentation tests'
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 4-11.0"]'
+      NDK_VERSION: r21d
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
   - label: ':android: NDK 21 SDK 10.0 Instrumentation tests'
     timeout_in_minutes: 30
     command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -156,6 +156,21 @@ steps:
     soft_fail:
       - exit_status: "*"
 
+  - label: ':android: Android 11 end-to-end tests'
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_11_0"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
+
   - label: ':android: Android size reporting'
     timeout_in_minutes: 10
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -311,7 +311,19 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: NDK 21 SDK 11.0 Instrumentation tests'
+  - label: ':android: NDK 21d SDK 10.0 Instrumentation tests'
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
+      NDK_VERSION: r21d
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 21d SDK 11.0 Instrumentation tests'
     timeout_in_minutes: 30
     command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
     plugins:
@@ -320,17 +332,5 @@ steps:
     env:
       INSTRUMENTATION_DEVICES: '["Google Pixel 4-11.0"]'
       NDK_VERSION: r21d
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 21 SDK 10.0 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
-      NDK_VERSION: r21
     concurrency: 10
     concurrency_group: 'browserstack-app'

--- a/dockerfiles/Dockerfile.android-common
+++ b/dockerfiles/Dockerfile.android-common
@@ -22,7 +22,7 @@ RUN yes | sdkmanager "platform-tools" > /dev/null
 RUN wget -q https://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip
 RUN wget -q https://dl.google.com/android/repository/android-ndk-r16b-linux-x86_64.zip
 RUN wget -q https://dl.google.com/android/repository/android-ndk-r19-linux-x86_64.zip
-RUN wget -q https://dl.google.com/android/repository/android-ndk-r21-linux-x86_64.zip
+RUN wget -q https://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip
 
 # Unzip all NDKs
 RUN unzip -q 'android-ndk-*-linux-x86_64.zip'


### PR DESCRIPTION
## Goal

Add instrumentation and e2e tests against Android 11 to the pipeline.

## Design

The e2e tests are set to soft fail pending further investigation of some failures.

## Changeset

CI pipeline.

## Testing

Adds tests against Android 11. 