### PR TITLE
Temporary soft fail for Android 6/7

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -256,8 +256,6 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 5 end-to-end tests'
     depends_on: "fixture-apk"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -239,8 +239,27 @@ steps:
           run: android-jvm
     command: './gradlew test'
 
+  - label: ':android: Android 4.4 end-to-end tests'
+    depends_on: "fixture-apk"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v3.3.0:
+        run: android-maze-runner
+        command:
+          - "--app=/app/build/fixture.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_4_4"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--fail-fast"
+    concurrency: 10
+    concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
+
   - label: ':android: Android 5 end-to-end tests'
-    skip: Temporarily disabled due to flakiness with BrowserStack tunneling
     depends_on: "fixture-apk"
     timeout_in_minutes: 60
     plugins:
@@ -257,6 +276,8 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 6 end-to-end tests'
     depends_on: "fixture-apk"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -273,9 +273,13 @@ steps:
         - "--username=$BROWSER_STACK_USERNAME"
         - "--access-key=$BROWSER_STACK_ACCESS_KEY"
         - "--fail-fast"
-
     concurrency: 10
     concurrency_group: 'browserstack-app'
+    #
+    # TODO: Remove as soon as possible - working around BrowserStack network problem
+    #
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 7 end-to-end tests'
     depends_on: "fixture-apk"
@@ -294,6 +298,11 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
+    #
+    # TODO: Remove as soon as possible - working around BrowserStack network problem
+    #
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 8.0 end-to-end tests'
     depends_on: "fixture-apk"


### PR DESCRIPTION
## Goal

Mitigate the impact of an issue with Android 6 and 7 on BrowserStack meaning that we are currently unable to test on them.

## Design

Temporarily adds soft fails to Android 6 and 7, which should be removed as soon as the BrowserStack issue is resolved.

I have added Android 4.4, which passed on the first attempt and so have not introduced a soft fail at this stage.  Android 5 appears to have the same problem as 6 and 7, but have added with soft fail for completeness.

## Changeset

CI pipeline only.

## Testing

No direct impact on the notifier and part of a larger picture for doing the testing we need before release without holding up engineering operations unduly.