### PR TITLE
Take maze runner image from releases repository

### DIFF
--- a/dockerfiles/Dockerfile.android-maze-runner
+++ b/dockerfiles/Dockerfile.android-maze-runner
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli as android-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as android-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 
 COPY features features


### PR DESCRIPTION
## Goal

Take the Maze Runner image from its releases repository.

## Design

maze-runner-releases is a new ECR repository of ours that is dedicated to releases and separate to images built for development branches.  It means that releases will not get swept away as part of our housekeeping policy.

## Changeset

Maze Runner docker file(s).

## Testing

Covered by standard CI.