### PR TITLE
Prevent potential SHA-1 hash mismatch in Bugsnag-Integrity header for session requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Prevent potential SHA-1 hash mismatch in Bugsnag-Integrity header for session requests
+  [#1043](https://github.com/bugsnag/bugsnag-android/pull/1043)
+
 ## 5.3.1 (2020-12-09)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,13 +42,11 @@ public final class Session implements JsonStream.Streamable, UserAware {
 
     Session(String id, Date startedAt, User user, boolean autoCaptured,
             Notifier notifier, Logger logger) {
+        this(null, notifier, logger);
         this.id = id;
         this.startedAt = new Date(startedAt.getTime());
         this.user = user;
-        this.logger = logger;
         this.autoCaptured.set(autoCaptured);
-        this.file = null;
-        this.notifier = notifier;
     }
 
     Session(String id, Date startedAt, User user, int unhandledCount, int handledCount,
@@ -61,7 +60,9 @@ public final class Session implements JsonStream.Streamable, UserAware {
     Session(File file, Notifier notifier, Logger logger) {
         this.file = file;
         this.logger = logger;
-        this.notifier = notifier;
+        Notifier copy = new Notifier(notifier.getName(), notifier.getVersion(), notifier.getUrl());
+        copy.setDependencies(new ArrayList<>(notifier.getDependencies()));
+        this.notifier = copy;
     }
 
     private void logNull(String property) {
@@ -187,6 +188,10 @@ public final class Session implements JsonStream.Streamable, UserAware {
      */
     boolean isV2Payload() {
         return file != null && file.getName().endsWith("_v2.json");
+    }
+
+    Notifier getNotifier() {
+        return notifier;
     }
 
     @Override

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionSerializationTest.kt
@@ -13,17 +13,14 @@ import java.util.Date
 internal class SessionSerializationTest {
 
     companion object {
-        private val notifier = Notifier()
+        private val notifier = Notifier("AndroidBugsnagNotifier", "9.9.9", "https://bugsnag.com")
 
         @JvmStatic
         @Parameters
         fun testCases(): Collection<Pair<Any, String>> {
             val session = Session("123", Date(0), User(null, null, null), 1, 0, notifier, NoopLogger)
-            notifier.version = "9.9.9"
-            notifier.name = "AndroidBugsnagNotifier"
-            notifier.url = "https://bugsnag.com"
-            session.setApp(generateApp())
-            session.setDevice(generateDevice())
+            session.app = generateApp()
+            session.device = generateDevice()
             return generateSerializationTestCases("session", session)
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -94,6 +95,21 @@ class SessionTest {
             Notifier(),
             NoopLogger
         ).isV2Payload)
+    }
+
+    @Test
+    fun testCloneNotifier() {
+        val original = Notifier()
+        val dep = Notifier("bugsnag-cobol")
+        original.dependencies = listOf(dep)
+        val payload = Session(null, original, NoopLogger)
+        val copy = payload.notifier
+        assertNotSame(original, copy)
+        assertNotSame(original.dependencies, copy.dependencies)
+        assertEquals(original.dependencies, copy.dependencies)
+        assertEquals(original.name, copy.name)
+        assertEquals(original.url, copy.url)
+        assertEquals(original.version, copy.version)
     }
 
     private fun validateSessionCopied(copy: Session) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
@@ -48,6 +48,7 @@ internal class SessionTrackerPauseResumeTest {
 
     @Before
     fun setUp() {
+        `when`(client.getNotifier()).thenReturn(Notifier())
         `when`(client.getAppContext()).thenReturn(context)
         `when`(client.getAppDataCollector()).thenReturn(appDataCollector)
         `when`(appDataCollector.generateApp()).thenReturn(app)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
@@ -55,6 +55,7 @@ public class SessionTrackerTest {
      */
     @Before
     public void setUp() {
+        when(client.getNotifier()).thenReturn(new Notifier());
         when(client.getAppContext()).thenReturn(context);
         when(client.getAppDataCollector()).thenReturn(appDataCollector);
         when(appDataCollector.generateApp()).thenReturn(app);


### PR DESCRIPTION
## Goal

Prevents a SHA-1 hash mismatch when the React Native notifier changes the `notifier` field on startup. Because the Android notifier assigns the event payload value by reference from `Client#notifier`, the request payload can change between generating a SHA-1 hash and making the request.

## Changeset

Copied the `notifier` parameter when constructing a `Session`, so that it does not hold a copy of global state.

## Testing

Added unit test to verify that the `notifier` property is always copied when constructing a `Session`.