### PR TITLE
Support passing siginfo_t *info and void *user_context from the ANR signal handler to the JVM side.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+ * Support native stack traces in the ANR plugin
+   [#972](https://github.com/bugsnag/bugsnag-android/pull/972)
+
 ## 5.2.3 (2020-10-29)
 
 ### Bug fixes

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -46,7 +46,8 @@ internal class AnrPlugin : Plugin {
      * Notifies bugsnag that an ANR has occurred, by generating an Error report and populating it
      * with details of the ANR. Intended for internal use only.
      */
-    private fun notifyAnrDetected() {
+    @Suppress("UNUSED_PARAMETER")
+    private fun notifyAnrDetected(info: Long, userContext: Long) {
         val thread = Looper.getMainLooper().thread
 
         // generate a full report as soon as possible, then wait for extra process error info


### PR DESCRIPTION
## Goal

This is the first step to supporting native stack traces in ANRs caused by native code. The fields `siginfo_t *info` and `void *user_context` are required in order to produce a native stack trace. Since we don't want to tie the ANR plugin to the native plugin, we need to temporarily pass these pointers through the JVM into the NDK plugin (only when it's available)


## Design

Both pointers are passed to the Java side as `long` values.

## Testing

ran unit tests, ran example app triggering both native and JVM ANR, observed them on the dashboard.
