### PR TITLE
Prevent potential SHA-1 hash mismatch in Bugsnag-Integrity header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Prevent potential SHA-1 hash mismatch in Bugsnag-Integrity header
+  [#1028](https://github.com/bugsnag/bugsnag-android/pull/1028)
+
 ## 5.3.0 (2020-12-02)
 
 * Add integrity header to verify Error and Session API payloads have not changed

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
@@ -9,25 +9,15 @@ import java.io.IOException
  * This payload contains an error report and identifies the source application
  * using your API key.
  */
-class EventPayload : JsonStream.Streamable {
+class EventPayload @JvmOverloads internal constructor(
+    var apiKey: String?,
+    val event: Event? = null,
+    private val eventFile: File? = null,
+    notifier: Notifier
+) : JsonStream.Streamable {
 
-    var apiKey: String?
-    private val eventFile: File?
-    val event: Event?
-    private val notifier: Notifier
-
-    internal constructor(apiKey: String?, eventFile: File, notifier: Notifier) {
-        this.apiKey = apiKey
-        this.eventFile = eventFile
-        this.event = null
-        this.notifier = notifier
-    }
-
-    internal constructor(apiKey: String?, event: Event, notifier: Notifier) {
-        this.apiKey = apiKey
-        this.eventFile = null
-        this.event = event
-        this.notifier = notifier
+    internal val notifier = Notifier(notifier.name, notifier.version, notifier.url).apply {
+        dependencies = notifier.dependencies.toMutableList()
     }
 
     @Throws(IOException::class)
@@ -36,7 +26,6 @@ class EventPayload : JsonStream.Streamable {
         writer.name("apiKey").value(apiKey)
         writer.name("payloadVersion").value("4.0")
         writer.name("notifier").value(notifier)
-
         writer.name("events").beginArray()
 
         when {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -153,7 +153,7 @@ class EventStore extends FileStore {
                 apiKey = config.getApiKey();
             }
 
-            EventPayload payload = new EventPayload(apiKey, eventFile, notifier);
+            EventPayload payload = new EventPayload(apiKey, null, eventFile, notifier);
             DeliveryParams deliveryParams = config.getErrorApiDeliveryParams(payload);
             DeliveryStatus deliveryStatus = config.getDelivery().deliver(payload, deliveryParams);
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -88,7 +88,8 @@ internal class DeliveryDelegateTest {
 
     @Test
     fun deliverReport() {
-        val status = deliveryDelegate.deliverPayloadInternal(EventPayload("api-key", event, notifier), event)
+        val eventPayload = EventPayload("api-key", event, null, notifier)
+        val status = deliveryDelegate.deliverPayloadInternal(eventPayload, event)
         assertEquals(DeliveryStatus.DELIVERED, status)
         assertEquals("Sent 1 new event to Bugsnag", logger.msg)
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventPayloadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventPayloadSerializationTest.kt
@@ -21,7 +21,7 @@ internal class EventPayloadSerializationTest {
             notifier.url = "https://bugsnag.com"
             return generateSerializationTestCases(
                 "report",
-                EventPayload("api-key", File(""), notifier)
+                EventPayload("api-key", null, File(""), notifier)
             )
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventPayloadTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventPayloadTest.kt
@@ -1,0 +1,20 @@
+package com.bugsnag.android
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class EventPayloadTest {
+
+    @Test
+    fun testCloneNotifier() {
+        val original = Notifier()
+        val payload = EventPayload("api-key", null, null, original)
+        val copy = payload.notifier
+        assertNotSame(original, copy)
+        assertNotSame(original.dependencies, copy.dependencies)
+        assertEquals(original.dependencies, copy.dependencies)
+        assertEquals(original.name, copy.name)
+        assertEquals(original.url, copy.url)
+        assertEquals(original.version, copy.version)
+    }
+}


### PR DESCRIPTION
## Goal

Prevents a SHA-1 hash mismatch when the React Native notifier changes the `notifier` field on startup. Because the Android notifier assigns the event payload value by reference from `Client#notifier`, the request payload can change between generating a SHA-1 hash and making the request.

## Changeset

Copied the `notifier` parameter when constructing an `EventPayload`, so that it does not hold a copy of global state.

## Testing

Added unit test to verify that the `notifier` property is always copied when constructing an `EventPayload`. Additionally ran artefact against failing React Native scenario and confirmed that this change fixes the immediate issue.