### PR TITLE
Remove temporary soft fails

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -103,9 +103,6 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # temp workaround browserstack network issue where 400 status codes fail the tests
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 5 NDK r16 end-to-end tests'
     depends_on:
@@ -150,9 +147,6 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # temp workaround browserstack network issue where 400 status codes fail the tests
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 7 NDK r19 end-to-end tests'
     depends_on:
@@ -174,9 +168,6 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # temp workaround browserstack network issue where 400 status codes fail the tests
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 8.0 NDK r19 end-to-end tests'
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -172,9 +172,6 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # temp workaround browserstack network issue where 400 status codes fail the tests
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 5 NDK r16 smoke tests'
     key: 'android-5-smoke'
@@ -217,9 +214,6 @@ steps:
         - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # temp workaround browserstack network issue where 400 status codes fail the tests
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 7 NDK r19 smoke tests'
     key: 'android-7-smoke'
@@ -240,9 +234,6 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # temp workaround browserstack network issue where 400 status codes fail the tests
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 8.0 NDK r19 smoke tests'
     key: 'android-8-smoke'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.6.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.7.0'
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b73093f128efdea444966969cd3526e26de8ed5b
-  tag: v3.6.0
+  revision: dfe41e657bbf40ad85661b193555bc59773302ba
+  tag: v3.7.0
   specs:
-    bugsnag-maze-runner (3.6.0)
+    bugsnag-maze-runner (3.7.0)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -26,7 +26,7 @@ GEM
     appium_lib_core (3.11.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    backports (3.18.2)
+    backports (3.20.1)
     builder (3.2.4)
     childprocess (3.0.0)
     cucumber (3.1.2)
@@ -52,21 +52,23 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.2)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.0)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
     power_assert (1.2.0)
+    racc (1.5.2)
     rake (12.3.3)
     rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    test-unit (3.3.7)
+    test-unit (3.3.9)
       power_assert
     tomlrb (1.3.0)
     websocket-driver (0.7.3)


### PR DESCRIPTION
Remove the temporary soft fail put in place on Android 4,6 and 7 end-to-end tests now that we have determined the cause (enabled network logs in on BrowserStack) and deployed a workaround in MazeRunner (no not enable the logs!).