### PR TITLE
Use consistent device ID for multi process apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TBD
 
+* Use consistent device ID for multi process apps
+  [#1013](https://github.com/bugsnag/bugsnag-android/pull/1013)
+
 * Create synchronized store for user information
   [#1010](https://github.com/bugsnag/bugsnag-android/pull/1010)
 

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -31,10 +31,10 @@
     <ID>TooGenericExceptionCaught:CallbackState.kt$CallbackState$ex: Throwable</ID>
     <ID>TooGenericExceptionCaught:DefaultDelivery.kt$DefaultDelivery$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:DeviceDataCollector.kt$DeviceDataCollector$exception: Exception</ID>
+    <ID>TooGenericExceptionCaught:DeviceIdStore.kt$DeviceIdStore$exc: Exception</ID>
     <ID>TooGenericExceptionCaught:ManifestConfigLoader.kt$ManifestConfigLoader$exc: Exception</ID>
     <ID>TooGenericExceptionCaught:PluginClient.kt$PluginClient$exc: Throwable</ID>
     <ID>TooGenericExceptionCaught:Stacktrace.kt$Stacktrace$lineEx: Exception</ID>
-    <ID>TooGenericExceptionCaught:SynchronizedStreamableStore.kt$SynchronizedStreamableStore$exc: Throwable</ID>
     <ID>TooGenericExceptionThrown:BreadcrumbStateTest.kt$BreadcrumbStateTest$throw Exception("Oh no")</ID>
     <ID>TooManyFunctions:ConfigInternal.kt$ConfigInternal : CallbackAwareMetadataAwareUserAware</ID>
     <ID>TooManyFunctions:DeviceDataCollector.kt$DeviceDataCollector</ID>

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -148,7 +148,6 @@ public class ClientTest {
 
         // Check that the user was not stored in prefs
         SharedPreferences sharedPref = getSharedPrefs(context);
-        assertNotNull(sharedPref.getString("install.iud", null));
         assertFalse(sharedPref.contains("user.id"));
         assertFalse(sharedPref.contains("user.email"));
         assertFalse(sharedPref.contains("user.name"));

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceIdStoreTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DeviceIdStoreTest.kt
@@ -1,0 +1,164 @@
+package com.bugsnag.android
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import junit.framework.TestCase.assertNull
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+internal class DeviceIdStoreTest {
+
+    lateinit var file: File
+    lateinit var storageDir: File
+    lateinit var ctx: Context
+
+    private val uuidProvider = {
+        UUID.fromString("ab0c1482-2ffe-11eb-adc1-0242ac120002")
+    }
+    private val diffUuidProvider = {
+        UUID.fromString("d9901bff-2ffe-11eb-adc1-0242ac120002")
+    }
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext<Context>()
+        storageDir = ctx.cacheDir
+        file = File(storageDir, "device.json")
+        file.delete()
+    }
+
+    /**
+     * A file should be created if it does not already exist
+     */
+    @Test
+    fun nonExistentFile() {
+        val nonExistentFile = File(storageDir, "foo")
+        nonExistentFile.delete()
+        val store = DeviceIdStore(ctx, nonExistentFile, NoopLogger)
+        val deviceId = store.loadDeviceId(uuidProvider)
+        requireNotNull(deviceId)
+        assertEquals("ab0c1482-2ffe-11eb-adc1-0242ac120002", deviceId)
+    }
+
+    /**
+     * An empty file should be overwritten with a new device ID
+     */
+    @Test
+    fun emptyFile() {
+        val store = DeviceIdStore(ctx, file, NoopLogger)
+        val deviceId = store.loadDeviceId(uuidProvider)
+        requireNotNull(deviceId)
+        assertEquals("ab0c1482-2ffe-11eb-adc1-0242ac120002", deviceId)
+    }
+
+    /**
+     * A file of the incorrect length should be overwritten with a new device ID
+     */
+    @Test
+    fun incorrectFileLength() {
+        val store = DeviceIdStore(ctx, file, NoopLogger)
+        val deviceId = store.loadDeviceId(uuidProvider)
+        requireNotNull(deviceId)
+        assertEquals("ab0c1482-2ffe-11eb-adc1-0242ac120002", deviceId)
+    }
+
+    /**
+     * A file of the correct length with invalid contents should be overwritten with a new device ID
+     */
+    @Test
+    fun invalidFileContents() {
+        file.writeText("{\"hamster\": 2}")
+        val store = DeviceIdStore(ctx, file, NoopLogger)
+        val deviceId = store.loadDeviceId(uuidProvider)
+        requireNotNull(deviceId)
+        assertEquals("ab0c1482-2ffe-11eb-adc1-0242ac120002", deviceId)
+    }
+
+    /**
+     * A valid file should not be overwritten with a new device ID
+     */
+    @Test
+    fun validFileContents() {
+        file.writeText("{\"id\": \"24c51482-2ffe-11eb-adc1-0242ac120002\"}")
+        val store = DeviceIdStore(ctx, file, NoopLogger)
+
+        // device ID is loaded without writing file
+        assertEquals(
+            "24c51482-2ffe-11eb-adc1-0242ac120002",
+            store.loadDeviceId(uuidProvider)
+        )
+        // same device ID is retrieved as before
+        assertEquals(
+            "24c51482-2ffe-11eb-adc1-0242ac120002",
+            store.loadDeviceId(diffUuidProvider)
+        )
+    }
+
+    /**
+     * A non-writable file does not crash the app
+     */
+    @Test
+    fun nonWritableFile() {
+        val nonReadableFile = File(storageDir, "foo").apply {
+            delete()
+            createNewFile()
+            setWritable(false)
+        }
+        val store = DeviceIdStore(ctx, nonReadableFile, NoopLogger)
+        val deviceId = store.loadDeviceId(uuidProvider)
+        assertNull(deviceId)
+    }
+
+    /**
+     * The device ID store should take out a file lock to prevent concurrent writes to the file.
+     */
+    @Test(timeout = 2000)
+    fun fileLockUsed() {
+        val store = DeviceIdStore(ctx, file, NoopLogger)
+
+        // load the device ID on many different background threads.
+        // each thread races with each other, but only one should generate a device ID
+        // and persist it to disk.
+        val deviceIds = mutableSetOf<String>()
+        val attempts = 16
+        val executor = Executors.newFixedThreadPool(attempts)
+        val latch = CountDownLatch(attempts)
+
+        repeat(attempts) {
+            executor.submit {
+                val id = store.loadDeviceId(uuidProvider)
+                requireNotNull(id)
+                deviceIds.add(id)
+                latch.countDown()
+            }
+        }
+        latch.await()
+
+        // validate that the device ID is consistent for each.
+        // the device ID of whichever thread won the race first should be used.
+        assertEquals(1, deviceIds.size)
+    }
+
+    /**
+     * The device ID store should migrate legacy IDs from shared preferences if they are present
+     */
+    @Test
+    fun sharedPrefMigration() {
+        val store = DeviceIdStore(ctx, file, NoopLogger)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        val prefs =
+            context.getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE)
+        prefs.edit().putString("install.iud", "55670bff-9024-fc0a-b392-0242ac88ccd9").commit()
+
+        val prefDeviceId = SharedPrefMigrator(context).loadDeviceId()
+        val storeDeviceId = store.loadDeviceId()
+        assertEquals("55670bff-9024-fc0a-b392-0242ac88ccd9", storeDeviceId)
+        assertEquals(prefDeviceId, storeDeviceId)
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceIdStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceIdStore.kt
@@ -1,0 +1,182 @@
+package com.bugsnag.android
+
+import android.content.Context
+import android.util.JsonReader
+import java.io.File
+import java.io.IOException
+import java.lang.Thread
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
+import java.util.UUID
+
+/**
+ * This class is responsible for persisting and retrieving the device ID which uniquely
+ * identifies this device.
+ *
+ * This class is made multi-process safe through the use of a [FileLock], and thread safe
+ * through the use of a [ReadWriteLock] in [SynchronizedStreamableStore].
+ */
+internal class DeviceIdStore @JvmOverloads constructor(
+    private val context: Context,
+    private val file: File = File(context.filesDir, "device-id"),
+    private val logger: Logger
+) {
+
+    private val synchronizedStreamableStore: SynchronizedStreamableStore<DeviceId>
+
+    init {
+        try {
+            if (!file.exists()) {
+                file.createNewFile()
+            }
+        } catch (exc: IOException) {
+            logger.w("Failed to created device ID file", exc)
+        }
+        this.synchronizedStreamableStore = SynchronizedStreamableStore(file)
+    }
+
+    /**
+     * Loads the device ID from its file system location. Device IDs are UUIDs which are
+     * persisted on a per-install basis. This method is thread-safe and multi-process safe.
+     *
+     * If no device ID exists then the legacy value stored in [SharedPreferences] will
+     * be used. If no value is present then a random UUID will be generated and persisted.
+     */
+    fun loadDeviceId(): String? {
+        val sharedPrefMigrator = SharedPrefMigrator(context)
+        val legacyDeviceId = sharedPrefMigrator.loadDeviceId()
+
+        return loadDeviceId {
+            when (legacyDeviceId) {
+                null -> UUID.randomUUID()
+                else -> UUID.fromString(legacyDeviceId)
+            }
+        }
+    }
+
+    internal fun loadDeviceId(uuidProvider: () -> UUID): String? {
+        return try {
+            // optimistically read device ID without a lock - the majority of the time
+            // the device ID will already be present so no synchronization is required.
+            val deviceId = loadDeviceIdInternal()
+
+            if (deviceId?.id != null) {
+                deviceId.id
+            } else {
+                return persistNewDeviceUuid(uuidProvider)
+            }
+        } catch (exc: Exception) {
+            logger.w("Failed to load device ID", exc)
+            null
+        }
+    }
+
+    /**
+     * Loads the device ID from the file.
+     *
+     * If the file has zero length it can't contain device ID, so reading will be skipped.
+     */
+    private fun loadDeviceIdInternal(): DeviceId? {
+        if (file.length() > 0) {
+            try {
+                return synchronizedStreamableStore.load(DeviceId.Companion::fromReader)
+            } catch (exc: IOException) {
+                logger.w("Failed to load device ID", exc)
+            }
+        }
+        return null
+    }
+
+    /**
+     * Write a new Device ID to the file.
+     */
+    private fun persistNewDeviceUuid(uuidProvider: () -> UUID): String? {
+        return try {
+            // acquire a FileLock to prevent Clients in different processes writing
+            // to the same file concurrently
+            file.outputStream().channel.use { channel ->
+                persistNewDeviceIdWithLock(channel, uuidProvider)
+            }
+        } catch (exc: IOException) {
+            logger.w("Failed to persist device ID", exc)
+            null
+        }
+    }
+
+    private fun persistNewDeviceIdWithLock(
+        channel: FileChannel,
+        uuidProvider: () -> UUID
+    ): String? {
+        val lock = waitForFileLock(channel) ?: return null
+
+        return try {
+            // read the device ID again as it could have changed
+            // between the last read and when the lock was acquired
+            val deviceId = loadDeviceIdInternal()
+
+            if (deviceId?.id != null) {
+                // the device ID changed between the last read
+                // and acquiring the lock, so return the generated value
+                deviceId.id
+            } else {
+                // generate a new device ID and persist it
+                val newId = DeviceId(uuidProvider().toString())
+                synchronizedStreamableStore.persist(newId)
+                newId.id
+            }
+        } finally {
+            lock.release()
+        }
+    }
+
+    /**
+     * Attempt to acquire a file lock. If [OverlappingFileLockException] is thrown
+     * then the method will wait for 50ms then try again, for a maximum of 10 attempts.
+     */
+    private fun waitForFileLock(channel: FileChannel): FileLock? {
+        repeat(MAX_FILE_LOCK_ATTEMPTS) {
+            try {
+                return channel.tryLock()
+            } catch (exc: OverlappingFileLockException) {
+                Thread.sleep(FILE_LOCK_WAIT_MS)
+            }
+        }
+        return null
+    }
+
+    companion object {
+        private const val MAX_FILE_LOCK_ATTEMPTS = 20
+        private const val FILE_LOCK_WAIT_MS = 25L
+    }
+}
+
+/**
+ * Serializes and deserializes the device ID to/from JSON.
+ */
+private class DeviceId(val id: String?) : JsonStream.Streamable {
+
+    override fun toStream(stream: JsonStream) {
+        with(stream) {
+            beginObject()
+            name(KEY_ID)
+            value(id)
+            endObject()
+        }
+    }
+
+    companion object : JsonReadable<DeviceId> {
+        private const val KEY_ID = "id"
+
+        override fun fromReader(reader: JsonReader): DeviceId {
+            var id: String? = null
+            with(reader) {
+                beginObject()
+                if (hasNext() && KEY_ID == nextName()) {
+                    id = nextString()
+                }
+            }
+            return DeviceId(id)
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SharedPrefMigrator.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SharedPrefMigrator.kt
@@ -1,0 +1,18 @@
+package com.bugsnag.android
+
+import android.content.Context
+
+/**
+ * Reads legacy information left in SharedPreferences and migrates it to the new location.
+ */
+internal class SharedPrefMigrator(context: Context) {
+
+    private val prefs = context
+        .getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE)
+
+    fun loadDeviceId() = prefs.getString(INSTALL_ID_KEY, null)
+
+    companion object {
+        private const val INSTALL_ID_KEY = "install.iud"
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserRepository.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserRepository.kt
@@ -3,25 +3,27 @@ package com.bugsnag.android
 import android.content.SharedPreferences
 import java.util.UUID
 
-internal class UserRepository(private val prefs: SharedPreferences, private val persist: Boolean) {
+internal class UserRepository(
+    private val prefs: SharedPreferences,
+    private val persist: Boolean,
+    private val deviceId: String?
+) {
 
     companion object {
-        private const val INSTALL_ID_KEY = "install.iud"
         private const val USER_ID_KEY = "user.id"
         private const val USER_NAME_KEY = "user.name"
         private const val USER_EMAIL_KEY = "user.email"
     }
 
     fun load(): User {
-        val installId = getDeviceId()
         return when {
             persist -> // Check to see if a user was stored in the SharedPreferences
                 User(
-                    prefs.getString(USER_ID_KEY, installId),
+                    prefs.getString(USER_ID_KEY, deviceId),
                     prefs.getString(USER_EMAIL_KEY, null),
                     prefs.getString(USER_NAME_KEY, null)
                 )
-            else -> User(installId, null, null)
+            else -> User(deviceId, null, null)
         }
     }
 
@@ -39,18 +41,5 @@ internal class UserRepository(private val prefs: SharedPreferences, private val 
                 .remove(USER_EMAIL_KEY)
         }
         editor.apply()
-    }
-
-    /**
-     * Retrieves the device ID. This is a UUID which is generated per installation
-     * and persisted in SharedPreferences.
-     */
-    fun getDeviceId(): String {
-        var installId = prefs.getString(INSTALL_ID_KEY, null)
-        if (installId == null) {
-            installId = UUID.randomUUID().toString()
-            prefs.edit().putString(INSTALL_ID_KEY, installId).apply()
-        }
-        return installId
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SharedPrefMigratorTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SharedPrefMigratorTest.kt
@@ -1,0 +1,43 @@
+package com.bugsnag.android
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+internal class SharedPrefMigratorTest {
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var prefs: SharedPreferences
+
+    lateinit var prefMigrator: SharedPrefMigrator
+
+    @Before
+    fun setUp() {
+        `when`(context.getSharedPreferences(eq("com.bugsnag.android"), eq(0))).thenReturn(prefs)
+        prefMigrator = SharedPrefMigrator(context)
+    }
+
+    @Test
+    fun nullDeviceId() {
+        `when`(prefs.getString("install.iud", null)).thenReturn(null)
+        assertNull(prefMigrator.loadDeviceId())
+    }
+
+    @Test
+    fun validDeviceId() {
+        `when`(prefs.getString("install.iud", null)).thenReturn("f09asdfb")
+        assertEquals("f09asdfb", prefMigrator.loadDeviceId())
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/UserRepositoryTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/UserRepositoryTest.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android
 
 import android.content.SharedPreferences
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -34,7 +33,7 @@ class UserRepositoryTest {
         `when`(prefs.getString(contains("user.name"), any())).thenReturn("Jane Fonda")
         `when`(prefs.getString(contains("user.email"), any())).thenReturn("test@example.com")
 
-        val repository = UserRepository(prefs, true)
+        val repository = UserRepository(prefs, true, "0asdf")
         val user = repository.load()
 
         assertEquals("jf123", user.id)
@@ -44,8 +43,7 @@ class UserRepositoryTest {
 
     @Test
     fun loadNoPersist() {
-        `when`(prefs.getString(contains("install.iud"), any())).thenReturn("device-id-123")
-        val repository = UserRepository(prefs, false)
+        val repository = UserRepository(prefs, false, "device-id-123")
         val user = repository.load()
         assertEquals("device-id-123", user.id)
         assertNull(user.email)
@@ -54,7 +52,7 @@ class UserRepositoryTest {
 
     @Test
     fun saveWithPersist() {
-        val repository = UserRepository(prefs, true)
+        val repository = UserRepository(prefs, true, "")
         repository.save(User("123", "joe@yahoo.com", "Joe Bloggs"))
         verify(editor, times(1)).putString("user.id", "123")
         verify(editor, times(1)).putString("user.email", "joe@yahoo.com")
@@ -64,28 +62,11 @@ class UserRepositoryTest {
 
     @Test
     fun saveNoPersist() {
-        val repository = UserRepository(prefs, false)
+        val repository = UserRepository(prefs, false, "")
         repository.save(User("123", "joe@yahoo.com", "Joe Bloggs"))
         verify(editor, times(1)).remove("user.id")
         verify(editor, times(1)).remove("user.email")
         verify(editor, times(1)).remove("user.name")
         verify(editor, times(1)).apply()
-    }
-
-    @Test
-    fun getDeviceIdFirstTime() {
-        `when`(prefs.getString(contains("install.iud"), any())).thenReturn(null)
-        val repository = UserRepository(prefs, false)
-        val deviceId = repository.getDeviceId()
-        assertNotNull(deviceId)
-        verify(editor, times(1)).putString(matches("install.iud"), any())
-    }
-
-    @Test
-    fun getDeviceIdExistingValue() {
-        `when`(prefs.getString(contains("install.iud"), any())).thenReturn("4a09cbe2")
-        val repository = UserRepository(prefs, false)
-        val deviceId = repository.getDeviceId()
-        assertEquals("4a09cbe2", deviceId)
     }
 }


### PR DESCRIPTION
## Goal

This changeset makes the notifier use a consistent device ID for apps which initialize Bugsnag in multiple processes. This is achieved by storing the device ID in a single file location which can be accessed concurrently from each process and is protected by a [FileLock](https://developer.android.com/reference/java/nio/channels/FileLock).

## Changeset

- Created `DeviceIdStore` which is responsible for loading/saving the device ID to the file system
- Guarded the device ID file with a `FileLock` to prevent concurrent access in multiple processes, and a `ReadWriteLock` to prevent concurrent access from multiple threads.
- Updated the `Client` to persist a device ID to a file and to migrate any existing device ID from `SharedPreferences` or generating a random UUID if none already exists
- Created `SharedPrefMigrator` which reads legacy information from `SharedPreferences`. A separate PR will build on this by making this class read user information too, and delete the `SharedPreferences` file once the migration is complete
- Removed responsibility for storing the device ID from `UserRepository`
- Updated `SynchronizedStreamableStore` to use buffered IO

## Testing

Added unit test coverage for new classes, and to verify that a file lock is used. Relied on existing E2E test coverage for regression testing, and also manually tested to verify that the device ID is stored in the new location.