### PR TITLE
Reduce size of APK test fixture by excluding unnecessary ABIs

### DIFF
--- a/features/fixtures/mazerunner/app/build.gradle
+++ b/features/fixtures/mazerunner/app/build.gradle
@@ -65,6 +65,11 @@ android {
             }
         }
     }
+    defaultConfig {
+        ndk {
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86"
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Goal

Reduces the size of the mazerunner test fixture from 1.8Mb to 1.4Mb by excluding the `x86_64` architecture. We don't actively test with these so excluding them makes sense to decrease the time spent waiting for APKs to upload.

Tested x86 by running on an emulator, and arm_64 by running the E2E smoke tests.