### PR TITLE
Tweak detekt rules to supress common issues

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -2,8 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>EmptyFunctionBlock:SessionLifecycleCallback.kt$SessionLifecycleCallback${}</ID>
-    <ID>EmptyKtFile:Configuration.kt$.Configuration.kt</ID>
     <ID>LongParameterList:App.kt$App$( /** * The architecture of the running application binary */ var binaryArch: String?, /** * The package name of the application */ var id: String?, /** * The release stage set in [Configuration.releaseStage] */ var releaseStage: String?, /** * The version of the application set in [Configuration.version] */ var version: String?, /** The revision ID from the manifest (React Native apps only) */ var codeBundleId: String?, /** * The unique identifier for the build of the application set in [Configuration.buildUuid] */ var buildUuid: String?, /** * The application type set in [Configuration#version] */ var type: String?, /** * The version code of the application set in [Configuration.versionCode] */ var versionCode: Number? )</ID>
     <ID>LongParameterList:AppWithState.kt$AppWithState$( binaryArch: String?, id: String?, releaseStage: String?, version: String?, codeBundleId: String?, buildUuid: String?, type: String?, versionCode: Number?, /** * The number of milliseconds the application was running before the event occurred */ var duration: Number?, /** * The number of milliseconds the application was running in the foreground before the * event occurred */ var durationInForeground: Number?, /** * Whether the application was in the foreground when the event occurred */ var inForeground: Boolean? )</ID>
     <ID>LongParameterList:AppWithState.kt$AppWithState$( config: ImmutableConfig, binaryArch: String?, id: String?, releaseStage: String?, version: String?, codeBundleId: String?, duration: Number?, durationInForeground: Number?, inForeground: Boolean? )</ID>
@@ -17,27 +15,11 @@
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$429</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>
     <ID>MatchingDeclarationName:Breadcrumb.kt$BreadcrumbInternal : Streamable</ID>
-    <ID>MaxLineLength:ImmutableConfig.kt$val appInfo = runCatching { packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA ) }.getOrNull()</ID>
-    <ID>MaxLineLength:InternalEventPayloadDelegateTest.kt$InternalEventPayloadDelegateTest$`when`(deviceDataCollector.generateDeviceWithState(ArgumentMatchers.anyLong())).thenReturn(generateDeviceWithState())</ID>
-    <ID>MaxLineLength:SessionTest.kt$SessionTest$assertFalse(Session(File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json"), Notifier(), NoopLogger).isV2Payload)</ID>
     <ID>ProtectedMemberInFinalClass:ConfigInternal.kt$ConfigInternal$protected val plugins = mutableSetOf&lt;Plugin&gt;()</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun isAnr(event: Event): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun shouldDiscardClass(): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>
     <ID>ProtectedMemberInFinalClass:PluginClient.kt$PluginClient$protected val plugins: Set&lt;Plugin&gt;</ID>
-    <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?&gt; ): DeliveryStatus</ID>
-    <ID>ReturnCount:DeviceDataCollector.kt$DeviceDataCollector$ private fun isRooted(): Boolean</ID>
-    <ID>TooGenericExceptionCaught:AppDataCollector.kt$AppDataCollector$exception: Exception</ID>
-    <ID>TooGenericExceptionCaught:CallbackState.kt$CallbackState$ex: Throwable</ID>
-    <ID>TooGenericExceptionCaught:DefaultDelivery.kt$DefaultDelivery$exception: Exception</ID>
-    <ID>TooGenericExceptionCaught:DeviceDataCollector.kt$DeviceDataCollector$exception: Exception</ID>
-    <ID>TooGenericExceptionCaught:ManifestConfigLoader.kt$ManifestConfigLoader$exc: Exception</ID>
-    <ID>TooGenericExceptionCaught:PluginClient.kt$PluginClient$exc: Throwable</ID>
-    <ID>TooGenericExceptionCaught:Stacktrace.kt$Stacktrace$lineEx: Exception</ID>
-    <ID>TooGenericExceptionThrown:BreadcrumbStateTest.kt$BreadcrumbStateTest$throw Exception("Oh no")</ID>
-    <ID>TooManyFunctions:ConfigInternal.kt$ConfigInternal : CallbackAwareMetadataAwareUserAware</ID>
-    <ID>TooManyFunctions:DeviceDataCollector.kt$DeviceDataCollector</ID>
-    <ID>TooManyFunctions:EventInternal.kt$EventInternal : StreamableMetadataAwareUserAware</ID>
     <ID>VariableNaming:EventInternal.kt$EventInternal$/** * @return user information associated with this Event */ internal var _user = User(null, null, null)</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ImmutableConfig.kt
@@ -89,7 +89,9 @@ internal fun sanitiseConfiguration(
     val packageName = appContext.packageName
     val packageManager = appContext.packageManager
     val packageInfo = runCatching { packageManager.getPackageInfo(packageName, 0) }.getOrNull()
-    val appInfo = runCatching { packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA ) }.getOrNull()
+    val appInfo = runCatching {
+        packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA )
+    }.getOrNull()
 
     // populate releaseStage
     if (configuration.releaseStage == null) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -161,7 +161,7 @@ class BreadcrumbStateTest {
     fun testOnBreadcrumbCallbackException() {
         val breadcrumb = Breadcrumb("Whoops", NoopLogger)
         breadcrumbState.callbackState.addOnBreadcrumb(OnBreadcrumbCallback {
-            throw Exception("Oh no")
+            throw IllegalStateException("Oh no")
         })
         breadcrumbState.callbackState.addOnBreadcrumb(OnBreadcrumbCallback { givenBreadcrumb ->
             givenBreadcrumb.metadata?.put("callback", "second")

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
@@ -37,7 +37,9 @@ internal class InternalEventPayloadDelegateTest {
         `when`(this.appDataCollector.generateAppWithState()).thenReturn(app)
         app.durationInForeground = 500L
         app.inForeground = true
-        `when`(deviceDataCollector.generateDeviceWithState(ArgumentMatchers.anyLong())).thenReturn(generateDeviceWithState())
+        `when`(deviceDataCollector
+            .generateDeviceWithState(ArgumentMatchers.anyLong()))
+            .thenReturn(generateDeviceWithState())
 
         val config = generateImmutableConfig()
         val delegate = InternalReportDelegate(

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
@@ -89,7 +89,8 @@ class SessionTest {
     @Test
     fun isV2() {
         assertFalse(session.isV2Payload)
-        assertFalse(Session(File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json"), Notifier(), NoopLogger).isV2Payload)
+        val file = File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc.json")
+        assertFalse(Session(file, Notifier(), NoopLogger).isV2Payload)
         assertTrue(Session(
             File("150450000000053a27e4e-967c-4e5c-91be-2e86f2eb7cdc_v2.json"),
             Notifier(),

--- a/bugsnag-plugin-android-anr/detekt-baseline.xml
+++ b/bugsnag-plugin-android-anr/detekt-baseline.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>TooGenericExceptionCaught:AnrDetailsCollector.kt$AnrDetailsCollector$exc: RuntimeException</ID>
-  </CurrentIssues>
+  <CurrentIssues></CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -4,11 +4,7 @@
   <CurrentIssues>
     <ID>ComplexMethod:NativeBridge.kt$NativeBridge$override fun update(observable: Observable, arg: Any?)</ID>
     <ID>LongParameterList:NativeBridge.kt$NativeBridge$( apiKey: String, reportingDirectory: String, autoDetectNdkCrashes: Boolean, apiLevel: Int, is32bit: Boolean, appVersion: String, buildUuid: String, releaseStage: String )</ID>
-    <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is AddBreadcrumb -&gt; addBreadcrumb(makeSafe(msg.message), makeSafe(msg.type.toString()), makeSafe(msg.timestamp), msg.metadata)</ID>
-    <ID>MaxLineLength:NativeBridge.kt$NativeBridge$is StartSession -&gt; startedSession(makeSafe(msg.id), makeSafe(msg.startedAt), msg.handledCount, msg.unhandledCount)</ID>
     <ID>NestedBlockDepth:NativeBridge.kt$NativeBridge$private fun deliverPendingReports()</ID>
-    <ID>ReturnCount:NativeBridge.kt$NativeBridge$private fun isInvalidMessage(msg: Any?): Boolean</ID>
-    <ID>TooGenericExceptionCaught:NativeBridge.kt$NativeBridge$ex: Exception</ID>
     <ID>TooManyFunctions:NativeBridge.kt$NativeBridge : Observer</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -97,14 +97,30 @@ class NativeBridge : Observer {
             DeliverPending -> deliverPendingReports()
             is AddMetadata -> handleAddMetadata(msg)
             is ClearMetadataSection -> clearMetadataTab(makeSafe(msg.section))
-            is ClearMetadataValue -> removeMetadata(makeSafe(msg.section), makeSafe(msg.key ?: ""))
-            is AddBreadcrumb -> addBreadcrumb(makeSafe(msg.message), makeSafe(msg.type.toString()), makeSafe(msg.timestamp), msg.metadata)
+            is ClearMetadataValue -> removeMetadata(
+                makeSafe(msg.section),
+                makeSafe(msg.key ?: "")
+            )
+            is AddBreadcrumb -> addBreadcrumb(
+                makeSafe(msg.message),
+                makeSafe(msg.type.toString()),
+                makeSafe(msg.timestamp),
+                msg.metadata
+            )
             NotifyHandled -> addHandledEvent()
             NotifyUnhandled -> addUnhandledEvent()
             PauseSession -> pausedSession()
-            is StartSession -> startedSession(makeSafe(msg.id), makeSafe(msg.startedAt), msg.handledCount, msg.unhandledCount)
+            is StartSession -> startedSession(
+                makeSafe(msg.id),
+                makeSafe(msg.startedAt),
+                msg.handledCount,
+                msg.unhandledCount
+            )
             is UpdateContext -> updateContext(makeSafe(msg.context ?: ""))
-            is UpdateInForeground -> updateInForeground(msg.inForeground, makeSafe(msg.contextActivity ?: ""))
+            is UpdateInForeground -> updateInForeground(
+                msg.inForeground,
+                makeSafe(msg.contextActivity ?: "")
+            )
             is UpdateOrientation -> updateOrientation(msg.orientation ?: "")
             is UpdateUser -> {
                 updateUserId(makeSafe(msg.user.id ?: ""))

--- a/bugsnag-plugin-react-native/detekt-baseline.xml
+++ b/bugsnag-plugin-react-native/detekt-baseline.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>EmptyFunctionBlock:BugsnagReactNativePlugin.kt$BugsnagReactNativePlugin${}</ID>
-    <ID>TooManyFunctions:BugsnagReactNativePlugin.kt$BugsnagReactNativePlugin : Plugin</ID>
-  </CurrentIssues>
+  <CurrentIssues></CurrentIssues>
 </SmellBaseline>

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,32 @@
+# Overrides the default detekt behaviour.
+# see: https://detekt.github.io/detekt/configurations.html
+
+# The default number of functions is 10, which is too low given
+# some of the APIs we are required to implement
+complexity:
+  active: true
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 21
+    thresholdInClasses: 21
+    thresholdInObjects: 21
+
+# There are some cases where Bugsnag prefers to swallow exceptions rather than crashing,
+# so disable this check
+exceptions:
+  active: true
+  TooGenericExceptionCaught:
+    active: false
+
+# allow performing no action in overridden functions
+empty-blocks:
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: true
+
+# default for return count is excessively low - increased to allow for use of early returns
+style:
+  active: true
+  ReturnCount:
+    active: true
+    max: 4

--- a/gradle/detekt.gradle
+++ b/gradle/detekt.gradle
@@ -1,4 +1,6 @@
 detekt {
     input = files("src/androidTest", "src/main/java", "src/test")
     baseline = file("detekt-baseline.xml")
+    buildUponDefaultConfig = true
+    config = files("$projectDir/../config/detekt/detekt.yml")
 }


### PR DESCRIPTION
## Goal

Several static analysis checks commonly need to be suppressed. This changeset tweaks the [default behaviour](https://detekt.github.io/detekt/empty-blocks.html) of Detekt to avoid the need for adding acceptable violations to the baseline file, and addresses some existing violations in the codebase (explanation commented inline).