### PR TITLE
Run gradle builds with parallelization

### DIFF
--- a/examples/sdk-app-example/gradle.properties
+++ b/examples/sdk-app-example/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx4096m
+org.gradle.parallel=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## Goal

Enables [parallelized builds](https://guides.gradle.org/performance/#parallel_execution) for Gradle, which should reduce the amount of time taken in our builds.