### PR TITLE
Add configuration option to control maximum number of persisted events/sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Add configuration option to control maximum number of persisted events/sessions
+  [#980](https://github.com/bugsnag/bugsnag-android/pull/980)
+
 ## 5.3.0 (TBD)
 
 * Add integrity header to verify Error and Session API payloads have not changed

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -49,6 +49,19 @@ final class BugsnagTestUtils {
         return new JSONArray(streamableToString(streamable));
     }
 
+    static Event generateEvent() {
+        Throwable exc = new RuntimeException();
+        Event event = new Event(
+                exc,
+                BugsnagTestUtils.generateImmutableConfig(),
+                HandledState.newInstance(HandledState.REASON_HANDLED_EXCEPTION),
+                NoopLogger.INSTANCE
+        );
+        event.setApp(generateAppWithState());
+        event.setDevice(generateDeviceWithState());
+        return event;
+    }
+
     static SharedPreferences getSharedPrefs(Context context) {
         return context.getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE);
     }
@@ -109,7 +122,8 @@ final class BugsnagTestUtils {
     @NonNull
     static SessionStore generateSessionStore() {
         Context applicationContext = ApplicationProvider.getApplicationContext();
-        return new SessionStore(applicationContext, NoopLogger.INSTANCE, null);
+        ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
+        return new SessionStore(applicationContext, config, NoopLogger.INSTANCE, null);
     }
 
     public static Delivery generateDelivery() {

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
@@ -1,0 +1,85 @@
+package com.bugsnag.android
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
+import com.bugsnag.android.BugsnagTestUtils.generateEvent
+import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+/**
+ * Verifies that the maxPersistedEvents configuration option is respected when writing events.
+ */
+class EventStoreMaxLimitTest {
+
+    private lateinit var eventStore: EventStore
+    private lateinit var storageDir: File
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        storageDir = File(ctx.cacheDir, "bugsnag-errors")
+        storageDir.deleteRecursively()
+    }
+
+    @After
+    fun tearDown() {
+        storageDir.deleteRecursively()
+    }
+
+    @Test
+    fun testDefaultLimit() {
+        val config = generateImmutableConfig()
+        eventStore = createEventStore(config)
+
+        val event = generateEvent()
+        repeat(40) {
+            eventStore.write(event)
+        }
+        val files = storageDir.list()
+        assertEquals(32, files.size)
+    }
+
+    @Test
+    fun testDifferentLimit() {
+        val config = generateConfiguration().apply {
+            maxPersistedEvents = 5
+        }
+        eventStore = createEventStore(convertToImmutableConfig(config))
+
+        val event = generateEvent()
+        repeat(7) {
+            eventStore.write(event)
+        }
+        val files = storageDir.list()
+        assertEquals(5, files.size)
+    }
+
+    @Test
+    fun testZeroLimit() {
+        val config = generateConfiguration().apply {
+            maxPersistedEvents = 0
+        }
+        eventStore = createEventStore(convertToImmutableConfig(config))
+
+        val event = generateEvent()
+        eventStore.write(event)
+        val files = storageDir.list()
+        assertEquals(0, files.size)
+    }
+
+    private fun createEventStore(config: ImmutableConfig): EventStore {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        return EventStore(
+            config,
+            ctx,
+            NoopLogger,
+            Notifier(),
+            FileStore.Delegate { _, _, _ -> }
+        )
+    }
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -46,6 +46,8 @@ class ManifestConfigLoaderTest {
 
             // misc
             assertEquals(maxBreadcrumbs, 25)
+            assertEquals(maxPersistedEvents, 32)
+            assertEquals(maxPersistedSessions, 32)
             assertEquals(launchCrashThresholdMs, 5000)
             assertEquals("android", appType)
         }
@@ -79,6 +81,8 @@ class ManifestConfigLoaderTest {
 
             // misc
             putInt("com.bugsnag.android.MAX_BREADCRUMBS", 50)
+            putInt("com.bugsnag.android.MAX_PERSISTED_EVENTS", 52)
+            putInt("com.bugsnag.android.MAX_PERSISTED_SESSIONS", 64)
             putInt("com.bugsnag.android.LAUNCH_CRASH_THRESHOLD_MS", 7000)
             putString("com.bugsnag.android.APP_TYPE", "react-native")
             putString("com.bugsnag.android.CODE_BUNDLE_ID", "123")
@@ -110,6 +114,8 @@ class ManifestConfigLoaderTest {
 
             // misc
             assertEquals(maxBreadcrumbs, 50)
+            assertEquals(maxPersistedEvents, 52)
+            assertEquals(maxPersistedSessions, 64)
             assertEquals(launchCrashThresholdMs, 7000)
             assertEquals("react-native", appType)
         }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionStoreMaxLimitTest.kt
@@ -1,0 +1,84 @@
+package com.bugsnag.android
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
+import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import com.bugsnag.android.BugsnagTestUtils.generateSession
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+/**
+ * Verifies that the maxPersistedSessions configuration option is respected when writing sessions.
+ */
+class SessionStoreMaxLimitTest {
+
+    private lateinit var sessionStore: SessionStore
+    private lateinit var storageDir: File
+
+    @Before
+    fun setUp() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        storageDir = File(ctx.cacheDir, "bugsnag-sessions")
+        storageDir.deleteRecursively()
+    }
+
+    @After
+    fun tearDown() {
+        storageDir.deleteRecursively()
+    }
+
+    @Test
+    fun testDefaultLimit() {
+        val config = generateImmutableConfig()
+        sessionStore = createSessionStore(config)
+
+        val session = generateSession()
+        repeat(40) {
+            sessionStore.write(session)
+        }
+        val files = storageDir.list()
+        assertEquals(32, files.size)
+    }
+
+    @Test
+    fun testDifferentLimit() {
+        val config = generateConfiguration().apply {
+            maxPersistedSessions = 5
+        }
+        sessionStore = createSessionStore(convertToImmutableConfig(config))
+
+        val session = generateSession()
+        repeat(7) {
+            sessionStore.write(session)
+        }
+        val files = storageDir.list()
+        assertEquals(5, files.size)
+    }
+
+    @Test
+    fun testZeroLimit() {
+        val config = generateConfiguration().apply {
+            maxPersistedSessions = 0
+        }
+        sessionStore = createSessionStore(convertToImmutableConfig(config))
+
+        val session = generateSession()
+        sessionStore.write(session)
+        val files = storageDir.list()
+        assertEquals(0, files.size)
+    }
+
+    private fun createSessionStore(config: ImmutableConfig): SessionStore {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        return SessionStore(
+            ctx,
+            config,
+            NoopLogger,
+            FileStore.Delegate { _, _, _ -> }
+        )
+    }
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -28,7 +28,8 @@ public class SessionStoreTest {
     @Before
     public void setUp() {
         Context context = ApplicationProvider.getApplicationContext();
-        SessionStore sessionStore = new SessionStore(context, NoopLogger.INSTANCE, null);
+        ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
+        SessionStore sessionStore = new SessionStore(context, config, NoopLogger.INSTANCE, null);
         assertNotNull(sessionStore.storeDirectory);
         storageDir = new File(sessionStore.storeDirectory);
         FileUtils.clearFilesInDir(storageDir);

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionV1PayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionV1PayloadTest.java
@@ -40,7 +40,8 @@ public class SessionV1PayloadTest {
     @Before
     public void setUp() throws Exception {
         Context context = ApplicationProvider.getApplicationContext();
-        sessionStore = new SessionStore(context, NoopLogger.INSTANCE, null);
+        ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
+        sessionStore = new SessionStore(context, config, NoopLogger.INSTANCE, null);
 
         Assert.assertNotNull(sessionStore.storeDirectory);
         storageDir = new File(sessionStore.storeDirectory);

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionV2PayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionV2PayloadTest.java
@@ -39,7 +39,8 @@ public class SessionV2PayloadTest {
     @Before
     public void setUp() throws Exception {
         Context context = ApplicationProvider.getApplicationContext();
-        sessionStore = new SessionStore(context, NoopLogger.INSTANCE, null);
+        ImmutableConfig config = BugsnagTestUtils.generateImmutableConfig();
+        sessionStore = new SessionStore(context, config, NoopLogger.INSTANCE, null);
 
         Assert.assertNotNull(sessionStore.storeDirectory);
         storageDir = new File(sessionStore.storeDirectory);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -147,7 +147,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         contextState = new ContextState();
         contextState.setContext(configuration.getContext());
 
-        sessionStore = new SessionStore(appContext, logger, null);
+        sessionStore = new SessionStore(appContext, immutableConfig, logger, null);
         sessionTracker = new SessionTracker(immutableConfig, callbackState, this,
                 sessionStore, logger);
         metadataState = copyMetadataState(configuration);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android
 
 import android.content.Context
-import java.util.Collections
 
 internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware, UserAware {
 
@@ -31,7 +30,9 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
         }
     var delivery: Delivery? = null
     var endpoints: EndpointConfiguration = EndpointConfiguration()
-    var maxBreadcrumbs: Int = DEFAULT_MAX_SIZE
+    var maxBreadcrumbs: Int = DEFAULT_MAX_BREADCRUMBS
+    var maxPersistedEvents: Int = DEFAULT_MAX_PERSISTED_PAYLOADS
+    var maxPersistedSessions: Int = DEFAULT_MAX_PERSISTED_PAYLOADS
     var context: String? = null
 
     var redactedKeys: Set<String> = metadataState.metadata.redactedKeys
@@ -75,7 +76,8 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     }
 
     companion object {
-        private const val DEFAULT_MAX_SIZE = 25
+        private const val DEFAULT_MAX_BREADCRUMBS = 25
+        private const val DEFAULT_MAX_PERSISTED_PAYLOADS = 32
         private const val DEFAULT_LAUNCH_CRASH_THRESHOLD_MS: Long = 5000
 
         @JvmStatic

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -438,6 +438,58 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
     }
 
     /**
+     * Sets the maximum number of persisted events which will be stored. Once the threshold is
+     * reached, the oldest event will be deleted.
+     *
+     * By default, 32 events are persisted.
+     */
+    public int getMaxPersistedEvents() {
+        return impl.getMaxPersistedEvents();
+    }
+
+    /**
+     * Sets the maximum number of persisted events which will be stored. Once the threshold is
+     * reached, the oldest event will be deleted.
+     *
+     * By default, 32 events are persisted.
+     */
+    public void setMaxPersistedEvents(int maxPersistedEvents) {
+        if (maxPersistedEvents >= 0) {
+            impl.setMaxPersistedEvents(maxPersistedEvents);
+        } else {
+            getLogger().e(String.format(Locale.US, "Invalid configuration value detected. "
+                    + "Option maxPersistedEvents should be a positive integer."
+                    + "Supplied value is %d", maxPersistedEvents));
+        }
+    }
+
+    /**
+     * Sets the maximum number of persisted sessions which will be stored. Once the threshold is
+     * reached, the oldest session will be deleted.
+     *
+     * By default, 32 sessions are persisted.
+     */
+    public int getMaxPersistedSessions() {
+        return impl.getMaxPersistedSessions();
+    }
+
+    /**
+     * Sets the maximum number of persisted sessions which will be stored. Once the threshold is
+     * reached, the oldest session will be deleted.
+     *
+     * By default, 32 sessions are persisted.
+     */
+    public void setMaxPersistedSessions(int maxPersistedSessions) {
+        if (maxPersistedSessions >= 0) {
+            impl.setMaxPersistedSessions(maxPersistedSessions);
+        } else {
+            getLogger().e(String.format(Locale.US, "Invalid configuration value detected. "
+                    + "Option maxPersistedSessions should be a positive integer."
+                    + "Supplied value is %d", maxPersistedSessions));
+        }
+    }
+
+    /**
      * Bugsnag uses the concept of "contexts" to help display and group your errors. Contexts
      * represent what was happening in your application at the time an error occurs.
      *

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -26,7 +26,6 @@ class EventStore extends FileStore {
     private static final String STARTUP_CRASH = "_startupcrash";
     private static final long LAUNCH_CRASH_TIMEOUT_MS = 2000;
     private static final int LAUNCH_CRASH_POLL_MS = 50;
-    private static final int MAX_EVENT_COUNT = 32;
 
     volatile boolean flushOnLaunchCompleted = false;
     private final Semaphore semaphore = new Semaphore(1);
@@ -54,9 +53,12 @@ class EventStore extends FileStore {
     };
 
     EventStore(@NonNull ImmutableConfig config,
-               @NonNull Context appContext, @NonNull Logger logger,
-               Notifier notifier, Delegate delegate) {
-        super(appContext, "/bugsnag-errors/", MAX_EVENT_COUNT, EVENT_COMPARATOR, logger, delegate);
+               @NonNull Context appContext,
+               @NonNull Logger logger,
+               Notifier notifier,
+               Delegate delegate) {
+        super(appContext, "/bugsnag-errors/", config.getMaxPersistedEvents(),
+                EVENT_COMPARATOR, logger, delegate);
         this.config = config;
         this.logger = logger;
         this.delegate = delegate;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -24,7 +24,9 @@ internal data class ImmutableConfig(
     val persistUser: Boolean,
     val launchCrashThresholdMs: Long,
     val logger: Logger,
-    val maxBreadcrumbs: Int
+    val maxBreadcrumbs: Int,
+    val maxPersistedEvents: Int,
+    val maxPersistedSessions: Int
 ) {
 
     /**
@@ -78,6 +80,8 @@ internal fun convertToImmutableConfig(
         launchCrashThresholdMs = config.launchCrashThresholdMs,
         logger = config.logger!!,
         maxBreadcrumbs = config.maxBreadcrumbs,
+        maxPersistedEvents = config.maxPersistedEvents,
+        maxPersistedSessions = config.maxPersistedSessions,
         enabledBreadcrumbTypes = config.enabledBreadcrumbTypes?.toSet()
     )
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -36,8 +36,9 @@ internal class ManifestConfigLoader {
 
         // misc
         private const val MAX_BREADCRUMBS = "$BUGSNAG_NS.MAX_BREADCRUMBS"
+        private const val MAX_PERSISTED_EVENTS = "$BUGSNAG_NS.MAX_PERSISTED_EVENTS"
+        private const val MAX_PERSISTED_SESSIONS = "$BUGSNAG_NS.MAX_PERSISTED_SESSIONS"
         private const val LAUNCH_CRASH_THRESHOLD_MS = "$BUGSNAG_NS.LAUNCH_CRASH_THRESHOLD_MS"
-        private const val CODE_BUNDLE_ID = "$BUGSNAG_NS.CODE_BUNDLE_ID"
         private const val APP_TYPE = "$BUGSNAG_NS.APP_TYPE"
     }
 
@@ -73,6 +74,8 @@ internal class ManifestConfigLoader {
             // misc config
             with(config) {
                 maxBreadcrumbs = data.getInt(MAX_BREADCRUMBS, maxBreadcrumbs)
+                maxPersistedEvents = data.getInt(MAX_PERSISTED_EVENTS, maxPersistedEvents)
+                maxPersistedSessions = data.getInt(MAX_PERSISTED_SESSIONS, maxPersistedSessions)
                 launchCrashThresholdMs =
                     data.getInt(LAUNCH_CRASH_THRESHOLD_MS, launchCrashThresholdMs.toInt()).toLong()
             }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
@@ -34,8 +34,12 @@ class SessionStore extends FileStore {
         }
     };
 
-    SessionStore(@NonNull Context appContext, @NonNull Logger logger, @Nullable Delegate delegate) {
-        super(appContext, "/bugsnag-sessions/", 128, SESSION_COMPARATOR, logger, delegate);
+    SessionStore(@NonNull Context appContext,
+                 @NonNull ImmutableConfig config,
+                 @NonNull Logger logger,
+                 @Nullable Delegate delegate) {
+        super(appContext, "/bugsnag-sessions/", config.getMaxPersistedSessions(),
+                SESSION_COMPARATOR, logger, delegate);
     }
 
     @NonNull

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -30,6 +30,11 @@ final class BugsnagTestUtils {
         return new EventPayload(config.getApiKey(), generateEvent(), new Notifier());
     }
 
+    static Session generateSession() {
+        return new Session("test", new Date(), new User(), false,
+                new Notifier(), NoopLogger.INSTANCE);
+    }
+
     static Event generateEvent() {
         Throwable exc = new RuntimeException();
         Event event = new Event(

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
@@ -173,6 +173,30 @@ public class ConfigurationFacadeTest {
     }
 
     @Test
+    public void maxPersistedEventsValid() {
+        config.setMaxPersistedEvents(55);
+        assertEquals(55, config.impl.getMaxPersistedEvents());
+    }
+
+    @Test
+    public void maxPersistedEventsInvalid() {
+        config.setMaxPersistedEvents(-1);
+        assertEquals(32, config.impl.getMaxPersistedEvents());
+    }
+
+    @Test
+    public void maxPersistedSessionsValid() {
+        config.setMaxPersistedSessions(55);
+        assertEquals(55, config.impl.getMaxPersistedSessions());
+    }
+
+    @Test
+    public void maxPersistedSessionsInvalid() {
+        config.setMaxPersistedSessions(-1);
+        assertEquals(32, config.impl.getMaxPersistedSessions());
+    }
+
+    @Test
     public void contextValid() {
         config.setContext("Whoops");
         assertEquals("Whoops", config.impl.getContext());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -73,6 +73,8 @@ internal class ImmutableConfigTest {
             assertEquals(seed.launchCrashThresholdMs, launchCrashThresholdMs)
             assertEquals(NoopLogger, seed.logger)
             assertEquals(seed.maxBreadcrumbs, maxBreadcrumbs)
+            assertEquals(seed.maxPersistedEvents, maxPersistedEvents)
+            assertEquals(seed.maxPersistedSessions, maxPersistedSessions)
             assertEquals(seed.persistUser, persistUser)
             assertEquals(seed.enabledBreadcrumbTypes, BreadcrumbType.values().toSet())
         }
@@ -98,6 +100,8 @@ internal class ImmutableConfigTest {
         seed.endpoints = endpoints
         seed.launchCrashThresholdMs = 7000
         seed.maxBreadcrumbs = 37
+        seed.maxPersistedEvents = 55
+        seed.maxPersistedSessions = 103
         seed.persistUser = true
         seed.enabledBreadcrumbTypes = emptySet()
 
@@ -133,6 +137,8 @@ internal class ImmutableConfigTest {
             assertEquals(7000, seed.launchCrashThresholdMs)
             assertEquals(NoopLogger, seed.logger)
             assertEquals(37, seed.maxBreadcrumbs)
+            assertEquals(55, seed.maxPersistedEvents)
+            assertEquals(103, seed.maxPersistedSessions)
             assertTrue(seed.persistUser)
             assertTrue(seed.enabledBreadcrumbTypes!!.isEmpty())
         }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
@@ -26,7 +26,9 @@ class TestData {
                 true,
                 55,
                 NoopLogger.INSTANCE,
-                22
+                22,
+                32,
+                32
         );
     }
 


### PR DESCRIPTION
## Goal

The bugsnag-android SDK persists events & sessions to disk if it is unable to deliver them to the API due to network failure. This provides a configuration option to control how many payloads should be stored on disk for both events and sessions.

## Changeset

- Added `maxPersistedEvents` and `maxPersistedSessions` to `Configuration` with a default value of 32
- Added `MAX_PERSISTED_EVENTS` and `MAX_PERSISTED_SESSIONS` for reading configuration options from the manifest
- Updated `EventStore` and `SessionStore` so that they respect the configuration options
- Fixed a bug in `discardOldestFileIfNeeded()`, where in the unlikely scenario that >32 payloads were persisted on disk, the function would delete all the payloads if another payload needed persisting

## Testing

Added integration tests which verify the event/session store classes only persist up to the configured limit, and that this limit can be changed. Unit tests verify that the max persisted events/sessions configuration options are validated as necessary.