### PR TITLE
Separate steps for launching and relaunching the app

### DIFF
--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -37,7 +37,7 @@ Feature: Synchronizing app/device metadata in the native layer
         When I run "CXXDelayedCrashScenario"
         And I send the app to the background for 10 seconds
         And I clear any error dialogue
-        And I relaunch the app
+        And I relaunch the app after a crash
         And I configure Bugsnag for "CXXDelayedCrashScenario"
         And I wait to receive a request
         Then the request payload contains a completed handled native report

--- a/features/full_tests/session_tracking.feature
+++ b/features/full_tests/session_tracking.feature
@@ -40,7 +40,7 @@ Scenario: User is persisted between sessions
     And the session "user.email" equals "test@test.test"
     And the session "user.name" equals "test user"
     When I discard the oldest request
-    And I relaunch the app
+    And I close and relaunch the app
     And I configure the app to run in the "no_user" state
     And I run "SessionPersistUserScenario"
     And I wait to receive a request
@@ -59,7 +59,7 @@ Scenario: User is not persisted between sessions
     And the session "user.email" equals "test@test.test"
     And the session "user.name" equals "test user"
     When I discard the oldest request
-    And I relaunch the app
+    And I close and relaunch the app
     And I configure the app to run in the "no_user" state
     And I run "SessionPersistUserDisabledScenario"
     And I wait to receive a request

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -54,7 +54,7 @@ Scenario: Automated sessions send
 Scenario: Manual session control works
     When I run "ManualSessionSmokeScenario"
     And I wait for 8 seconds
-    And I relaunch the app
+    And I relaunch the app after a crash
     And I configure Bugsnag for "ManualSessionSmokeScenario"
     And I wait to receive 4 requests
 

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -10,7 +10,7 @@ When("I run {string} and relaunch the app") do |event_type|
   steps %Q{
     When I run "#{event_type}"
     And I clear any error dialogue
-    And I relaunch the app
+    And I relaunch the app after a crash
   }
 end
 
@@ -29,8 +29,15 @@ When("I configure Bugsnag for {string}") do |event_type|
   }
 end
 
-When("I relaunch the app") do
+When("I close and relaunch the app") do
   MazeRunner.driver.close_app
+  MazeRunner.driver.launch_app
+end
+
+When("I relaunch the app after a crash") do
+  # This step should only be used when the app has crashed, but the notifier needs a little
+  # time to write the crash report before being forced to reopen.  From trials, 2s was not enough.
+  sleep(5)
   MazeRunner.driver.launch_app
 end
 


### PR DESCRIPTION
## Goal

Separate `I relaunch the app` step into its two separate uses.

## Design

`I relaunch the app` was being used for two subtly different purposes:
- Launching the app after a crash
- Closing the app whilst it is running and then launching it

This PR separates the two concepts into more explicitly worded steps.  With the extra delay before launching the app after a crash, it's possible that some flakes will resolve, because MazeRunner won't be forcefully closing or opening the app while it is writing to file.

## Changeset

Cucumber step split into two.

## Testing

Covered by CI.