### PR TITLE
Reinstate fast-failing e2e tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -248,9 +248,13 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v3.3.0:
         run: android-maze-runner
-    env:
-      DEVICE_TYPE: "ANDROID_5_0"
-      APP_LOCATION: "/app/build/fixture.apk"
+        command:
+          - "--app=/app/build/fixture.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_5_0"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -268,6 +272,8 @@ steps:
         - "--device=ANDROID_6_0"
         - "--username=$BROWSER_STACK_USERNAME"
         - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+        - "--fail-fast"
+
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -285,6 +291,7 @@ steps:
           - "--device=ANDROID_7_1"
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -302,6 +309,7 @@ steps:
           - "--device=ANDROID_8_0"
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -321,6 +329,7 @@ steps:
           - "--device=ANDROID_8_1"
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -340,6 +349,7 @@ steps:
           - "--device=ANDROID_9_0"
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
@@ -357,6 +367,7 @@ steps:
           - "--device=ANDROID_10_0"
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -376,6 +387,7 @@ steps:
           - "--device=ANDROID_11_0"
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
     soft_fail:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,6 @@ services:
       BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}
       DEVICE_TYPE:
       APP_LOCATION:
-    command: ["--tags", "not @ignore", "--fail-fast"]
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output


### PR DESCRIPTION
## Goal

Reinstates the `fail-fast` option, which was accidentally overridden when moving to Maze Runner v3.

## Design

Removed the `command` entry from `docker-compose.yml`, which is a bit hidden away as it is, and added to the command arrays in the build steps.  I have omitted the `--tags` option to reduce noise in the pipeline, as the use of `@ignore` appears to be historical.

## Changeset

Docker compose file and e2e testing steps in the pipeline.

## Testing

Covered by standard CI.