### PR TITLE
Account for Android 11 when skipping/running scenarios

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,19 +13,19 @@ After do |scenario|
 end
 
 Before('@skip_above_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") if %w[ANDROID_9_0 ANDROID_10_0].include? bs_device
+  skip_this_scenario("Skipping scenario") if %w[ANDROID_9_0 ANDROID_10_0 ANDROID_11_0].include? bs_device
 end
 
 Before('@skip_above_android_7') do |scenario|
-  skip_this_scenario("Skipping scenario") if %w[ANDROID_8_0 ANDROID_8_1 ANDROID_9_0 ANDROID_10_0].include? bs_device
+  skip_this_scenario("Skipping scenario") if %w[ANDROID_8_0 ANDROID_8_1 ANDROID_9_0 ANDROID_10_0 ANDROID_11_0].include? bs_device
 end
 
 Before('@skip_below_android_9') do |scenario|
-  skip_this_scenario("Skipping scenario") unless %w[ANDROID_9_0 ANDROID_10_0].include? bs_device
+  skip_this_scenario("Skipping scenario") unless %w[ANDROID_9_0 ANDROID_10_0 ANDROID_11_0].include? bs_device
 end
 
 Before('@skip_below_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") unless %w[ANDROID_8_0 ANDROID_8_1 ANDROID_9_0 ANDROID_10_0].include? bs_device
+  skip_this_scenario("Skipping scenario") unless %w[ANDROID_8_0 ANDROID_8_1 ANDROID_9_0 ANDROID_10_0 ANDROID_11_0].include? bs_device
 end
 
 Before('@skip_android_8_1') do |scenario|


### PR DESCRIPTION
## Goal

Account for the recently added Android 11 when skipping/running test scenarios.

## Design

This is a quick fix.  The use of device type names will evaporate in the next major MazeRunner release, simplifying the steps here to use simple numeric operations on a configured OS version.

## Changeset

Scenarios skipping steps.

## Testing

Covered by standard CI.