### PR TITLE
Alter foreground/background scenarios to use activity lifecycle callbacks

### DIFF
--- a/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
+++ b/features/fixtures/mazerunner/src/main/cpp/bugsnags.cpp
@@ -78,6 +78,12 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXDelayedNotifyScenario_activate(
   bugsnag_notify_env(env, (char *)"Ferret Escape!", (char *)"oh no", BSG_SEVERITY_ERR);
 }
 
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXBackgroundNotifyScenario_activate(JNIEnv *env,
+                                                                         jobject instance) {
+  bugsnag_notify_env(env, (char *)"Ferret Escape!", (char *)"oh no", BSG_SEVERITY_ERR);
+}
+
 JNIEXPORT int JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXDelayedCrashScenario_activate(JNIEnv *env,
                                                                          jobject instance,

--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXBackgroundNotifyScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXBackgroundNotifyScenario.kt
@@ -1,0 +1,28 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.app.Activity
+import android.content.Context
+
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+internal class CXXBackgroundNotifyScenario(
+    config: Configuration,
+    context: Context
+) : Scenario(config, context) {
+
+    init {
+        System.loadLibrary("bugsnag-ndk")
+        System.loadLibrary("entrypoint")
+        config.autoTrackSessions = false
+    }
+
+    external fun activate()
+
+    override fun run() {
+        super.run()
+        registerActivityLifecycleCallbacks()
+    }
+
+    override fun onActivityStopped(activity: Activity) = activate()
+}

--- a/features/native_event_tracking.feature
+++ b/features/native_event_tracking.feature
@@ -11,8 +11,8 @@ Feature: Synchronizing app/device metadata in the native layer
     # Skip due to an issue on later Android platforms - [PLAT-5464]
     @skip_android_10 @skip_android_11
     Scenario: Capture foreground state while in the background
-        When I run "CXXDelayedNotifyScenario"
-        And I send the app to the background for 10 seconds
+        When I run "CXXBackgroundNotifyScenario"
+        And I send the app to the background for 5 seconds
         And I wait to receive a request
         Then the request payload contains a completed handled native report
         And the event "app.inForeground" is false


### PR DESCRIPTION
## Goal

This should help avoid a source of flakiness in the E2E scenarios by making the foreground/background scenarios use [activity lifecycle](https://developer.android.com/guide/components/activities/activity-lifecycle) callbacks. These are invoked when the activity is put in the stopped state, which is interpreted by bugsnag as when the application is in the background.

Previously the `CXXDelayedNotifyScenario` used an arbitrary 3 second sleep before calling `bugsnag_notify_env` - this is not always long enough for the activity to be put into the background by the Android OS, leading to test failures.

## Testing

Ran the feature ~5 times on browserstack local.