### PR TITLE
Bump Android Gradle Plugin to 3.5.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     ext.kotlin_version = "1.3.61"
-    ext.agpVersion = "3.4.2"
+    ext.agpVersion = "3.5.4"
 
     dependencies {
         classpath "com.android.tools.build:gradle:${agpVersion}"


### PR DESCRIPTION
## Goal

Bumps the AGP dependency to 3.5.4. This is the highest we can bump it without making changes to how Bugsnag publishes artefacts, as AGP 3.6 altered the API for this.

The change is backwards compatible with users still stuck on Android Studio 3 if they wish to open our repository.

## Testing

Ran the example app and generated an APK by hand. Relied on CI to run lint/test tasks.