### PR TITLE
Update check task to depend on checkstyle task

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -7,16 +7,10 @@ Commands can be run on the entire project, or on an individual module:
 ./gradlew bugsnag-plugin-android-anr:build // builds bugsnag-plugin-android-anr module only
 ```
 
-## Static analysis
-
-```shell
-./gradlew lint checkstyle detekt
-```
-
 ## Running Tests Locally
 
 Running the full test suite requires a connected android device or emulator. JVM tests can be run
-in isolation by only running the `check` task.
+in isolation by only running the `check` task. The `check` task also runs all static analysis checks:
 
 ```shell
 ./gradlew check connectedCheck

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -4,10 +4,12 @@ checkstyle {
     toolVersion = "8.18"
 }
 
-task("checkstyle", type: Checkstyle) {
+def checkstyle = task("checkstyle", type: Checkstyle) {
     configFile rootProject.file("config/checkstyle/checkstyle.xml")
     source  "src/"
     include "**/*.java"
     exclude "**/external/**/*.java"
     classpath = files()
 }
+
+tasks.findByName("check").dependsOn(checkstyle)


### PR DESCRIPTION
## Goal

Updates the `checkstyle` task so that it always runs when the `check` task is run. This means that running `./gradlew check` runs all the static analysis and unit tests in the project, making it easier to run all the tasks locally.

Confirmed this works by running a [build scan](https://scans.gradle.com/s/4vmnjcdhvdl4k/timeline) and checking that the checkstyle task now appears in the build timeline.