### PR TITLE
Improve debugging logging to support mazerunner

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -666,6 +666,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
     void notifyInternal(@NonNull Event event,
                         @Nullable OnErrorCallback onError) {
+        String type = event.impl.getSeverityReasonType();
+        logger.d("Client#notifyInternal() - event captured by Client, type=" + type);
         // Don't notify if this event class should be ignored
         if (event.shouldDiscardClass()) {
             return;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -30,6 +30,7 @@ class DeliveryDelegate extends BaseObservable {
     }
 
     void deliver(@NonNull Event event) {
+        logger.d("DeliveryDelegate#deliver() - event being stored/delivered by Client");
         // Build the eventPayload
         EventPayload eventPayload = new EventPayload(event.getApiKey(), event, notifier);
         Session session = event.getSession();
@@ -75,6 +76,8 @@ class DeliveryDelegate extends BaseObservable {
 
     @VisibleForTesting
     DeliveryStatus deliverPayloadInternal(@NonNull EventPayload payload, @NonNull Event event) {
+        logger.d("DeliveryDelegate#deliverPayloadInternal() - attempting event delivery");
+
         String apiKey = payload.getApiKey();
         DeliveryParams deliveryParams = immutableConfig.getErrorApiDeliveryParams(apiKey);
         Delivery delivery = immutableConfig.getDelivery();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -103,6 +103,8 @@ class InternalReportDelegate implements EventStore.Delegate {
                 @Override
                 public void run() {
                     try {
+                        logger.d("InternalReportDelegate - sending internal event");
+
                         Delivery delivery = immutableConfig.getDelivery();
                         String apiKey = eventPayload.getApiKey();
                         DeliveryParams params = immutableConfig.getErrorApiDeliveryParams(apiKey);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -146,6 +146,8 @@ class SessionTracker extends BaseObservable {
      * @param session the session
      */
     private void trackSessionIfNeeded(final Session session) {
+        logger.d("SessionTracker#trackSessionIfNeeded() - session captured by Client");
+
         boolean notifyForRelease = configuration.shouldNotifyForReleaseStage();
 
         session.setApp(client.getAppDataCollector().generateApp());
@@ -165,6 +167,8 @@ class SessionTracker extends BaseObservable {
                         flushStoredSessions();
 
                         try {
+                            logger.d("SessionTracker#trackSessionIfNeeded() " +
+                                    "- attempting initial delivery");
                             DeliveryStatus deliveryStatus = deliverSessionPayload(session);
 
                             switch (deliveryStatus) {
@@ -263,6 +267,7 @@ class SessionTracker extends BaseObservable {
     }
 
     void flushStoredSession(File storedFile) {
+        logger.d("SessionTracker#flushStoredSession() - attempting delivery");
         Session payload = new Session(storedFile, client.getNotifier(), logger);
 
         if (!payload.isV2Payload()) { // collect data here

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -167,8 +167,8 @@ class SessionTracker extends BaseObservable {
                         flushStoredSessions();
 
                         try {
-                            logger.d("SessionTracker#trackSessionIfNeeded() " +
-                                    "- attempting initial delivery");
+                            logger.d("SessionTracker#trackSessionIfNeeded() "
+                                + "- attempting initial delivery");
                             DeliveryStatus deliveryStatus = deliverSessionPayload(session);
 
                             switch (deliveryStatus) {


### PR DESCRIPTION
## Goal

Adds additional logging at the debug level to facilitate debugging of mazerunner/Appium issues.

I can make a follow on PR for the mazerunner test fixture if that would also be helpful.

## Testing

Manually verified in an example app. Something is now logged out whenever an event or session is captured and before delivery occurs. Example logs can be found here:


>2020-11-05 15:12:40.403 13847-13847/com.bugsnag.android.example D/Bugsnag: SessionTracker#trackSessionIfNeeded() - session captured by Client
2020-11-05 15:12:40.409 13847-13892/com.bugsnag.android.example D/Bugsnag: SessionTracker#trackSessionIfNeeded() - attempting initial delivery
2020-11-05 15:12:42.024 13847-13892/com.bugsnag.android.example I/Bugsnag: Request completed with code 202, message: Accepted, headers: {null=[HTTP/1.1 202 Accepted], Access-Control-Allow-Origin=[*], Alt-Svc=[clear], Content-Length=[21], Content-Type=[application/json], Date=[Thu, 05 Nov 2020 15:12:42 GMT], Via=[1.1 google], X-Android-Received-Millis=[1604589162020], X-Android-Response-Source=[NETWORK 202], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1604589161705]}
2020-11-05 15:12:42.025 13847-13892/com.bugsnag.android.example I/Bugsnag: Session API request finished with status DELIVERED
2020-11-05 15:12:47.194 13847-13847/com.bugsnag.android.example D/Bugsnag: Client#notifyInternal() - event captured by Client, type=handledException
2020-11-05 15:12:47.194 13847-13847/com.bugsnag.android.example D/Bugsnag: DeliveryDelegate#deliver() - event stored/delivered by Client
2020-11-05 15:12:47.244 13847-13890/com.bugsnag.android.example D/Bugsnag: DeliveryDelegate#deliverPayloadInternal() - attempting event delivery
2020-11-05 15:12:48.100 13847-13890/com.bugsnag.android.example I/Bugsnag: Request completed with code 200, message: OK, headers: {null=[HTTP/1.1 200 OK], Access-Control-Allow-Origin=[*], Alt-Svc=[clear], Bugsnag-Event-Id=[5fa4167000621ce62a610000], Content-Length=[2], Content-Type=[text/plain; charset=utf-8], Date=[Thu, 05 Nov 2020 15:12:48 GMT], Via=[1.1 google], X-Android-Received-Millis=[1604589168100], X-Android-Response-Source=[NETWORK 200], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1604589167786]}
2020-11-05 15:12:48.101 13847-13890/com.bugsnag.android.example I/Bugsnag: Error API request finished with status DELIVERED
2020-11-05 15:12:48.102 13847-13890/com.bugsnag.android.example I/Bugsnag: Sent 1 new event to Bugsnag
2020-11-05 15:12:49.447 13847-13847/com.bugsnag.android.example D/Bugsnag: Client#notifyInternal() - event captured by Client, type=handledException
2020-11-05 15:12:49.447 13847-13847/com.bugsnag.android.example D/Bugsnag: DeliveryDelegate#deliver() - event stored/delivered by Client
2020-11-05 15:12:49.447 13847-13888/com.bugsnag.android.example D/Bugsnag: DeliveryDelegate#deliverPayloadInternal() - attempting event delivery
2020-11-05 15:12:50.021 13847-13888/com.bugsnag.android.example I/Bugsnag: Request completed with code 200, message: OK, headers: {null=[HTTP/1.1 200 OK], Access-Control-Allow-Origin=[*], Alt-Svc=[clear], Bugsnag-Event-Id=[5fa416720062158191f00000], Content-Length=[2], Content-Type=[text/plain; charset=utf-8], Date=[Thu, 05 Nov 2020 15:12:50 GMT], Via=[1.1 google], X-Android-Received-Millis=[1604589170020], X-Android-Response-Source=[NETWORK 200], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1604589169659]}
2020-11-05 15:12:50.021 13847-13888/com.bugsnag.android.example I/Bugsnag: Error API request finished with status DELIVERED
2020-11-05 15:12:50.022 13847-13888/com.bugsnag.android.example I/Bugsnag: Sent 1 new event to Bugsnag
2020-11-05 15:13:16.048 13847-13889/com.bugsnag.android.example D/Bugsnag: Client#notifyInternal() - event captured by Client, type=anrError
2020-11-05 15:13:16.049 13847-13889/com.bugsnag.android.example D/Bugsnag: DeliveryDelegate#deliver() - event stored/delivered by Client
2020-11-05 15:13:16.070 13847-13889/com.bugsnag.android.example I/Bugsnag: Saved unsent payload to disk (/data/user/0/com.bugsnag.android.example/cache/bugsnag-errors/1604589196052_your-api-key_f7755c37-0729-4c0a-a59b-44fb25fd6657.json) 
2020-11-05 15:13:16.072 13847-13892/com.bugsnag.android.example I/Bugsnag: Sending 1 saved error(s) to Bugsnag
2020-11-05 15:13:16.539 13847-13892/com.bugsnag.android.example I/Bugsnag: Request completed with code 200, message: OK, headers: {null=[HTTP/1.1 200 OK], Access-Control-Allow-Origin=[*], Alt-Svc=[clear], Bugsnag-Event-Id=[5fa4168c00622e42b2f40000], Content-Length=[2], Content-Type=[text/plain; charset=utf-8], Date=[Thu, 05 Nov 2020 15:13:17 GMT], Via=[1.1 google], X-Android-Received-Millis=[1604589196538], X-Android-Response-Source=[NETWORK 200], X-Android-Selected-Protocol=[http/1.1], X-Android-Sent-Millis=[1604589196224]}
2020-11-05 15:13:16.540 13847-13892/com.bugsnag.android.example I/Bugsnag: Error API request finished with status DELIVERED
2020-11-05 15:13:16.541 13847-13892/com.bugsnag.android.example I/Bugsnag: Deleting sent error file 1604589196052_your-api-key_f7755c37-0729-4c0a-a59b-44fb25fd6657.json
2020-11-05 15:13:26.456 13847-13847/com.bugsnag.android.example D/Bugsnag: Client#notifyInternal() - event captured by Client, type=unhandledException
2020-11-05 15:13:26.456 13847-13847/com.bugsnag.android.example D/Bugsnag: DeliveryDelegate#deliver() - event stored/delivered by Client
2020-11-05 15:13:26.461 13847-13847/com.bugsnag.android.example I/Bugsnag: Saved unsent payload to disk (/data/user/0/com.bugsnag.android.example/cache/bugsnag-errors/1604589206456_your-api-key_a66214a2-bf74-4f4c-9522-6b103bd9feba.json) 
