### PR TITLE
Fix failing multi process scenario

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.6.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.7.2'
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b73093f128efdea444966969cd3526e26de8ed5b
-  tag: v3.6.0
+  revision: d022bf3269fe1a36c7f719f91d0e9f243ce70577
+  tag: v3.7.2
   specs:
-    bugsnag-maze-runner (3.6.0)
+    bugsnag-maze-runner (3.7.2)
       appium_lib (~> 10.2)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -26,7 +26,7 @@ GEM
     appium_lib_core (3.11.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    backports (3.18.2)
+    backports (3.20.1)
     builder (3.2.4)
     childprocess (3.0.0)
     cucumber (3.1.2)
@@ -52,21 +52,23 @@ GEM
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
-    mini_portile2 (2.4.0)
-    minitest (5.14.2)
+    mini_portile2 (2.5.0)
+    minitest (5.14.3)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.10.10)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
     power_assert (1.2.0)
+    racc (1.5.2)
     rake (12.3.3)
     rubyzip (2.3.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    test-unit (3.3.7)
+    test-unit (3.3.9)
       power_assert
     tomlrb (1.3.0)
     websocket-driver (0.7.3)

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
@@ -322,7 +322,7 @@ Java_com_bugsnag_android_mazerunner_scenarios_MultiProcessUnhandledCXXErrorScena
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_MultiProcessUnhandledCXXErrorScenario_activate(JNIEnv *env,
                                                                                              jobject instance) {
-  __builtin_trap();
+  abort();
 }
 
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessUnhandledCXXErrorScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessUnhandledCXXErrorScenario.kt
@@ -38,10 +38,8 @@ internal class MultiProcessUnhandledCXXErrorScenario(
                     )
                 )
             } else {
-                runOnBgThread {
-                    user1()
-                    activate()
-                }
+                user1()
+                activate()
             }
         } else {
             if (!isRunningFromBackgroundService()) {

--- a/features/full_tests/multi_process.feature
+++ b/features/full_tests/multi_process.feature
@@ -92,8 +92,8 @@ Scenario: Unhandled NDK error
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the request payload contains a completed handled native report
     And the payload field "events" is an array with 1 elements
-    And the exception "errorClass" equals "SIGTRAP"
-    And the exception "message" equals "Trace/breakpoint trap"
+    And the exception "errorClass" equals "SIGABRT"
+    And the exception "message" equals "Abort program"
     And the event "unhandled" is true
     And the payload field "events.0.metaData.process.name" equals "com.bugsnag.android.mazerunner"
     And the payload field "events.0.device.id" is stored as the value "first_device_id"
@@ -105,8 +105,8 @@ Scenario: Unhandled NDK error
     And the request is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the request payload contains a completed handled native report
     And the payload field "events" is an array with 1 elements
-    And the exception "errorClass" equals "SIGTRAP"
-    And the exception "message" equals "Trace/breakpoint trap"
+    And the exception "errorClass" equals "SIGABRT"
+    And the exception "message" equals "Abort program"
     And the event "unhandled" is true
     And the payload field "events.0.metaData.process.name" equals "com.example.bugsnag.android.mazerunner.multiprocess"
     And the payload field "events.0.device.id" equals the stored value "first_device_id"


### PR DESCRIPTION
## Goal

Fixes a multi process E2E scenario which failed on Android <6 due to SIGILL rather than SIGTRAP. This appears to be caused by a difference in platform behaviour by the crashing code - this has been simplified by just calling `abort()` so that it's consistent across API levels. The scenario was also failing on 4.4 due to the service finishing before the error could be thrown - running the crashy code on the main thread has resolved this issue.

Additionally this changeset bumps mazerunner to the latest version.