### PR TITLE
Enable gradle build scan on CI

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -26,6 +26,14 @@ steps:
       docker-compose#v3.3.0:
         run: android-ci
 
+  - label: ':android: Build Scan'
+    depends_on: "android-jvm"
+    timeout_in_minutes: 10
+    plugins:
+      - docker-compose#v3.7.0:
+          run: android-jvm
+    command: './gradlew clean assembleRelease check --scan'
+
   - label: ':android: Android 9 end-to-end tests'
     depends_on:
       - "fixture-apk"

--- a/dockerfiles/Dockerfile.android-ci-base
+++ b/dockerfiles/Dockerfile.android-ci-base
@@ -40,5 +40,6 @@ COPY bugsnag-android-core/ bugsnag-android-core/
 COPY bugsnag-plugin-android-ndk/ bugsnag-plugin-android-ndk/
 COPY bugsnag-plugin-react-native/ bugsnag-plugin-react-native/
 COPY scripts/ scripts/
+COPY LICENSE LICENSE
 
 RUN ./gradlew

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,14 @@
+plugins {
+    id "com.gradle.enterprise" version "3.5"
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+    }
+}
+
 include(
     ":bugsnag-android",
     ":bugsnag-android-ndk",


### PR DESCRIPTION
## Goal

Adds a job to the CI which runs a Gradle [build scan](https://scans.gradle.com/) on a full run. This will allow us to identify deprecated Gradle elements and highlight performance bottlenecks in the Gradle build.

The gradle scan for this build is available here: https://scans.gradle.com/s/66v3e4ofxhwko