### PR TITLE
Setup NDK code to use ClangFormat

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -121,6 +121,14 @@ steps:
     timeout_in_minutes: 10
     plugins:
       - docker-compose#v3.7.0:
+          run: android-ci
+    command: 'bash ./scripts/run-clang-format-ci-check.sh'
+
+  - label: ':android: ClangFormat'
+    depends_on: "android-ci"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.7.0:
           run: android-builder
     command: 'cd features/fixtures/mazerunner && ./gradlew ktlintCheck detekt checkstyle'
 

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
@@ -1,10 +1,10 @@
 #include "anr_handler.h"
+#include <android/log.h>
 #include <errno.h>
+#include <jni.h>
 #include <pthread.h>
 #include <signal.h>
 #include <string.h>
-#include <android/log.h>
-#include <jni.h>
 
 #include "utils/string.h"
 
@@ -26,7 +26,6 @@ static jobject obj_plugin = NULL;
 /* The previous SIGQUIT handler */
 struct sigaction bsg_sigquit_sigaction_previous;
 
-
 void bsg_notify_anr_detected(JNIEnv *env) {
   (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
 }
@@ -41,7 +40,8 @@ bool bsg_configure_anr_jni(JNIEnv *env) {
   }
 
   jclass clz = (*env)->FindClass(env, "com/bugsnag/android/AnrPlugin");
-  mthd_notify_anr_detected = (*env)->GetMethodID(env, clz, "notifyAnrDetected", "()V");
+  mthd_notify_anr_detected =
+      (*env)->GetMethodID(env, clz, "notifyAnrDetected", "()V");
   return true;
 }
 
@@ -56,14 +56,16 @@ void bsg_handle_sigquit(int signum, siginfo_t *info, void *user_context) {
     } else if (result == JNI_EDETACHED) { // attach before calling JNI
       if ((*bsg_jvm)->AttachCurrentThread(bsg_jvm, &env, NULL) == 0) {
         bsg_notify_anr_detected(env);
-        (*bsg_jvm)->DetachCurrentThread(bsg_jvm); // detach to restore initial condition
+        (*bsg_jvm)->DetachCurrentThread(
+            bsg_jvm); // detach to restore initial condition
       }
     } // All other results are error codes
   }
 
   // Invoke previous handler, if a custom handler has been set
-  // This can be conditionally switched off on certain platforms (e.g. Unity) where
-  // this behaviour is not desirable due to Unity's implementation failing with a SIGSEGV
+  // This can be conditionally switched off on certain platforms (e.g. Unity)
+  // where this behaviour is not desirable due to Unity's implementation failing
+  // with a SIGSEGV
   if (invokePrevHandler) {
     struct sigaction previous = bsg_sigquit_sigaction_previous;
     if (previous.sa_flags & SA_SIGINFO) {
@@ -85,9 +87,9 @@ void *bsg_monitor_anrs(void *_arg) {
   sigemptyset(&handler.sa_mask);
   handler.sa_sigaction = bsg_handle_sigquit;
 
-  // remove SA_ONSTACK flag as we don't require information about the SIGQUIT signal.
-  // specifying this flag results in a crash when performing a JNI call. For further context
-  // see https://issuetracker.google.com/issues/37035211
+  // remove SA_ONSTACK flag as we don't require information about the SIGQUIT
+  // signal. specifying this flag results in a crash when performing a JNI call.
+  // For further context see https://issuetracker.google.com/issues/37035211
   handler.sa_flags = SA_SIGINFO;
   int success = sigaction(SIGQUIT, &handler, &bsg_sigquit_sigaction_previous);
   if (success != 0) {
@@ -97,7 +99,8 @@ void *bsg_monitor_anrs(void *_arg) {
   return NULL;
 }
 
-bool bsg_handler_install_anr(JNIEnv *env, jobject plugin, jboolean callPreviousSigquitHandler) {
+bool bsg_handler_install_anr(JNIEnv *env, jobject plugin,
+                             jboolean callPreviousSigquitHandler) {
   pthread_mutex_lock(&bsg_anr_handler_config);
   invokePrevHandler = callPreviousSigquitHandler;
 

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_handler.h
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_handler.h
@@ -1,7 +1,7 @@
 #ifndef BUGSNAG_ANR_HANDLER_H
 #define BUGSNAG_ANR_HANDLER_H
-#include <stdbool.h>
 #include <jni.h>
+#include <stdbool.h>
 
 /**
  * The Application Not Responding (ANR) handler captures SIGQUIT being raised,
@@ -26,9 +26,11 @@ extern "C" {
  * Monitor for ANRs, writing to a byte buffer when detected
  * @param env the JNIEnv used to notify when an ANR occurs
  * @param plugin the AnrPlugin object that shouild be used to notify bugsnag
- * @param callPreviousSigquitHandler whether the previous SIGQUIT handler should be invoked
+ * @param callPreviousSigquitHandler whether the previous SIGQUIT handler should
+ * be invoked
  */
-bool bsg_handler_install_anr(JNIEnv *env, jobject plugin, jboolean callPreviousSigquitHandler);
+bool bsg_handler_install_anr(JNIEnv *env, jobject plugin,
+                             jboolean callPreviousSigquitHandler);
 
 void bsg_handler_uninstall_anr(void);
 

--- a/bugsnag-plugin-android-anr/src/main/jni/bugsnag_anr.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/bugsnag_anr.c
@@ -8,13 +8,13 @@ extern "C" {
 #endif
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_AnrPlugin_enableAnrReporting(
-        JNIEnv *env, jobject _this, jboolean callPreviousSigquitHandler) {
-    bsg_handler_install_anr(env, _this, callPreviousSigquitHandler);
+    JNIEnv *env, jobject _this, jboolean callPreviousSigquitHandler) {
+  bsg_handler_install_anr(env, _this, callPreviousSigquitHandler);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_AnrPlugin_disableAnrReporting(
-        JNIEnv *env, jobject _this) {
-    bsg_handler_uninstall_anr();
+    JNIEnv *env, jobject _this) {
+  bsg_handler_uninstall_anr();
 }
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-anr/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/utils/string.c
@@ -1,13 +1,13 @@
 #include "string.h"
 
 void bsg_strncpy(char *dst, char *src, size_t len) {
-    int i = 0;
-    while (i <= len) {
-        char current = src[i];
-        dst[i] = current;
-        if (current == '\0') {
-            break;
-        }
-        i++;
+  int i = 0;
+  while (i <= len) {
+    char current = src[i];
+    dst[i] = current;
+    if (current == '\0') {
+      break;
     }
+    i++;
+  }
 }

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
@@ -2,8 +2,8 @@
 #ifndef BUGSNAG_ANDROID_NDK_BUGSNAG_API_H
 #define BUGSNAG_ANDROID_NDK_BUGSNAG_API_H
 
-#include <jni.h>
 #include "event.h"
+#include <jni.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,26 +22,29 @@ void bugsnag_start(JNIEnv *env);
  * @param message  The error message
  * @param severity The severity of the error
  */
-void bugsnag_notify(char* name, char* message, bugsnag_severity severity);
-void bugsnag_notify_env(JNIEnv *env, char* name, char* message, bugsnag_severity severity);
+void bugsnag_notify(char *name, char *message, bugsnag_severity severity);
+void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
+                        bugsnag_severity severity);
 /**
  * Set the current user
  * @param id    The identifier of the user
  * @param email The user's email
  * @param name  The user's name
  */
-void bugsnag_set_user(char* id, char* email, char* name);
-void bugsnag_set_user_env(JNIEnv *env, char* id, char* email, char* name);
+void bugsnag_set_user(char *id, char *email, char *name);
+void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name);
 /**
- * Leave a breadcrumb, indicating an event of significance which will be logged in subsequent
- * error reports
+ * Leave a breadcrumb, indicating an event of significance which will be logged
+ * in subsequent error reports
  */
 void bugsnag_leave_breadcrumb(char *message, bugsnag_breadcrumb_type type);
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message, bugsnag_breadcrumb_type type);
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
+                                  bugsnag_breadcrumb_type type);
 
 /**
- * Adds a callback which is invoked whenever a fatal error occurs. The callback will be passed a
- * pointer to the event payload as a parameter, allowing for data to be added/removed.
+ * Adds a callback which is invoked whenever a fatal error occurs. The callback
+ * will be passed a pointer to the event payload as a parameter, allowing for
+ * data to be added/removed.
  * @param on_error the callback
  */
 void bugsnag_add_on_error(bsg_on_error on_error);
@@ -55,4 +58,4 @@ void bugsnag_remove_on_error();
 }
 #endif
 
-#endif //BUGSNAG_ANDROID_NDK_BUGSNAG_API_H
+#endif // BUGSNAG_ANDROID_NDK_BUGSNAG_API_H

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -51,26 +51,26 @@ typedef enum {
 } bugsnag_breadcrumb_type;
 
 typedef struct {
-    char name[64];
-    char email[64];
-    char id[64];
+  char name[64];
+  char email[64];
+  char id[64];
 } bugsnag_user;
 
 typedef enum {
-    BSG_METADATA_NONE_VALUE,
-    BSG_METADATA_BOOL_VALUE,
-    BSG_METADATA_CHAR_VALUE,
-    BSG_METADATA_NUMBER_VALUE,
+  BSG_METADATA_NONE_VALUE,
+  BSG_METADATA_BOOL_VALUE,
+  BSG_METADATA_CHAR_VALUE,
+  BSG_METADATA_NUMBER_VALUE,
 } bugsnag_metadata_type;
 
 typedef struct {
-    uintptr_t frame_address;
-    uintptr_t symbol_address;
-    uintptr_t load_address;
-    uintptr_t line_number;
+  uintptr_t frame_address;
+  uintptr_t symbol_address;
+  uintptr_t load_address;
+  uintptr_t line_number;
 
-    char filename[256];
-    char method[256];
+  char filename[256];
+  char method[256];
 } bugsnag_stackframe;
 
 #ifdef __cplusplus
@@ -109,29 +109,28 @@ char *bugsnag_event_get_context(void *event_ptr);
  */
 void bugsnag_event_set_context(void *event_ptr, char *value);
 
-
 /* Accessors for event.app */
-
 
 /**
  * Retrieves the binary_arch value reported for this event.
  *
- * To obtain a pointer to the bugsnag event you are modifying, you will need to implement an
- * on_error callback. on_error callbacks are executed from within a signal handler so your implementation must
- * be async-safe, otherwise the process may terminate before an error report can be captured.
+ * To obtain a pointer to the bugsnag event you are modifying, you will need to
+ * implement an on_error callback. on_error callbacks are executed from within a
+ * signal handler so your implementation must be async-safe, otherwise the
+ * process may terminate before an error report can be captured.
  *
  * @param event_ptr - a pointer to the bugsnag event
  * @return the binary_arch in the event
  */
 char *bugsnag_app_get_binary_arch(void *event_ptr);
 
-
 /**
  * Sets a new value for the binary_arch value reported for this event.
  *
- * To obtain a pointer to the bugsnag event you are modifying, you will need to implement an
- * on_error callback. on_error callbacks are executed from within a signal handler so your implementation must
- * be async-safe, otherwise the process may terminate before an error report can be captured.
+ * To obtain a pointer to the bugsnag event you are modifying, you will need to
+ * implement an on_error callback. on_error callbacks are executed from within a
+ * signal handler so your implementation must be async-safe, otherwise the
+ * process may terminate before an error report can be captured.
  *
  * @param event_ptr - a pointer to the bugsnag event
  * @param value - the new value for the binary_arch field (nullable)
@@ -165,9 +164,7 @@ void bugsnag_app_set_version(void *event_ptr, char *value);
 int bugsnag_app_get_version_code(void *event_ptr);
 void bugsnag_app_set_version_code(void *event_ptr, int value);
 
-
 /* Accessors for event.device */
-
 
 bool bugsnag_device_get_jailbroken(void *event_ptr);
 void bugsnag_device_set_jailbroken(void *event_ptr, bool value);
@@ -199,9 +196,7 @@ void bugsnag_device_set_time(void *event_ptr, time_t value);
 char *bugsnag_device_get_os_name(void *event_ptr);
 void bugsnag_device_set_os_name(void *event_ptr, char *value);
 
-
 /* Accessors for event.error */
-
 
 char *bugsnag_error_get_error_class(void *event_ptr);
 void bugsnag_error_set_error_class(void *event_ptr, char *value);
@@ -212,41 +207,37 @@ void bugsnag_error_set_error_message(void *event_ptr, char *value);
 char *bugsnag_error_get_error_type(void *event_ptr);
 void bugsnag_error_set_error_type(void *event_ptr, char *value);
 
-
 /* Accessors for event.user */
 
-
 /**
- * Retrieves the user value reported for this event. The user struct has an ID, email, and name.
+ * Retrieves the user value reported for this event. The user struct has an ID,
+ * email, and name.
  *
- * To obtain a pointer to the bugsnag event you are modifying, you will need to implement an
- * on_error callback. on_error callbacks are executed from within a signal handler so your implementation must
- * be async-safe, otherwise the process may terminate before an error report can be captured.
+ * To obtain a pointer to the bugsnag event you are modifying, you will need to
+ * implement an on_error callback. on_error callbacks are executed from within a
+ * signal handler so your implementation must be async-safe, otherwise the
+ * process may terminate before an error report can be captured.
  *
  * @param event_ptr - a pointer to the bugsnag event
  * @return the user in the event, represented as a struct
  */
 bugsnag_user bugsnag_event_get_user(void *event_ptr);
-void bugsnag_event_set_user(void *event_ptr, char* id, char* email, char* name);
-
+void bugsnag_event_set_user(void *event_ptr, char *id, char *email, char *name);
 
 /* Accessors for event.severity */
-
 
 bugsnag_severity bugsnag_event_get_severity(void *event_ptr);
 void bugsnag_event_set_severity(void *event_ptr, bugsnag_severity value);
 
-
 /* Accessors for event.unhandled */
 
-
 /**
- * Whether the event was a crash (i.e. unhandled) or handled error in which the system
- * continued running.
+ * Whether the event was a crash (i.e. unhandled) or handled error in which the
+ * system continued running.
  *
- * Unhandled errors count towards your stability score. If you don't want certain errors
- * to count towards your stability score, you can alter this property through
- * bugsnag_add_on_error.
+ * Unhandled errors count towards your stability score. If you don't want
+ * certain errors to count towards your stability score, you can alter this
+ * property through bugsnag_add_on_error.
  *
  * @param event_ptr a pointer to the event supplied in a bsg_on_error callback
  * @return whether the event is unhandled or not
@@ -254,31 +245,31 @@ void bugsnag_event_set_severity(void *event_ptr, bugsnag_severity value);
 bool bugsnag_event_is_unhandled(void *event_ptr);
 
 /**
- * Whether the event was a crash (i.e. unhandled) or handled error in which the system
- * continued running.
+ * Whether the event was a crash (i.e. unhandled) or handled error in which the
+ * system continued running.
  *
- * Unhandled errors count towards your stability score. If you don't want certain errors
- * to count towards your stability score, you can alter this property through
- * bugsnag_add_on_error.
+ * Unhandled errors count towards your stability score. If you don't want
+ * certain errors to count towards your stability score, you can alter this
+ * property through bugsnag_add_on_error.
  *
  * @param event_ptr a pointer to the event supplied in a bsg_on_error callback
  * @param value the new unhandled value
  */
 void bugsnag_event_set_unhandled(void *event_ptr, bool value);
 
-
 /* Accessors for event.groupingHash */
-
 
 char *bugsnag_event_get_grouping_hash(void *event_ptr);
 void bugsnag_event_set_grouping_hash(void *event_ptr, char *value);
 
-
 /* Accessors for event.metadata */
 
-void bugsnag_event_add_metadata_double(void *event_ptr, char *section, char *name, double value);
-void bugsnag_event_add_metadata_string(void *event_ptr, char *section, char *name, char *value);
-void bugsnag_event_add_metadata_bool(void *event_ptr, char *section, char *name, bool value);
+void bugsnag_event_add_metadata_double(void *event_ptr, char *section,
+                                       char *name, double value);
+void bugsnag_event_add_metadata_string(void *event_ptr, char *section,
+                                       char *name, char *value);
+void bugsnag_event_add_metadata_bool(void *event_ptr, char *section, char *name,
+                                     bool value);
 
 void bugsnag_event_clear_metadata_section(void *event_ptr, char *section);
 void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name);
@@ -286,47 +277,53 @@ void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name);
 /**
  * Retrieves the metadata type for a given section and key in this event.
  *
- * You should call this method before attempting to call bugsnag_event_get_metadata. If a
- * value has been set for a given section/name, this method will return one of:
- * BSG_METADATA_CHAR_VALUE, BSG_METADATA_NUMBER_VALUE, BSG_METADATA_BOOL_VALUE. You should then
- * call the appropriate bugsnag_event_get_metadata method to retrieve the actual value.
+ * You should call this method before attempting to call
+ * bugsnag_event_get_metadata. If a value has been set for a given section/name,
+ * this method will return one of: BSG_METADATA_CHAR_VALUE,
+ * BSG_METADATA_NUMBER_VALUE, BSG_METADATA_BOOL_VALUE. You should then call the
+ * appropriate bugsnag_event_get_metadata method to retrieve the actual value.
  *
  * If no value has been set, this method will return BSG_METADATA_NONE_VALUE.
  *
- * To obtain a pointer to the bugsnag event you are modifying, you will need to implement an
- * on_error callback. on_error callbacks are executed from within a signal handler so your implementation must
- * be async-safe, otherwise the process may terminate before an error report can be captured.
+ * To obtain a pointer to the bugsnag event you are modifying, you will need to
+ * implement an on_error callback. on_error callbacks are executed from within a
+ * signal handler so your implementation must be async-safe, otherwise the
+ * process may terminate before an error report can be captured.
  *
  * @param event_ptr - a pointer to the bugsnag event
  * @param section - the metadata section key
  * @param name - the metadata section name
- * @return the type of the metadata, or BSG_METADATA_NONE_VALUE if no value exists
+ * @return the type of the metadata, or BSG_METADATA_NONE_VALUE if no value
+ * exists
  */
-bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr, char *section, char *name);
+bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr, char *section,
+                                                 char *name);
 
 /**
  * Retrieves the metadata value for a given section and key in this event.
  *
- * Before calling this method you should first check whether a metadata value exists by using
- * bugsnag_event_has_metadata. If no value exists, a default value will be returned. For numeric
- * values, the default value will be 0.0.
+ * Before calling this method you should first check whether a metadata value
+ * exists by using bugsnag_event_has_metadata. If no value exists, a default
+ * value will be returned. For numeric values, the default value will be 0.0.
  *
- * To obtain a pointer to the bugsnag event you are modifying, you will need to implement an
- * on_error callback. on_error callbacks are executed from within a signal handler so your implementation must
- * be async-safe, otherwise the process may terminate before an error report can be captured.
+ * To obtain a pointer to the bugsnag event you are modifying, you will need to
+ * implement an on_error callback. on_error callbacks are executed from within a
+ * signal handler so your implementation must be async-safe, otherwise the
+ * process may terminate before an error report can be captured.
  *
  * @param event_ptr - a pointer to the bugsnag event
  * @param section - the metadata section key
  * @param name - the metadata section name
  * @param value - the value to set on the given key/name
  */
-double bugsnag_event_get_metadata_double(void *event_ptr, char *section, char *name);
-char *bugsnag_event_get_metadata_string(void *event_ptr, char *section, char *name);
-bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section, char *name);
-
+double bugsnag_event_get_metadata_double(void *event_ptr, char *section,
+                                         char *name);
+char *bugsnag_event_get_metadata_string(void *event_ptr, char *section,
+                                        char *name);
+bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section,
+                                     char *name);
 
 /* Accessors for event.error.stacktrace */
-
 
 int bugsnag_event_get_stacktrace_size(void *event_ptr);
 bugsnag_stackframe *bugsnag_event_get_stackframe(void *event_ptr, int index);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -1,11 +1,11 @@
 /** \brief The public API
  */
+#include "../assets/include/bugsnag.h"
 #include "bugsnag_ndk.h"
 #include "event.h"
+#include "metadata.h"
 #include "utils/stack_unwinder.h"
 #include "utils/string.h"
-#include "metadata.h"
-#include "../assets/include/bugsnag.h"
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -75,7 +75,8 @@ jbyteArray bsg_byte_ary_from_string(JNIEnv *env, char *text) {
 
 void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
   if (array != NULL) {
-    (*env)->ReleaseByteArrayElements(env, array, (jbyte *)original_text, JNI_COMMIT);
+    (*env)->ReleaseByteArrayElements(env, array, (jbyte *)original_text,
+                                     JNI_COMMIT);
   }
 }
 
@@ -149,23 +150,22 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
 }
 
 void bugsnag_set_binary_arch(JNIEnv *env) {
-    jclass interface_class =
-        (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-    jmethodID set_arch_method = (*env)->GetStaticMethodID(
-        env, interface_class, "setBinaryArch", "(Ljava/lang/String;)V");
+  jclass interface_class =
+      (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
+  jmethodID set_arch_method = (*env)->GetStaticMethodID(
+      env, interface_class, "setBinaryArch", "(Ljava/lang/String;)V");
 
-    jstring arch = (*env)->NewStringUTF(env, bsg_binary_arch());
-    (*env)->CallStaticVoidMethod(env, interface_class, set_arch_method, arch);
-    (*env)->DeleteLocalRef(env, arch);
-    (*env)->DeleteLocalRef(env, interface_class);
+  jstring arch = (*env)->NewStringUTF(env, bsg_binary_arch());
+  (*env)->CallStaticVoidMethod(env, interface_class, set_arch_method, arch);
+  (*env)->DeleteLocalRef(env, arch);
+  (*env)->DeleteLocalRef(env, interface_class);
 }
 
 void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
   jclass interface_class =
       (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-  jmethodID set_user_method = (*env)->GetStaticMethodID(
-      env, interface_class, "setUser",
-      "([B[B[B)V");
+  jmethodID set_user_method =
+      (*env)->GetStaticMethodID(env, interface_class, "setUser", "([B[B[B)V");
 
   jbyteArray jid = bsg_byte_ary_from_string(env, id);
   jbyteArray jemail = bsg_byte_ary_from_string(env, email);
@@ -210,14 +210,14 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
                                   bugsnag_breadcrumb_type type) {
   jclass interface_class =
       (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-  jmethodID leave_breadcrumb_method = (*env)->GetStaticMethodID(
-      env, interface_class, "leaveBreadcrumb",
-      "([BLcom/bugsnag/android/BreadcrumbType;)V");
+  jmethodID leave_breadcrumb_method =
+      (*env)->GetStaticMethodID(env, interface_class, "leaveBreadcrumb",
+                                "([BLcom/bugsnag/android/BreadcrumbType;)V");
   jclass type_class =
       (*env)->FindClass(env, "com/bugsnag/android/BreadcrumbType");
 
   jobject jtype = (*env)->GetStaticObjectField(
-          env, type_class, bsg_parse_jcrumb_type(env, type, type_class));
+      env, type_class, bsg_parse_jcrumb_type(env, type, type_class));
   jbyteArray jmessage = bsg_byte_ary_from_string(env, message);
   (*env)->CallStaticVoidMethod(env, interface_class, leave_breadcrumb_method,
                                jmessage, jtype);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -6,10 +6,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "handlers/signal_handler.h"
-#include "handlers/cpp_handler.h"
-#include "metadata.h"
 #include "event.h"
+#include "handlers/cpp_handler.h"
+#include "handlers/signal_handler.h"
+#include "metadata.h"
 #include "utils/serializer.h"
 #include "utils/string.h"
 
@@ -57,15 +57,16 @@ void bugsnag_remove_on_error() {
 bool bsg_run_on_error() {
   bsg_on_error on_error = bsg_global_env->on_error;
   if (on_error != NULL) {
-      return on_error(&bsg_global_env->next_event);
+    return on_error(&bsg_global_env->next_event);
   }
   return true;
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_NdkPlugin_enableCrashReporting(
-        JNIEnv *env, jobject _this) {
+    JNIEnv *env, jobject _this) {
   if (bsg_global_env == NULL) {
-    BUGSNAG_LOG("Attempted to enable crash reporting without first calling install()");
+    BUGSNAG_LOG(
+        "Attempted to enable crash reporting without first calling install()");
     return;
   }
   bsg_handler_install_signal(bsg_global_env);
@@ -73,23 +74,26 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_NdkPlugin_enableCrashReporting(
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_NdkPlugin_disableCrashReporting(
-        JNIEnv *env, jobject _this) {
+    JNIEnv *env, jobject _this) {
   bsg_handler_uninstall_signal();
   bsg_handler_uninstall_cpp();
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_enableCrashReporting(
-    JNIEnv *env, jobject _this) {
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_ndk_NativeBridge_enableCrashReporting(JNIEnv *env,
+                                                               jobject _this) {
   if (bsg_global_env == NULL) {
-    BUGSNAG_LOG("Attempted to enable crash reporting without first calling install()");
+    BUGSNAG_LOG(
+        "Attempted to enable crash reporting without first calling install()");
     return;
   }
   bsg_handler_install_signal(bsg_global_env);
   bsg_handler_install_cpp(bsg_global_env);
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_disableCrashReporting(
-    JNIEnv *env, jobject _this) {
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_ndk_NativeBridge_disableCrashReporting(JNIEnv *env,
+                                                                jobject _this) {
   bsg_handler_uninstall_signal();
   bsg_handler_uninstall_cpp();
 }
@@ -128,7 +132,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   }
 
   const char *api_key = (*env)->GetStringUTFChars(env, _api_key, 0);
-  bsg_strncpy_safe(bugsnag_env->next_event.api_key, (char *) api_key, sizeof(bugsnag_env->next_event.api_key));
+  bsg_strncpy_safe(bugsnag_env->next_event.api_key, (char *)api_key,
+                   sizeof(bugsnag_env->next_event.api_key));
   (*env)->ReleaseStringUTFChars(env, _api_key, api_key);
 
   bsg_global_env = bugsnag_env;
@@ -141,31 +146,33 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   static pthread_mutex_t bsg_native_delivery_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&bsg_native_delivery_mutex);
   const char *event_path = (*env)->GetStringUTFChars(env, _report_path, 0);
-  bugsnag_event *event =
-          bsg_deserialize_event_from_file((char *) event_path);
+  bugsnag_event *event = bsg_deserialize_event_from_file((char *)event_path);
 
   if (event != NULL) {
     char *payload = bsg_serialize_event_to_json_string(event);
     if (payload != NULL) {
       jclass interface_class =
           (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-      jmethodID jdeliver_method =
-          (*env)->GetStaticMethodID(env, interface_class, "deliverReport",
-                                    "([B[BLjava/lang/String;)V");
+      jmethodID jdeliver_method = (*env)->GetStaticMethodID(
+          env, interface_class, "deliverReport", "([B[BLjava/lang/String;)V");
       size_t payload_length = bsg_strlen(payload);
       jbyteArray jpayload = (*env)->NewByteArray(env, payload_length);
-      (*env)->SetByteArrayRegion(env, jpayload, 0, payload_length, (jbyte *)payload);
+      (*env)->SetByteArrayRegion(env, jpayload, 0, payload_length,
+                                 (jbyte *)payload);
 
       size_t stage_length = bsg_strlen(event->app.release_stage);
       jbyteArray jstage = (*env)->NewByteArray(env, stage_length);
-      (*env)->SetByteArrayRegion(env, jstage, 0, stage_length, (jbyte *)event->app.release_stage);
+      (*env)->SetByteArrayRegion(env, jstage, 0, stage_length,
+                                 (jbyte *)event->app.release_stage);
 
       jstring japi_key = (*env)->NewStringUTF(env, event->api_key);
       (*env)->CallStaticVoidMethod(env, interface_class, jdeliver_method,
                                    jstage, jpayload, japi_key);
       (*env)->DeleteLocalRef(env, japi_key);
-      (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload, 0); // <-- frees payload
-      (*env)->ReleaseByteArrayElements(env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
+      (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload,
+                                       0); // <-- frees payload
+      (*env)->ReleaseByteArrayElements(
+          env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
       (*env)->DeleteLocalRef(env, jpayload);
       (*env)->DeleteLocalRef(env, jstage);
     } else {
@@ -197,15 +204,15 @@ Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addUnhandledEvent(JNIEnv *env,
                                                             jobject _this) {
-    if (bsg_global_env == NULL)
-        return;
-    bsg_request_env_write_lock();
-    bugsnag_event *event = &bsg_global_env->next_event;
+  if (bsg_global_env == NULL)
+    return;
+  bsg_request_env_write_lock();
+  bugsnag_event *event = &bsg_global_env->next_event;
 
-    if (bugsnag_event_has_session(event)) {
-        event->unhandled_events++;
-    }
-    bsg_release_env_write_lock();
+  if (bugsnag_event_has_session(event)) {
+    event->unhandled_events++;
+  }
+  bsg_release_env_write_lock();
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
@@ -226,16 +233,16 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_pausedSession(
     JNIEnv *env, jobject _this) {
-    if (bsg_global_env == NULL) {
-        return;
-    }
-    bsg_request_env_write_lock();
-    bugsnag_event *event = &bsg_global_env->next_event;
-    memset(event->session_id, 0, strlen(event->session_id));
-    memset(event->session_start, 0, strlen(event->session_start));
-    event->handled_events = 0;
-    event->unhandled_events = 0;
-    bsg_release_env_write_lock();
+  if (bsg_global_env == NULL) {
+    return;
+  }
+  bsg_request_env_write_lock();
+  bugsnag_event *event = &bsg_global_env->next_event;
+  memset(event->session_id, 0, strlen(event->session_id));
+  memset(event->session_start, 0, strlen(event->session_start));
+  event->handled_events = 0;
+  event->unhandled_events = 0;
+  bsg_release_env_write_lock();
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
@@ -357,7 +364,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateLowMemory(JNIEnv *env,
   if (bsg_global_env == NULL)
     return;
   bsg_request_env_write_lock();
-  bugsnag_event_add_metadata_bool(&bsg_global_env->next_event, "app", "lowMemory", (bool)new_value);
+  bugsnag_event_add_metadata_bool(&bsg_global_env->next_event, "app",
+                                  "lowMemory", (bool)new_value);
   bsg_release_env_write_lock();
 }
 
@@ -404,7 +412,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
   bsg_request_env_write_lock();
   bugsnag_event event = bsg_global_env->next_event;
-  bugsnag_event_set_user(&bsg_global_env->next_event, value, event.user.email, event.user.name);
+  bugsnag_event_set_user(&bsg_global_env->next_event, value, event.user.email,
+                         event.user.name);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
     (*env)->ReleaseStringUTFChars(env, new_value, value);
@@ -420,7 +429,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserName(
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
   bsg_request_env_write_lock();
   bugsnag_event event = bsg_global_env->next_event;
-  bugsnag_event_set_user(&bsg_global_env->next_event, event.user.id, event.user.email, value);
+  bugsnag_event_set_user(&bsg_global_env->next_event, event.user.id,
+                         event.user.email, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
     (*env)->ReleaseStringUTFChars(env, new_value, value);
@@ -438,7 +448,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateUserEmail(JNIEnv *env,
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
   bsg_request_env_write_lock();
   bugsnag_event event = bsg_global_env->next_event;
-  bugsnag_event_set_user(&bsg_global_env->next_event, event.user.id, value, event.user.name);
+  bugsnag_event_set_user(&bsg_global_env->next_event, event.user.id, value,
+                         event.user.name);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
     (*env)->ReleaseStringUTFChars(env, new_value, value);
@@ -471,7 +482,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataDouble(
   char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
   bsg_request_env_write_lock();
   bugsnag_event_add_metadata_double(&bsg_global_env->next_event, tab, key,
-                                    (double) value_);
+                                    (double)value_);
   bsg_release_env_write_lock();
   (*env)->ReleaseStringUTFChars(env, tab_, tab);
   (*env)->ReleaseStringUTFChars(env, key_, key);
@@ -486,7 +497,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataBoolean(
   char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
   bsg_request_env_write_lock();
   bugsnag_event_add_metadata_bool(&bsg_global_env->next_event, tab, key,
-                                  (bool) value_);
+                                  (bool)value_);
   bsg_release_env_write_lock();
   (*env)->ReleaseStringUTFChars(env, tab_, tab);
   (*env)->ReleaseStringUTFChars(env, key_, key);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -7,9 +7,9 @@
 #include <android/log.h>
 #include <stdbool.h>
 
+#include "../assets/include/bugsnag.h"
 #include "event.h"
 #include "utils/stack_unwinder.h"
-#include "../assets/include/bugsnag.h"
 
 #ifndef BUGSNAG_LOG
 #define BUGSNAG_LOG(fmt, ...)                                                  \
@@ -21,55 +21,57 @@ extern "C" {
 #endif
 
 typedef struct {
-    /**
-     * Unwinding style used for signal-safe handling
-     */
-    bsg_unwinder signal_unwind_style;
-    /**
-     * Preferred unwinding style
-     */
-    bsg_unwinder unwind_style;
-    /**
-     * Records the version of the bugsnag NDK report being serialized to disk.
-     */
-    bsg_report_header report_header;
-    /**
-     * File path on disk where the next crash report will be written if needed.
-     */
-    char next_event_path[384];
-    /**
-     * Cache of static metadata and event info. Exception/time information is populated at crash time.
-     */
-    bugsnag_event next_event;
-    /**
-     * Time when installed
-     */
-    time_t start_time;
-    /**
-     * Time when last re-entering foreground
-     */
-    time_t foreground_start_time;
-    /**
-     * true if a crash is currently being handled. Disallows multiple crashes
-     * from being processed simultaneously
-     */
-    bool handling_crash;
-    /**
-     * true if a handler has completed crash handling
-     */
-    bool crash_handled;
+  /**
+   * Unwinding style used for signal-safe handling
+   */
+  bsg_unwinder signal_unwind_style;
+  /**
+   * Preferred unwinding style
+   */
+  bsg_unwinder unwind_style;
+  /**
+   * Records the version of the bugsnag NDK report being serialized to disk.
+   */
+  bsg_report_header report_header;
+  /**
+   * File path on disk where the next crash report will be written if needed.
+   */
+  char next_event_path[384];
+  /**
+   * Cache of static metadata and event info. Exception/time information is
+   * populated at crash time.
+   */
+  bugsnag_event next_event;
+  /**
+   * Time when installed
+   */
+  time_t start_time;
+  /**
+   * Time when last re-entering foreground
+   */
+  time_t foreground_start_time;
+  /**
+   * true if a crash is currently being handled. Disallows multiple crashes
+   * from being processed simultaneously
+   */
+  bool handling_crash;
+  /**
+   * true if a handler has completed crash handling
+   */
+  bool crash_handled;
 
-    bsg_on_error on_error;
+  bsg_on_error on_error;
 } bsg_environment;
 
 bsg_unwinder bsg_configured_unwind_style();
 
 /**
- * Invokes the user-supplied on_error callback, if it has been set. This allows users to mutate
- * the bugsnag_event payload before it is persisted to disk, and to discard the report
- * by returning false..
+ * Invokes the user-supplied on_error callback, if it has been set. This allows
+ * users to mutate the bugsnag_event payload before it is persisted to disk, and
+ * to discard the report by returning false..
  *
- * @return true if the report should be delivered, false if it should be discarded
+ * @return true if the report should be delivered, false if it should be
+ * discarded
  */
 bool bsg_run_on_error();
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -15,7 +15,8 @@ int bsg_find_next_free_metadata_index(bugsnag_metadata *const metadata) {
   return -1;
 }
 
-int bsg_allocate_metadata_index(bugsnag_metadata *metadata, char *section, char *name) {
+int bsg_allocate_metadata_index(bugsnag_metadata *metadata, char *section,
+                                char *name) {
   int index = bsg_find_next_free_metadata_index(metadata);
   if (index < 0) {
     return index;
@@ -60,24 +61,24 @@ void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, char *section,
 
 void bugsnag_event_add_metadata_double(void *event_ptr, char *section,
                                        char *name, double value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_add_metadata_value_double(&event->metadata, section, name, value);
 }
 
 void bugsnag_event_add_metadata_string(void *event_ptr, char *section,
                                        char *name, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_add_metadata_value_str(&event->metadata, section, name, value);
 }
 
-void bugsnag_event_add_metadata_bool(void *event_ptr, char *section,
-                                     char *name, bool value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+void bugsnag_event_add_metadata_bool(void *event_ptr, char *section, char *name,
+                                     bool value) {
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_add_metadata_value_bool(&event->metadata, section, name, value);
 }
 
 void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   for (int i = 0; i < event->metadata.value_count; ++i) {
     if (strcmp(event->metadata.values[i].section, section) == 0 &&
         strcmp(event->metadata.values[i].name, name) == 0) {
@@ -93,7 +94,7 @@ void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name) {
 }
 
 void bugsnag_event_clear_metadata_section(void *event_ptr, char *section) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   for (int i = 0; i < event->metadata.value_count; ++i) {
     if (strcmp(event->metadata.values[i].section, section) == 0) {
       event->metadata.values[i].type = BSG_METADATA_NONE_VALUE;
@@ -101,8 +102,9 @@ void bugsnag_event_clear_metadata_section(void *event_ptr, char *section) {
   }
 }
 
-bsg_metadata_value bugsnag_get_metadata_value(void *event_ptr, char *section, char *name) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+bsg_metadata_value bugsnag_get_metadata_value(void *event_ptr, char *section,
+                                              char *name) {
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
 
   for (int k = 0; k < event->metadata.value_count; ++k) {
     bsg_metadata_value val = event->metadata.values[k];
@@ -115,12 +117,15 @@ bsg_metadata_value bugsnag_get_metadata_value(void *event_ptr, char *section, ch
   return data;
 }
 
-bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr, char *section, char *name) {
+bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr, char *section,
+                                                 char *name) {
   return bugsnag_get_metadata_value(event_ptr, section, name).type;
 }
 
-double bugsnag_event_get_metadata_double(void *event_ptr, char *section, char *name) {
-  bsg_metadata_value value = bugsnag_get_metadata_value(event_ptr, section, name);
+double bugsnag_event_get_metadata_double(void *event_ptr, char *section,
+                                         char *name) {
+  bsg_metadata_value value =
+      bugsnag_get_metadata_value(event_ptr, section, name);
 
   if (value.type == BSG_METADATA_NUMBER_VALUE) {
     return value.double_value;
@@ -128,20 +133,23 @@ double bugsnag_event_get_metadata_double(void *event_ptr, char *section, char *n
   return 0.0;
 }
 
-char *bugsnag_event_get_metadata_string(void *event_ptr, char *section, char *name) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+char *bugsnag_event_get_metadata_string(void *event_ptr, char *section,
+                                        char *name) {
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
 
   for (int k = 0; k < event->metadata.value_count; ++k) {
-    if (strcmp(event->metadata.values[k].section, section) == 0 && strcmp(
-            event->metadata.values[k].name, name) == 0) {
+    if (strcmp(event->metadata.values[k].section, section) == 0 &&
+        strcmp(event->metadata.values[k].name, name) == 0) {
       return event->metadata.values[k].char_value;
     }
   }
   return NULL;
 }
 
-bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section, char *name) {
-  bsg_metadata_value value = bugsnag_get_metadata_value(event_ptr, section, name);
+bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section,
+                                     char *name) {
+  bsg_metadata_value value =
+      bugsnag_get_metadata_value(event_ptr, section, name);
 
   if (value.type == BSG_METADATA_BOOL_VALUE) {
     return value.bool_value;
@@ -150,7 +158,8 @@ bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section, char *name)
 }
 
 void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
-                                 char *started_at, int handled_count, int unhandled_count) {
+                                 char *started_at, int handled_count,
+                                 int unhandled_count) {
   bsg_strncpy_safe(event->session_id, session_id, sizeof(event->session_id));
   bsg_strncpy_safe(event->session_start, started_at,
                    sizeof(event->session_start));
@@ -159,27 +168,28 @@ void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
 }
 
 char *bugsnag_event_get_api_key(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->api_key;
 }
 
 void bugsnag_event_set_api_key(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->api_key, value, sizeof(event->api_key));
 }
 
 char *bugsnag_event_get_context(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->context;
 }
 
 void bugsnag_event_set_context(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->context, value, sizeof(event->context));
 }
 
-void bugsnag_event_set_user(void *event_ptr, char* id, char* email, char* name) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+void bugsnag_event_set_user(void *event_ptr, char *id, char *email,
+                            char *name) {
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->user.id, id, sizeof(event->user.id));
   bsg_strncpy_safe(event->user.email, email, sizeof(event->user.email));
   bsg_strncpy_safe(event->user.name, name, sizeof(event->user.name));
@@ -205,293 +215,295 @@ void bugsnag_event_clear_breadcrumbs(bugsnag_event *event) {
 }
 
 bool bugsnag_event_has_session(bugsnag_event *event) {
-    return strlen(event->session_id) > 0;
+  return strlen(event->session_id) > 0;
 }
-
 
 /* Accessors for event.app */
 
-
 char *bugsnag_app_get_binary_arch(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.binary_arch;
 }
 
 void bugsnag_app_set_binary_arch(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
-  bsg_strncpy_safe(event->app.binary_arch, value, sizeof(event->app.binary_arch));
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
+  bsg_strncpy_safe(event->app.binary_arch, value,
+                   sizeof(event->app.binary_arch));
 }
 
 char *bugsnag_app_get_build_uuid(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.build_uuid;
 }
 
 void bugsnag_app_set_build_uuid(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.build_uuid, value, sizeof(event->app.build_uuid));
 }
 
 char *bugsnag_app_get_id(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.id;
 }
 
 void bugsnag_app_set_id(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.id, value, sizeof(event->app.id));
 }
 
 char *bugsnag_app_get_release_stage(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.release_stage;
 }
 
 void bugsnag_app_set_release_stage(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
-  bsg_strncpy_safe(event->app.release_stage, value, sizeof(event->app.release_stage));
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
+  bsg_strncpy_safe(event->app.release_stage, value,
+                   sizeof(event->app.release_stage));
 }
 
 char *bugsnag_app_get_type(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.type;
 }
 
 void bugsnag_app_set_type(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.type, value, sizeof(event->app.type));
 }
 
 char *bugsnag_app_get_version(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.version;
 }
 
 void bugsnag_app_set_version(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.version, value, sizeof(event->app.version));
 }
 
 int bugsnag_app_get_version_code(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.version_code;
 }
 
 void bugsnag_app_set_version_code(void *event_ptr, int value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->app.version_code = value;
 }
 
 time_t bugsnag_app_get_duration(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.duration;
 }
 
 void bugsnag_app_set_duration(void *event_ptr, time_t value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->app.duration = value;
 }
 
 time_t bugsnag_app_get_duration_in_foreground(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.duration_in_foreground;
 }
 
 void bugsnag_app_set_duration_in_foreground(void *event_ptr, time_t value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->app.duration_in_foreground = value;
 }
 
 bool bugsnag_app_get_in_foreground(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->app.in_foreground;
 }
 
 void bugsnag_app_set_in_foreground(void *event_ptr, bool value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->app.in_foreground = value;
 }
 
-
 /* Accessors for event.device */
 
-
 bool bugsnag_device_get_jailbroken(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.jailbroken;
 }
 
 void bugsnag_device_set_jailbroken(void *event_ptr, bool value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->device.jailbroken = value;
 }
 
 char *bugsnag_device_get_id(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.id;
 }
 
 void bugsnag_device_set_id(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.id, value, sizeof(event->device.id));
 }
 
 char *bugsnag_device_get_locale(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.locale;
 }
 
 void bugsnag_device_set_locale(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.locale, value, sizeof(event->device.locale));
 }
 
 char *bugsnag_device_get_manufacturer(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.manufacturer;
 }
 
 void bugsnag_device_set_manufacturer(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
-  bsg_strncpy_safe(event->device.manufacturer, value, sizeof(event->device.manufacturer));
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
+  bsg_strncpy_safe(event->device.manufacturer, value,
+                   sizeof(event->device.manufacturer));
 }
 
 char *bugsnag_device_get_model(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.model;
 }
 
 void bugsnag_device_set_model(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.model, value, sizeof(event->device.model));
 }
 
 char *bugsnag_device_get_os_version(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.os_version;
 }
 
 void bugsnag_device_set_os_version(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
-  bsg_strncpy_safe(event->device.os_version, value, sizeof(event->device.os_version));
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
+  bsg_strncpy_safe(event->device.os_version, value,
+                   sizeof(event->device.os_version));
 }
 
 long bugsnag_device_get_total_memory(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.total_memory;
 }
 
 void bugsnag_device_set_total_memory(void *event_ptr, long value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->device.total_memory = value;
 }
 
 char *bugsnag_device_get_orientation(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.orientation;
 }
 
 void bugsnag_device_set_orientation(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
-  bsg_strncpy_safe(event->device.orientation, value, sizeof(event->device.orientation));
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
+  bsg_strncpy_safe(event->device.orientation, value,
+                   sizeof(event->device.orientation));
 }
 
 time_t bugsnag_device_get_time(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.time;
 }
 
 void bugsnag_device_set_time(void *event_ptr, time_t value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->device.time = value;
 }
 
 char *bugsnag_device_get_os_name(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->device.os_name;
 }
 
 void bugsnag_device_set_os_name(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.os_name, value, sizeof(event->device.os_name));
 }
 
 char *bugsnag_error_get_error_class(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->error.errorClass;
 }
 
 void bugsnag_error_set_error_class(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
-  bsg_strncpy_safe(event->error.errorClass, value, sizeof(event->error.errorClass));
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
+  bsg_strncpy_safe(event->error.errorClass, value,
+                   sizeof(event->error.errorClass));
 }
 
 char *bugsnag_error_get_error_message(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->error.errorMessage;
 }
 
 void bugsnag_error_set_error_message(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
-  bsg_strncpy_safe(event->error.errorMessage, value, sizeof(event->error.errorMessage));
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
+  bsg_strncpy_safe(event->error.errorMessage, value,
+                   sizeof(event->error.errorMessage));
 }
 
 char *bugsnag_error_get_error_type(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->error.type;
 }
 
 void bugsnag_error_set_error_type(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->error.type, value, sizeof(event->error.type));
 }
 
 bugsnag_severity bugsnag_event_get_severity(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->severity;
 }
 
 void bugsnag_event_set_severity(void *event_ptr, bugsnag_severity value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->severity = value;
 }
 
 bool bugsnag_event_is_unhandled(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->unhandled;
 }
 
 void bugsnag_event_set_unhandled(void *event_ptr, bool value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   event->unhandled = value;
 }
 
 bugsnag_user bugsnag_event_get_user(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->user;
 }
 
 char *bugsnag_event_get_grouping_hash(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->grouping_hash;
 }
 
 void bugsnag_event_set_grouping_hash(void *event_ptr, char *value) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->grouping_hash, value, sizeof(event->grouping_hash));
 }
 
 int bugsnag_event_get_stacktrace_size(void *event_ptr) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   return event->error.frame_count;
 }
 
 bugsnag_stackframe *bugsnag_event_get_stackframe(void *event_ptr, int index) {
-  bugsnag_event *event = (bugsnag_event *) event_ptr;
+  bugsnag_event *event = (bugsnag_event *)event_ptr;
   if (index >= 0 && index < event->error.frame_count) {
     return &event->error.stacktrace[index];
   } else {
     return NULL;
   }
 }
-

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -34,7 +34,6 @@
  */
 #define BUGSNAG_EVENT_VERSION 4
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,50 +43,50 @@ extern "C" {
  *********************************/
 
 typedef struct {
-    char id[64];
-    char release_stage[64];
-    char type[32];
-    char version[32];
-    char active_screen[64];
-    int version_code;
-    char build_uuid[64];
-    time_t duration;
-    time_t duration_in_foreground;
-    /**
-     * The elapsed time in milliseconds between when the system clock starts and
-     * when bugsnag-ndk install() is called
-     */
-    time_t duration_ms_offset;
-    /**
-     * The elapsed time in the foreground in milliseconds between when the app
-     * first enters the foreground and when bugsnag-ndk install() is called, if
-     * the app is in the foreground when install() occurs and the app never enters
-     * the background. This value is zero in all other cases.
-     */
-    time_t duration_in_foreground_ms_offset;
-    bool in_foreground;
-    char binary_arch[32];
+  char id[64];
+  char release_stage[64];
+  char type[32];
+  char version[32];
+  char active_screen[64];
+  int version_code;
+  char build_uuid[64];
+  time_t duration;
+  time_t duration_in_foreground;
+  /**
+   * The elapsed time in milliseconds between when the system clock starts and
+   * when bugsnag-ndk install() is called
+   */
+  time_t duration_ms_offset;
+  /**
+   * The elapsed time in the foreground in milliseconds between when the app
+   * first enters the foreground and when bugsnag-ndk install() is called, if
+   * the app is in the foreground when install() occurs and the app never enters
+   * the background. This value is zero in all other cases.
+   */
+  time_t duration_in_foreground_ms_offset;
+  bool in_foreground;
+  char binary_arch[32];
 } bsg_app_info;
 
 typedef struct {
-    char value[32];
+  char value[32];
 } bsg_cpu_abi;
 
 typedef struct {
-    int api_level;
-    int cpu_abi_count;
-    bsg_cpu_abi cpu_abi[8];
-    char orientation[32];
-    time_t time;
-    char id[64];
-    bool jailbroken;
-    char locale[32];
-    char manufacturer[64];
-    char model[64];
-    char os_build[64];
-    char os_version[64];
-    char os_name[64];
-    long total_memory;
+  int api_level;
+  int cpu_abi_count;
+  bsg_cpu_abi cpu_abi[8];
+  char orientation[32];
+  time_t time;
+  char id[64];
+  bool jailbroken;
+  char locale[32];
+  char manufacturer[64];
+  char model[64];
+  char os_build[64];
+  char os_version[64];
+  char os_name[64];
+  long total_memory;
 } bsg_device_info;
 
 /**
@@ -95,125 +94,126 @@ typedef struct {
  * including system info for potential debugging
  */
 typedef struct {
-    /**
-     * The value of BUGSNAG_EVENT_VERSION
-     */
-    int version;
-    /**
-     * 0 if big endian
-     */
-    int big_endian;
-    /**
-     * The value of device.runtimeVersions.osBuild
-     */
-    char os_build[64];
+  /**
+   * The value of BUGSNAG_EVENT_VERSION
+   */
+  int version;
+  /**
+   * 0 if big endian
+   */
+  int big_endian;
+  /**
+   * The value of device.runtimeVersions.osBuild
+   */
+  char os_build[64];
 } bsg_report_header;
 
 /**
  * A single value in metadata
  */
 typedef struct {
-    /**
-     * The key identifying this metadata entry
-     */
-    char name[32];
-    /**
-     * The metadata tab
-     */
-    char section[32];
-    /**
-     * The value type from bool, char, number
-     */
-    bugsnag_metadata_type type;
+  /**
+   * The key identifying this metadata entry
+   */
+  char name[32];
+  /**
+   * The metadata tab
+   */
+  char section[32];
+  /**
+   * The value type from bool, char, number
+   */
+  bugsnag_metadata_type type;
 
-    /**
-     * Value if type is BSG_BOOL_VALUE
-     */
-    bool bool_value;
-    /**
-     * Value if type is BSG_CHAR_VALUE
-     */
-    char char_value[64];
-    /**
-     * Value if type is BSG_DOUBLE_VALUE
-     */
-    double double_value;
+  /**
+   * Value if type is BSG_BOOL_VALUE
+   */
+  bool bool_value;
+  /**
+   * Value if type is BSG_CHAR_VALUE
+   */
+  char char_value[64];
+  /**
+   * Value if type is BSG_DOUBLE_VALUE
+   */
+  double double_value;
 } bsg_metadata_value;
 
 typedef struct {
-    /** The number of values in use */
-    int value_count;
-    bsg_metadata_value values[BUGSNAG_METADATA_MAX];
+  /** The number of values in use */
+  int value_count;
+  bsg_metadata_value values[BUGSNAG_METADATA_MAX];
 } bugsnag_metadata;
 
 /** a Bugsnag exception */
 typedef struct {
-    /** The exception name or stringified code */
-    char errorClass[64];
-    /** A description of what went wrong */
-    char errorMessage[256];
-    /** The variety of exception which needs to be processed by the pipeline */
-    char type[32];
+  /** The exception name or stringified code */
+  char errorClass[64];
+  /** A description of what went wrong */
+  char errorMessage[256];
+  /** The variety of exception which needs to be processed by the pipeline */
+  char type[32];
 
-    /**
-     * The number of frames used in the stacktrace. Must be less than
-     * BUGSNAG_FRAMES_MAX.
-     */
-    ssize_t frame_count;
-    /**
-     * An ordered list of stack frames from the oldest to the most recent
-     */
-    bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+  /**
+   * The number of frames used in the stacktrace. Must be less than
+   * BUGSNAG_FRAMES_MAX.
+   */
+  ssize_t frame_count;
+  /**
+   * An ordered list of stack frames from the oldest to the most recent
+   */
+  bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
 } bsg_error;
 
 typedef struct {
-    char name[64];
-    char timestamp[37];
-    bugsnag_breadcrumb_type type;
+  char name[64];
+  char timestamp[37];
+  bugsnag_breadcrumb_type type;
 
-    /**
-     * Key/value pairs of related information for debugging
-     */
-    bugsnag_metadata metadata;
+  /**
+   * Key/value pairs of related information for debugging
+   */
+  bugsnag_metadata metadata;
 } bugsnag_breadcrumb;
 
 typedef struct {
-    char name[64];
-    char version[16];
-    char url[64];
+  char name[64];
+  char version[16];
+  char url[64];
 } bsg_notifier;
 
 typedef struct {
-    bsg_notifier notifier;
-    bsg_app_info app;
-    bsg_device_info device;
-    bugsnag_user user;
-    bsg_error error;
-    bugsnag_metadata metadata;
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
 
-    int crumb_count;
-    // Breadcrumbs are a ring; the first index moves as the
-    // structure is filled and replaced.
-    int crumb_first_index;
-    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
 
-    char context[64];
-    bugsnag_severity severity;
+  char context[64];
+  bugsnag_severity severity;
 
-    char session_id[33];
-    char session_start[33];
-    int handled_events;
-    int unhandled_events;
-    char grouping_hash[64];
-    bool unhandled;
-    char api_key[64];
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
 } bugsnag_event;
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,
                                   bugsnag_breadcrumb *crumb);
 void bugsnag_event_clear_breadcrumbs(bugsnag_event *event);
 void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
-                                 char *started_at, int handled_count, int unhandled_count);
+                                 char *started_at, int handled_count,
+                                 int unhandled_count);
 bool bugsnag_event_has_session(bugsnag_event *event);
 
 void bsg_add_metadata_value_double(bugsnag_metadata *metadata, char *section,

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -91,9 +91,9 @@ void bsg_handle_cpp_terminate() {
   bsg_global_env->handling_crash = true;
   bsg_populate_event_as(bsg_global_env);
   bsg_global_env->next_event.unhandled = true;
-  bsg_global_env->next_event.error.frame_count = bsg_unwind_stack(
-      bsg_global_env->unwind_style,
-      bsg_global_env->next_event.error.stacktrace, NULL, NULL);
+  bsg_global_env->next_event.error.frame_count =
+      bsg_unwind_stack(bsg_global_env->unwind_style,
+                       bsg_global_env->next_event.error.stacktrace, NULL, NULL);
 
   std::type_info *tinfo = __cxxabiv1::__cxa_current_exception_type();
   if (tinfo != NULL) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -2,9 +2,9 @@
 
 #include <bugsnag_ndk.h>
 #include <errno.h>
+#include <event.h>
 #include <fcntl.h>
 #include <pthread.h>
-#include <event.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.h
@@ -18,8 +18,8 @@
  * * sigaction(2), sigaltstack(2)
  */
 
-#include "bugsnag_ndk.h"
 #include "../utils/build.h"
+#include "bugsnag_ndk.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -36,8 +36,9 @@ typedef struct {
   jmethodID get_context;
 } bsg_jni_cache;
 
-void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst, bsg_jni_cache *jni_cache,
-                                 char *section, char *name, jobject _value);
+void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
+                                 bsg_jni_cache *jni_cache, char *section,
+                                 char *name, jobject _value);
 
 bsg_jni_cache *bsg_populate_jni_cache(JNIEnv *env) {
   bsg_jni_cache *jni_cache = malloc(sizeof(bsg_jni_cache));
@@ -93,10 +94,11 @@ bsg_jni_cache *bsg_populate_jni_cache(JNIEnv *env) {
 
 jobject bsg_get_map_value_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
                               jobject map, const char *_key) {
-    jstring key = (*env)->NewStringUTF(env, _key);
-    jobject obj = (*env)->CallObjectMethod(env, map, jni_cache->hash_map_get, key);
-    (*env)->DeleteLocalRef(env, key);
-    return obj;
+  jstring key = (*env)->NewStringUTF(env, _key);
+  jobject obj =
+      (*env)->CallObjectMethod(env, map, jni_cache->hash_map_get, key);
+  (*env)->DeleteLocalRef(env, key);
+  return obj;
 }
 
 void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
@@ -193,15 +195,17 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
   for (int i = 0; i < map_size; i++) {
     jstring _key = (*env)->CallObjectMethod(env, keylist,
                                             jni_cache->arraylist_get, (jint)i);
-    jobject _value = (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);
+    jobject _value =
+        (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);
 
     if (_key == NULL || _value == NULL) {
       (*env)->DeleteLocalRef(env, _key);
       (*env)->DeleteLocalRef(env, _value);
     } else {
-        char *key = (char *)(*env)->GetStringUTFChars(env, _key, 0);
-        bsg_populate_metadata_value(env, &crumb->metadata, jni_cache, "metaData", key, _value);
-        (*env)->ReleaseStringUTFChars(env, _key, key);
+      char *key = (char *)(*env)->GetStringUTFChars(env, _key, 0);
+      bsg_populate_metadata_value(env, &crumb->metadata, jni_cache, "metaData",
+                                  key, _value);
+      (*env)->ReleaseStringUTFChars(env, _key, key);
     }
   }
   free(jni_cache);
@@ -211,15 +215,15 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
 
 char *bsg_binary_arch() {
 #if defined(__i386__)
-    return "x86";
+  return "x86";
 #elif defined(__x86_64__)
-    return "x86_64";
+  return "x86_64";
 #elif defined(__arm__)
-    return "arm32";
+  return "arm32";
 #elif defined(__aarch64__)
-    return "arm64";
+  return "arm64";
 #else
-    return "unknown";
+  return "unknown";
 #endif
 }
 
@@ -228,22 +232,21 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   jobject data = (*env)->CallStaticObjectMethod(
       env, jni_cache->native_interface, jni_cache->get_app_data);
 
-  bsg_strncpy_safe(event->app.binary_arch,
-                   bsg_binary_arch(),
+  bsg_strncpy_safe(event->app.binary_arch, bsg_binary_arch(),
                    sizeof(event->app.binary_arch));
 
   bsg_copy_map_value_string(env, jni_cache, data, "buildUUID",
                             event->app.build_uuid,
                             sizeof(event->app.build_uuid));
   event->app.duration_ms_offset =
-          bsg_get_map_value_long(env, jni_cache, data, "duration");
+      bsg_get_map_value_long(env, jni_cache, data, "duration");
   event->app.duration_in_foreground_ms_offset =
-          bsg_get_map_value_long(env, jni_cache, data, "durationInForeground");
+      bsg_get_map_value_long(env, jni_cache, data, "durationInForeground");
 
   bsg_copy_map_value_string(env, jni_cache, data, "id", event->app.id,
                             sizeof(event->app.id));
   event->app.in_foreground =
-          bsg_get_map_value_bool(env, jni_cache, data, "inForeground");
+      bsg_get_map_value_bool(env, jni_cache, data, "inForeground");
 
   char name[64];
   bsg_copy_map_value_string(env, jni_cache, data, "name", name, sizeof(name));
@@ -254,41 +257,51 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                             sizeof(event->app.release_stage));
   bsg_copy_map_value_string(env, jni_cache, data, "type", event->app.type,
                             sizeof(event->app.type));
-  bsg_copy_map_value_string(env, jni_cache, data, "version",
-                            event->app.version, sizeof(event->app.version));
+  bsg_copy_map_value_string(env, jni_cache, data, "version", event->app.version,
+                            sizeof(event->app.version));
   event->app.version_code =
       bsg_get_map_value_int(env, jni_cache, data, "versionCode");
 
   (*env)->DeleteLocalRef(env, data);
 }
 
-char *bsg_os_name() {
-  return "android";
-}
+char *bsg_os_name() { return "android"; }
 
 void populate_device_metadata(JNIEnv *env, bsg_jni_cache *jni_cache,
                               bugsnag_event *event, void *data) {
   char brand[64];
-  bsg_copy_map_value_string(env, jni_cache, data, "brand", brand, sizeof(brand));
+  bsg_copy_map_value_string(env, jni_cache, data, "brand", brand,
+                            sizeof(brand));
   bugsnag_event_add_metadata_string(event, "device", "brand", brand);
 
-  bugsnag_event_add_metadata_double(event, "device", "dpi", bsg_get_map_value_int(env, jni_cache, data, "dpi"));
-  bugsnag_event_add_metadata_bool(event, "device", "emulator", bsg_get_map_value_bool(env, jni_cache, data, "emulator"));
+  bugsnag_event_add_metadata_double(
+      event, "device", "dpi",
+      bsg_get_map_value_int(env, jni_cache, data, "dpi"));
+  bugsnag_event_add_metadata_bool(
+      event, "device", "emulator",
+      bsg_get_map_value_bool(env, jni_cache, data, "emulator"));
 
   char location_status[32];
-  bsg_copy_map_value_string(env, jni_cache, data, "locationStatus", location_status, sizeof(location_status));
-  bugsnag_event_add_metadata_string(event, "device", "locationStatus", location_status);
+  bsg_copy_map_value_string(env, jni_cache, data, "locationStatus",
+                            location_status, sizeof(location_status));
+  bugsnag_event_add_metadata_string(event, "device", "locationStatus",
+                                    location_status);
 
   char network_access[64];
-  bsg_copy_map_value_string(env, jni_cache, data, "networkAccess", network_access, sizeof(network_access));
-  bugsnag_event_add_metadata_string(event, "device", "networkAccess", network_access);
+  bsg_copy_map_value_string(env, jni_cache, data, "networkAccess",
+                            network_access, sizeof(network_access));
+  bugsnag_event_add_metadata_string(event, "device", "networkAccess",
+                                    network_access);
 
-  bugsnag_event_add_metadata_double(event, "device", "screenDensity", bsg_get_map_value_float(env, jni_cache, data, "screenDensity"));
+  bugsnag_event_add_metadata_double(
+      event, "device", "screenDensity",
+      bsg_get_map_value_float(env, jni_cache, data, "screenDensity"));
 
   char screen_resolution[32];
-  bsg_copy_map_value_string(env, jni_cache, data, "screenResolution", screen_resolution,
-                            sizeof(screen_resolution));
-  bugsnag_event_add_metadata_string(event, "device", "screenResolution", screen_resolution);
+  bsg_copy_map_value_string(env, jni_cache, data, "screenResolution",
+                            screen_resolution, sizeof(screen_resolution));
+  bugsnag_event_add_metadata_string(event, "device", "screenResolution",
+                                    screen_resolution);
 }
 
 void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
@@ -300,11 +313,11 @@ void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
 
   bsg_copy_map_value_string(env, jni_cache, data, "id", event->device.id,
                             sizeof(event->device.id));
-  event->device.jailbroken = bsg_get_map_value_bool(env, jni_cache, data, "jailbroken");
+  event->device.jailbroken =
+      bsg_get_map_value_bool(env, jni_cache, data, "jailbroken");
 
   bsg_copy_map_value_string(env, jni_cache, data, "locale",
-                            event->device.locale,
-                            sizeof(event->device.locale));
+                            event->device.locale, sizeof(event->device.locale));
 
   bsg_copy_map_value_string(env, jni_cache, data, "manufacturer",
                             event->device.manufacturer,
@@ -320,17 +333,20 @@ void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                             event->device.os_version,
                             sizeof(event->device.os_version));
 
-  jobject _runtime_versions = bsg_get_map_value_obj(env, jni_cache, data, "runtimeVersions");
+  jobject _runtime_versions =
+      bsg_get_map_value_obj(env, jni_cache, data, "runtimeVersions");
 
   if (_runtime_versions != NULL) {
     bsg_copy_map_value_string(env, jni_cache, _runtime_versions, "osBuild",
                               event->device.os_build,
                               sizeof(event->device.os_build));
 
-    event->device.api_level = bsg_get_map_value_int(env, jni_cache, _runtime_versions, "androidApiLevel");
+    event->device.api_level = bsg_get_map_value_int(
+        env, jni_cache, _runtime_versions, "androidApiLevel");
     (*env)->DeleteLocalRef(env, _runtime_versions);
   }
-  event->device.total_memory = bsg_get_map_value_long(env, jni_cache, data, "totalMemory");
+  event->device.total_memory =
+      bsg_get_map_value_long(env, jni_cache, data, "totalMemory");
 
   // add fields to device metadata
   populate_device_metadata(env, jni_cache, event, data);
@@ -372,18 +388,19 @@ void bsg_populate_event(JNIEnv *env, bugsnag_event *event) {
   free(jni_cache);
 }
 
-void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst, bsg_jni_cache *jni_cache,
-                                 char *section, char *name, jobject _value) {
+void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
+                                 bsg_jni_cache *jni_cache, char *section,
+                                 char *name, jobject _value) {
   if ((*env)->IsInstanceOf(env, _value, jni_cache->number)) {
-    double value = (*env)->CallDoubleMethod(
-            env, _value, jni_cache->number_double_value);
+    double value =
+        (*env)->CallDoubleMethod(env, _value, jni_cache->number_double_value);
     bsg_add_metadata_value_double(dst, section, name, value);
   } else if ((*env)->IsInstanceOf(env, _value, jni_cache->boolean)) {
-    bool value = (*env)->CallBooleanMethod(env, _value,
-                                           jni_cache->boolean_bool_value);
+    bool value =
+        (*env)->CallBooleanMethod(env, _value, jni_cache->boolean_bool_value);
     bsg_add_metadata_value_bool(dst, section, name, value);
   } else if ((*env)->IsInstanceOf(env, _value, jni_cache->string)) {
-    char *value = (char *) (*env)->GetStringUTFChars(env, _value, 0);
+    char *value = (char *)(*env)->GetStringUTFChars(env, _value, 0);
     bsg_add_metadata_value_str(dst, section, name, value);
     free(value);
   }
@@ -414,7 +431,7 @@ void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst,
           (*env)->CallObjectMethod(env, _section, jni_cache->map_key_set);
       jobject section_keylist =
           (*env)->NewObject(env, jni_cache->arraylist,
-                                jni_cache->arraylist_init_with_obj, section_keyset);
+                            jni_cache->arraylist_init_with_obj, section_keyset);
       for (int j = 0; j < section_size; j++) {
         jstring section_key = (*env)->CallObjectMethod(
             env, section_keylist, jni_cache->arraylist_get, (jint)j);

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
@@ -1,18 +1,21 @@
 #ifndef BUGSNAG_METADATA_H
 #define BUGSNAG_METADATA_H
 
-#include <jni.h>
 #include "event.h"
+#include <jni.h>
 
 /**
- * Load all app, device, user, and custom metadata from NativeInterface into a event
+ * Load all app, device, user, and custom metadata from NativeInterface into a
+ * event
  */
 void bsg_populate_event(JNIEnv *env, bugsnag_event *event);
 /**
- * Load custom metadata from NativeInterface into a native metadata struct, optionally from an object.
- * If metadata is not provided, load from NativeInterface
+ * Load custom metadata from NativeInterface into a native metadata struct,
+ * optionally from an object. If metadata is not provided, load from
+ * NativeInterface
  */
-void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst, jobject metadata);
+void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst,
+                           jobject metadata);
 
 /**
  * Parse as java.util.Map<String, String> to populate crumb metadata

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/build.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/build.h
@@ -5,4 +5,4 @@
 #else
 #define __asyncsafe
 #endif
-#endif //BUGSNAG_ANDROID_BUILD_H
+#endif // BUGSNAG_ANDROID_BUILD_H

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/crash_info.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/crash_info.c
@@ -10,8 +10,8 @@ void bsg_populate_event_as(bsg_environment *env) {
 
   env->next_event.device.time = time(&now);
   // Convert to milliseconds:
-  env->next_event.app.duration = env->next_event.app.duration_ms_offset +
-                                  ((now - env->start_time) * 1000);
+  env->next_event.app.duration =
+      env->next_event.app.duration_ms_offset + ((now - env->start_time) * 1000);
   if (env->next_event.app.in_foreground && env->foreground_start_time > 0) {
     env->next_event.app.duration_in_foreground =
         env->next_event.app.duration_in_foreground_ms_offset +

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -12,172 +12,173 @@ extern "C" {
 #endif
 
 /**
- * migrate.h contains definitions of structs that were used in previous versions of a notifier
- * release.
+ * migrate.h contains definitions of structs that were used in previous versions
+ * of a notifier release.
  *
- * Because these structs are serialized to disk directly, we need to retain the original structs
- * whenever a field is added or changed.
+ * Because these structs are serialized to disk directly, we need to retain the
+ * original structs whenever a field is added or changed.
  *
- * The bsg_report_header indicates what version was serialized to disk. Knowing this information,
- * it is possible to migrate old payloads by first serializing them into an old struct, and then
- * mapping them into the latest version of bugsnag_event.
+ * The bsg_report_header indicates what version was serialized to disk. Knowing
+ * this information, it is possible to migrate old payloads by first serializing
+ * them into an old struct, and then mapping them into the latest version of
+ * bugsnag_event.
  */
 
 typedef struct {
-    char name[64];
-    char version[16];
-    char url[64];
+  char name[64];
+  char version[16];
+  char url[64];
 } bsg_library;
 
 /** a Bugsnag exception */
 typedef struct {
-    /** The exception name or stringified code */
-    char name[64];
-    /** A description of what went wrong */
-    char message[256];
-    /** The variety of exception which needs to be processed by the pipeline */
-    char type[32];
+  /** The exception name or stringified code */
+  char name[64];
+  /** A description of what went wrong */
+  char message[256];
+  /** The variety of exception which needs to be processed by the pipeline */
+  char type[32];
 
-    /**
-     * The number of frames used in the stacktrace. Must be less than
-     * BUGSNAG_FRAMES_MAX.
-     */
-    ssize_t frame_count;
-    /**
-     * An ordered list of stack frames from the oldest to the most recent
-     */
-    bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+  /**
+   * The number of frames used in the stacktrace. Must be less than
+   * BUGSNAG_FRAMES_MAX.
+   */
+  ssize_t frame_count;
+  /**
+   * An ordered list of stack frames from the oldest to the most recent
+   */
+  bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
 } bsg_exception;
 
 typedef struct {
-    char key[64];
-    char value[64];
+  char key[64];
+  char value[64];
 } bsg_char_metadata_pair;
 
 typedef struct {
-    char name[33];
-    char timestamp[37];
-    bugsnag_breadcrumb_type type;
+  char name[33];
+  char timestamp[37];
+  bugsnag_breadcrumb_type type;
 
-    /**
-     * Key/value pairs of related information for debugging
-     */
-    bsg_char_metadata_pair metadata[8];
+  /**
+   * Key/value pairs of related information for debugging
+   */
+  bsg_char_metadata_pair metadata[8];
 } bugsnag_breadcrumb_v1;
 
 typedef struct {
-    char name[64];
-    char id[64];
-    char package_name[64];
-    char release_stage[64];
-    char type[32];
-    char version[32];
-    char version_name[32];
-    char active_screen[64];
-    int version_code;
-    char build_uuid[64];
-    time_t duration;
-    time_t duration_in_foreground;
-    time_t duration_ms_offset;
-    time_t duration_in_foreground_ms_offset;
-    bool in_foreground;
-    bool low_memory;
-    size_t memory_usage;
-    char binaryArch[32];
+  char name[64];
+  char id[64];
+  char package_name[64];
+  char release_stage[64];
+  char type[32];
+  char version[32];
+  char version_name[32];
+  char active_screen[64];
+  int version_code;
+  char build_uuid[64];
+  time_t duration;
+  time_t duration_in_foreground;
+  time_t duration_ms_offset;
+  time_t duration_in_foreground_ms_offset;
+  bool in_foreground;
+  bool low_memory;
+  size_t memory_usage;
+  char binaryArch[32];
 } bsg_app_info_v1;
 
 typedef struct {
-    int api_level;
-    double battery_level;
-    char brand[64];
-    int cpu_abi_count;
-    bsg_cpu_abi cpu_abi[8];
-    int dpi;
-    bool emulator;
-    char orientation[32];
-    time_t time;
-    char id[64];
-    bool jailbroken;
-    char locale[32];
-    char location_status[32];
-    char manufacturer[64];
-    char model[64];
-    char network_access[64];
-    char os_build[64];
-    char os_version[64];
-    float screen_density;
-    char screen_resolution[32];
-    long total_memory;
+  int api_level;
+  double battery_level;
+  char brand[64];
+  int cpu_abi_count;
+  bsg_cpu_abi cpu_abi[8];
+  int dpi;
+  bool emulator;
+  char orientation[32];
+  time_t time;
+  char id[64];
+  bool jailbroken;
+  char locale[32];
+  char location_status[32];
+  char manufacturer[64];
+  char model[64];
+  char network_access[64];
+  char os_build[64];
+  char os_version[64];
+  float screen_density;
+  char screen_resolution[32];
+  long total_memory;
 } bsg_device_info_v1;
 
 typedef struct {
-    bsg_library notifier;
-    bsg_app_info_v1 app;
-    bsg_device_info_v1 device;
-    bugsnag_user user;
-    bsg_exception exception;
-    bugsnag_metadata metadata;
+  bsg_library notifier;
+  bsg_app_info_v1 app;
+  bsg_device_info_v1 device;
+  bugsnag_user user;
+  bsg_exception exception;
+  bugsnag_metadata metadata;
 
-    int crumb_count;
-    // Breadcrumbs are a ring; the first index moves as the
-    // structure is filled and replaced.
-    int crumb_first_index;
-    bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
 
-    char context[64];
-    bugsnag_severity severity;
+  char context[64];
+  bugsnag_severity severity;
 
-    char session_id[33];
-    char session_start[33];
-    int handled_events;
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
 } bugsnag_report_v1;
 
 typedef struct {
-    bsg_library notifier;
-    bsg_app_info_v1 app;
-    bsg_device_info_v1 device;
-    bugsnag_user user;
-    bsg_exception exception;
-    bugsnag_metadata metadata;
+  bsg_library notifier;
+  bsg_app_info_v1 app;
+  bsg_device_info_v1 device;
+  bugsnag_user user;
+  bsg_exception exception;
+  bugsnag_metadata metadata;
 
-    int crumb_count;
-    // Breadcrumbs are a ring; the first index moves as the
-    // structure is filled and replaced.
-    int crumb_first_index;
-    bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
 
-    char context[64];
-    bugsnag_severity severity;
+  char context[64];
+  bugsnag_severity severity;
 
-    char session_id[33];
-    char session_start[33];
-    int handled_events;
-    int unhandled_events;
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
 } bugsnag_report_v2;
 
 typedef struct {
-    bsg_notifier notifier;
-    bsg_app_info app;
-    bsg_device_info device;
-    bugsnag_user user;
-    bsg_error error;
-    bugsnag_metadata metadata;
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
 
-    int crumb_count;
-    // Breadcrumbs are a ring; the first index moves as the
-    // structure is filled and replaced.
-    int crumb_first_index;
-    bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
 
-    char context[64];
-    bugsnag_severity severity;
+  char context[64];
+  bugsnag_severity severity;
 
-    char session_id[33];
-    char session_start[33];
-    int handled_events;
-    int unhandled_events;
-    char grouping_hash[64];
-    bool unhandled;
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
 } bugsnag_report_v3;
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -1,11 +1,11 @@
-#include <stdlib.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <unistd.h>
-#include <string.h>
-#include <parson/parson.h>
 #include "../bugsnag_ndk.h"
 #include "build.h"
+#include <fcntl.h>
+#include <parson/parson.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,16 +18,21 @@ bool bsg_serialize_event_to_file(bsg_environment *env) __asyncsafe;
 bugsnag_event *bsg_deserialize_event_from_file(char *filepath);
 
 void bsg_serialize_context(const bugsnag_event *event, JSON_Object *event_obj);
-void bsg_serialize_severity_reason(const bugsnag_event *event, JSON_Object *event_obj);
+void bsg_serialize_severity_reason(const bugsnag_event *event,
+                                   JSON_Object *event_obj);
 void bsg_serialize_app(const bsg_app_info app, JSON_Object *event_obj);
 void bsg_serialize_app_metadata(const bsg_app_info app, JSON_Object *event_obj);
 void bsg_serialize_device(const bsg_device_info device, JSON_Object *event_obj);
-void bsg_serialize_device_metadata(const bsg_device_info device, JSON_Object *event_obj);
-void bsg_serialize_custom_metadata(const bugsnag_metadata metadata, JSON_Object *event_obj);
+void bsg_serialize_device_metadata(const bsg_device_info device,
+                                   JSON_Object *event_obj);
+void bsg_serialize_custom_metadata(const bugsnag_metadata metadata,
+                                   JSON_Object *event_obj);
 void bsg_serialize_user(const bugsnag_user user, JSON_Object *event_obj);
 void bsg_serialize_session(bugsnag_event *event, JSON_Object *event_obj);
-void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, JSON_Array *stacktrace);
-void bsg_serialize_error(bsg_error exc, JSON_Object *exception, JSON_Array *stacktrace);
+void bsg_serialize_stackframe(bugsnag_stackframe *stackframe,
+                              JSON_Array *stacktrace);
+void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
+                         JSON_Array *stacktrace);
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.h
@@ -1,9 +1,9 @@
 #ifndef BSG_STACK_UNWINDER_H
 #define BSG_STACK_UNWINDER_H
 
+#include "build.h"
 #include <event.h>
 #include <signal.h>
-#include "build.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,7 +16,6 @@ typedef enum {
   BSG_CUSTOM_UNWIND,
 } bsg_unwinder;
 
-
 /**
  * Based on the current environment, determine what unwinding library to use.
  *
@@ -25,8 +24,7 @@ typedef enum {
  * libcorkscrew.
  * Everything else: custom unwinding logic
  */
-void bsg_set_unwind_types(int apiLevel, bool is32bit,
-                          bsg_unwinder *signal_type,
+void bsg_set_unwind_types(int apiLevel, bool is32bit, bsg_unwinder *signal_type,
                           bsg_unwinder *other_type);
 
 /**
@@ -37,7 +35,7 @@ void bsg_set_unwind_types(int apiLevel, bool is32bit,
  * @return the number of frames
  */
 ssize_t bsg_unwind_stack(bsg_unwinder unwind_style,
-                     bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+                         bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
                          siginfo_t *info, void *user_context) __asyncsafe;
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwind.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwind.c
@@ -1,7 +1,7 @@
-#include "build.h"
 #include "stack_unwinder_libunwind.h"
-#include <malloc.h>
+#include "build.h"
 #include <event.h>
+#include <malloc.h>
 #include <unwind.h>
 
 #if defined(__arm__)
@@ -40,9 +40,9 @@ bsg_libunwind_callback(struct _Unwind_Context *context, void *arg) __asyncsafe {
 }
 
 #if defined(__arm__)
-ssize_t
-bsg_unwind_stack_libunwind_arm32(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                                 siginfo_t *info, void *user_context) __asyncsafe {
+ssize_t bsg_unwind_stack_libunwind_arm32(
+    bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX], siginfo_t *info,
+    void *user_context) __asyncsafe {
   unw_cursor_t cursor;
   unw_context_t uc;
   int index = 0;

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwindstack.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwindstack.cpp
@@ -1,5 +1,5 @@
-#include "string.h"
 #include "stack_unwinder_libunwindstack.h"
+#include "string.h"
 #include <stdlib.h>
 #include <ucontext.h>
 #include <unwindstack/Elf.h>
@@ -8,9 +8,9 @@
 #include <unwindstack/Memory.h>
 #include <unwindstack/Regs.h>
 
-ssize_t
-bsg_unwind_stack_libunwindstack(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                                siginfo_t *info, void *user_context) {
+ssize_t bsg_unwind_stack_libunwindstack(
+    bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX], siginfo_t *info,
+    void *user_context) {
   if (user_context == NULL) {
     return 0; // only handle unwinding from signals
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwindstack.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libunwindstack.h
@@ -7,7 +7,8 @@
 #ifdef __cplusplus
 extern "C"
 #endif
-ssize_t
-bsg_unwind_stack_libunwindstack(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                                siginfo_t *info, void *user_context);
+    ssize_t
+    bsg_unwind_stack_libunwindstack(
+        bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX], siginfo_t *info,
+        void *user_context);
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_simple.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_simple.c
@@ -1,10 +1,11 @@
-#include "string.h"
 #include "stack_unwinder_simple.h"
+#include "string.h"
 #include <stdlib.h>
 #include <ucontext.h>
 
-ssize_t bsg_unwind_stack_simple(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                                siginfo_t *info, void *user_context) {
+ssize_t
+bsg_unwind_stack_simple(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+                        siginfo_t *info, void *user_context) {
   if (user_context != NULL) {
     // program counter / instruction pointer
     uintptr_t ip = 0;

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_simple.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_simple.h
@@ -4,6 +4,7 @@
 #include "../event.h"
 #include <signal.h>
 
-ssize_t bsg_unwind_stack_simple(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                                siginfo_t *info, void *user_context);
+ssize_t
+bsg_unwind_stack_simple(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+                        siginfo_t *info, void *user_context);
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -1,22 +1,20 @@
 #include "string.h"
-#include <stdbool.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <string.h>
 
-void bsg_strcpy(char *dst, char *src) {
-    bsg_strncpy(dst, src, INT_MAX);
-}
+void bsg_strcpy(char *dst, char *src) { bsg_strncpy(dst, src, INT_MAX); }
 
 void bsg_strncpy(char *dst, char *src, size_t len) {
-    int i = 0;
-    while (i <= len) {
-        char current = src[i];
-        dst[i] = current;
-        if (current == '\0') {
-            break;
-        }
-        i++;
+  int i = 0;
+  while (i <= len) {
+    char current = src[i];
+    dst[i] = current;
+    if (current == '\0') {
+      break;
     }
+    i++;
+  }
 }
 
 size_t bsg_strlen(char *str) {
@@ -36,8 +34,7 @@ void bsg_strncpy_safe(char *dst, char *src, int dst_size) {
   if (dst_size == 0)
     return;
   dst[0] = '\0';
-    if (src != NULL) {
-        strncat(dst, src, dst_size - 1);
-    }
+  if (src != NULL) {
+    strncat(dst, src, dst_size - 1);
+  }
 }
-

--- a/dockerfiles/Dockerfile.android-common
+++ b/dockerfiles/Dockerfile.android-common
@@ -1,8 +1,8 @@
-FROM openjdk:11-jdk-buster
+FROM ubuntu:20.04
 
-RUN apt-get update
-RUN apt-get install -y wget maven gnupg1 cppcheck libncurses5 jq git
-RUN apt-get clean
+RUN apt-get update > /dev/null
+RUN apt-get install -y wget maven gnupg1 cppcheck libncurses5 jq clang-format unzip curl git > /dev/null
+RUN apt-get clean > /dev/null
 
 ENV ANDROID_SDK_ROOT="/sdk"
 ENV ANDROID_CMDLINE_TOOLS="${ANDROID_SDK_ROOT}/cmdline-tools/latest"

--- a/examples/sdk-app-example/src/main/cpp/entrypoint.cpp
+++ b/examples/sdk-app-example/src/main/cpp/entrypoint.cpp
@@ -1,40 +1,44 @@
-#include <jni.h>
 #include <bugsnag.h>
+#include <jni.h>
 
 extern "C" {
 
 static void __attribute__((used)) somefakefunc(void) {}
 
 int crash_write_read_only() {
-    // Write to a read-only page
-    volatile char *ptr = (char *)somefakefunc;
-    *ptr = 0;
+  // Write to a read-only page
+  volatile char *ptr = (char *)somefakefunc;
+  *ptr = 0;
 
-    return 5;
+  return 5;
 }
 
 bool my_on_error_b(void *event) {
-    bugsnag_event_set_user(event, "999999", "ndk override", "j@ex.co");
-    bugsnag_event_add_metadata_string(event, "Native", "field", "value");
-    bugsnag_event_add_metadata_bool(event, "Native", "field", true);
-    return true;
+  bugsnag_event_set_user(event, "999999", "ndk override", "j@ex.co");
+  bugsnag_event_add_metadata_string(event, "Native", "field", "value");
+  bugsnag_event_add_metadata_bool(event, "Native", "field", true);
+  return true;
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_example_ExampleApplication_performNativeBugsnagSetup(JNIEnv *env, jobject instance) {
-    bugsnag_add_on_error(&my_on_error_b);
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_example_ExampleApplication_performNativeBugsnagSetup(
+    JNIEnv *env, jobject instance) {
+  bugsnag_add_on_error(&my_on_error_b);
 }
 
-
-JNIEXPORT void JNICALL Java_com_bugsnag_android_example_ExampleActivity_doCrash(JNIEnv *env, jobject instance) {
-    crash_write_read_only();
+JNIEXPORT void JNICALL Java_com_bugsnag_android_example_ExampleActivity_doCrash(
+    JNIEnv *env, jobject instance) {
+  crash_write_read_only();
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_example_ExampleActivity_notifyFromCXX(JNIEnv *env, jobject instance) {
-    // Set the current user
-    bugsnag_set_user_env(env, "124323", "joe mills", "j@ex.co");
-    // Leave a breadcrumb
-    bugsnag_leave_breadcrumb_env(env, "Critical failure", BSG_CRUMB_LOG);
-    // Send an error report
-    bugsnag_notify_env(env, "Oh no", "The mill!", BSG_SEVERITY_INFO);
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_example_ExampleActivity_notifyFromCXX(
+    JNIEnv *env, jobject instance) {
+  // Set the current user
+  bugsnag_set_user_env(env, "124323", "joe mills", "j@ex.co");
+  // Leave a breadcrumb
+  bugsnag_leave_breadcrumb_env(env, "Critical failure", BSG_CRUMB_LOG);
+  // Send an error report
+  bugsnag_notify_env(env, "Oh no", "The mill!", BSG_SEVERITY_INFO);
 }
 }

--- a/scripts/run-clang-format-ci-check.sh
+++ b/scripts/run-clang-format-ci-check.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+find bugsnag-plugin-android-anr/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format --dry-run -Werror
+find bugsnag-plugin-android-ndk/src/main -iname *.h -o -iname *.cpp -o -iname *.c | grep -v src/main/jni/external/ | grep -v src/main/jni/deps/ | xargs clang-format --dry-run -Werror
+find examples/sdk-app-example/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format --dry-run -Werror

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+find bugsnag-plugin-android-anr/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format -i
+find bugsnag-plugin-android-ndk/src/main -iname *.h -o -iname *.cpp -o -iname *.c | grep -v src/main/jni/external/ | grep -v src/main/jni/deps/ | xargs clang-format -i
+find examples/sdk-app-example/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format -i


### PR DESCRIPTION
## Goal

This changeset uses [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) to enforce the [LLVM style guide](https://llvm.org/docs/CodingStandards.html) on our NDK code. 

## Changeset

- Added `ClangFormat` job to CI which fails if there are style violations
- Generated `.clang_format` file which uses the default LLVM code style
- Added `scripts/run-clang-format.sh` for local use before pushing to CI
- Formatted codebase so that existing style violations are resolved
- Altered Dockerfile to use Ubuntu 20.04, as the necessary version of clang-format is not present on any of the openjdk docker images (discussed this solution with @Cawllec)
