### PR TITLE
Add one full set of e2e tests to quick build

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -54,8 +54,6 @@ steps:
           - "--app=/app/build/release/fixture-minimal.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
           - "features/full_tests/handled_exception.feature"
     concurrency: 9
@@ -111,8 +109,6 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_4_4"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -132,8 +128,6 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_5_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -155,8 +149,6 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -176,8 +168,6 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -197,8 +187,6 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_8_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -220,8 +208,6 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -243,8 +229,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -264,8 +248,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,17 +1,4 @@
 steps:
-  - label: ':android: Build fixture APK r19'
-    key: "fixture-r19"
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    artifact_paths: build/release/fixture-r19.apk
-    plugins:
-      - docker-compose#v3.7.0:
-          run: android-builder
-    env:
-      MAVEN_VERSION: "3.6.1"
-      TEST_FIXTURE_NDK_VERSION: "19.2.5345600"
-      TEST_FIXTURE_NAME: "fixture-r19.apk"
-
   - label: ':android: Build minimal fixture APK'
     key: "fixture-minimal"
     depends_on: "android-ci"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,4 +1,17 @@
 steps:
+  - label: ':android: Build fixture APK r19'
+    key: "fixture-r19"
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    artifact_paths: build/release/fixture-r19.apk
+    plugins:
+      - docker-compose#v3.7.0:
+          run: android-builder
+    env:
+      MAVEN_VERSION: "3.6.1"
+      TEST_FIXTURE_NDK_VERSION: "19.2.5345600"
+      TEST_FIXTURE_NAME: "fixture-r19.apk"
+
   - label: ':android: Build minimal fixture APK'
     key: "fixture-minimal"
     depends_on: "android-ci"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -228,27 +228,6 @@ steps:
     soft_fail:
       - exit_status: "*"
 
-  - label: ':android: Android 9 NDK r21 end-to-end tests'
-    depends_on:
-      - "fixture-r21"
-      - "android-9-smoke"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/release/fixture-r21.apk"
-      docker-compose#v3.7.0:
-        run: android-maze-runner
-        command:
-          - "features/full_tests"
-          - "--app=/app/build/release/fixture-r21.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_9_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
-          - "--fail-fast"
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-
   - label: ':android: Android 10 NDK r21 end-to-end tests'
     depends_on:
       - "fixture-r21"

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -26,8 +26,6 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_5_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -48,8 +46,6 @@ steps:
         - "--app=/app/build/release/fixture-r16.apk"
         - "--farm=bs"
         - "--device=ANDROID_6_0"
-        - "--username=$BROWSER_STACK_USERNAME"
-        - "--access-key=$BROWSER_STACK_ACCESS_KEY"
         - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -68,8 +64,6 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -88,8 +82,6 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_8_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -110,8 +102,6 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -132,8 +122,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -153,8 +141,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--retry=1"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -173,8 +159,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -1,4 +1,17 @@
 steps:
+  - label: ':android: Build fixture APK r19'
+    key: "fixture-r19"
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    artifact_paths: build/release/fixture-r19.apk
+    plugins:
+      - docker-compose#v3.7.0:
+          run: android-builder
+    env:
+      MAVEN_VERSION: "3.6.1"
+      TEST_FIXTURE_NDK_VERSION: "19.2.5345600"
+      TEST_FIXTURE_NAME: "fixture-r19.apk"
+
   - label: ':android: Android 5 NDK r16 smoke tests'
     key: 'android-5-smoke'
     depends_on: "fixture-r16"

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -1,17 +1,4 @@
 steps:
-  - label: ':android: Build fixture APK r19'
-    key: "fixture-r19"
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    artifact_paths: build/release/fixture-r19.apk
-    plugins:
-      - docker-compose#v3.7.0:
-          run: android-builder
-    env:
-      MAVEN_VERSION: "3.6.1"
-      TEST_FIXTURE_NDK_VERSION: "19.2.5345600"
-      TEST_FIXTURE_NAME: "fixture-r19.apk"
-
   - label: ':android: Android 5 NDK r16 smoke tests'
     key: 'android-5-smoke'
     depends_on: "fixture-r16"

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -138,6 +138,27 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
+  - label: ':android: Android 9 NDK r21 end-to-end tests'
+    depends_on:
+      - "fixture-r21"
+      - "android-9-smoke"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/release/fixture-r21.apk"
+      docker-compose#v3.7.0:
+        run: android-maze-runner
+        command:
+          - "features/full_tests"
+          - "--app=/app/build/release/fixture-r21.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_9_0"
+          - "--username=$BROWSER_STACK_USERNAME"
+          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
+          - "--retry=1"
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
   - label: ':android: Android 10 NDK r21 smoke tests'
     key: 'android-10-smoke'
     depends_on: "fixture-r21"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,19 +50,6 @@ steps:
       TEST_FIXTURE_NDK_VERSION: "16.1.4479499"
       TEST_FIXTURE_NAME: "fixture-r16.apk"
 
-  - label: ':android: Build fixture APK r19'
-    key: "fixture-r19"
-    depends_on: "android-ci"
-    timeout_in_minutes: 30
-    artifact_paths: build/release/fixture-r19.apk
-    plugins:
-      - docker-compose#v3.7.0:
-          run: android-builder
-    env:
-      MAVEN_VERSION: "3.6.1"
-      TEST_FIXTURE_NDK_VERSION: "19.2.5345600"
-      TEST_FIXTURE_NAME: "fixture-r19.apk"
-
   - label: ':android: Build fixture APK r21'
     key: "fixture-r21"
     depends_on: "android-ci"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -154,8 +154,6 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_4_4"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
@@ -176,8 +174,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
-          - "--username=$BROWSER_STACK_USERNAME"
-          - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,6 +50,19 @@ steps:
       TEST_FIXTURE_NDK_VERSION: "16.1.4479499"
       TEST_FIXTURE_NAME: "fixture-r16.apk"
 
+  - label: ':android: Build fixture APK r19'
+    key: "fixture-r19"
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    artifact_paths: build/release/fixture-r19.apk
+    plugins:
+      - docker-compose#v3.7.0:
+          run: android-builder
+    env:
+      MAVEN_VERSION: "3.6.1"
+      TEST_FIXTURE_NDK_VERSION: "19.2.5345600"
+      TEST_FIXTURE_NAME: "fixture-r19.apk"
+
   - label: ':android: Build fixture APK r21'
     key: "fixture-r21"
     depends_on: "android-ci"

--- a/.buildkite/pipeline_trigger.sh
+++ b/.buildkite/pipeline_trigger.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env sh
 
-if [[ "$BUILDKITE_MESSAGE" == *"[barebones ci]"* ]]; then
+barebones_description() {
   echo "Running barebones build due to commit messages"
   echo "Unit and static tests will be run"
   echo "Minimal instrumentation tests will be run"
   echo "End-to-end smoke tests will be run on minimum and maximum supported Android versions"
+}
+
+if [[ "$BUILDKITE_MESSAGE" == *"[barebones ci]"* ]]; then
+  barebones_description
 elif [[ "$BUILDKITE_MESSAGE" == *"[full ci]"* ||
   "$BUILDKITE_BRANCH" == "next" ||
   "$BUILDKITE_BRANCH" == "master" ]]; then
@@ -31,11 +35,9 @@ elif [[ "$BUILDKITE_MESSAGE" == *"[quick ci]"* ]]; then
   echo "Unit and static tests will be run"
   echo "Minimal instrumentation tests will be run"
   echo "End-to-end smoke tests will be run on all supported Android versions"
+  echo "All end-to-end tests will be run on a single supported Android versions"
   buildkite-agent pipeline upload .buildkite/pipeline.quick.yml
 else
-  echo "Running barebones build by default"
-  echo "Unit and static tests will be run"
-  echo "Minimal instrumentation tests will be run"
-  echo "End-to-end smoke tests will be run on minimum and maximum supported Android versions"
+  barebones_description
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ test:
 	./gradlew connectedCheck
 
 remote-test:
-ifeq ($(BROWSER_STACK_USERNAME),)
-	@$(error BROWSER_STACK_USERNAME is not defined)
+ifeq ($(MAZE_DEVICE_FARM_USERNAME),)
+	@$(error MAZE_DEVICE_FARM_USERNAME is not defined)
 endif
-ifeq ($(BROWSER_STACK_ACCESS_KEY),)
-	@$(error BROWSER_STACK_ACCESS_KEY is not defined)
+ifeq ($(MAZE_DEVICE_FARM_ACCESS_KEY),)
+	@$(error MAZE_DEVICE_FARM_ACCESS_KEY is not defined)
 endif
 	@APP_LOCATION=/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk \
 	 INSTRUMENTATION_DEVICES='["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]' \

--- a/TESTING.md
+++ b/TESTING.md
@@ -44,26 +44,25 @@ __Your session will periodically expire__, so you'll need to run this command to
 
 Remote tests can be run against real devices provided by BrowserStack. In order to run these tests, you need:
 
-A BrowserStack App Automate Username: `BROWSER_STACK_USERNAME`
-A BrowserStack App Automate Access Key: `BROWSER_STACK_ACCESS_KEY`
+A BrowserStack App Automate Username: `MAZE_DEVICE_FARM_USERNAME`
+A BrowserStack App Automate Access Key: `MAZE_DEVICE_FARM_ACCESS_KEY`
 A local docker and docker-compose installation.
 
 ### Instrumentation tests
 
 Ensure that the following environment variables are set:
 
-* `BROWSER_STACK_USERNAME`: The BrowserStack App Automate Username
-* `BROWSER_STACK_ACCESS_KEY`: The BrowserStack App Automate Access Key
+* `MAZE_DEVICE_FARM_USERNAME`: The BrowserStack App Automate Username
+* `MAZE_DEVICE_FARM_ACCESS_KEY`: The BrowserStack App Automate Access Key
 
 Run `make remote-test`
 
 ### End-to-end tests
 
 Ensure that the following environment variables are set:
-* `BROWSER_STACK_USERNAME`: Your BrowserStack App Automate Username
-* `BROWSER_STACK_ACCESS_KEY`: You BrowserStack App Automate Access Key
-
-See https://www.browserstack.com/local-testing/app-automate for details of the required local testing binary.
+* `MAZE_DEVICE_FARM_USERNAME`: Your BrowserStack App Automate Username
+* `MAZE_DEVICE_FARM_ACCESS_KEY`: You BrowserStack App Automate Access Key
+* `MAZE_BS_LOCAL`: Location of the BrowserStack local testing binary (see https://www.browserstack.com/local-testing/app-automate).
 
 1. Build the test fixture `make test-fixture`
 1. Check the contents of `Gemfile` to select the version of `maze-runner` to use
@@ -73,9 +72,6 @@ See https://www.browserstack.com/local-testing/app-automate for details of the r
     bundle exec maze-runner --app=build/fixture.apk                 \
                             --farm=bs                               \
                             --device=ANDROID_9_0                    \
-                            --username=$BROWSER_STACK_USERNAME      \
-                            --access-key=$BROWSER_STACK_ACCESS_KEY  \
-                            --bs-local=~/BrowserStackLocal          \
                             features/smoke_tests/unhandled.feature
     ```
 1. To run all features, omit the final argument.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,9 @@ services:
   android-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v3-cli
     environment:
-      VERBOSE:
       DEBUG:
+      BUILDKITE:
+      BUILDKITE_PIPELINE_NAME:
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       DEBUG:
       BUILDKITE:
       BUILDKITE_PIPELINE_NAME:
+      MAZE_DEVICE_FARM_USERNAME:
+      MAZE_DEVICE_FARM_ACCESS_KEY:
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.android-ci-base
     environment:
-      BROWSER_STACK_USERNAME:
-      BROWSER_STACK_ACCESS_KEY:
+      MAZE_DEVICE_FARM_USERNAME:
+      MAZE_DEVICE_FARM_ACCESS_KEY:
       INSTRUMENTATION_DEVICES:
 
   android-builder:

--- a/scripts/run-instrumentation-test.sh
+++ b/scripts/run-instrumentation-test.sh
@@ -10,7 +10,7 @@ export TEST_LOCATION=bugsnag-android-core/build/outputs/apk/androidTest/debug/bu
 # First app.  This is not actually used, but must be present and different to the test app.
 echo "Android Tests [$(timestamp)]: Starting instrumentation test run against devices: $INSTRUMENTATION_DEVICES"
 echo "Android Tests [$(timestamp)]: Uploading first test app from $APP_LOCATION to BrowserStack"
-app_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@$APP_LOCATION")
+app_response=$(curl -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@$APP_LOCATION")
 app_url=$(echo "$app_response" | jq -r ".app_url")
 
 if [ -z "$app_url" ]; then
@@ -23,7 +23,7 @@ echo "Android Tests [$(timestamp)]: First app upload successful, url: $app_url"
 
 # Second app - the tests.
 echo "Android Tests [$(timestamp)]: Uploading second test app from $TEST_LOCATION to BrowserStack"
-test_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/espresso/test-suite" -F "file=@$TEST_LOCATION")
+test_response=$(curl -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/espresso/test-suite" -F "file=@$TEST_LOCATION")
 test_url=$(echo "$test_response" | jq -r ".test_url")
 
 if [ -z "$test_url" ]; then
@@ -35,7 +35,7 @@ fi
 echo "Android Tests [$(timestamp)]: Second app upload successful, url: $test_url"
 
 echo "Android Tests [$(timestamp)]: Starting test run"
-build_response=$(curl -X POST "https://api-cloud.browserstack.com/app-automate/espresso/build" -d \ "{\"devices\": $INSTRUMENTATION_DEVICES, \"app\": \"$app_url\", \"deviceLogs\" : true, \"testSuite\": \"$test_url\"}" -H "Content-Type: application/json" -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY")
+build_response=$(curl -X POST "https://api-cloud.browserstack.com/app-automate/espresso/build" -d \ "{\"devices\": $INSTRUMENTATION_DEVICES, \"app\": \"$app_url\", \"deviceLogs\" : true, \"testSuite\": \"$test_url\"}" -H "Content-Type: application/json" -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY")
 
 build_id=$(echo "$build_response" | jq -r ".build_id")
 
@@ -50,7 +50,7 @@ echo "Android Tests [$(timestamp)]: Test run creation successful, id: $build_id"
 echo "Android Tests [$(timestamp)]: Waiting for test run to begin"
 sleep 10 # Allow the tests to kick off
 
-status_response=$(curl -s -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+status_response=$(curl -s -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
 status=$(echo "$status_response" | jq -r ".status")
 
 WAIT_COUNT=0
@@ -58,7 +58,7 @@ until [ "$status" == "\"done\"" ] || [ "$status" == "\"error\"" ] || [ "$status"
     echo "Android Tests [$(timestamp)]: Current test status: $status, Time waited: $((WAIT_COUNT * 15))"
     ((WAIT_COUNT++))
     sleep 15
-    status_response=$(curl -s -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+    status_response=$(curl -s -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
     status=$(echo "$status_response" | jq ".status")
 done
 


### PR DESCRIPTION
## Goal

Move the full set of e2e tests for Android 9 from the Full to Quick build.  

## Design

The theory is that a single full run is generally sufficient to realise any issues and may reduce the likelihood of an engineer triggering a Full build, consuming a lot of test device bandwidth.

## Changeset

As well as moving the build step, I have also made a few improvements generally now that MazeRunner itself supports specific environment variables (the previous variables came only from a commonly used convention).

## Testing

Covered by CI and I checked the pipeline that was generated for the PR, before opening the gate.