### PR TITLE
Prepare for MazeRunner v3.6.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
     environment:
       VERBOSE:
       DEBUG:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli
     environment:
       VERBOSE:
       DEBUG:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,7 +3,7 @@
 $api_key = "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
 AfterConfiguration do |_config|
-  MazeRunner.config.receive_no_requests_wait = 10
+  MazeRunner.config.receive_no_requests_wait = 10 if MazeRunner.config.respond_to? :receive_no_requests_wait=
 end
 
 Before('@skip') do |scenario|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,9 +3,7 @@
 $api_key = "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
 AfterConfiguration do |_config|
-  MazeRunner.config.receive_no_requests_wait = 10 if MazeRunner.config.respond_to? :receive_no_requests_wait=
-  # TODO: Remove once the Bugsnag-Integrity header has been implemented
-  MazeRunner.config.enforce_bugsnag_integrity = false if MazeRunner.config.respond_to? :enforce_bugsnag_integrity=
+  MazeRunner.config.receive_no_requests_wait = 10
 end
 
 Before('@skip') do |scenario|


### PR DESCRIPTION
## Goal

Prepare for the release of MazeRunner v3.6.0.  Also adds a retry for Buildkite steps failed due to lost agents (which occurs due to us using AWS spot instances).

## Design

MazeRunner v3.6.0 fixes a long standing problem with the `I should receive no requests` step, meaning that the test harness will now wait for a default time of 30s each time it is used.  As this is longer that the time needed on Android, we can prepare for the release by setting the appropriate config value to 10s, if it is available.

## Changeset

Pipeline files, MazeRunner support file.

## Testing

All changes for v3.6.0 are now on the MazeRunner master branch and before creating this PR I set the `docker-compose.yml` file to consume the MazeRunner Docker image for that version.  I ensured that both quick and full builds were run, so when v3.6.0 is released we should not notice any difference on the Android pipeline.