### PR TITLE
Update CI pipeline to form Buildkite dependency tree

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,13 @@
 steps:
+  - label: ':docker: Build Android maze runner image'
+    key: "maze-runner"
+    timeout_in_minutes: 20
+    plugins:
+      - docker-compose#v3.3.0:
+          build: android-maze-runner
+
   - label: ':docker: Build Android base image'
+    key: "android-common"
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v3.3.0:
@@ -12,9 +20,9 @@ steps:
           push:
             - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:latest
 
-  - wait
-
   - label: ':docker: Build Android base CI image (using NDK r16b)'
+    key: "android-ci"
+    depends_on: "android-common"
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v3.3.0:
@@ -27,15 +35,16 @@ steps:
           push:
             - android-ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-${BRANCH_NAME}
 
-  - label: ':docker: Build Android maze runner image'
-    timeout_in_minutes: 20
+  - label: ':android: Android size reporting'
+    depends_on: "android-ci"
+    timeout_in_minutes: 10
     plugins:
       - docker-compose#v3.3.0:
-          build: android-maze-runner
-
-  - wait
+          run: android-sizer
 
   - label: ':docker: Build Android JVM test image'
+    key: "android-jvm"
+    depends_on: "android-ci"
     timeout_in_minutes: 10
     plugins:
       - docker-compose#v3.3.0:
@@ -48,6 +57,8 @@ steps:
             - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
 
   - label: ':android: Build fixture APK'
+    key: "fixture-apk"
+    depends_on: "android-ci"
     timeout_in_minutes: 30
     artifact_paths: build/fixture.apk
     plugins:
@@ -56,12 +67,181 @@ steps:
     env:
       MAVEN_VERSION: "3.6.1"
 
-  - wait
+  - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r12b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
 
-  # End-to-end tests take the longest to run, so start as soon as possible.
+  - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r12b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r12b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r16b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r16b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r16b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r16b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r19
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r19
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r19
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 21d SDK 10.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
+      NDK_VERSION: r21d
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 21d SDK 11.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 4-11.0"]'
+      NDK_VERSION: r21d
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Linter'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-jvm
+    command: 'bash ./scripts/run-linter.sh'
+
+  - label: ':android: JVM tests'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-jvm
+    command: './gradlew test'
 
   - label: ':android: Android 5 end-to-end tests'
     skip: Temporarily disabled due to flakiness with BrowserStack tunneling
+    depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -75,6 +255,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 6 end-to-end tests'
+    depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -88,6 +269,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 7 end-to-end tests'
+    depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -101,6 +283,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 8.0 end-to-end tests'
+    depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -116,6 +299,7 @@ steps:
       - exit_status: "*"
 
   - label: ':android: Android 8.1 end-to-end tests'
+    depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -131,6 +315,7 @@ steps:
       - exit_status: "*"
 
   - label: ':android: Android 9 end-to-end tests'
+    depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -144,6 +329,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 10 end-to-end tests'
+    depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -159,6 +345,7 @@ steps:
       - exit_status: "*"
 
   - label: ':android: Android 11 end-to-end tests'
+    depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -172,167 +359,3 @@ steps:
     concurrency_group: 'browserstack-app'
     soft_fail:
       - exit_status: "*"
-
-  - label: ':android: Android size reporting'
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-sizer
-
-  - label: ':android: Linter'
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-jvm
-    command: 'bash ./scripts/run-linter.sh'
-
-  - label: ':android: JVM tests'
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-jvm
-    command: './gradlew test'
-
-  - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-      NDK_VERSION: r12b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-      NDK_VERSION: r12b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-      NDK_VERSION: r12b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-      NDK_VERSION: r16b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-      NDK_VERSION: r16b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-      NDK_VERSION: r16b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-      NDK_VERSION: r16b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-      NDK_VERSION: r19
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-      NDK_VERSION: r19
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-      NDK_VERSION: r19
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 21d SDK 10.0 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
-      NDK_VERSION: r21d
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 21d SDK 11.0 Instrumentation tests'
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 4-11.0"]'
-      NDK_VERSION: r21d
-    concurrency: 10
-    concurrency_group: 'browserstack-app'


### PR DESCRIPTION
## Goal

Use the Buildkite `depends_on` feature to form a dependency tree of build steps instead of running in a series of parallel steps.  This avoids steps needlessly waiting for steps in previous groups to complete if their dependency steps have already completed, potentially saving elapsed time on the overall build.

## Design

Pipeline step `key` and `depends_on` used as documented by Buildkite.

## Changeset

Pipelines ordering and dependency mechanism only.

## Testing

Covered by standard CI.