### PR TITLE
Resolve build warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}
       DEVICE_TYPE:
       APP_LOCATION:
-    command: --tags not @ignore --fail-fast
+    command: ["--tags", "not @ignore", "--fail-fast"]
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}
       DEVICE_TYPE:
       APP_LOCATION:
-    command: --tags ~@ignore --fail-fast
+    command: --tags not @ignore --fail-fast
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output


### PR DESCRIPTION
## Goal

Trivial change to resolve an annoying warning when running the end-to-end tests.

## Testing

Passing CI, verifying that the previous warning has gone.