### PR TITLE
Assert that exception stacktrace is equal to thread stacktrace

### DIFF
--- a/features/full/_smoke_test.feature
+++ b/features/full/_smoke_test.feature
@@ -29,6 +29,7 @@ Scenario: Test Unhandled Java Exception with Session
     And the payload field "events.0.exceptions.0.stacktrace.0.type" is null
     And the payload field "events.0.threads.0.type" equals "android"
     And the payload field "events.0.threads.0.stacktrace.0.type" is null
+    And the exception stacktrace matches the thread stacktrace
 
 Scenario: Notifying in C
     When I run "CXXNotifyScenario"
@@ -81,3 +82,4 @@ Scenario: Sleeping the main thread with pending touch events when autoDetectAnrs
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
     And the exception "message" starts with " Input dispatching timed out"
+    And the exception stacktrace matches the thread stacktrace

--- a/features/full/detect_anr_cxx.feature
+++ b/features/full/detect_anr_cxx.feature
@@ -20,6 +20,7 @@ Scenario: ANR triggered in CXX code is captured
     And the payload field "events.0.threads.0.stacktrace.0.type" equals "c"
     And the payload field "events.0.threads.0.stacktrace.1.type" equals "c"
     And the payload field "events.0.threads.0.stacktrace.19.type" is null
+    And the exception stacktrace matches the thread stacktrace
 
 @skip_android_8_1
 Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -213,3 +213,14 @@ Then(/^the event has a "(.+)" breadcrumb with the message "(.+)"(?: for request 
   end
   fail("No breadcrumb matched: #{value}") unless found
 end
+
+Then("the exception stacktrace matches the thread stacktrace") do
+  exc_trace = read_key_path(Server.current_request[:body], "events.0.exceptions.0.stacktrace")
+  thread_trace = read_key_path(Server.current_request[:body], "events.0.threads.0.stacktrace")
+  assert_equal(exc_trace.length(), thread_trace.length(), "Exception and thread stacktraces are different lengths.")
+
+  thread_trace.each_with_index do |thread_frame, index|
+    exc_frame = exc_trace[index]
+    assert_equal(exc_frame, thread_frame)
+  end
+end


### PR DESCRIPTION
## Goal

Adds E2E assertions that the exception stacktrace is equal to the thread stacktrace for unhandled errors. #1001 contains changes so that the stacktrace is reported correctly for C++ `notify()` calls and ANRs - this adds additional test coverage.