### PR TITLE
Disable generation of BuildConfig class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,13 @@ private void configureAndroidProject(Project proj) {
         testOptions {
             unitTests.returnDefaultValues = true
         }
+        buildFeatures {
+            aidl = false
+            renderScript = false
+            shaders = false
+            resValues = false
+            buildConfig = false
+        }
     }
 }
 


### PR DESCRIPTION
## Goal

Disables generation of the `BuildConfig` class through the use of the [BuildFeatures](https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/BuildFeatures) DSL which became available in AGP 4.1. The `BuildConfig` class is unused by bugsnag and adds unnecessary size to the final artefact.

This also disables gradle tasks for aidl, renderscript, shaders, and resValues, which are all unused by the plugin.

## Testing

Confirmed that compared to an [old build](https://scans.gradle.com/s/nbyrg2fdz5y4w/performance/execution) these changes mean [183 tasks](https://scans.gradle.com/s/dl2xe6hn6k3ea/performance/execution) are registered rather than 225, boosting build speed. Inspected AAR in APK analyzer and confirmed that `BuildConfig` is no longer present.