### PR TITLE
Refresh instructions for running end-to-end tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+# You can run against local Maze Runner branches and uncommitted changes:
+gem 'bugsnag-maze-runner', path: '../maze-runner'
+
+# Or a specific release:
+#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.2.0'
+
+# Or follow master:
+#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,81 @@
+PATH
+  remote: ../maze-runner
+  specs:
+    bugsnag-maze-runner (3.2.0)
+      appium_lib (~> 10.2)
+      cucumber (~> 3.1.2)
+      cucumber-expressions (~> 6.0.0)
+      curb (~> 0.9.6)
+      gherkin (~> 5.1.0)
+      minitest (~> 5.0)
+      optimist (~> 3.0.1)
+      os (~> 1.0.0)
+      rake (~> 12.3.3)
+      selenium-webdriver (~> 3.11)
+      test-unit (~> 3.3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    appium_lib (10.6.0)
+      appium_lib_core (~> 3.3)
+      nokogiri (~> 1.8, >= 1.8.1)
+      tomlrb (~> 1.1)
+    appium_lib_core (3.11.0)
+      faye-websocket (~> 0.11.0)
+      selenium-webdriver (~> 3.14, >= 3.14.1)
+    backports (3.18.2)
+    builder (3.2.4)
+    childprocess (3.0.0)
+    cucumber (3.1.2)
+      builder (>= 2.1.2)
+      cucumber-core (~> 3.2.0)
+      cucumber-expressions (~> 6.0.1)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 5.1.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (3.2.1)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (~> 1.1.0)
+      gherkin (~> 5.0)
+    cucumber-expressions (6.0.1)
+    cucumber-tag_expressions (1.1.1)
+    cucumber-wire (0.0.1)
+    curb (0.9.11)
+    diff-lcs (1.4.4)
+    eventmachine (1.2.7)
+    faye-websocket (0.11.0)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
+    gherkin (5.1.0)
+    mini_portile2 (2.4.0)
+    minitest (5.14.2)
+    multi_json (1.15.0)
+    multi_test (0.1.2)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
+    optimist (3.0.1)
+    os (1.0.1)
+    power_assert (1.2.0)
+    rake (12.3.3)
+    rubyzip (2.3.0)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    test-unit (3.3.6)
+      power_assert
+    tomlrb (1.3.0)
+    websocket-driver (0.7.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bugsnag-maze-runner!
+
+BUNDLED WITH
+   2.1.4

--- a/Makefile
+++ b/Makefile
@@ -22,23 +22,10 @@ endif
 	 INSTRUMENTATION_DEVICES='["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]' \
 	 docker-compose up --build android-instrumentation-tests
 
-remote-integration-tests:
-ifeq ($(BROWSER_STACK_USERNAME),)
-	@$(error BROWSER_STACK_USERNAME is not defined)
-endif
-ifeq ($(BROWSER_STACK_ACCESS_KEY),)
-	@$(error BROWSER_STACK_ACCESS_KEY is not defined)
-endif
+test-fixture:
 	@./gradlew -PVERSION_NAME=9.9.9 assembleRelease publishToMavenLocal
 	@./gradlew -p=features/fixtures/mazerunner/ assembleRelease
 	@cp features/fixtures/mazerunner/build/outputs/apk/release/mazerunner-release.apk build/fixture.apk
-	@BRANCH_NAME= docker-compose build android-maze-runner
-
-ifneq ($(TEST_FEATURE),)
-	@BRANCH_NAME= APP_LOCATION=/app/build/fixture.apk docker-compose run android-maze-runner features/$(TEST_FEATURE)
-else
-	@BRANCH_NAME= APP_LOCATION=/app/build/fixture.apk docker-compose run android-maze-runner
-endif
 
 bump:
 ifneq ($(shell git diff --staged),)

--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,6 @@ Remote tests can be run against real devices provided by BrowserStack. In order 
 A BrowserStack App Automate Username: `BROWSER_STACK_USERNAME`
 A BrowserStack App Automate Access Key: `BROWSER_STACK_ACCESS_KEY`
 A local docker and docker-compose installation.
-The `DEVICE_TYPE` environment variable should also be set to one of those supported by MazeRunner, e.g ANDROID_9_0 (see /.buildkite/pipeline.yml for further examples).
 
 ### Instrumentation tests
 
@@ -68,14 +67,22 @@ Run `make remote-test`
 ### End-to-end tests
 
 Ensure that the following environment variables are set:
+* `BROWSER_STACK_USERNAME`: Your BrowserStack App Automate Username
+* `BROWSER_STACK_ACCESS_KEY`: You BrowserStack App Automate Access Key
 
-* `BROWSER_STACK_USERNAME`: The BrowserStack App Automate Username
-* `BROWSER_STACK_ACCESS_KEY`: The BrowserStack App Automate Access Key
-* `DEVICE_TYPE`: The android version to run the tests against, one of: ANDROID_5, ANDROID_6, ANDROID_7, ANDROID_8, ANDROID_9
+See https://www.browserstack.com/local-testing/app-automate for details of the required local testing binary.
 
-Run `make remote-integration-tests`
-
-If you wish to test a single feature, set the `TEST_FEATURE` environment variable to the name of the feature file.
-For example, to test the `breadcrumb` feature, use the following command:
-
-`TEST_FEATURE=breadcrumb.feature make remote-integration-tests`
+1. Build the test fixture `make test-fixture`
+1. Check the contents of `Gemfile` to select the version of `maze-runner` to use
+1. To run a single feature:
+    ```shell script
+    bundle exec maze-runner --app=build/fixture.apk                 \
+                            --farm=bs                               \
+                            --device=ANDROID_9_0                    \
+                            --username=$BROWSER_STACK_USERNAME      \
+                            --access-key=$BROWSER_STACK_ACCESS_KEY  \
+                            --bs-local=~/BrowserStackLocal          \
+                            features/app_version.feature
+    ```
+1. To run all features, omit the final argument.
+1. Maze Runner also supports all options that Cucumber does.  Run `bundle exec maze-runner --help` for full details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,11 +52,6 @@ services:
     environment:
       VERBOSE:
       DEBUG:
-      BROWSER_STACK_USERNAME:
-      BROWSER_STACK_ACCESS_KEY:
-      BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}
-      DEVICE_TYPE:
-      APP_LOCATION:
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output


### PR DESCRIPTION
## Goal

Refreshes the instructions and mechanics for running end-to-end tests locally (using devices on BrowserStack).

## Design

This is the standard approach for using Maze Runner v3.

## Changeset

- Gemfile added to reference Maze Runner Gem (or source)
- Updated Makefile and instructions
- Redundant environment variables removed from `docker-compose.yml`

## Testing

Updated instructions tested locally prior to raising the PR.