### PR TITLE
Use MazeRunner v3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,7 +262,7 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v3.3.0:
         run: android-maze-runner
-    command: bundle exec bugsnag-maze-runner --app=/app/build/fixture.apk --farm=bs --device=ANDROID_6_0 --username=$BROWSER_STACK_USERNAME --access-key=$BROWSER_STACK_ACCESS_KEY
+        command: ["--app=/app/build/fixture.apk", "--farm=bs", "--device=ANDROID_6_0", "--username=$BROWSER_STACK_USERNAME", "--access-key=$BROWSER_STACK_ACCESS_KEY"]
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,26 +35,26 @@ steps:
           push:
             - android-ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-${BRANCH_NAME}
 
-  - label: ':android: Android size reporting'
-    depends_on: "android-ci"
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-sizer
+#  - label: ':android: Android size reporting'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 10
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-sizer
 
-  - label: ':docker: Build Android JVM test image'
-    key: "android-jvm"
-    depends_on: "android-ci"
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.3.0:
-          build: android-jvm
-          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
-          cache-from:
-            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
-      - docker-compose#v3.3.0:
-          push:
-            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
+#  - label: ':docker: Build Android JVM test image'
+#    key: "android-jvm"
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 10
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          build: android-jvm
+#          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
+#          cache-from:
+#            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
+#      - docker-compose#v3.3.0:
+#          push:
+#            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
 
   - label: ':android: Build fixture APK'
     key: "fixture-apk"
@@ -67,192 +67,192 @@ steps:
     env:
       MAVEN_VERSION: "3.6.1"
 
-  - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-      NDK_VERSION: r12b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-      NDK_VERSION: r12b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-      NDK_VERSION: r12b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-      NDK_VERSION: r16b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-      NDK_VERSION: r16b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-      NDK_VERSION: r16b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-      NDK_VERSION: r16b
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-      NDK_VERSION: r19
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-      NDK_VERSION: r19
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-      NDK_VERSION: r19
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 21d SDK 10.0 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
-      NDK_VERSION: r21d
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: NDK 21d SDK 11.0 Instrumentation tests'
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel 4-11.0"]'
-      NDK_VERSION: r21d
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: Linter'
-    depends_on: "android-jvm"
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-jvm
-    command: 'bash ./scripts/run-linter.sh'
-
-  - label: ':android: JVM tests'
-    depends_on: "android-jvm"
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.3.0:
-          run: android-jvm
-    command: './gradlew test'
-
-  - label: ':android: Android 5 end-to-end tests'
-    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
-    depends_on: "fixture-apk"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_5_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
+#  - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+#      NDK_VERSION: r12b
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+#      NDK_VERSION: r12b
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+#      NDK_VERSION: r12b
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+#      NDK_VERSION: r16b
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+#      NDK_VERSION: r16b
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+#      NDK_VERSION: r16b
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+#      NDK_VERSION: r16b
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+#      NDK_VERSION: r19
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+#      NDK_VERSION: r19
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+#      NDK_VERSION: r19
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 21d SDK 10.0 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
+#      NDK_VERSION: r21d
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: NDK 21d SDK 11.0 Instrumentation tests'
+#    depends_on: "android-ci"
+#    timeout_in_minutes: 30
+#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-ci
+#    env:
+#      INSTRUMENTATION_DEVICES: '["Google Pixel 4-11.0"]'
+#      NDK_VERSION: r21d
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: Linter'
+#    depends_on: "android-jvm"
+#    timeout_in_minutes: 10
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-jvm
+#    command: 'bash ./scripts/run-linter.sh'
+#
+#  - label: ':android: JVM tests'
+#    depends_on: "android-jvm"
+#    timeout_in_minutes: 10
+#    plugins:
+#      - docker-compose#v3.3.0:
+#          run: android-jvm
+#    command: './gradlew test'
+#
+#  - label: ':android: Android 5 end-to-end tests'
+#    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
+#    depends_on: "fixture-apk"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_5_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 6 end-to-end tests'
     depends_on: "fixture-apk"
@@ -262,100 +262,104 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v3.3.0:
         run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_6_0"
-      APP_LOCATION: "/app/build/fixture.apk"
+    command: >-
+      bundle exec bugsnag-maze-runner
+      --app=/app/build/fixture.apk
+      --farm=bs
+      --device=ANDROID_6_0
+      --username=$BROWSER_STACK_USERNAME
+      --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Android 7 end-to-end tests'
-    depends_on: "fixture-apk"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_7_1"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: Android 8.0 end-to-end tests'
-    depends_on: "fixture-apk"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_8_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
-
-  - label: ':android: Android 8.1 end-to-end tests'
-    depends_on: "fixture-apk"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_8_1"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
-
-  - label: ':android: Android 9 end-to-end tests'
-    depends_on: "fixture-apk"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_9_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-
-  - label: ':android: Android 10 end-to-end tests'
-    depends_on: "fixture-apk"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_10_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
-
-  - label: ':android: Android 11 end-to-end tests'
-    depends_on: "fixture-apk"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/fixture.apk"
-      docker-compose#v3.3.0:
-        run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_11_0"
-      APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 10
-    concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
+#  - label: ':android: Android 7 end-to-end tests'
+#    depends_on: "fixture-apk"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_7_1"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: Android 8.0 end-to-end tests'
+#    depends_on: "fixture-apk"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_8_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#    soft_fail:
+#      - exit_status: "*"
+#
+#  - label: ':android: Android 8.1 end-to-end tests'
+#    depends_on: "fixture-apk"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_8_1"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#    soft_fail:
+#      - exit_status: "*"
+#
+#  - label: ':android: Android 9 end-to-end tests'
+#    depends_on: "fixture-apk"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_9_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#
+#  - label: ':android: Android 10 end-to-end tests'
+#    depends_on: "fixture-apk"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_10_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#    soft_fail:
+#      - exit_status: "*"
+#
+#  - label: ':android: Android 11 end-to-end tests'
+#    depends_on: "fixture-apk"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.2.0:
+#        download: "build/fixture.apk"
+#      docker-compose#v3.3.0:
+#        run: android-maze-runner
+#    env:
+#      DEVICE_TYPE: "ANDROID_11_0"
+#      APP_LOCATION: "/app/build/fixture.apk"
+#    concurrency: 10
+#    concurrency_group: 'browserstack-app'
+#    soft_fail:
+#      - exit_status: "*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,7 +262,12 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v3.3.0:
         run: android-maze-runner
-        command: ["--app=/app/build/fixture.apk", "--farm=bs", "--device=ANDROID_6_0", "--username=$BROWSER_STACK_USERNAME", "--access-key=$BROWSER_STACK_ACCESS_KEY"]
+        command: >-
+          --app=/app/build/fixture.apk
+          --farm=bs
+          --device=ANDROID_6_0
+          --username=$BROWSER_STACK_USERNAME
+          --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,13 +262,7 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v3.3.0:
         run: android-maze-runner
-    command: >-
-      bundle exec bugsnag-maze-runner
-      --app=/app/build/fixture.apk
-      --farm=bs
-      --device=ANDROID_6_0
-      --username=$BROWSER_STACK_USERNAME
-      --access-key=$BROWSER_STACK_ACCESS_KEY
+    command: bundle exec bugsnag-maze-runner --app=/app/build/fixture.apk --farm=bs --device=ANDROID_6_0 --username=$BROWSER_STACK_USERNAME --access-key=$BROWSER_STACK_ACCESS_KEY
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -262,12 +262,12 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v3.3.0:
         run: android-maze-runner
-        command: >-
-          --app=/app/build/fixture.apk
-          --farm=bs
-          --device=ANDROID_6_0
-          --username=$BROWSER_STACK_USERNAME
-          --access-key=$BROWSER_STACK_ACCESS_KEY
+        command:
+        - "--app=/app/build/fixture.apk"
+        - "--farm=bs"
+        - "--device=ANDROID_6_0"
+        - "--username=$BROWSER_STACK_USERNAME"
+        - "--access-key=$BROWSER_STACK_ACCESS_KEY"
     concurrency: 10
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,26 +35,26 @@ steps:
           push:
             - android-ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-${BRANCH_NAME}
 
-#  - label: ':android: Android size reporting'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 10
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-sizer
+  - label: ':android: Android size reporting'
+    depends_on: "android-ci"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-sizer
 
-#  - label: ':docker: Build Android JVM test image'
-#    key: "android-jvm"
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 10
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          build: android-jvm
-#          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
-#          cache-from:
-#            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
-#      - docker-compose#v3.3.0:
-#          push:
-#            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
+  - label: ':docker: Build Android JVM test image'
+    key: "android-jvm"
+    depends_on: "android-ci"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          build: android-jvm
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
+          cache-from:
+            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
+      - docker-compose#v3.3.0:
+          push:
+            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-jvm-${BRANCH_NAME}
 
   - label: ':android: Build fixture APK'
     key: "fixture-apk"
@@ -67,192 +67,192 @@ steps:
     env:
       MAVEN_VERSION: "3.6.1"
 
-#  - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-#      NDK_VERSION: r12b
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-#      NDK_VERSION: r12b
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-#      NDK_VERSION: r12b
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-#      NDK_VERSION: r16b
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-#      NDK_VERSION: r16b
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-#      NDK_VERSION: r16b
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-#      NDK_VERSION: r16b
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
-#      NDK_VERSION: r19
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-#      NDK_VERSION: r19
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
-#      NDK_VERSION: r19
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 21d SDK 10.0 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
-#      NDK_VERSION: r21d
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: NDK 21d SDK 11.0 Instrumentation tests'
-#    depends_on: "android-ci"
-#    timeout_in_minutes: 30
-#    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-ci
-#    env:
-#      INSTRUMENTATION_DEVICES: '["Google Pixel 4-11.0"]'
-#      NDK_VERSION: r21d
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: Linter'
-#    depends_on: "android-jvm"
-#    timeout_in_minutes: 10
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-jvm
-#    command: 'bash ./scripts/run-linter.sh'
-#
-#  - label: ':android: JVM tests'
-#    depends_on: "android-jvm"
-#    timeout_in_minutes: 10
-#    plugins:
-#      - docker-compose#v3.3.0:
-#          run: android-jvm
-#    command: './gradlew test'
-#
-#  - label: ':android: Android 5 end-to-end tests'
-#    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
-#    depends_on: "fixture-apk"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_5_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
+  - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r12b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r12b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r12b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r16b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r16b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r16b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r16b
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
+      NDK_VERSION: r19
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
+      NDK_VERSION: r19
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
+      NDK_VERSION: r19
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 21d SDK 10.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 4-10.0"]'
+      NDK_VERSION: r21d
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: NDK 21d SDK 11.0 Instrumentation tests'
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-ci
+    env:
+      INSTRUMENTATION_DEVICES: '["Google Pixel 4-11.0"]'
+      NDK_VERSION: r21d
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Linter'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-jvm
+    command: 'bash ./scripts/run-linter.sh'
+
+  - label: ':android: JVM tests'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-jvm
+    command: './gradlew test'
+
+  - label: ':android: Android 5 end-to-end tests'
+    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
+    depends_on: "fixture-apk"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+    env:
+      DEVICE_TYPE: "ANDROID_5_0"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 6 end-to-end tests'
     depends_on: "fixture-apk"
@@ -271,94 +271,112 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-#  - label: ':android: Android 7 end-to-end tests'
-#    depends_on: "fixture-apk"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_7_1"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: Android 8.0 end-to-end tests'
-#    depends_on: "fixture-apk"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_8_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#    soft_fail:
-#      - exit_status: "*"
-#
-#  - label: ':android: Android 8.1 end-to-end tests'
-#    depends_on: "fixture-apk"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_8_1"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#    soft_fail:
-#      - exit_status: "*"
-#
-#  - label: ':android: Android 9 end-to-end tests'
-#    depends_on: "fixture-apk"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_9_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#
-#  - label: ':android: Android 10 end-to-end tests'
-#    depends_on: "fixture-apk"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_10_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#    soft_fail:
-#      - exit_status: "*"
-#
-#  - label: ':android: Android 11 end-to-end tests'
-#    depends_on: "fixture-apk"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.2.0:
-#        download: "build/fixture.apk"
-#      docker-compose#v3.3.0:
-#        run: android-maze-runner
-#    env:
-#      DEVICE_TYPE: "ANDROID_11_0"
-#      APP_LOCATION: "/app/build/fixture.apk"
-#    concurrency: 10
-#    concurrency_group: 'browserstack-app'
-#    soft_fail:
-#      - exit_status: "*"
+  - label: ':android: Android 7 end-to-end tests'
+    depends_on: "fixture-apk"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+        command:
+          - "--app=/app/build/fixture.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_7_1"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 8.0 end-to-end tests'
+    depends_on: "fixture-apk"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+        command:
+          - "--app=/app/build/fixture.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_8_0"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
+
+  - label: ':android: Android 8.1 end-to-end tests'
+    depends_on: "fixture-apk"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+        command:
+          - "--app=/app/build/fixture.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_8_1"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
+
+  - label: ':android: Android 9 end-to-end tests'
+    depends_on: "fixture-apk"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+        command:
+          - "--app=/app/build/fixture.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_9_0"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 10 end-to-end tests'
+    depends_on: "fixture-apk"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+        command:
+          - "--app=/app/build/fixture.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_10_0"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
+
+  - label: ':android: Android 11 end-to-end tests'
+    depends_on: "fixture-apk"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+        command:
+          - "--app=/app/build/fixture.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_11_0"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"

--- a/dockerfiles/Dockerfile.android-maze-runner
+++ b/dockerfiles/Dockerfile.android-maze-runner
@@ -1,6 +1,4 @@
-# CI test image for unit/lint/type tests
 #FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as android-maze-runner
 FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-os-version-cli as android-maze-runner
-#RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 
 COPY features features

--- a/dockerfiles/Dockerfile.android-maze-runner
+++ b/dockerfiles/Dockerfile.android-maze-runner
@@ -1,5 +1,6 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as android-maze-runner
+#FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as android-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-os-version-cli as android-maze-runner
 #RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 
 COPY features features

--- a/dockerfiles/Dockerfile.android-maze-runner
+++ b/dockerfiles/Dockerfile.android-maze-runner
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as android-maze-runner
-RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as android-maze-runner
+#RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 
 COPY features features

--- a/dockerfiles/Dockerfile.android-maze-runner
+++ b/dockerfiles/Dockerfile.android-maze-runner
@@ -1,4 +1,3 @@
-#FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as android-maze-runner
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-os-version-cli as android-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli as android-maze-runner
 
 COPY features features

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,42 +1,23 @@
 # Configure app environment
-bs_username = ENV['BROWSER_STACK_USERNAME']
-bs_access_key = ENV['BROWSER_STACK_ACCESS_KEY']
-bs_local_id = ENV['BROWSER_STACK_LOCAL_IDENTIFIER'] || 'maze_browser_stack_test_id'
-bs_device = ENV['DEVICE_TYPE']
-app_location = ENV['APP_LOCATION']
-
 # Set this explicitly
 $api_key = "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
-After do |scenario|
-  $driver.reset
-end
-
 Before('@skip_above_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") if %w[ANDROID_9_0 ANDROID_10_0 ANDROID_11_0].include? bs_device
+  skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version >= 9
 end
 
 Before('@skip_above_android_7') do |scenario|
-  skip_this_scenario("Skipping scenario") if %w[ANDROID_8_0 ANDROID_8_1 ANDROID_9_0 ANDROID_10_0 ANDROID_11_0].include? bs_device
+  skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version >= 8
 end
 
 Before('@skip_below_android_9') do |scenario|
-  skip_this_scenario("Skipping scenario") unless %w[ANDROID_9_0 ANDROID_10_0 ANDROID_11_0].include? bs_device
+  skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version < 9
 end
 
 Before('@skip_below_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") unless %w[ANDROID_8_0 ANDROID_8_1 ANDROID_9_0 ANDROID_10_0 ANDROID_11_0].include? bs_device
+  skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version < 8
 end
 
 Before('@skip_android_8_1') do |scenario|
-  skip_this_scenario("Skipping scenario") if %w[ANDROID_8_1].include? bs_device
-end
-
-AfterConfiguration do |config|
-  AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
-  $driver.start_driver
-end
-
-at_exit do
-  $driver.driver_quit
+  skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version == 8.1
 end


### PR DESCRIPTION
## Goal

This is a relatively straightforward move to using MazeRunner v3.

## Design

MazeRunner v3 internalizes the interaction with the Appium driver, meaning that we move from setting environment variables to passing in command line options.  Also, because v3 is more agnostic of specific device farms, it means we need to stop using the `DEVICE_HASH`entries (`ANDROID_6_0` etc) in areas of common code as these are  BrowserStack specific.  v3 provides `MazeRunner.config` to pull certain values from instead.

## Changeset

CI pipeline, Docker file and `env.rb` - the touch points with MazeRunner.

## Testing

Covered by passing CI, although I have also performed some basic sanity checks that any failures needing retries are covered by existing tickets and that the number of scenario run is the same as before the change.