### PR TITLE
Prevent ConcurrentModificationException when setting redactedKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Prevent ConcurrentModificationException when setting redactedKeys
+  [#947](https://github.com/bugsnag/bugsnag-android/pull/947)
+
 ## 5.2.1 (2020-10-01)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -36,7 +36,7 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
 
     var redactedKeys: Set<String> = metadataState.metadata.redactedKeys
         set(value) {
-            metadataState.metadata.setRedactedKeys(value)
+            metadataState.metadata.redactedKeys = value
             field = value
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
@@ -146,6 +146,6 @@ internal data class Metadata @JvmOverloads constructor(
 
     fun copy(): Metadata {
         return this.copy(store = toMap())
-            .also { it.redactedKeys = redactedKeys }
+            .also { it.redactedKeys = redactedKeys.toSet() }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
@@ -3,7 +3,6 @@
 package com.bugsnag.android
 
 import java.io.IOException
-import java.util.HashSet
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -13,10 +12,16 @@ import java.util.concurrent.ConcurrentHashMap
  * Diagnostic information is presented on your Bugsnag dashboard in tabs.
  */
 internal data class Metadata @JvmOverloads constructor(
-    internal val store: ConcurrentHashMap<String, Any> = ConcurrentHashMap(),
-    val jsonStreamer: ObjectJsonStreamer = ObjectJsonStreamer(),
-    val redactedKeys: Set<String> = jsonStreamer.redactedKeys
+    internal val store: ConcurrentHashMap<String, Any> = ConcurrentHashMap()
 ) : JsonStream.Streamable, MetadataAware {
+
+    val jsonStreamer: ObjectJsonStreamer = ObjectJsonStreamer()
+
+    var redactedKeys: Set<String>
+        get() = jsonStreamer.redactedKeys
+        set(value) {
+            jsonStreamer.redactedKeys = value
+        }
 
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {
@@ -93,18 +98,12 @@ internal data class Metadata @JvmOverloads constructor(
         return hashMap
     }
 
-    fun setRedactedKeys(redactKeys: Collection<String>) {
-        val data = HashSet(redactKeys)
-        jsonStreamer.redactedKeys.clear()
-        jsonStreamer.redactedKeys.addAll(data)
-    }
-
     companion object {
         fun merge(vararg data: Metadata): Metadata {
             val stores = data.map { it.toMap() }
             val redactKeys = data.flatMap { it.jsonStreamer.redactedKeys }
             val newMeta = Metadata(mergeMaps(stores))
-            newMeta.setRedactedKeys(redactKeys.toSet())
+            newMeta.redactedKeys = redactKeys.toSet()
             return newMeta
         }
 
@@ -145,9 +144,8 @@ internal data class Metadata @JvmOverloads constructor(
         }
     }
 
-    fun copy() = this.copy(
-        store = toMap(),
-        jsonStreamer = jsonStreamer,
-        redactedKeys = redactedKeys
-    )
+    fun copy(): Metadata {
+        return this.copy(store = toMap())
+            .also { it.redactedKeys = redactedKeys }
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
@@ -10,7 +10,7 @@ internal class ObjectJsonStreamer {
         private const val OBJECT_PLACEHOLDER = "[OBJECT]"
     }
 
-    val redactedKeys = mutableSetOf("password")
+    var redactedKeys = setOf("password")
 
     // Write complex/nested values to a JsonStreamer
     @Throws(IOException::class)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataConcurrentModificationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataConcurrentModificationTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Test
 import java.util.concurrent.Executors
@@ -20,6 +21,10 @@ internal class MetadataConcurrentModificationTest {
         }
     }
 
+    /**
+     * Regression unit test that verifies setting redactedKeys
+     * concurrently on [Metadata] does not throw a ConcurrentModificationException
+     */
     @Test()
     fun testConcurrentModificationRedactedKeys() {
         val keys = mutableSetOf("alpha", "omega")
@@ -39,6 +44,6 @@ internal class MetadataConcurrentModificationTest {
         val orig = Metadata()
         orig.redactedKeys = mutableSetOf("alpha", "omega")
         val copy = orig.copy()
-        assertSame(orig.redactedKeys, copy.redactedKeys)
+        assertNotSame(orig.redactedKeys, copy.redactedKeys)
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataConcurrentModificationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataConcurrentModificationTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
@@ -45,5 +46,6 @@ internal class MetadataConcurrentModificationTest {
         orig.redactedKeys = mutableSetOf("alpha", "omega")
         val copy = orig.copy()
         assertNotSame(orig.redactedKeys, copy.redactedKeys)
+        assertEquals(mutableSetOf("alpha", "omega"), copy.redactedKeys)
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataConcurrentModificationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataConcurrentModificationTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
 import org.junit.Test
 import java.util.concurrent.Executors
 
@@ -17,5 +18,27 @@ internal class MetadataConcurrentModificationTest {
                 metadata.store["$count"] = count
             }
         }
+    }
+
+    @Test()
+    fun testConcurrentModificationRedactedKeys() {
+        val keys = mutableSetOf("alpha", "omega")
+        val orig = Metadata()
+        val executor = Executors.newSingleThreadExecutor()
+
+        repeat(100) {
+            orig.redactedKeys = keys
+            executor.execute {
+                keys.add("$it")
+            }
+        }
+    }
+
+    @Test()
+    fun testRedactedKeysCopy() {
+        val orig = Metadata()
+        orig.redactedKeys = mutableSetOf("alpha", "omega")
+        val copy = orig.copy()
+        assertSame(orig.redactedKeys, copy.redactedKeys)
     }
 }


### PR DESCRIPTION
## Goal

Prevents a `ConcurrentModificationException` from being thrown when `redactedKeys` is set on the `Metadata` of an `Event`. This can manifest as a crash when `notify()` is called concurrently.

## Changeset

- Converted `ObjectJsonStreamer` to use `var Set<String>` rather than `val MutableSet<String>`, as this avoids the problem of mutating a collection concurrently
- Converted `redactedKeys` to a property on `Metadata` rather than a property and function, as this is more consistent
- Removed `ObjectJsonStreamer` from the constructor as there is no need for it to be injectable

## Testing

Added a unit test to verify that when `redactedKeys` is set on `Metadata` a crash does not occur. Additionally added an integration test which calls `notify()` concurrently to confirm that no further crashes occur with the default configuration.