### PR TITLE
Add git to docker image

### DIFF
--- a/dockerfiles/Dockerfile.android-common
+++ b/dockerfiles/Dockerfile.android-common
@@ -1,7 +1,7 @@
 FROM openjdk:11-jdk-buster
 
 RUN apt-get update
-RUN apt-get install -y wget maven gnupg1 cppcheck libncurses5 jq
+RUN apt-get install -y wget maven gnupg1 cppcheck libncurses5 jq git
 RUN apt-get clean
 
 ENV ANDROID_SDK_ROOT="/sdk"


### PR DESCRIPTION
## Goal

`git` isn't included in the ubuntu 20.04 image which was causing the Android Size reporting step to fail. No other CI jobs are affected.