### PR TITLE
Use correct assertion for native throw scenarios

### DIFF
--- a/features/full_tests/native_throw_crash.feature
+++ b/features/full_tests/native_throw_crash.feature
@@ -8,12 +8,8 @@ Feature: Native crash reporting with thrown objects
         And the request payload contains a completed unhandled native report
         And the event "severity" equals "error"
         And the event "unhandled" is true
-        And the exception "errorClass" equals "PSt13runtime_error"
-        And the exception "message" equals "How about NO"
-        And the first significant stack frame methods and files should match:
-            | run_away(bool)       | | libentrypoint.so |
-            | trigger_an_exception | | libentrypoint.so |
-            | Java_com_bugsnag_android_mazerunner_scenarios_CXXExceptionScenario_crash | | libentrypoint.so |
+        And the exception "errorClass" equals "SIGABRT"
+        And the exception "message" equals "Abort program"
 
     Scenario: Throwing an object in C++
         When I run "CXXThrowSomethingScenario" and relaunch the app
@@ -23,9 +19,5 @@ Feature: Native crash reporting with thrown objects
         And the request payload contains a completed unhandled native report
         And the event "severity" equals "error"
         And the event "unhandled" is true
-        And the exception "errorClass" equals "i"
-        And the exception "message" equals "42"
-        And the first significant stack frame methods and files should match:
-            | run_back(int, int) | crash_abort | libentrypoint.so |
-            | throw_an_object    | | libentrypoint.so |
-            | Java_com_bugsnag_android_mazerunner_scenarios_CXXThrowSomethingScenario_crash | | libentrypoint.so |
+        And the exception "errorClass" equals "SIGABRT"
+        And the exception "message" equals "Abort program"


### PR DESCRIPTION
## Goal

#1049 allowed the CI pipeline to build multiple fixture APKs so that a 'minimal' test fixture which only uses `bugsnag-android-core` could be tested. A bad merge with #1055 resulted in two scenarios failing in `native_throw_crash.feature`, due to the old assertions being used. This changeset adds the correct assertions to the test cases.

As part of #1049 the two scenarios were moved to a separate `cxx-scenarios` module to allow the building of a minimal test fixture that doesn't rely on bugsnag's NDK layer. Both two scenarios throw a C++ exception, and were previously asserting that information about the top stackframes were available. Because the scenario code has been migrated to another module they are now in a separate SO file, so the app is unable to obtain the previous information through the C++ exception handling APIs.