### PR TITLE
Encode react native promise rejections as a mixed stacktrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 
+* Encode react native promise rejections as a mixed stacktrace
+   [#1006](https://github.com/bugsnag/bugsnag-android/pull/1006)
+
 * Support setting error type on individual stack frames
    [#1001](https://github.com/bugsnag/bugsnag-android/pull/1001)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -933,8 +933,9 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     /**
      * Retrieves an instantiated plugin of the given type, or null if none has been created
      */
+    @SuppressWarnings("rawtypes")
     @Nullable
-    Plugin getPlugin(@NonNull Class<Plugin> clz) {
+    Plugin getPlugin(@NonNull Class clz) {
         Set<Plugin> plugins = pluginClient.getPlugins();
         for (Plugin plugin : plugins) {
             if (plugin.getClass().equals(clz)) {

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -51,13 +51,9 @@ internal class EventDeserializer(
         if (map.containsKey("nativeStack") && event.errors.isNotEmpty()) {
             runCatching {
                 val jsError = event.errors.first()
-                val nativeErrorDeserializer = NativeErrorDeserializer(
-                    jsError,
-                    projectPackages,
-                    client.logger
-                )
-                val nativeError = nativeErrorDeserializer.deserialize(map)
-                event.errors.add(nativeError)
+                val nativeStackDeserializer = NativeStackDeserializer(projectPackages)
+                val nativeStack = nativeStackDeserializer.deserialize(map)
+                jsError.stacktrace.addAll(0, nativeStack)
             }
         }
 

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeStackDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeStackDeserializer.java
@@ -6,46 +6,32 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Deserializes an error from the 'nativeStack' property supplied by React Native
- *
- * This requires the original JS error, whose error message/class is used by the native error.
+ * Deserializes a stacktrace from the 'nativeStack' property supplied by React Native.
  */
-class NativeErrorDeserializer implements MapDeserializer<Error> {
+class NativeStackDeserializer implements MapDeserializer<List<Stackframe>> {
 
-    private final Error jsError;
-    private final Logger logger;
     private final Collection<String> projectPackages;
 
-    NativeErrorDeserializer(Error jsError, Collection<String> projectPackages, Logger logger) {
-        this.jsError = jsError;
+    NativeStackDeserializer(Collection<String> projectPackages) {
         this.projectPackages = projectPackages;
-        this.logger = logger;
     }
 
     /**
-     * Constructs a native error from the given payload. This assumes that 'nativeStack' contains
-     * a list of stackframes containing the methodName, class, file, and lineNumber.
+     * Constructs a native stacktrace from the given payload. This assumes that 'nativeStack'
+     * contains a list of stackframes containing the methodName, class, file, and lineNumber.
      *
      * @param map the JSON payload passed from the JS layer
-     * @return a representation of a native error
+     * @return a representation of a native stacktrace
      */
     @Override
-    public Error deserialize(Map<String, Object> map) {
+    public List<Stackframe> deserialize(Map<String, Object> map) {
         List<Map<String, Object>> nativeStack = MapUtils.getOrThrow(map, "nativeStack");
         List<Stackframe> frames = new ArrayList<>();
 
         for (Map<String, Object> frame : nativeStack) {
             frames.add(deserializeStackframe(frame, projectPackages));
         }
-
-        Stacktrace trace = new Stacktrace(frames);
-        ErrorInternal impl = new ErrorInternal(
-                jsError.getErrorClass(),
-                jsError.getErrorMessage(),
-                trace,
-                ErrorType.ANDROID
-        );
-        return new Error(impl, logger);
+        return new Stacktrace(frames).getTrace();
     }
 
     private Stackframe deserializeStackframe(Map<String, Object> map,
@@ -64,11 +50,13 @@ class NativeErrorDeserializer implements MapDeserializer<Error> {
             clz = "";
             method = methodName;
         }
-        return new Stackframe(
+        Stackframe stackframe = new Stackframe(
                 method,
                 MapUtils.<String>getOrNull(map, "file"),
                 MapUtils.<Integer>getOrNull(map, "lineNumber"),
                 Stacktrace.Companion.inProject(clz, projectPackages)
         );
+        stackframe.setType(ErrorType.ANDROID);
+        return stackframe;
     }
 }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/NativeStackDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/NativeStackDeserializerTest.kt
@@ -1,13 +1,12 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.TestData.generateError
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-class NativeErrorDeserializerTest {
+class NativeStackDeserializerTest {
 
     private lateinit var map: Map<String, Any>
 
@@ -58,30 +57,29 @@ class NativeErrorDeserializerTest {
 
     @Test
     fun deserialize() {
-        val logger = object : Logger {}
         val packages = listOf("com.reactnativetest")
-        val error = NativeErrorDeserializer(generateError(), packages, logger).deserialize(map)
-        assertEquals("BrowserException", error.errorClass)
-        assertEquals("whoops!", error.errorMessage)
-        assertEquals(ErrorType.ANDROID, error.type)
-        assertEquals(3, error.stacktrace.count())
+        val nativeStack = NativeStackDeserializer(packages).deserialize(map)
+        assertEquals(3, nativeStack.size)
 
-        val firstFrame = error.stacktrace[0]
+        val firstFrame = nativeStack[0]
         assertEquals("com.reactnativetest.BenCrash.asyncReject", firstFrame.method)
         assertEquals("BenCrash.java", firstFrame.file)
         assertEquals(42, firstFrame.lineNumber)
         assertTrue(firstFrame.inProject!!)
+        assertEquals(ErrorType.ANDROID, firstFrame.type)
 
-        val secondFrame = error.stacktrace[1]
+        val secondFrame = nativeStack[1]
         assertEquals("com.example.Foo.invokeFoo", secondFrame.method)
         assertEquals("Foo.kt", secondFrame.file)
         assertEquals(57, secondFrame.lineNumber)
         assertNull(secondFrame.inProject)
+        assertEquals(ErrorType.ANDROID, secondFrame.type)
 
-        val thirdFrame = error.stacktrace[2]
+        val thirdFrame = nativeStack[2]
         assertEquals("invokeWham", thirdFrame.method)
         assertEquals("Wham.kt", thirdFrame.file)
         assertEquals(159, thirdFrame.lineNumber)
         assertNull(secondFrame.inProject)
+        assertEquals(ErrorType.ANDROID, thirdFrame.type)
     }
 }


### PR DESCRIPTION
## Goal

Alters the `nativeStack` property added in #937 so that it is deserialized as a list of `Stackframe` objects, which are set on an individual `Error`. This forms a mixed stacktrace rather than two separate error objects. The `getPlugin` method has also been updated to allow a raw class, so that both the `NdkPlugin` and `AnrPlugin` can be accessed from Java/Kotlin files as needed. This was originally changed [here](https://github.com/bugsnag/bugsnag-android/commit/239d12a613ef770d1bdfb70324dade17b3a9b8e7#diff-c952c857a72826421f5588f79a4f32113c19fb0860aa4f6571408dc6158d521a) but the solution didn't work for React Native - this covers both scenarios.

## Testing

Updated unit test coverage, and manually tested on React Native to confirm that the nativeStack is set:

<img width="987" alt="Screenshot 2020-11-24 at 11 10 00" src="https://user-images.githubusercontent.com/11800640/100086825-d5d41800-2e45-11eb-904e-1cffa51b106b.png">
