### PR TITLE
Increase kotlin dependency version to 1.3.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Increase kotlin dependency version to 1.3.72
+  [#1050](https://github.com/bugsnag/bugsnag-android/pull/1050)
+
 ## 5.4.0 (2020-12-14)
 
 * Make `event.unhandled` overridable for NDK errors

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
     }
-    ext.kotlin_version = "1.3.61"
+    ext.kotlin_version = "1.3.72"
     ext.agpVersion = "3.4.2"
 
     dependencies {


### PR DESCRIPTION
## Goal

Increases the Kotlin dependency version to 1.3.72. This contains the [following changes](https://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released/) and allows us to keep up to date.