### PR TITLE
Soft fail Android 4, 6, and 7 E2E tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -198,6 +198,9 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    # temp workaround browserstack network issue where 400 status codes fail the tests
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 5 end-to-end tests'
     depends_on:
@@ -242,6 +245,9 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    # temp workaround browserstack network issue where 400 status codes fail the tests
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 7 end-to-end tests'
     depends_on:
@@ -263,6 +269,9 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    # temp workaround browserstack network issue where 400 status codes fail the tests
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 8.0 end-to-end tests'
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -168,6 +168,9 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    # temp workaround browserstack network issue where 400 status codes fail the tests
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 5 smoke tests'
     key: 'android-5-smoke'
@@ -210,6 +213,9 @@ steps:
         - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    # temp workaround browserstack network issue where 400 status codes fail the tests
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 7 smoke tests'
     key: 'android-7-smoke'
@@ -230,6 +236,9 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    # temp workaround browserstack network issue where 400 status codes fail the tests
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 8.0 smoke tests'
     key: 'android-8-smoke'


### PR DESCRIPTION
## Goal

Adds a temporary soft fail to the Android 4, 6, and 7 E2E tests which are experiencing 400 status codes due to BrowserStack network issues.