### PR TITLE
Load bugsnag-ndk lib for multi process scenario

### DIFF
--- a/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessUnhandledCXXErrorScenario.kt
+++ b/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessUnhandledCXXErrorScenario.kt
@@ -17,6 +17,7 @@ internal class MultiProcessUnhandledCXXErrorScenario(
 
     init {
         config.autoTrackSessions = false
+        System.loadLibrary("bugsnag-ndk")
         System.loadLibrary("entrypoint")
     }
 


### PR DESCRIPTION
## Goal

Loads the `bugsnag-ndk` library for the unhandled multi process scenario. This manifested as a failure on the E2E tests as the scenario tries to call C++ code which has not been loaded: https://buildkite.com/bugsnag/bugsnag-android/builds/2807#b6514d4f-cf03-4550-b11f-02110c44b8ed