### PR TITLE
Add integrity header to verify Error and Session payloads have not changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
-## TBD
+## 5.3.0 (TBD)
 
 * Add integrity header to verify Error API payloads have not changed
   [#978](https://github.com/bugsnag/bugsnag-android/pull/978)
-
-## 5.2.3 (2020-10-29)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Add integrity header to verify Error API payloads have not changed
+  [#978](https://github.com/bugsnag/bugsnag-android/pull/978)
+
 ## 5.2.3 (2020-10-29)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.3.0 (TBD)
 
-* Add integrity header to verify Error API payloads have not changed
+* Add integrity header to verify Error and Session API payloads have not changed
   [#978](https://github.com/bugsnag/bugsnag-android/pull/978)
 
 ### Bug fixes

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -25,7 +25,7 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun shouldDiscardClass(): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>
     <ID>ProtectedMemberInFinalClass:PluginClient.kt$PluginClient$protected val plugins: Set&lt;Plugin&gt;</ID>
-    <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String&gt; ): DeliveryStatus</ID>
+    <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?&gt; ): DeliveryStatus</ID>
     <ID>ReturnCount:DeviceDataCollector.kt$DeviceDataCollector$ private fun isRooted(): Boolean</ID>
     <ID>TooGenericExceptionCaught:AppDataCollector.kt$AppDataCollector$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:CallbackState.kt$CallbackState$ex: Throwable</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
-import java.io.BufferedWriter
 import java.io.IOException
+import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.HttpURLConnection.HTTP_BAD_REQUEST
@@ -9,6 +9,8 @@ import java.net.HttpURLConnection.HTTP_CLIENT_TIMEOUT
 import java.net.HttpURLConnection.HTTP_OK
 import java.net.URL
 import java.nio.charset.Charset
+import java.security.DigestOutputStream
+import java.security.MessageDigest
 
 internal class DefaultDelivery(private val connectivity: Connectivity?, val logger: Logger) : Delivery {
 
@@ -27,7 +29,7 @@ internal class DefaultDelivery(private val connectivity: Connectivity?, val logg
     fun deliver(
         urlString: String,
         streamable: JsonStream.Streamable,
-        headers: Map<String, String>
+        headers: Map<String, String?>
     ): DeliveryStatus {
 
         if (connectivity != null && !connectivity.hasNetworkConnection()) {
@@ -43,19 +45,13 @@ internal class DefaultDelivery(private val connectivity: Connectivity?, val logg
             conn.addRequestProperty("Content-Type", "application/json")
 
             headers.forEach { (key, value) ->
-                conn.addRequestProperty(key, value)
+                if (value != null) {
+                    conn.addRequestProperty(key, value)
+                }
             }
 
-            var stream: JsonStream? = null
-
-            try {
-                val out = conn.outputStream
-                val charset = Charset.forName("UTF-8")
-                val writer = BufferedWriter(OutputStreamWriter(out, charset))
-                stream = JsonStream(writer)
-                streamable.toStream(stream)
-            } finally {
-                IOUtils.closeQuietly(stream)
+            conn.outputStream.bufferedWriter().use { writer ->
+                streamable.toStream(JsonStream(writer))
             }
 
             // End the request, get the response code

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
@@ -1,16 +1,11 @@
 package com.bugsnag.android
 
 import java.io.IOException
-import java.io.OutputStream
-import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.HttpURLConnection.HTTP_BAD_REQUEST
 import java.net.HttpURLConnection.HTTP_CLIENT_TIMEOUT
 import java.net.HttpURLConnection.HTTP_OK
 import java.net.URL
-import java.nio.charset.Charset
-import java.security.DigestOutputStream
-import java.security.MessageDigest
 
 internal class DefaultDelivery(private val connectivity: Connectivity?, val logger: Logger) : Delivery {
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -75,8 +75,7 @@ class DeliveryDelegate extends BaseObservable {
 
     @VisibleForTesting
     DeliveryStatus deliverPayloadInternal(@NonNull EventPayload payload, @NonNull Event event) {
-        String apiKey = payload.getApiKey();
-        DeliveryParams deliveryParams = immutableConfig.getErrorApiDeliveryParams(apiKey);
+        DeliveryParams deliveryParams = immutableConfig.getErrorApiDeliveryParams(payload);
         Delivery delivery = immutableConfig.getDelivery();
         DeliveryStatus deliveryStatus = delivery.deliver(payload, deliveryParams);
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryHeaders.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryHeaders.kt
@@ -30,13 +30,14 @@ internal fun errorApiHeaders(payload: EventPayload): Map<String, String?> {
  *
  * @return the HTTP headers
  */
-internal fun sessionApiHeaders(apiKey: String): Map<String, String?> = mapOf(
+internal fun sessionApiHeaders(apiKey: String, payload: Session): Map<String, String?> = mapOf(
     HEADER_API_PAYLOAD_VERSION to "1.0",
     HEADER_API_KEY to apiKey,
-    HEADER_BUGSNAG_SENT_AT to DateUtils.toIso8601(Date())
+    HEADER_BUGSNAG_SENT_AT to DateUtils.toIso8601(Date()),
+    HEADER_BUGSNAG_INTEGRITY to computeSha1Digest(payload)
 )
 
-internal fun computeSha1Digest(payload: EventPayload): String? {
+internal fun computeSha1Digest(payload: JsonStream.Streamable): String? {
     runCatching {
         val shaDigest = MessageDigest.getInstance("SHA-1")
         val builder = StringBuilder("sha1 ")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryHeaders.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryHeaders.kt
@@ -1,9 +1,13 @@
 package com.bugsnag.android
 
+import java.io.OutputStream
+import java.security.DigestOutputStream
+import java.security.MessageDigest
 import java.util.Date
 
 private const val HEADER_API_PAYLOAD_VERSION = "Bugsnag-Payload-Version"
 private const val HEADER_BUGSNAG_SENT_AT = "Bugsnag-Sent-At"
+private const val HEADER_BUGSNAG_INTEGRITY = "Bugsnag-Integrity"
 internal const val HEADER_API_KEY = "Bugsnag-Api-Key"
 internal const val HEADER_INTERNAL_ERROR = "Bugsnag-Internal-Error"
 
@@ -12,19 +16,44 @@ internal const val HEADER_INTERNAL_ERROR = "Bugsnag-Internal-Error"
  *
  * @return the HTTP headers
  */
-internal fun errorApiHeaders(apiKey: String) = mapOf(
-    HEADER_API_PAYLOAD_VERSION to "4.0",
-    HEADER_API_KEY to apiKey,
-    HEADER_BUGSNAG_SENT_AT to DateUtils.toIso8601(Date())
-)
+internal fun errorApiHeaders(payload: EventPayload): Map<String, String?> {
+    return mapOf(
+        HEADER_API_PAYLOAD_VERSION to "4.0",
+        HEADER_API_KEY to payload.apiKey,
+        HEADER_BUGSNAG_SENT_AT to DateUtils.toIso8601(Date()),
+        HEADER_BUGSNAG_INTEGRITY to computeSha1Digest(payload)
+    )
+}
 
 /**
  * Supplies the headers which must be used in any request sent to the Session Tracking API.
  *
  * @return the HTTP headers
  */
-internal fun sessionApiHeaders(apiKey: String) = mapOf(
+internal fun sessionApiHeaders(apiKey: String): Map<String, String?> = mapOf(
     HEADER_API_PAYLOAD_VERSION to "1.0",
     HEADER_API_KEY to apiKey,
     HEADER_BUGSNAG_SENT_AT to DateUtils.toIso8601(Date())
 )
+
+internal fun computeSha1Digest(payload: EventPayload): String? {
+    runCatching {
+        val shaDigest = MessageDigest.getInstance("SHA-1")
+        val builder = StringBuilder("sha1 ")
+
+        // Pipe the object through a no-op output stream
+        DigestOutputStream(NullOutputStream(), shaDigest).use { stream ->
+            stream.bufferedWriter().use { writer ->
+                payload.toStream(JsonStream(writer))
+            }
+            shaDigest.digest().forEach { byte ->
+                builder.append(String.format("%02x", byte))
+            }
+        }
+        return builder.toString()
+    }.getOrElse { return null }
+}
+
+internal class NullOutputStream : OutputStream() {
+    override fun write(b: Int) = Unit
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryParams.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryParams.kt
@@ -13,5 +13,5 @@ class DeliveryParams(
     /**
      * The HTTP headers which must be attached to the request
      */
-    val headers: Map<String, String>
+    val headers: Map<String, String?>
 )

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -154,7 +154,7 @@ class EventStore extends FileStore {
             }
 
             EventPayload payload = new EventPayload(apiKey, eventFile, notifier);
-            DeliveryParams deliveryParams = config.getErrorApiDeliveryParams(payload.getApiKey());
+            DeliveryParams deliveryParams = config.getErrorApiDeliveryParams(payload);
             DeliveryStatus deliveryStatus = config.getDelivery().deliver(payload, deliveryParams);
 
             switch (deliveryStatus) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -3,8 +3,6 @@ package com.bugsnag.android
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import java.util.Date
-import java.util.HashMap
 
 internal data class ImmutableConfig(
     val apiKey: String,
@@ -43,8 +41,8 @@ internal data class ImmutableConfig(
         enabledBreadcrumbTypes == null || enabledBreadcrumbTypes.contains(type)
 
     @JvmName("getErrorApiDeliveryParams")
-    internal fun getErrorApiDeliveryParams(apiKey: String) =
-        DeliveryParams(endpoints.notify, errorApiHeaders(apiKey))
+    internal fun getErrorApiDeliveryParams(payload: EventPayload) =
+        DeliveryParams(endpoints.notify, errorApiHeaders(payload))
 
     @JvmName("getSessionApiDeliveryParams")
     internal fun getSessionApiDeliveryParams() =

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -45,8 +45,8 @@ internal data class ImmutableConfig(
         DeliveryParams(endpoints.notify, errorApiHeaders(payload))
 
     @JvmName("getSessionApiDeliveryParams")
-    internal fun getSessionApiDeliveryParams() =
-        DeliveryParams(endpoints.sessions, sessionApiHeaders(apiKey))
+    internal fun getSessionApiDeliveryParams(session: Session) =
+        DeliveryParams(endpoints.sessions, sessionApiHeaders(apiKey, session))
 }
 
 internal fun convertToImmutableConfig(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -97,15 +97,14 @@ class InternalReportDelegate implements EventStore.Delegate {
         event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "notifierVersion", notifier.getVersion());
         event.addMetadata(INTERNAL_DIAGNOSTICS_TAB, "apiKey", immutableConfig.getApiKey());
 
-        final EventPayload eventPayload = new EventPayload(null, event, notifier);
+        final EventPayload payload = new EventPayload(null, event, notifier);
         try {
             Async.run(new Runnable() {
                 @Override
                 public void run() {
                     try {
                         Delivery delivery = immutableConfig.getDelivery();
-                        String apiKey = eventPayload.getApiKey();
-                        DeliveryParams params = immutableConfig.getErrorApiDeliveryParams(apiKey);
+                        DeliveryParams params = immutableConfig.getErrorApiDeliveryParams(payload);
 
                         // can only modify headers if DefaultDelivery is in use
                         if (delivery instanceof DefaultDelivery) {
@@ -113,7 +112,7 @@ class InternalReportDelegate implements EventStore.Delegate {
                             headers.put(HEADER_INTERNAL_ERROR, "true");
                             headers.remove(DeliveryHeadersKt.HEADER_API_KEY);
                             DefaultDelivery defaultDelivery = (DefaultDelivery) delivery;
-                            defaultDelivery.deliver(params.getEndpoint(), eventPayload, headers);
+                            defaultDelivery.deliver(params.getEndpoint(), payload, headers);
                         }
 
                     } catch (Exception exception) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,7 +7,7 @@ import java.io.IOException
  */
 class Notifier @JvmOverloads constructor(
     var name: String = "Android Bugsnag Notifier",
-    var version: String = "5.2.3",
+    var version: String = "5.3.0",
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -291,7 +291,7 @@ class SessionTracker extends BaseObservable {
     }
 
     DeliveryStatus deliverSessionPayload(Session payload) {
-        DeliveryParams params = configuration.getSessionApiDeliveryParams();
+        DeliveryParams params = configuration.getSessionApiDeliveryParams(payload);
         Delivery delivery = configuration.getDelivery();
         return delivery.deliver(payload, params);
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -26,6 +26,22 @@ final class BugsnagTestUtils {
         return convert(generateConfiguration());
     }
 
+    static EventPayload generateEventPayload(ImmutableConfig config) {
+        return new EventPayload(config.getApiKey(), generateEvent(), new Notifier());
+    }
+
+    static Event generateEvent() {
+        Throwable exc = new RuntimeException();
+        Event event = new Event(
+                exc,
+                BugsnagTestUtils.generateImmutableConfig(),
+                HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION),
+                NoopLogger.INSTANCE
+        );
+        event.setApp(generateAppWithState());
+        event.setDevice(generateDeviceWithState());
+        return event;
+    }
 
     static ImmutableConfig convert(Configuration config) {
         return ImmutableConfigKt.convertToImmutableConfig(config, null);

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryHeadersTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryHeadersTest.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeliveryHeadersTest {
+
+    private val sha1Regex = "sha1 [0-9a-f]{40}".toRegex()
+
+    @Test
+    fun computeSha1Digest() {
+        val payload = BugsnagTestUtils.generateEventPayload(generateImmutableConfig())
+        val firstSha = requireNotNull(computeSha1Digest(payload))
+        val secondSha = requireNotNull(computeSha1Digest(payload))
+
+        // the hash equals the expected value
+        assertTrue(firstSha.matches(sha1Regex))
+
+        // the hash is consistent
+        assertEquals(firstSha, secondSha)
+
+        // altering the streamable alters the hash
+        payload.event!!.device.id = "50923"
+        val differentSha = requireNotNull(computeSha1Digest(payload))
+        assertNotEquals(firstSha, differentSha)
+        assertTrue(differentSha.matches(sha1Regex))
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryHeadersTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryHeadersTest.kt
@@ -1,10 +1,12 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Date
 
 class DeliveryHeadersTest {
 
@@ -27,5 +29,32 @@ class DeliveryHeadersTest {
         val differentSha = requireNotNull(computeSha1Digest(payload))
         assertNotEquals(firstSha, differentSha)
         assertTrue(differentSha.matches(sha1Regex))
+    }
+
+    @Test
+    fun verifyErrorApiHeaders() {
+        val config = convertToImmutableConfig(BugsnagTestUtils.generateConfiguration())
+        val payload = BugsnagTestUtils.generateEventPayload(config)
+        val headers = config.getErrorApiDeliveryParams(payload).headers
+        assertEquals(config.apiKey, headers["Bugsnag-Api-Key"])
+        Assert.assertNotNull(headers["Bugsnag-Sent-At"])
+        Assert.assertNotNull(headers["Bugsnag-Payload-Version"])
+
+        val integrity = requireNotNull(headers["Bugsnag-Integrity"])
+        assertTrue(integrity.matches(sha1Regex))
+    }
+
+    @Test
+    fun verifySessionApiHeaders() {
+        val config = generateImmutableConfig()
+        val user = User("123", "hi@foo.com", "Li")
+        val session = Session("abc", Date(0), user, 1, 0, Notifier(), NoopLogger)
+        val headers = config.getSessionApiDeliveryParams(session).headers
+        assertEquals(config.apiKey, headers["Bugsnag-Api-Key"])
+        Assert.assertNotNull(headers["Bugsnag-Sent-At"])
+        Assert.assertNotNull(headers["Bugsnag-Payload-Version"])
+
+        val integrity = requireNotNull(headers["Bugsnag-Integrity"])
+        assertTrue(integrity.matches(sha1Regex))
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -139,30 +139,6 @@ internal class ImmutableConfigTest {
     }
 
     @Test
-    fun verifyErrorApiHeaders() {
-        val config = convertToImmutableConfig(seed)
-        val payload = BugsnagTestUtils.generateEventPayload(config)
-        val headers = config.getErrorApiDeliveryParams(payload).headers
-        assertEquals(config.apiKey, headers["Bugsnag-Api-Key"])
-        assertNotNull(headers["Bugsnag-Sent-At"])
-        assertNotNull(headers["Bugsnag-Payload-Version"])
-
-        val integrity = requireNotNull(headers["Bugsnag-Integrity"])
-        val sha1Regex = "sha1 [0-9a-f]{40}".toRegex()
-        assertTrue(integrity.matches(sha1Regex))
-    }
-
-    @Test
-    fun verifySessionApiHeaders() {
-        val config = convertToImmutableConfig(seed)
-        val headers = config.getSessionApiDeliveryParams().headers
-        assertEquals(config.apiKey, headers["Bugsnag-Api-Key"])
-        assertNotNull(headers["Bugsnag-Sent-At"])
-        assertNotNull(headers["Bugsnag-Payload-Version"])
-        assertNull(headers["Bugsnag-Integrity"])
-    }
-
-    @Test
     fun configSanitisation() {
         `when`(context.packageName).thenReturn("com.example.foo")
         `when`(context.packageManager).thenReturn(packageManager)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -141,10 +141,15 @@ internal class ImmutableConfigTest {
     @Test
     fun verifyErrorApiHeaders() {
         val config = convertToImmutableConfig(seed)
-        val headers = config.getErrorApiDeliveryParams(config.apiKey).headers
+        val payload = BugsnagTestUtils.generateEventPayload(config)
+        val headers = config.getErrorApiDeliveryParams(payload).headers
         assertEquals(config.apiKey, headers["Bugsnag-Api-Key"])
         assertNotNull(headers["Bugsnag-Sent-At"])
         assertNotNull(headers["Bugsnag-Payload-Version"])
+
+        val integrity = requireNotNull(headers["Bugsnag-Integrity"])
+        val sha1Regex = "sha1 [0-9a-f]{40}".toRegex()
+        assertTrue(integrity.matches(sha1Regex))
     }
 
     @Test
@@ -154,6 +159,7 @@ internal class ImmutableConfigTest {
         assertEquals(config.apiKey, headers["Bugsnag-Api-Key"])
         assertNotNull(headers["Bugsnag-Sent-At"])
         assertNotNull(headers["Bugsnag-Payload-Version"])
+        assertNull(headers["Bugsnag-Integrity"])
     }
 
     @Test

--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -7,10 +7,8 @@
     <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is AddBreadcrumb -&gt; addBreadcrumb(makeSafe(msg.message), makeSafe(msg.type.toString()), makeSafe(msg.timestamp), msg.metadata)</ID>
     <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is StartSession -&gt; startedSession(makeSafe(msg.id), makeSafe(msg.startedAt), msg.handledCount, msg.unhandledCount)</ID>
     <ID>NestedBlockDepth:NativeBridge.kt$NativeBridge$private fun deliverPendingReports()</ID>
-    <ID>NewLineAtEndOfFile:VerifyUtils.kt$com.bugsnag.android.ndk.VerifyUtils.kt</ID>
     <ID>ReturnCount:NativeBridge.kt$NativeBridge$private fun isInvalidMessage(msg: Any?): Boolean</ID>
     <ID>TooGenericExceptionCaught:NativeBridge.kt$NativeBridge$ex: Exception</ID>
     <ID>TooManyFunctions:NativeBridge.kt$NativeBridge : Observer</ID>
-    <ID>WildcardImport:NativeBridge.kt$import com.bugsnag.android.StateEvent.*</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -4,6 +4,7 @@ Scenario: Automatic Session Tracking sends
     When I run "AutoSessionScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
+    And the "Bugsnag-Integrity" header is a SHA-1 digest
     And the payload field "notifier.name" equals "Android Bugsnag Notifier"
     And the payload field "sessions" is an array with 1 elements
     And the session "user.id" equals "123"
@@ -16,6 +17,7 @@ Scenario: Manual Session sends
     When I run "ManualSessionScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
+    And the "Bugsnag-Integrity" header is a SHA-1 digest
     And the payload field "sessions" is an array with 1 elements
     And the session "user.id" equals "123"
     And the session "user.email" equals "user@example.com"
@@ -27,11 +29,13 @@ Scenario: Set Auto Capture Sessions sends
     When I run "SessionSetAutoCaptureScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
+    And the "Bugsnag-Integrity" header is a SHA-1 digest
 
 Scenario: User is persisted between sessions
     When I run "SessionPersistUserScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
+    And the "Bugsnag-Integrity" header is a SHA-1 digest
     And the session "user.id" equals "12345"
     And the session "user.email" equals "test@test.test"
     And the session "user.name" equals "test user"
@@ -41,6 +45,7 @@ Scenario: User is persisted between sessions
     And I run "SessionPersistUserScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
+    And the "Bugsnag-Integrity" header is a SHA-1 digest
     And the session "user.id" equals "12345"
     And the session "user.email" equals "test@test.test"
     And the session "user.name" equals "test user"
@@ -49,6 +54,7 @@ Scenario: User is not persisted between sessions
     When I run "SessionPersistUserDisabledScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
+    And the "Bugsnag-Integrity" header is a SHA-1 digest
     And the session "user.id" equals "12345"
     And the session "user.email" equals "test@test.test"
     And the session "user.name" equals "test user"
@@ -58,6 +64,7 @@ Scenario: User is not persisted between sessions
     And I run "SessionPersistUserDisabledScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
+    And the "Bugsnag-Integrity" header is a SHA-1 digest
     And the session "user.id" is not null
     And the session "user.name" is null
     And the session "user.email" is null

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -185,6 +185,7 @@ Then("the request is valid for the error reporting API version {string} for the 
     And the payload contains the payloadVersion "#{payload_version}"
     And the "Content-Type" header equals "application/json"
     And the "Bugsnag-Sent-At" header is a timestamp
+    And the "Bugsnag-Integrity" header is a SHA-1 digest
 
     And the payload field "notifier.name" equals "#{notifier_name}"
     And the payload field "notifier.url" is not null
@@ -196,6 +197,12 @@ Then("the request is valid for the error reporting API version {string} for the 
     And each element in payload field "events" has "unhandled"
     And each element in payload field "events" has "exceptions"
   }
+end
+
+Then('the {string} header is a SHA-1 digest') do |header_name|
+  header = Server.current_request[:request][header_name]
+  SHA1_REGEX = /^sha1 [0-9a-f]{40}$/
+  assert_match(SHA1_REGEX, header)
 end
 
 Then("the event has {int} breadcrumbs") do |expected_count|

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx4096m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-VERSION_NAME=5.2.3
+VERSION_NAME=5.3.0
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git


### PR DESCRIPTION
## Goal

Adds the `Bugsnag-Integrity` header to Error API requests whose value is a SHA-1 digest of the payload. If the payload is altered in transit then it will be rejected by the server.

## Changeset

- Added method for computing SHA-1 digest from an `EventPayload` to `DeliveryHeaders` by using a `DigestOutputStream` with a no-op output
- Added `Bugsnag-Integrity` to the request headers for each Error API request
- Simplified `DefaultDelivery` implementation by using [kotlin stdlib](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/use.html) functions

## Testing

Added unit tests to cover generation of the SHA-1 digest, and updated E2E scenarios so that they assert the header is set on error report payloads. Additionally verified via Android Studio's Profiler that an error request contains the header and the payload is received by the dashboard.