### PR TITLE
Support changing NDK Event's api key in OnErrorCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Increase breadcrumb time precision to milliseconds
   [#954](https://github.com/bugsnag/bugsnag-android/pull/954)
 
+* Support changing NDK Event's api key in OnErrorCallback
+  [#964](https://github.com/bugsnag/bugsnag-android/pull/964)
+
 ## 5.2.2 (2020-10-19)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/FileStoreTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/FileStoreTest.kt
@@ -37,10 +37,10 @@ class FileStoreTest {
         dir.mkdir()
 
         val store = CustomFileStore(appContext, "", 1, null, delegate)
-        store.enqueueContentForDelivery("foo")
+        store.enqueueContentForDelivery("foo", "foo.json")
 
         assertEquals("NDK Crash report copy", delegate.context)
-        assertEquals(File("/foo.json"), delegate.errorFile)
+        assertEquals(File("foo.json"), delegate.errorFile)
         assertTrue(delegate.exception is FileNotFoundException)
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
@@ -9,8 +9,11 @@ internal class ClientObservable : BaseObservable() {
     fun postNdkInstall(conf: ImmutableConfig) {
         notifyObservers(
             StateEvent.Install(
-                conf.enabledErrorTypes.ndkCrashes, conf.appVersion,
-                conf.buildUuid, conf.releaseStage
+                conf.apiKey,
+                conf.enabledErrorTypes.ndkCrashes,
+                conf.appVersion,
+                conf.buildUuid,
+                conf.releaseStage
             )
         )
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -226,10 +226,11 @@ class EventStore extends FileStore {
     String getFilename(Object object) {
         String uuid = UUID.randomUUID().toString();
         long now = System.currentTimeMillis();
-        return getFilename(object, uuid, now, storeDirectory);
+        return getFilename(object, uuid, null, now, storeDirectory);
     }
 
-    String getFilename(Object object, String uuid, long timestamp, String storeDirectory) {
+    String getFilename(Object object, String uuid, String apiKey,
+                       long timestamp, String storeDirectory) {
         String suffix = "";
 
         if (object instanceof Event) {
@@ -239,14 +240,21 @@ class EventStore extends FileStore {
             if (duration != null && isStartupCrash(duration.longValue())) {
                 suffix = STARTUP_CRASH;
             }
-            return String.format(Locale.US, "%s%d_%s_%s%s.json",
-                    storeDirectory, timestamp, event.getApiKey(), uuid, suffix);
-
+            apiKey = event.getApiKey();
         } else { // generating a filename for an NDK event
             suffix = "not-jvm";
-            return String.format(Locale.US, "%s%d_%s%s.json",
-                    storeDirectory, timestamp, uuid, suffix);
+            if (apiKey.isEmpty()) {
+                apiKey = config.getApiKey();
+            }
         }
+        return String.format(Locale.US, "%s%d_%s_%s%s.json",
+                storeDirectory, timestamp, apiKey, uuid, suffix);
+    }
+
+    String getNdkFilename(Object object, String apiKey) {
+        String uuid = UUID.randomUUID().toString();
+        long now = System.currentTimeMillis();
+        return getFilename(object, uuid, apiKey, now, storeDirectory);
     }
 
     boolean isStartupCrash(long durationMs) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -69,11 +69,10 @@ abstract class FileStore {
         this.storeDirectory = path;
     }
 
-    void enqueueContentForDelivery(String content) {
+    void enqueueContentForDelivery(String content, String filename) {
         if (storeDirectory == null) {
             return;
         }
-        String filename = getFilename(content);
         discardOldestFileIfNeeded();
         lock.lock();
         Writer out = null;
@@ -96,7 +95,7 @@ abstract class FileStore {
                 }
             } catch (Exception exception) {
                 logger.w(String.format("Failed to close unsent payload writer (%s) ",
-                    filename), exception);
+                        filename), exception);
             }
             lock.unlock();
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -299,12 +299,12 @@ public class NativeInterface {
      *                          should be discarded, based on configured release
      *                          stages
      * @param payloadBytes The raw JSON payload of the event
-     * @param eventPath The path where the event was stored
+     * @param apiKey The apiKey for the event
      */
     @SuppressWarnings("unused")
     public static void deliverReport(@Nullable byte[] releaseStageBytes,
                                      @NonNull byte[] payloadBytes,
-                                     @NonNull String eventPath) {
+                                     @NonNull String apiKey) {
         if (payloadBytes == null) {
             return;
         }
@@ -319,21 +319,10 @@ public class NativeInterface {
                 || config.shouldNotifyForReleaseStage()) {
             EventStore eventStore = client.getEventStore();
 
-            String apiKey = getApiKeyFromEventPath(eventPath, config);
             String filename = eventStore.getNdkFilename(payload, apiKey);
             eventStore.enqueueContentForDelivery(payload, filename);
             eventStore.flushAsync();
         }
-    }
-
-    private static String getApiKeyFromEventPath(String eventPath, ImmutableConfig config) {
-        int start = eventPath.indexOf("_") + 1;
-        int end = eventPath.lastIndexOf(".");
-
-        if (end > start && start != 0) {
-            return eventPath.substring(start, end);
-        }
-        return config.getApiKey();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -327,10 +327,10 @@ public class NativeInterface {
     }
 
     private static String getApiKeyFromEventPath(String eventPath, ImmutableConfig config) {
-        int start = eventPath.indexOf("_");
+        int start = eventPath.indexOf("_") + 1;
         int end = eventPath.lastIndexOf(".");
 
-        if (end > start && start != -1) {
+        if (end > start && start != 0) {
             return eventPath.substring(start, end);
         }
         return config.getApiKey();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 sealed class StateEvent {
     class Install(
+        val apiKey: String,
         val autoDetectNdkCrashes: Boolean,
         val appVersion: String?,
         val buildUuid: String?,

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
@@ -100,7 +100,7 @@ class EventFilenameTest {
 
     @Test
     fun regularJvmEventName() {
-        val filename = eventStore.getFilename(event, "my-uuid-123", 1504255147933, "/errors/")
+        val filename = eventStore.getFilename(event, "my-uuid-123", null, 1504255147933, "/errors/")
         assertEquals("/errors/1504255147933_0000111122223333aaaabbbbcccc9999_my-uuid-123.json", filename)
     }
 
@@ -110,7 +110,7 @@ class EventFilenameTest {
     @Test
     fun startupCrashJvmEventName() {
         `when`(app.duration).thenReturn(1000)
-        val filename = eventStore.getFilename(event, "my-uuid-123", 1504255147933, "/errors/")
+        val filename = eventStore.getFilename(event, "my-uuid-123", null, 1504255147933, "/errors/")
         assertEquals("/errors/1504255147933_0000111122223333aaaabbbbcccc9999_my-uuid-123_startupcrash.json", filename)
     }
 
@@ -120,14 +120,21 @@ class EventFilenameTest {
     @Test
     fun nonStartupCrashCrashJvmEventName() {
         `when`(app.duration).thenReturn(10000)
-        val filename = eventStore.getFilename(event, "my-uuid-123", 1504255147933, "/errors/")
+        val filename = eventStore.getFilename(event, "my-uuid-123", null, 1504255147933, "/errors/")
         assertEquals("/errors/1504255147933_0000111122223333aaaabbbbcccc9999_my-uuid-123.json", filename)
     }
 
     @Test
     fun ndkEventName() {
-        val filename = eventStore.getFilename("{}", "my-uuid-123", 1504255147933, "/errors/")
-        assertEquals("/errors/1504255147933_my-uuid-123not-jvm.json", filename)
+        val filename = eventStore.getFilename("{}", "my-uuid-123",
+            "0000111122223333aaaabbbbcccc9999", 1504255147933, "/errors/")
+        assertEquals("/errors/1504255147933_0000111122223333aaaabbbbcccc9999_my-uuid-123not-jvm.json", filename)
+    }
+
+    @Test
+    fun ndkEventNameNoApiKey() {
+        val filename = eventStore.getFilename("{}", "my-uuid-123", "", 1504255147933, "/errors/")
+        assertEquals("/errors/1504255147933_5d1ec5bd39a74caa1267142706a7fb21_my-uuid-123not-jvm.json", filename)
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
@@ -158,4 +158,17 @@ class EventFilenameTest {
                 "_683c6b92-b325-4987-80ad-77086509ca1e.json")
         assertEquals("0000111122223333aaaabbbbcccc9999", eventStore.getApiKeyFromFilename(file))
     }
+
+    @Test
+    fun apiKeyFromLegacyNdkFilename() {
+        `when`(file.name).thenReturn("1603191800142_7e1041e0-7f37-4cfb-9d29-0aa6930bbb72not-jvm.json")
+        assertNull(eventStore.getApiKeyFromFilename(file))
+    }
+
+    @Test
+    fun apiKeyFromNdkFilename() {
+        `when`(file.name).thenReturn("1603191800142_5d1ec8bd39a74caa1267142706a7fb20_" +
+                "7e1041e0-7f37-4cfb-9d29-0aa6930bbb72not-jvm.json")
+        assertEquals("5d1ec8bd39a74caa1267142706a7fb20", eventStore.getApiKeyFromFilename(file))
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -214,8 +214,8 @@ internal class NativeInterfaceApiTest {
 
     @Test
     fun deliverReport() {
-        NativeInterface.deliverReport(null, "{}".toByteArray())
-        verify(eventStore, times(1)).enqueueContentForDelivery("{}")
+        NativeInterface.deliverReport(null, "{}".toByteArray(), "")
+        verify(eventStore, times(1)).enqueueContentForDelivery(eq("{}"), any())
     }
 
     @Test

--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -3,7 +3,7 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>ComplexMethod:NativeBridge.kt$NativeBridge$override fun update(observable: Observable, arg: Any?)</ID>
-    <ID>LongParameterList:NativeBridge.kt$NativeBridge$( reportingDirectory: String, autoDetectNdkCrashes: Boolean, apiLevel: Int, is32bit: Boolean, appVersion: String, buildUuid: String, releaseStage: String )</ID>
+    <ID>LongParameterList:NativeBridge.kt$NativeBridge$( apiKey: String, reportingDirectory: String, autoDetectNdkCrashes: Boolean, apiLevel: Int, is32bit: Boolean, appVersion: String, buildUuid: String, releaseStage: String )</ID>
     <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is AddBreadcrumb -&gt; addBreadcrumb(makeSafe(msg.message), makeSafe(msg.type.toString()), makeSafe(msg.timestamp), msg.metadata)</ID>
     <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is StartSession -&gt; startedSession(makeSafe(msg.id), makeSafe(msg.startedAt), msg.handledCount, msg.unhandledCount)</ID>
     <ID>NestedBlockDepth:NativeBridge.kt$NativeBridge$private fun deliverPendingReports()</ID>

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -77,6 +77,22 @@ typedef struct {
 extern "C" {
 #endif
 
+/* Accessors for event.api_key */
+
+/**
+ * Retrieves the event api key
+ * @param event_ptr a pointer to the event supplied in an on_error callback
+ * @return the event api key, or NULL if this has not been set
+ */
+char *bugsnag_event_get_api_key(void *event_ptr);
+
+/**
+ * Sets the event api key
+ * @param event_ptr a pointer to the event supplied in an on_error callback
+ * @param value the new event api key value, which cannot be NULL
+ */
+void bugsnag_event_set_api_key(void *event_ptr, char *value);
+
 /* Accessors for event.context */
 
 /**

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -42,6 +42,7 @@ class NativeBridge : Observer {
         }
 
     external fun install(
+        apiKey: String,
         reportingDirectory: String,
         autoDetectNdkCrashes: Boolean,
         apiLevel: Int,
@@ -155,6 +156,7 @@ class NativeBridge : Observer {
             } else {
                 val reportPath = reportDirectory + UUID.randomUUID().toString() + ".crash"
                 install(
+                    makeSafe(arg.apiKey),
                     reportPath,
                     arg.autoDetectNdkCrashes,
                     Build.VERSION.SDK_INT,

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -154,7 +154,7 @@ class NativeBridge : Observer {
             if (installed.get()) {
                 logger.w("Received duplicate setup message with arg: $arg")
             } else {
-                val reportPath = reportDirectory + UUID.randomUUID().toString() + ".crash"
+                val reportPath = reportDirectory + UUID.randomUUID().toString()
                 install(
                     makeSafe(arg.apiKey),
                     reportPath,

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -154,7 +154,7 @@ class NativeBridge : Observer {
             if (installed.get()) {
                 logger.w("Received duplicate setup message with arg: $arg")
             } else {
-                val reportPath = reportDirectory + UUID.randomUUID().toString()
+                val reportPath = reportDirectory + UUID.randomUUID().toString() + ".crash"
                 install(
                     makeSafe(arg.apiKey),
                     reportPath,

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -114,22 +114,21 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   }
 
   // populate metadata from Java layer
-  bugsnag_event event = bugsnag_env->next_event;
-  bsg_populate_event(env, &event);
+  bsg_populate_event(env, &bugsnag_env->next_event);
   time(&bugsnag_env->start_time);
-  if (event.app.in_foreground) {
+  if (bugsnag_env->next_event.app.in_foreground) {
     bugsnag_env->foreground_start_time = bugsnag_env->start_time;
   }
 
   // If set, save os build info to report info header
-  if (strlen(event.device.os_build) > 0) {
+  if (strlen(bugsnag_env->next_event.device.os_build) > 0) {
     bsg_strncpy_safe(bugsnag_env->report_header.os_build,
-                     event.device.os_build,
+                     bugsnag_env->next_event.device.os_build,
                      sizeof(bugsnag_env->report_header.os_build));
   }
 
   const char *api_key = (*env)->GetStringUTFChars(env, _api_key, 0);
-  bugsnag_event_set_api_key(&event, (char *) api_key);
+  bsg_strncpy_safe(bugsnag_env->next_event.api_key, (char *) api_key, sizeof(bugsnag_env->next_event.api_key));
   (*env)->ReleaseStringUTFChars(env, _api_key, api_key);
 
   bsg_global_env = bugsnag_env;

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -152,7 +152,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
           (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
       jmethodID jdeliver_method =
           (*env)->GetStaticMethodID(env, interface_class, "deliverReport",
-                                    "([B[B)V");
+                                    "([B[BLjava/lang/String;)V");
       size_t payload_length = bsg_strlen(payload);
       jbyteArray jpayload = (*env)->NewByteArray(env, payload_length);
       (*env)->SetByteArrayRegion(env, jpayload, 0, payload_length, (jbyte *)payload);
@@ -161,8 +161,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
       jbyteArray jstage = (*env)->NewByteArray(env, stage_length);
       (*env)->SetByteArrayRegion(env, jstage, 0, stage_length, (jbyte *)event->app.release_stage);
 
+      jstring jevent_path = (*env)->NewStringUTF(env, event_path);
       (*env)->CallStaticVoidMethod(env, interface_class, jdeliver_method,
-                                   jstage, jpayload);
+                                   jstage, jpayload, jevent_path);
+      (*env)->DeleteLocalRef(env, jevent_path);
       (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload, 0); // <-- frees payload
       (*env)->ReleaseByteArrayElements(env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
       (*env)->DeleteLocalRef(env, jpayload);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -160,10 +160,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
       jbyteArray jstage = (*env)->NewByteArray(env, stage_length);
       (*env)->SetByteArrayRegion(env, jstage, 0, stage_length, (jbyte *)event->app.release_stage);
 
-      jstring jevent_path = (*env)->NewStringUTF(env, event_path);
+      jstring japi_key = (*env)->NewStringUTF(env, event->api_key);
       (*env)->CallStaticVoidMethod(env, interface_class, jdeliver_method,
-                                   jstage, jpayload, jevent_path);
-      (*env)->DeleteLocalRef(env, jevent_path);
+                                   jstage, jpayload, japi_key);
+      (*env)->DeleteLocalRef(env, japi_key);
       (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload, 0); // <-- frees payload
       (*env)->ReleaseByteArrayElements(env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
       (*env)->DeleteLocalRef(env, jpayload);

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -158,6 +158,16 @@ void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
   event->unhandled_events = unhandled_count;
 }
 
+char *bugsnag_event_get_api_key(void *event_ptr) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  return event->api_key;
+}
+
+void bugsnag_event_set_api_key(void *event_ptr, char *value) {
+  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bsg_strncpy_safe(event->api_key, value, sizeof(event->api_key));
+}
+
 char *bugsnag_event_get_context(void *event_ptr) {
   bugsnag_event *event = (bugsnag_event *) event_ptr;
   return event->context;

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -32,7 +32,7 @@
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
-#define BUGSNAG_EVENT_VERSION 3
+#define BUGSNAG_EVENT_VERSION 4
 
 
 #ifdef __cplusplus
@@ -206,7 +206,7 @@ typedef struct {
     int unhandled_events;
     char grouping_hash[64];
     bool unhandled;
-    char api_key[64]; // TODO add migration here!!!
+    char api_key[64];
 } bugsnag_event;
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -206,6 +206,7 @@ typedef struct {
     int unhandled_events;
     char grouping_hash[64];
     bool unhandled;
+    char api_key[64]; // TODO add migration here!!!
 } bugsnag_event;
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -155,6 +155,31 @@ typedef struct {
     int unhandled_events;
 } bugsnag_report_v2;
 
+typedef struct {
+    bsg_notifier notifier;
+    bsg_app_info app;
+    bsg_device_info device;
+    bugsnag_user user;
+    bsg_error error;
+    bugsnag_metadata metadata;
+
+    int crumb_count;
+    // Breadcrumbs are a ring; the first index moves as the
+    // structure is filled and replaced.
+    int crumb_first_index;
+    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+    char context[64];
+    bugsnag_severity severity;
+
+    char session_id[33];
+    char session_start[33];
+    int handled_events;
+    int unhandled_events;
+    char grouping_hash[64];
+    bool unhandled;
+} bugsnag_report_v3;
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -34,11 +34,7 @@ void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *even
 #endif
 
 bool bsg_serialize_event_to_file(bsg_environment *env) {
-  // the filename uses the following format:
-  // <UUID>_<api_key>.crash
-  char path[384];
-  sprintf(path, "%s_%s.crash", env->next_event_path, env->next_event.api_key);
-  int fd = open(path, O_WRONLY | O_CREAT, 0644);
+  int fd = open(env->next_event_path, O_WRONLY | O_CREAT, 0644);
   if (fd == -1) {
     return false;
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -33,7 +33,11 @@ void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2, bugsnag_event *event);
 #endif
 
 bool bsg_serialize_event_to_file(bsg_environment *env) {
-  int fd = open(env->next_event_path, O_WRONLY | O_CREAT, 0644);
+  // the filename uses the following format:
+  // <UUID>_<api_key>.crash
+  char path[384];
+  sprintf(path, "%s_%s.crash", env->next_event_path, env->next_event.api_key);
+  int fd = open(path, O_WRONLY | O_CREAT, 0644);
   if (fd == -1) {
     return false;
   }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -6,6 +6,7 @@
 
 bugsnag_event *init_event() {
     bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+    bsg_strncpy_safe(event->api_key, "5d1e5fbd39a74caa1200142706a90b20", sizeof(event->api_key));
     bsg_strncpy_safe(event->context, "Foo", sizeof(event->context));
     bsg_strncpy_safe(event->user.id, "123", sizeof(event->user.id));
     bsg_strncpy_safe(event->user.email, "jane@example.com", sizeof(event->user.email));
@@ -48,6 +49,15 @@ bugsnag_event *init_event() {
     bsg_strncpy_safe(event->error.stacktrace->filename, "Something.c", sizeof(event->error.stacktrace->filename));
     event->error.stacktrace->line_number = 58;
     return event;
+}
+
+TEST test_event_api_key(void) {
+    bugsnag_event *event = init_event();
+    ASSERT_STR_EQ("5d1e5fbd39a74caa1200142706a90b20", bugsnag_event_get_api_key(event));
+    bugsnag_event_set_api_key(event, "00fab5bd39a74caa1200142706a90b20");
+    ASSERT_STR_EQ("00fab5bd39a74caa1200142706a90b20", bugsnag_event_get_api_key(event));
+    free(event);
+    PASS();
 }
 
 TEST test_event_context(void) {
@@ -368,6 +378,7 @@ TEST test_event_stacktrace(void) {
 }
 
 SUITE(event_mutators) {
+    RUN_TEST(test_event_api_key);
     RUN_TEST(test_event_context);
     RUN_TEST(test_event_severity);
     RUN_TEST(test_event_unhandled);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -30,6 +30,15 @@ bool bsg_report_v2_write(bsg_report_header *header, bugsnag_report_v2 *report,
   return len == sizeof(bugsnag_report_v2);
 }
 
+bool bsg_report_v3_write(bsg_report_header *header, bugsnag_report_v3 *report,
+                         int fd) {
+    if (!bsg_report_header_write(header, fd)) {
+        return false;
+    }
+    ssize_t len = write(fd, report, sizeof(bugsnag_report_v3));
+    return len == sizeof(bugsnag_report_v3);
+}
+
 bool bsg_serialize_report_v1_to_file(bsg_environment *env, bugsnag_report_v1 *report) {
   int fd = open(env->next_event_path, O_WRONLY | O_CREAT, 0644);
   if (fd == -1) {
@@ -44,6 +53,14 @@ bool bsg_serialize_report_v2_to_file(bsg_environment *env, bugsnag_report_v2 *re
     return false;
   }
   return bsg_report_v2_write(&env->report_header, report, fd);
+}
+
+bool bsg_serialize_report_v3_to_file(bsg_environment *env, bugsnag_report_v3 *report) {
+    int fd = open(env->next_event_path, O_WRONLY | O_CREAT, 0644);
+    if (fd == -1) {
+        return false;
+    }
+    return bsg_report_v3_write(&env->report_header, report, fd);
 }
 
 
@@ -94,6 +111,13 @@ void generate_basic_report(bugsnag_event *event) {
   strcpy(event->notifier.url, "bugsnag.com");
   strcpy(event->notifier.name, "Test Notifier");
 }
+
+bugsnag_report_v3 *bsg_generate_report_v3(void) {
+    bugsnag_report_v3 *report = calloc(1, sizeof(bugsnag_report_v3));
+    generate_basic_report((bugsnag_event *) report);
+    return report;
+}
+
 
 bugsnag_report_v2 *bsg_generate_report_v2(void) {
   bugsnag_report_v2 *report = calloc(1, sizeof(bugsnag_report_v2));
@@ -253,6 +277,37 @@ TEST test_report_v2_migration(void) {
   PASS();
 }
 
+TEST test_report_v3_migration(void) {
+  bsg_environment *env = malloc(sizeof(bsg_environment));
+  env->report_header.version = 3;
+  env->report_header.big_endian = 1;
+  strcpy(env->report_header.os_build, "macOS Sierra");
+
+  bugsnag_report_v3 *generated_report = bsg_generate_report_v3();
+  memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v3));
+  strcpy(env->next_event_path, OLD_TEST_FILE);
+  bsg_serialize_report_v3_to_file(env, generated_report);
+
+  bugsnag_event *event = bsg_deserialize_event_from_file(OLD_TEST_FILE);
+  ASSERT(event != NULL);
+
+  // api key is set to sensible default
+  ASSERT_STR_EQ("", event->api_key);
+
+  // other fields appear reasonable and are copied over
+  ASSERT_STR_EQ("Test Notifier", event->notifier.name);
+  ASSERT_STR_EQ("bugsnag.com", event->notifier.url);
+  ASSERT_STR_EQ("1.0", event->notifier.version);
+  ASSERT_STR_EQ("SIGBUS", event->error.errorClass);
+  ASSERT_STR_EQ("POSIX is serious about oncoming traffic", event->error.errorMessage);
+  ASSERT_STR_EQ("C", event->error.type);
+
+  free(generated_report);
+  free(env);
+  free(event);
+  PASS();
+}
+
 // helper function
 JSON_Value *bsg_generate_json(void) {
   bugsnag_event *event = bsg_generate_event();
@@ -383,6 +438,7 @@ SUITE(serialize_utils) {
   RUN_TEST(test_file_to_report);
   RUN_TEST(test_report_v1_migration);
   RUN_TEST(test_report_v2_migration);
+  RUN_TEST(test_report_v3_migration);
   RUN_TEST(test_session_handled_counts);
   RUN_TEST(test_context_to_json);
   RUN_TEST(test_grouping_hash_to_json);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -3,10 +3,7 @@
 #include <stdlib.h>
 #include <utils/migrate.h>
 
-#define OLD_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo.crash"
-
-#define SERIALIZE_NEW_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo"
-#define DESERIALIZE_NEW_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo_5d1e5fbd39a74caa1200142706a90b20.crash"
+#define SERIALIZE_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo.crash"
 
 bugsnag_breadcrumb *init_breadcrumb(const char *name, char *message, bugsnag_breadcrumb_type type);
 
@@ -175,7 +172,7 @@ TEST test_report_to_file(void) {
   bugsnag_event *report = bsg_generate_event();
   memcpy(&env->next_event, report, sizeof(bugsnag_event));
   strcpy(env->report_header.os_build, "macOS Sierra");
-  strcpy(env->next_event_path, SERIALIZE_NEW_TEST_FILE);
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
   ASSERT(bsg_serialize_event_to_file(env));
   free(report);
   free(env);
@@ -189,10 +186,10 @@ TEST test_file_to_report(void) {
   strcpy(env->report_header.os_build, "macOS Sierra");
   bugsnag_event *generated_report = bsg_generate_event();
   memcpy(&env->next_event, generated_report, sizeof(bugsnag_event));
-  strcpy(env->next_event_path, SERIALIZE_NEW_TEST_FILE);
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
   bsg_serialize_event_to_file(env);
 
-  bugsnag_event *report = bsg_deserialize_event_from_file(DESERIALIZE_NEW_TEST_FILE);
+  bugsnag_event *report = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
   ASSERT(report != NULL);
   ASSERT(strcmp("SIGBUS", report->error.errorClass) == 0);
   ASSERT(strcmp("POSIX is serious about oncoming traffic", report->error.errorMessage) == 0);
@@ -209,10 +206,10 @@ TEST test_report_v1_migration(void) {
   strcpy(env->report_header.os_build, "macOS Sierra");
   bugsnag_report_v1 *generated_report = bsg_generate_report_v1();
   memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v1));
-  strcpy(env->next_event_path, OLD_TEST_FILE);
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
   bsg_serialize_report_v1_to_file(env, generated_report);
 
-  bugsnag_event *event = bsg_deserialize_event_from_file(OLD_TEST_FILE);
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
   ASSERT(event != NULL);
   ASSERT(strcmp("f1ab", event->session_id) == 0);
   ASSERT(strcmp("2019-03-19T12:58:19+00:00", event->session_start) == 0);
@@ -233,10 +230,10 @@ TEST test_report_v2_migration(void) {
 
   bugsnag_report_v2 *generated_report = bsg_generate_report_v2();
   memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v2));
-  strcpy(env->next_event_path, OLD_TEST_FILE);
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
   bsg_serialize_report_v2_to_file(env, generated_report);
 
-  bugsnag_event *event = bsg_deserialize_event_from_file(OLD_TEST_FILE);
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
   ASSERT(event != NULL);
 
   // bsg_library -> bsg_notifier
@@ -285,10 +282,10 @@ TEST test_report_v3_migration(void) {
 
   bugsnag_report_v3 *generated_report = bsg_generate_report_v3();
   memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v3));
-  strcpy(env->next_event_path, OLD_TEST_FILE);
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
   bsg_serialize_report_v3_to_file(env, generated_report);
 
-  bugsnag_event *event = bsg_deserialize_event_from_file(OLD_TEST_FILE);
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
   ASSERT(event != NULL);
 
   // api key is set to sensible default


### PR DESCRIPTION
## Goal

Adds support for changing the apiKey on events from the NDK layer. #928 added equivalent functionality for JVM events.

## Changeset

The changeset consists mainly of five alterations:

1. Passing the api key to the NDK layer via a `StateEvent.Install` message
2. Populating the api key on the `bugsnag_event` struct, which requires a migration for legacy persisted structs
3. Adding accessors to the NDK API for altering the API key on an event
4. Decoding the apiKey from C struct in `deliverPendingReports()` and pass to the JVM layer along with the deserialized event payload

## Testing

Existing unit and integration tests have been updated to match the new assertions. New test cases have also been added for additional coverage and to verify the NDK migration.

Manual testing also covered:

- Unhandled NDK events are delivered
- API key can be changed on an Unhandled NDK event
- Unhandled NDK events using v3 of the `bugsnag_event` struct are delivered