### PR TITLE
Flush persisted sessions on launch and on connectivity changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Flush persisted sessions on launch and on connectivity changes
+  [#973](https://github.com/bugsnag/bugsnag-android/pull/973)
+
 * Increase breadcrumb time precision to milliseconds
   [#954](https://github.com/bugsnag/bugsnag-android/pull/954)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -126,6 +126,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 leaveAutoBreadcrumb("Connectivity changed", BreadcrumbType.STATE, data);
                 if (hasConnection) {
                     eventStore.flushAsync();
+                    sessionTracker.flushAsync();
                 }
                 return null;
             }
@@ -241,9 +242,11 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         // initialise plugins before attempting to flush any errors
         loadPlugins(configuration);
 
-        // Flush any on-disk errors
         connectivity.registerForNetworkChanges();
+
+        // Flush any on-disk errors and sessions
         eventStore.flushOnLaunch();
+        sessionTracker.flushAsync();
 
         // leave auto breadcrumb
         Map<String, Object> data = Collections.emptyMap();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -230,6 +230,22 @@ class SessionTracker extends BaseObservable {
     }
 
     /**
+     * Asynchronously flushes any session payloads stored on disk
+     */
+    void flushAsync() {
+        try {
+            Async.run(new Runnable() {
+                @Override
+                public void run() {
+                    flushStoredSessions();
+                }
+            });
+        } catch (RejectedExecutionException ex) {
+            logger.w("Failed to flush session reports", ex);
+        }
+    }
+
+    /**
      * Attempts to flush session payloads stored on disk
      */
     void flushStoredSessions() {


### PR DESCRIPTION
## Goal

Session payloads are persisted on disk if a request to bugsnag was unsuccessful. Delivery of these is only attempted currently when a new session is captured. To increase the speed with which requests are received, delivery should also be attempted on `Client` initialization` and whenever connectivity changes.

## Changeset

Called `flushAsync()` in the client constructor and connectivity change callback. Access to this method is guarded by a Semaphore so concurrent calls will be ignored.

## Testing

Relied on existing E2E tests, and manually verified that an undelivered session is now delivered when the client is launched or the connectivity is regained.