### PR TITLE
Separate static analysis into individual jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -223,13 +223,45 @@ steps:
     concurrency: 10
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Linter'
+  - label: ':android: Lint'
     depends_on: "android-jvm"
     timeout_in_minutes: 10
     plugins:
       - docker-compose#v3.3.0:
           run: android-jvm
-    command: 'bash ./scripts/run-linter.sh'
+    command: './gradlew lint'
+
+  - label: ':android: Checkstyle'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-jvm
+    command: './gradlew checkstyle'
+
+  - label: ':android: Detekt'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-jvm
+    command: './gradlew detekt'
+
+  - label: ':android: Ktlint'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-jvm
+    command: './gradlew ktlintCheck'
+
+  - label: ':android: CppCheck'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.3.0:
+          run: android-jvm
+    command: 'bash ./scripts/run-cpp-check.sh'
 
   - label: ':android: JVM tests'
     depends_on: "android-jvm"

--- a/scripts/run-cpp-check.sh
+++ b/scripts/run-cpp-check.sh
@@ -1,4 +1,3 @@
-./gradlew lint checkstyle detekt ktlintCheck && \
 cppcheck --enable=warning,performance bugsnag-plugin-android-anr/src/main/jni && \
 cppcheck --enable=warning,performance bugsnag-plugin-android-ndk/src/main/jni -i \
 bugsnag-plugin-android-ndk/src/main/jni/deps -i bugsnag-plugin-android-ndk/src/main/jni/external


### PR DESCRIPTION
## Goal

Separates static analysis into individual jobs on CI. This ensures that if multiple static analysis tools are failing, the developer is always aware of the failures without having to push multiple times. Parallelising the steps should also reduce the time taken to get feedback on the static analysis tasks by ~1 minute.