### PR TITLE
Stop instrumentation tests on error

### DIFF
--- a/scripts/run-instrumentation-test.sh
+++ b/scripts/run-instrumentation-test.sh
@@ -54,7 +54,7 @@ status_response=$(curl -s -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY"
 status=$(echo "$status_response" | jq -r ".status")
 
 WAIT_COUNT=0
-until [ "$status" == "\"done\"" ] || [ $WAIT_COUNT -eq 100 ]; do
+until [ "$status" == "\"done\"" ] || [ "$status" == "\"error\"" ] || [ $WAIT_COUNT -eq 100 ]; do
     echo "Android Tests [$(timestamp)]: Current test status: $status, Time waited: $((WAIT_COUNT * 15))"
     ((WAIT_COUNT++))
     sleep 15
@@ -63,7 +63,7 @@ until [ "$status" == "\"done\"" ] || [ $WAIT_COUNT -eq 100 ]; do
 done
 
 if [ "$status" != "\"done\"" ]; then
-    echo "Timed out waiting for tests to complete"
+    echo "Test error or timeout"
     exit 1
 fi
 


### PR DESCRIPTION
## Goal

Detect instrumentation tests that result in `error` and stop immediately rather than waiting for timeout.

## Testing

Covered by passing CI.