### PR TITLE
Tweak maxSessions default to 128

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -47,7 +47,7 @@ class ManifestConfigLoaderTest {
             // misc
             assertEquals(maxBreadcrumbs, 25)
             assertEquals(maxPersistedEvents, 32)
-            assertEquals(maxPersistedSessions, 32)
+            assertEquals(maxPersistedSessions, 128)
             assertEquals(launchCrashThresholdMs, 5000)
             assertEquals("android", appType)
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -32,8 +32,8 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     var delivery: Delivery? = null
     var endpoints: EndpointConfiguration = EndpointConfiguration()
     var maxBreadcrumbs: Int = DEFAULT_MAX_BREADCRUMBS
-    var maxPersistedEvents: Int = DEFAULT_MAX_PERSISTED_PAYLOADS
-    var maxPersistedSessions: Int = DEFAULT_MAX_PERSISTED_PAYLOADS
+    var maxPersistedEvents: Int = DEFAULT_MAX_PERSISTED_EVENTS
+    var maxPersistedSessions: Int = DEFAULT_MAX_PERSISTED_SESSIONS
     var context: String? = null
 
     var redactedKeys: Set<String> = metadataState.metadata.redactedKeys
@@ -79,7 +79,8 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
 
     companion object {
         private const val DEFAULT_MAX_BREADCRUMBS = 25
-        private const val DEFAULT_MAX_PERSISTED_PAYLOADS = 32
+        private const val DEFAULT_MAX_PERSISTED_SESSIONS = 128
+        private const val DEFAULT_MAX_PERSISTED_EVENTS = 32
         private const val DEFAULT_LAUNCH_CRASH_THRESHOLD_MS: Long = 5000
 
         @JvmStatic

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -505,7 +505,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
      * Sets the maximum number of persisted sessions which will be stored. Once the threshold is
      * reached, the oldest session will be deleted.
      *
-     * By default, 32 sessions are persisted.
+     * By default, 128 sessions are persisted.
      */
     public int getMaxPersistedSessions() {
         return impl.getMaxPersistedSessions();
@@ -515,7 +515,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
      * Sets the maximum number of persisted sessions which will be stored. Once the threshold is
      * reached, the oldest session will be deleted.
      *
-     * By default, 32 sessions are persisted.
+     * By default, 128 sessions are persisted.
      */
     public void setMaxPersistedSessions(int maxPersistedSessions) {
         if (maxPersistedSessions >= 0) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
@@ -196,7 +196,7 @@ public class ConfigurationFacadeTest {
     @Test
     public void maxPersistedSessionsInvalid() {
         config.setMaxPersistedSessions(-1);
-        assertEquals(32, config.impl.getMaxPersistedSessions());
+        assertEquals(128, config.impl.getMaxPersistedSessions());
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionStoreMaxLimitTest.kt
@@ -37,11 +37,11 @@ class SessionStoreMaxLimitTest {
         val sessionStore = createSessionStore(convertToImmutableConfig(config))
 
         val session = generateSession()
-        repeat(40) {
+        repeat(140) {
             sessionStore.write(session)
         }
         val files = sessionDir.list()
-        assertEquals(32, files.size)
+        assertEquals(128, files.size)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Tweaks the default maxSessions value to 128, to align with the notifier spec.