### PR TITLE
Refactor Stacktrace to not require logger

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -33,7 +33,7 @@
     <ID>TooGenericExceptionCaught:DeviceDataCollector.kt$DeviceDataCollector$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:ManifestConfigLoader.kt$ManifestConfigLoader$exc: Exception</ID>
     <ID>TooGenericExceptionCaught:PluginClient.kt$PluginClient$exc: Throwable</ID>
-    <ID>TooGenericExceptionCaught:Stacktrace.kt$Stacktrace$lineEx: Exception</ID>
+    <ID>TooGenericExceptionCaught:Stacktrace.kt$Stacktrace.Companion$lineEx: Exception</ID>
     <ID>TooGenericExceptionThrown:BreadcrumbStateTest.kt$BreadcrumbStateTest$throw Exception("Oh no")</ID>
     <ID>TooManyFunctions:ConfigInternal.kt$ConfigInternal : CallbackAwareMetadataAwareUserAware</ID>
     <ID>TooManyFunctions:DeviceDataCollector.kt$DeviceDataCollector</ID>

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadTest.java
@@ -27,7 +27,8 @@ public class ThreadTest {
         };
 
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
-        Stacktrace trace = new Stacktrace(stacktrace, Collections.<String>emptyList(),
+        Stacktrace trace = Stacktrace.Companion.stacktraceFromJavaTrace(stacktrace,
+                Collections.<String>emptyList(),
                 NoopLogger.INSTANCE);
         Thread thread = new Thread(24, "main-one", ThreadType.ANDROID, true, trace,
                 NoopLogger.INSTANCE);
@@ -59,7 +60,8 @@ public class ThreadTest {
         };
 
         ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
-        Stacktrace trace = new Stacktrace(stacktrace, Collections.<String>emptyList(),
+        Stacktrace trace = Stacktrace.Companion.stacktraceFromJavaTrace(stacktrace,
+                Collections.<String>emptyList(),
                 NoopLogger.INSTANCE);
         Thread thread = new Thread(24, "main-one", ThreadType.ANDROID,false, trace,
                 NoopLogger.INSTANCE);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
@@ -15,7 +15,7 @@ internal class ErrorInternal @JvmOverloads internal constructor(
 
             var currentEx: Throwable? = exc
             while (currentEx != null) {
-                val trace = Stacktrace(currentEx.stackTrace, projectPackages, logger)
+                val trace = Stacktrace.stacktraceFromJavaTrace(currentEx.stackTrace, projectPackages, logger)
                 errors.add(ErrorInternal(currentEx.javaClass.name, currentEx.localizedMessage, trace))
                 currentEx = currentEx.cause
             }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
@@ -27,23 +27,44 @@ internal class Stacktrace : JsonStream.Streamable {
             }
             return null
         }
+
+        fun stacktraceFromJavaTrace(
+            stacktrace: Array<StackTraceElement>,
+            projectPackages: Collection<String>,
+            logger: Logger): Stacktrace {
+            val frames = stacktrace.mapNotNull { serializeStackframe(it, projectPackages, logger) }
+            return Stacktrace(frames)
+        }
+
+        private fun serializeStackframe(
+            el: StackTraceElement,
+            projectPackages: Collection<String>,
+            logger: Logger
+        ): Stackframe? {
+            try {
+                val methodName = when {
+                    el.className.isNotEmpty() -> el.className + "." + el.methodName
+                    else -> el.methodName
+                }
+
+                return Stackframe(
+                    methodName,
+                    if (el.fileName == null) "Unknown" else el.fileName,
+                    el.lineNumber,
+                    inProject(el.className, projectPackages)
+                )
+            } catch (lineEx: Exception) {
+                logger.w("Failed to serialize stacktrace", lineEx)
+                return null
+            }
+        }
+
     }
 
     val trace: List<Stackframe>
-    val logger: Logger
 
-    constructor(
-        stacktrace: Array<StackTraceElement>,
-        projectPackages: Collection<String>,
-        logger: Logger
-    ) {
-        trace = limitTraceLength(stacktrace.mapNotNull { serializeStackframe(it, projectPackages) })
-        this.logger = logger
-    }
-
-    constructor(frames: List<Stackframe>, logger: Logger) {
+    constructor(frames: List<Stackframe>) {
         trace = limitTraceLength(frames)
-        this.logger = logger
     }
 
     private fun <T> limitTraceLength(frames: List<T>): List<T> {
@@ -60,25 +81,4 @@ internal class Stacktrace : JsonStream.Streamable {
         writer.endArray()
     }
 
-    private fun serializeStackframe(
-        el: StackTraceElement,
-        projectPackages: Collection<String>
-    ): Stackframe? {
-        try {
-            val methodName = when {
-                el.className.isNotEmpty() -> el.className + "." + el.methodName
-                else -> el.methodName
-            }
-
-            return Stackframe(
-                methodName,
-                if (el.fileName == null) "Unknown" else el.fileName,
-                el.lineNumber,
-                inProject(el.className, projectPackages)
-            )
-        } catch (lineEx: Exception) {
-            logger.w("Failed to serialize stacktrace", lineEx)
-            return null
-        }
-    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -57,7 +57,7 @@ internal class ThreadState @JvmOverloads constructor(
         return stackTraces.keys
             .sortedBy { it.id }
             .map {
-                val stacktrace = Stacktrace(stackTraces[it]!!, projectPackages, logger)
+                val stacktrace = Stacktrace.stacktraceFromJavaTrace(stackTraces[it]!!, projectPackages, logger)
                 val errorThread = it.id == currentThreadId
                 Thread(it.id, it.name, ThreadType.ANDROID, errorThread, stacktrace, logger)
             }.toMutableList()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -25,7 +25,7 @@ public class ErrorFacadeTest {
         logger = new InterceptingLogger();
         trace = Collections.emptyList();
         ErrorInternal impl = new ErrorInternal("com.bar.CrashyClass",
-                "Whoops", new Stacktrace(trace, logger), ErrorType.ANDROID);
+                "Whoops", new Stacktrace(trace), ErrorType.ANDROID);
         error = new Error(impl, logger);
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
@@ -14,7 +14,7 @@ internal class ErrorSerializationTest {
         @Parameters
         fun testCases() = generateSerializationTestCases(
             "error",
-            Error(ErrorInternal("foo", "bar", Stacktrace(listOf(), NoopLogger)), NoopLogger)
+            Error(ErrorInternal("foo", "bar", Stacktrace(listOf())), NoopLogger)
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -37,7 +37,7 @@ internal class EventSerializationTest {
 
                 // threads included
                 createEvent {
-                    val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
+                    val stacktrace = Stacktrace.stacktraceFromJavaTrace(arrayOf(), emptySet(), NoopLogger)
                     it.threads.clear()
                     it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, stacktrace, NoopLogger))
                 },
@@ -52,7 +52,7 @@ internal class EventSerializationTest {
                     val crumb = Breadcrumb("hello world", BreadcrumbType.MANUAL, mutableMapOf(), Date(0), NoopLogger)
                     it.breadcrumbs = listOf(crumb)
 
-                    val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
+                    val stacktrace = Stacktrace.stacktraceFromJavaTrace(arrayOf(), emptySet(), NoopLogger)
                     val err = Error(ErrorInternal("WhoopsException", "Whoops", stacktrace), NoopLogger)
                     it.errors.clear()
                     it.errors.add(err)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
@@ -43,10 +43,11 @@ public class NullMetadataTest {
         HandledState handledState = HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION);
         Event event = new Event(new RuntimeException(), config, handledState, NoopLogger.INSTANCE);
         List<String> projectPackages = Collections.emptyList();
-        Stacktrace stacktrace = new Stacktrace(new StackTraceElement[]{}, projectPackages,
+        Stacktrace trace = Stacktrace.Companion.stacktraceFromJavaTrace(new StackTraceElement[]{},
+                projectPackages,
                 NoopLogger.INSTANCE);
         Error err = new Error(new ErrorInternal("RuntimeException", "Something broke",
-                stacktrace), NoopLogger.INSTANCE);
+                trace), NoopLogger.INSTANCE);
         event.getErrors().clear();
         event.getErrors().add(err);
         validateDefaultMetadata(event);

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceSerializationTest.kt
@@ -18,10 +18,10 @@ internal class StacktraceSerializationTest {
                 "stacktrace",
 
                 // empty stacktrace element ctor
-                Stacktrace(arrayOf(), emptySet(), NoopLogger),
+                Stacktrace.stacktraceFromJavaTrace(arrayOf(), emptySet(), NoopLogger),
 
                 // empty custom frames ctor
-                Stacktrace(listOf(frame), NoopLogger),
+                Stacktrace(listOf(frame)),
 
                 // basic
                 basic(),
@@ -36,13 +36,13 @@ internal class StacktraceSerializationTest {
         }
 
         private fun basic() =
-            Stacktrace(
+                Stacktrace.stacktraceFromJavaTrace(
                 RuntimeException("Whoops").stackTrace.sliceArray(IntRange(0, 1)),
                 emptySet(),
                 NoopLogger
             )
 
-        private fun inProject() = Stacktrace(
+        private fun inProject() = Stacktrace.stacktraceFromJavaTrace(
             RuntimeException("Whoops").stackTrace.sliceArray(IntRange(0, 1)),
             setOf("com.bugsnag.android"),
             NoopLogger
@@ -52,14 +52,14 @@ internal class StacktraceSerializationTest {
             val elements = (0..999).map {
                 StackTraceElement("SomeClass", "someMethod", "someFile", it)
             }
-            return Stacktrace(elements.toTypedArray(), emptyList(), NoopLogger)
+            return Stacktrace.stacktraceFromJavaTrace(elements.toTypedArray(), emptyList(), NoopLogger)
         }
 
         private fun trimStacktraceListCtor(): Stacktrace {
             val elements = (0..999).map {
                 Stackframe("Foo", "Bar.kt", it, true)
             }
-            return Stacktrace(elements, NoopLogger)
+            return Stacktrace(elements)
         }
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceTest.kt
@@ -11,7 +11,7 @@ class StacktraceTest {
         for (i in 1..300) {
             stackList.add(Stackframe("A", "B", i, true))
         }
-        val stacktrace = Stacktrace(stackList, NoopLogger)
+        val stacktrace = Stacktrace(stackList)
         // Confirm the length of the stackList
         assertEquals(300, stackList.size)
         assertEquals(200, stacktrace.trace.size)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -26,7 +26,7 @@ public class ThreadFacadeTest {
     public void setUp() {
         logger = new InterceptingLogger();
         List<Stackframe> frames = Collections.emptyList();
-        stacktrace = new Stacktrace(frames, logger);
+        stacktrace = new Stacktrace(frames);
         thread = new Thread(1, "thread-2", ThreadType.ANDROID, false, stacktrace, logger);
     }
 
@@ -76,7 +76,7 @@ public class ThreadFacadeTest {
     public void stacktraceValid() {
         assertEquals(stacktrace.getTrace(), thread.getStacktrace());
         List<Stackframe> frames = Collections.emptyList();
-        Stacktrace other = new Stacktrace(frames, logger);
+        Stacktrace other = new Stacktrace(frames);
         thread.setStacktrace(other.getTrace());
         assertEquals(other.getTrace(), thread.getStacktrace());
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
@@ -19,7 +19,7 @@ internal class ThreadSerializationTest {
                 StackTraceElement("App", "launch", "App.java", 70)
             )
 
-            val thread = Thread(24, "main-one", ThreadType.ANDROID, true, Stacktrace(
+            val thread = Thread(24, "main-one", ThreadType.ANDROID, true, Stacktrace.stacktraceFromJavaTrace(
                 stacktrace,
                 emptySet(),
                 NoopLogger
@@ -31,7 +31,7 @@ internal class ThreadSerializationTest {
                 StackTraceElement("App", "launch", "App.java", 70)
             )
 
-            val thread1 = Thread(24, "main-one", ThreadType.ANDROID, false, Stacktrace(
+            val thread1 = Thread(24, "main-one", ThreadType.ANDROID, false, Stacktrace.stacktraceFromJavaTrace(
                 stacktrace1,
                 emptySet(),
                 NoopLogger

--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -7,10 +7,8 @@
     <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is AddBreadcrumb -&gt; addBreadcrumb(makeSafe(msg.message), makeSafe(msg.type.toString()), makeSafe(msg.timestamp), msg.metadata)</ID>
     <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is StartSession -&gt; startedSession(makeSafe(msg.id), makeSafe(msg.startedAt), msg.handledCount, msg.unhandledCount)</ID>
     <ID>NestedBlockDepth:NativeBridge.kt$NativeBridge$private fun deliverPendingReports()</ID>
-    <ID>NewLineAtEndOfFile:VerifyUtils.kt$com.bugsnag.android.ndk.VerifyUtils.kt</ID>
     <ID>ReturnCount:NativeBridge.kt$NativeBridge$private fun isInvalidMessage(msg: Any?): Boolean</ID>
     <ID>TooGenericExceptionCaught:NativeBridge.kt$NativeBridge$ex: Exception</ID>
     <ID>TooManyFunctions:NativeBridge.kt$NativeBridge : Observer</ID>
-    <ID>WildcardImport:NativeBridge.kt$import com.bugsnag.android.StateEvent.*</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
@@ -28,7 +28,7 @@ class ErrorDeserializer implements MapDeserializer<Error> {
         ErrorInternal impl = new ErrorInternal(
                 MapUtils.<String>getOrThrow(map, "errorClass"),
                 MapUtils.<String>getOrNull(map, "errorMessage"),
-                new Stacktrace(frames, logger),
+                new Stacktrace(frames),
                 ErrorType.valueOf(type.toUpperCase(Locale.US))
         );
         return new Error(impl, logger);

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeErrorDeserializer.java
@@ -38,7 +38,7 @@ class NativeErrorDeserializer implements MapDeserializer<Error> {
             frames.add(deserializeStackframe(frame, projectPackages));
         }
 
-        Stacktrace trace = new Stacktrace(frames, logger);
+        Stacktrace trace = new Stacktrace(frames);
         ErrorInternal impl = new ErrorInternal(
                 jsError.getErrorClass(),
                 jsError.getErrorMessage(),

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -32,7 +32,7 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
                 MapUtils.<String>getOrThrow(map, "name"),
                 ThreadType.valueOf(type.toUpperCase(Locale.US)),
                 errorReportingThread,
-                new Stacktrace(frames, logger),
+                new Stacktrace(frames),
                 logger
         );
     }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
@@ -41,7 +41,7 @@ class TestData {
         ErrorInternal impl = new ErrorInternal(
                 "BrowserException",
                 "whoops!",
-                new Stacktrace(frames, NoopLogger.INSTANCE),
+                new Stacktrace(frames),
                 ErrorType.REACTNATIVEJS
         );
         return new Error(impl, NoopLogger.INSTANCE);

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
@@ -35,7 +35,7 @@ public class ThreadSerializerTest {
 
         Stackframe stackframe = new Stackframe("foo()", "Bar.kt", 55, true);
         List<Stackframe> frames = Collections.singletonList(stackframe);
-        Stacktrace stacktrace = new Stacktrace(frames, NoopLogger.INSTANCE);
+        Stacktrace stacktrace = new Stacktrace(frames);
         thread = new Thread(1, "fake-thread", ThreadType.ANDROID,
                 true, stacktrace, NoopLogger.INSTANCE);
     }


### PR DESCRIPTION
## Goal

The new ANR native trace functionality will require native code to produce `Stacktrace` objects, however the constructors for `Stacktrace` require a logger, which is only used when converting JVM stack traces. Rather than passing a logger through native code, it's cleaner to move the "Java trace to Bugsnag trace format" code into a helper function.

## Design

This change moves the "java to bugsnag" constructor into a helper function in the object's companion. The `Stacktrace` object itself is now a POJO, containing data only.

## Testing

- Ran unit tests
- Ran example app, triggering crashes and verifying that the stack traces are correct in Java and native crashes.
