### PR TITLE
Generate native trace from signal info

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -931,13 +931,12 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     /**
      * Retrieves an instantiated plugin of the given type, or null if none has been created
      */
-    @SuppressWarnings("unchecked")
     @Nullable
-    <T extends Plugin> T getPlugin(@NonNull Class<T> clz) {
+    Plugin getPlugin(@NonNull Class<Plugin> clz) {
         Set<Plugin> plugins = pluginClient.getPlugins();
         for (Plugin plugin : plugins) {
             if (plugin.getClass().equals(clz)) {
-                return (T) plugin;
+                return plugin;
             }
         }
         return null;

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -54,6 +54,19 @@ internal class AnrPlugin : Plugin {
         val exc = RuntimeException()
         exc.stackTrace = thread.stackTrace
 
+        @Suppress("UNCHECKED_CAST")
+        val clz = Class.forName("com.bugsnag.android.NdkPlugin") as Class<Plugin>
+        val ndkPlugin = client.getPlugin(clz)
+        if (ndkPlugin != null) {
+            val method = ndkPlugin.javaClass.getMethod("getSignalStackTrace", Long::class.java, Long::class.java)
+            @Suppress("UNCHECKED_CAST")
+            val list = method.invoke(ndkPlugin, info, userContext) as List<Stackframe>
+
+            for (frame in list) client.logger.e(
+                "### TODO: ANR TRACE: " + frame.file + ": " + frame.lineNumber + ": " + frame.method
+            )
+        }
+
         val event = NativeInterface.createEvent(
             exc,
             client,

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.ndk
 
 import android.os.Build
 import com.bugsnag.android.NativeInterface
+import com.bugsnag.android.Stackframe
 import com.bugsnag.android.StateEvent
 import com.bugsnag.android.StateEvent.AddBreadcrumb
 import com.bugsnag.android.StateEvent.AddMetadata
@@ -75,6 +76,7 @@ class NativeBridge : Observer {
     external fun updateUserId(newValue: String)
     external fun updateUserEmail(newValue: String)
     external fun updateUserName(newValue: String)
+    external fun getSignalStackTrace(info: Long, userContext: Long): List<Stackframe>
 
     /**
      * Creates a new native bridge for interacting with native components.


### PR DESCRIPTION
## Goal

Since some ANRs can be caused by native code, we need a way to get native stack traces when such ANRs are triggered.

## Design

The NDK can generate a native stack trace from signal handler data since it already has signal handlers for fatal exceptions like `SIGILL` and `SIGBUS`. ANRs are signalled via `SIGQUIT` so we can use the same mechanism to get a native stack trace. We don't want a hard link between the ANR and NDK plugins, so we need to pass the signal handler data through the JVM layer so that the ANR plugin can then look up the NDK plugin and use it to generate native trace data when an ANR occurs.

Currently, nothing is done with this stack trace data, and it gets called regardless of where the ANR originated. Further changes to conditionally fetch this data if it's a native ANR and the NDK plugin is available will be added in a later PR.

## Changeset

NDK Plugin: New public method to extract native stack trace using signal handler info and user context pointers. This is returned to the JVM as a linked list of `Stackframe` objects.
ANR Plugin: Get a reference to the NDK plugin and extract the native stack trace portion on all ANRs. Currently the results of this are only logged.

## Testing

There's not enough functionality to test with automated tests yet, so I've manually verified that the temporary logging code displays the native portion of a stack trace on ANRs.
