### PR TITLE
Deserialize unhandledOverridden correctly for React Native

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -20,7 +20,7 @@ internal class EventDeserializer(
         val severityReasonType = severityReason["type"] as String
         val severity = map["severity"] as String
         val unhandled = map["unhandled"] as Boolean
-        val originalUnhandled = getOriginalUnhandled(map, unhandled)
+        val originalUnhandled = getOriginalUnhandled(severityReason, unhandled)
 
         val handledState = SeverityReason(
             severityReasonType,
@@ -83,7 +83,7 @@ internal class EventDeserializer(
     }
 
     private fun getOriginalUnhandled(
-        map: MutableMap<String, Any?>,
+        map: Map<String, Any>,
         unhandled: Boolean
     ): Boolean {
         val unhandledOverridden = map.getOrElse("unhandledOverridden", { false }) as Boolean

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -90,7 +90,23 @@ class EventDeserializerTest {
 
     @Test
     fun deserializeUnhandledOverridden() {
-        map["unhandledOverridden"] = true
+        val map: MutableMap<String, Any?> = hashMapOf(
+            "unhandled" to false,
+            "severityReason" to hashMapOf(
+                "type" to "unhandledException",
+                "unhandledOverridden" to true
+            )
+        )
+        map["severity"] = "info"
+        map["user"] = mapOf(Pair("id", "123"))
+        map["breadcrumbs"] = listOf(breadcrumbMap())
+        map["threads"] = listOf(threadMap())
+        map["errors"] = listOf(errorMap())
+        map["metadata"] = metadataMap()
+        map["app"] = mapOf(Pair("id", "app-id"))
+        map["device"] =
+            mapOf(Pair("id", "device-id"), Pair("runtimeVersions", mutableMapOf<String, Any>()))
+
         val event = EventDeserializer(client, emptyList()).deserialize(map)
         assertFalse(event.isUnhandled)
         assertTrue(TestHooks.getUnhandledOverridden(event))


### PR DESCRIPTION
## Goal

Deserialize `unhandledOverridden` from the `severityReason` part of the payload rather than at the root level. This changeset updates the tests also to ensure that the correct field is being deserialized.