### PR TITLE
Make unhandled overridable for React Native errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TBD
 
+* Make `event.unhandled` overridable for React Native errors
+  [#1039](https://github.com/bugsnag/bugsnag-android/pull/1039)
+
 * Make `event.unhandled` overridable for JVM errors
   [#1025](https://github.com/bugsnag/bugsnag-android/pull/1025)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SeverityReason.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SeverityReason.java
@@ -77,12 +77,17 @@ final class SeverityReason implements JsonStream.Streamable {
 
     SeverityReason(String severityReasonType, Severity currentSeverity, boolean unhandled,
                    @Nullable String attributeValue) {
+        this(severityReasonType, currentSeverity, unhandled, unhandled, attributeValue);
+    }
+
+    SeverityReason(String severityReasonType, Severity currentSeverity, boolean unhandled,
+                   boolean originalUnhandled, @Nullable String attributeValue) {
         this.severityReasonType = severityReasonType;
-        this.defaultSeverity = currentSeverity;
         this.unhandled = unhandled;
-        this.originalUnhandled = unhandled;
-        this.attributeValue = attributeValue;
+        this.originalUnhandled = originalUnhandled;
+        this.defaultSeverity = currentSeverity;
         this.currentSeverity = currentSeverity;
+        this.attributeValue = attributeValue;
     }
 
     String calculateSeverityReasonType() {

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -20,10 +20,13 @@ internal class EventDeserializer(
         val severityReasonType = severityReason["type"] as String
         val severity = map["severity"] as String
         val unhandled = map["unhandled"] as Boolean
+        val originalUnhandled = getOriginalUnhandled(map, unhandled)
+
         val handledState = SeverityReason(
             severityReasonType,
             Severity.valueOf(severity.toUpperCase(Locale.US)),
             unhandled,
+            originalUnhandled,
             null
         )
 
@@ -77,5 +80,16 @@ internal class EventDeserializer(
             event.addMetadata(it.key, it.value as Map<String, Any>)
         }
         return event
+    }
+
+    private fun getOriginalUnhandled(
+        map: MutableMap<String, Any?>,
+        unhandled: Boolean
+    ): Boolean {
+        val unhandledOverridden = map.getOrElse("unhandledOverridden", { false }) as Boolean
+        return when {
+            unhandledOverridden -> !unhandled
+            else -> unhandled
+        }
     }
 }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -36,7 +36,8 @@ class EventDeserializerTest {
         map["errors"] = listOf(errorMap())
         map["metadata"] = metadataMap()
         map["app"] = mapOf(Pair("id", "app-id"))
-        map["device"] = mapOf(Pair("id", "device-id"), Pair("runtimeVersions", mutableMapOf<String, Any>()))
+        map["device"] =
+            mapOf(Pair("id", "device-id"), Pair("runtimeVersions", mutableMapOf<String, Any>()))
 
         `when`(client.config).thenReturn(TestData.generateConfig())
         `when`(client.getLogger()).thenReturn(object : Logger {})
@@ -75,6 +76,7 @@ class EventDeserializerTest {
         assertNotNull(event)
         assertEquals(Severity.INFO, event.severity)
         assertFalse(event.isUnhandled)
+        assertFalse(TestHooks.getUnhandledOverridden(event))
         assertEquals("Foo", event.context)
         assertEquals("SomeHash", event.groupingHash)
         assertEquals("123", event.getUser().id)
@@ -84,5 +86,13 @@ class EventDeserializerTest {
         assertEquals("app-id", event.app.id)
         assertEquals("device-id", event.device.id)
         assertEquals("123", event.getMetadata("custom", "id"))
+    }
+
+    @Test
+    fun deserializeUnhandledOverridden() {
+        map["unhandledOverridden"] = true
+        val event = EventDeserializer(client, emptyList()).deserialize(map)
+        assertFalse(event.isUnhandled)
+        assertTrue(TestHooks.getUnhandledOverridden(event))
     }
 }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestHooks.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestHooks.java
@@ -1,0 +1,7 @@
+package com.bugsnag.android;
+
+class TestHooks {
+    static boolean getUnhandledOverridden(Event event) {
+        return event.impl.getUnhandledOverridden();
+    }
+}


### PR DESCRIPTION
## Goal

Makes `event.unhandled` overridable in React Native errors passed from the JS layer. This allows users to decide whether specific errors apply to their stability score.

## Changeset

Calculate the original unhandled value from the `unhandledOverridden` flag, and pass it to `SeverityReason` when constructing an event.

## Testing
Added unit tests to verify deserialization of event payload. PLAT-5595 will add E2E tests separately to the JS repo.
