### PR TITLE
[PLAT-5161] Remove soft fail from Android 10/11

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -430,8 +430,6 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 11 end-to-end tests'
     depends_on: "fixture-apk"
@@ -450,5 +448,3 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: 'browserstack-app'
-    soft_fail:
-      - exit_status: "*"

--- a/features/in_foreground.feature
+++ b/features/in_foreground.feature
@@ -6,6 +6,8 @@ Scenario: Test handled exception after delay
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the event "app.inForeground" is true
 
+# Skip due to an issue on later Android platforms - [PLAT-5464]
+@skip_android_11 @skip_android_10
 Scenario: Test handled exception in background
     When I run "InForegroundScenario"
     And I send the app to the background for 1 seconds

--- a/features/native_crash_handling.feature
+++ b/features/native_crash_handling.feature
@@ -65,6 +65,8 @@ Feature: Native crash reporting
         And the event "severity" equals "error"
         And the event "unhandled" is true
 
+    # Skip due to an issue on later Android platforms - [PLAT-5465]
+    @skip_android_10 @skip_android_11
     Scenario: Double free() allocated memory
         When I run "CXXDoubleFreeScenario" and relaunch the app
         And I configure the app to run in the "non-crashy" state

--- a/features/native_event_tracking.feature
+++ b/features/native_event_tracking.feature
@@ -8,6 +8,8 @@ Feature: Synchronizing app/device metadata in the native layer
         And the event "app.duration" is greater than 0
         And the event "unhandled" is false
 
+    # Skip due to an issue on later Android platforms - [PLAT-5464]
+    @skip_android_10 @skip_android_11
     Scenario: Capture foreground state while in the background
         When I run "CXXDelayedNotifyScenario"
         And I send the app to the background for 10 seconds
@@ -29,6 +31,8 @@ Feature: Synchronizing app/device metadata in the native layer
         And the event "app.duration" is not null
         And the event "unhandled" is true
 
+    # Skip due to an issue on later Android platforms - [PLAT-5464]
+    @skip_android_10 @skip_android_11
     Scenario: Capture foreground state while in a background crash
         When I run "CXXDelayedCrashScenario"
         And I send the app to the background for 10 seconds

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,3 +21,11 @@ end
 Before('@skip_android_8_1') do |scenario|
   skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version == 8.1
 end
+
+Before('@skip_android_10') do |scenario|
+  skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version == 10
+end
+
+Before('@skip_android_11') do |scenario|
+  skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version == 11
+end


### PR DESCRIPTION
Removes soft fail from Android 10/11 tests while skipping problematic scenarios.
This should allow us to get some test coverage on these platforms now, and these scenarios can be re-instated once appium issues have been investigated and resolved.