### PR TITLE
Default to allowing requests when checking connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Increase breadcrumb time precision to milliseconds
   [#954](https://github.com/bugsnag/bugsnag-android/pull/954)
 
+* Default to allowing requests when checking connectivity
+  [#970](https://github.com/bugsnag/bugsnag-android/pull/970)
+
 ## 5.2.2 (2020-10-19)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
@@ -93,14 +93,11 @@ internal class ConnectivityApi24(
     callback: NetworkChangeCallback?
 ) : Connectivity {
 
-    @JvmField
-    @Volatile
-    internal var activeNetwork: Network? = null
     private val networkCallback = ConnectivityTrackerCallback(callback)
 
     override fun registerForNetworkChanges() = cm.registerDefaultNetworkCallback(networkCallback)
     override fun unregisterForNetworkChanges() = cm.unregisterNetworkCallback(networkCallback)
-    override fun hasNetworkConnection() = activeNetwork != null
+    override fun hasNetworkConnection() = cm.activeNetwork != null
 
     override fun retrieveNetworkAccessState(): String {
         val network = cm.activeNetwork
@@ -119,13 +116,11 @@ internal class ConnectivityApi24(
         ConnectivityManager.NetworkCallback() {
         override fun onUnavailable() {
             super.onUnavailable()
-            activeNetwork = null
             cb?.invoke(false, retrieveNetworkAccessState())
         }
 
         override fun onAvailable(network: Network?) {
             super.onAvailable(network)
-            activeNetwork = network
             cb?.invoke(true, retrieveNetworkAccessState())
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityApi24Test.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityApi24Test.kt
@@ -35,8 +35,7 @@ class ConnectivityApi24Test {
     fun connectivityLegacyHasConnection() {
         val conn = ConnectivityApi24(cm, null)
         assertFalse(conn.hasNetworkConnection())
-
-        conn.activeNetwork = info;
+        Mockito.`when`(cm.activeNetwork).thenReturn(info)
         assertTrue(conn.hasNetworkConnection())
     }
 


### PR DESCRIPTION
## Goal

Alters the behaviour in the `ConnectivityApi24` class so that requests are allowed by default. The previous implementation has a bug where `hasNetworkConnection()` would return false until the `onAvailable()` callback had been invoked by the Android framework. This has been resolved by querying `connectivityManager#getActiveNetwork()`, which will return null if there is no system default network available.

## Testing

Relied on existing E2E scenarios. Attempted running the artefact in a local app with and without network connection and confirmed that request delivery was done accordingly.