### PR TITLE
Switch to Google-friendly ANR handler.

### DIFF
--- a/bugsnag-plugin-android-anr/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-anr/src/main/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library( # Specifies the name of the library.
              # Sets the library as a shared library.
              SHARED
              # Provides a relative path to your source file(s).
+    jni/anr_google.c
     jni/anr_handler.c
     jni/bugsnag_anr.c
     jni/utils/string.c

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_google.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_google.c
@@ -1,0 +1,155 @@
+// File:   anr_google.c
+// Author: Karl Stenerud
+// Date:   January 13, 2021
+//
+// Before starting an app, the Android runtime library first sets up its own SIGQUIT handler
+// (art/runtime/signal_catcher.cc, art/runtime/signal_set.h), which listens for SIGQUIT messages
+// that the OS sends to it when it detects an ANR. The handler uses sigwait() instead of the more
+// common sigaction() mechanism, which complicates things:
+//
+// - sigwait() only triggers when a signal becomes PENDING, which can only happen if the signal is
+//   blocked on all threads. As soon as a signal handler gets called, the signal is no longer
+//   pending. Also, an unblocked signal never becomes pending.
+//
+// - Blocked signals will never reach a signal handler registered via sigaction(), which is why the
+//   old BSG implementation had to unblock SIGQUIT to work (while at the same time breaking the
+//   Google handler).
+//
+// - Registering multiple handlers via sigwait() doesn't work because only the first registered
+//   handler gets called. Once the first handler runs, the signal is no longer pending. And since
+//   the first handler in this case is registered by the runtime library before our code even has
+//   a chance to run, we'd never get called.
+//
+// - Even though the runtime library has callback hooks for ANRs (art/runtime/runtime.cc), it's
+//   not a public API, so we can't use it.
+//
+// So we need a workaround. Calling raise() and signal() won't work, because the signal ends up
+// getting routed incorrectly. The only way to successfully signal the runtime handler is by use
+// of a syscall() of SYS_tgkill with SIGQUIT that targets the Google handler thread ID directly.
+//
+//
+// How to work around it:
+//
+// - Unblock SIGQUIT (breaking the Google handler)
+//
+// - Register a SIGQUIT handler via sigaction()
+//
+// - Our handler callback blocks SIGQUIT (allowing the Google handler to work again) and sets a
+//   flag like "should_report_anr"
+//
+// - We have another thread waiting on the "should_report_anr" flag, which then calls
+//   bsg_google_anr_call() after a short delay to raise a SIGQUIT on Google's handler thread.
+//   Re-raising the signal on the signal handler thread won't work because the signaling system
+//   in the OS won't finish updating the new blocking state until the current signal handler
+//   returns.
+//
+// - Do our handler stuff, delay a short while (like 2 seconds) for Google's handlers to finish,
+//   then exit our watchdog thread. It's important that our watchdog thread stops before the
+//   runtime's timeout (currently 20 seconds), or else we'll be force-killed, which breaks Google
+//   reporting and the ANR popup in some cases.
+//
+//
+// Functionality in this file:
+//
+// - bsg_google_anr_init (NOT async-safe): Find and save the Google ANR handler thread ID and the
+//   process ID, which are needed to make the syscall.
+//
+// - bsg_google_anr_call (async-safe): Make the syscall to send a SIGQUIT directly to the runtime
+//   library's ANR handler thread.
+
+#include "anr_google.h"
+
+#include <ctype.h>
+#include <dirent.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static pid_t process_id = -1;
+static pid_t google_thread_id = -1;
+
+static bool is_thread_named_signal_catcher(pid_t tid) {
+  static const char*const SIGNAL_CATCHER_THREAD_NAME = "Signal Catcher";
+
+  bool success = false;
+  char buff[256];
+
+  snprintf(buff, sizeof(buff), "/proc/%d/comm", tid);
+  FILE* fp = fopen(buff, "r");
+  if(fp == NULL) {
+    return false;
+  }
+
+  if(fgets(buff, sizeof(buff), fp) != NULL) {
+    success = strncmp(buff, SIGNAL_CATCHER_THREAD_NAME, strlen(SIGNAL_CATCHER_THREAD_NAME)) == 0;
+  }
+
+  fclose(fp);
+  return success;
+}
+
+static bool is_thread_signal_catcher_sigblk(pid_t tid) {
+  static const uint64_t SIGNAL_CATCHER_THREAD_SIGBLK = 0x1000;
+  static const char* SIGBLK_HEADER = "SigBlk:\t";
+  const size_t SIGBLK_HEADER_LENGTH = strlen(SIGBLK_HEADER);
+
+  char buff[256];
+  uint64_t sigblk = 0;
+
+  snprintf(buff, sizeof(buff), "/proc/%d/status", tid);
+  FILE* fp = fopen(buff, "r");
+  if(fp == NULL) {
+    return false;
+  }
+
+  while(fgets(buff, sizeof(buff), fp) != NULL) {
+    if (strncmp(buff, SIGBLK_HEADER, SIGBLK_HEADER_LENGTH) == 0) {
+      sigblk = strtoull(buff + SIGBLK_HEADER_LENGTH, NULL, 16);
+      break;
+    }
+  }
+  fclose(fp);
+  return sigblk == SIGNAL_CATCHER_THREAD_SIGBLK;
+}
+
+bool bsg_google_anr_init() {
+  pid_t pid = getpid();
+  pid_t tid = -1;
+
+  char path[256];
+  snprintf(path, sizeof(path), "/proc/%d/task", pid);
+  DIR* dir = opendir(path);
+  if(dir == NULL) {
+    return false;
+  }
+
+  struct dirent *dent;
+  while((dent = readdir(dir)) != NULL) {
+    if(dent->d_name[0] < '0' || dent->d_name[0] > '9') {
+      continue;
+    }
+
+    tid = strtol(dent->d_name, NULL, 10);
+    if(is_thread_named_signal_catcher(tid) && is_thread_signal_catcher_sigblk(tid)) {
+      break;
+    }
+    tid = -1;
+  }
+  closedir(dir);
+
+  if(tid < 0) {
+    return false;
+  }
+
+  google_thread_id = tid;
+  process_id = pid;
+  return true;
+}
+
+void bsg_google_anr_call() {
+  if(process_id >= 0 && google_thread_id >= 0) {
+    syscall(SYS_tgkill, process_id, google_thread_id, SIGQUIT);
+  }
+}

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_google.h
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_google.h
@@ -1,0 +1,27 @@
+#ifndef BUGSNAG_ANR_GOOGLE_H
+#define BUGSNAG_ANR_GOOGLE_H
+
+#include <stdbool.h>
+
+/**
+ * Initialize the Google ANR caller. This must be called before any other functions in this file.
+ * If the call fails, all other calls in this file will be no-ops.
+ *
+ * Note: This function is NOT async-safe.
+ *
+ * @return true if successful.
+ */
+bool bsg_google_anr_init(void);
+
+/**
+ * Raises a SIGQUIT signal directly on Google's "Signal Catcher" thread in the runtime library.
+ * This function will no-op if bsg_google_anr_init() was not called, or the call failed.
+ *
+ * Note: This MUST be called from a non-signal-handler thread (create a separate thread that waits
+ *       to call this function).
+ *
+ * Note: This function is async-safe.
+ */
+void bsg_google_anr_call(void);
+
+#endif

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
@@ -5,118 +5,128 @@
 #include <pthread.h>
 #include <signal.h>
 #include <string.h>
+#include <unistd.h>
 
-#include "utils/string.h"
-
-static pthread_t bsg_watchdog_thread;
-static sigset_t bsg_anr_sigmask;
+#include "anr_google.h"
 
 // Lock for changing the handler configuration
 static pthread_mutex_t bsg_anr_handler_config = PTHREAD_MUTEX_INITIALIZER;
+
 // A proxy for install/uninstall state, to avoid needing to unset the handler
 // on the sigquit-watching thread
 static bool enabled = false;
 static bool installed = false;
-static bool invokePrevHandler = true;
+
+static pthread_t watchdog_thread;
+static volatile bool should_report_anr = false;
+static struct sigaction original_sigquit_handler;
 
 static JavaVM *bsg_jvm = NULL;
 static jmethodID mthd_notify_anr_detected = NULL;
 static jobject obj_plugin = NULL;
 
-/* The previous SIGQUIT handler */
-struct sigaction bsg_sigquit_sigaction_previous;
-
-void bsg_notify_anr_detected(JNIEnv *env) {
-  (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
-}
-
-bool bsg_configure_anr_jni(JNIEnv *env) {
+static bool configure_anr_jni(JNIEnv *env) {
   // get a global reference to the AnrPlugin class
   // https://developer.android.com/training/articles/perf-jni#faq:-why-didnt-findclass-find-my-class
   int result = (*env)->GetJavaVM(env, &bsg_jvm);
   if (result != 0) {
-    // Failed to fetch VM, cannot continue
+    BUGSNAG_LOG("Failed to fetch Java VM. ANR handler not installed.");
     return false;
   }
 
   jclass clz = (*env)->FindClass(env, "com/bugsnag/android/AnrPlugin");
   mthd_notify_anr_detected =
-      (*env)->GetMethodID(env, clz, "notifyAnrDetected", "()V");
+          (*env)->GetMethodID(env, clz, "notifyAnrDetected", "()V");
   return true;
 }
 
-void bsg_handle_sigquit(int signum, siginfo_t *info, void *user_context) {
+static void notify_anr_detected() {
   if (enabled) {
-    // invoke a JNI call from the SIGQUIT handler
     JNIEnv *env;
-    int result = (*bsg_jvm)->GetEnv(bsg_jvm, (void **)&env, JNI_VERSION_1_4);
+    int result = (*bsg_jvm)->GetEnv(bsg_jvm, (void **) &env, JNI_VERSION_1_4);
 
     if (result == JNI_OK) { // already attached
-      bsg_notify_anr_detected(env);
+      (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
     } else if (result == JNI_EDETACHED) { // attach before calling JNI
       if ((*bsg_jvm)->AttachCurrentThread(bsg_jvm, &env, NULL) == 0) {
-        bsg_notify_anr_detected(env);
+        (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
         (*bsg_jvm)->DetachCurrentThread(
-            bsg_jvm); // detach to restore initial condition
+                bsg_jvm); // detach to restore initial condition
       }
     } // All other results are error codes
   }
-
-  // Invoke previous handler, if a custom handler has been set
-  // This can be conditionally switched off on certain platforms (e.g. Unity)
-  // where this behaviour is not desirable due to Unity's implementation failing
-  // with a SIGSEGV
-  if (invokePrevHandler) {
-    struct sigaction previous = bsg_sigquit_sigaction_previous;
-    if (previous.sa_flags & SA_SIGINFO) {
-      previous.sa_sigaction(SIGQUIT, info, user_context);
-    } else if (previous.sa_handler == SIG_DFL) {
-      // Do nothing, the default action is nothing
-    } else if (previous.sa_handler != SIG_IGN) {
-      void (*previous_handler)(int) = previous.sa_handler;
-      previous_handler(signum);
-    }
-  }
 }
 
-/**
- * Configure ANR detection using a signal handler listening for SIGQUIT
- */
-void *bsg_monitor_anrs(void *_arg) {
-  struct sigaction handler;
-  sigemptyset(&handler.sa_mask);
-  handler.sa_sigaction = bsg_handle_sigquit;
+static void* sigquit_watchdog_thread_main(void* _) {
+  static const useconds_t delay_2sec = 2000000;
+  static const useconds_t delay_100ms = 100000;
+  static const useconds_t delay_10ms = 10000;
 
-  // remove SA_ONSTACK flag as we don't require information about the SIGQUIT
-  // signal. specifying this flag results in a crash when performing a JNI call.
-  // For further context see https://issuetracker.google.com/issues/37035211
-  handler.sa_flags = SA_SIGINFO;
-  int success = sigaction(SIGQUIT, &handler, &bsg_sigquit_sigaction_previous);
-  if (success != 0) {
-    BUGSNAG_LOG("Failed to install SIGQUIT handler: %s", strerror(errno));
+  // Wait until our SIGQUIT handler is ready for us to start
+  while(!should_report_anr) {
+    usleep(delay_100ms);
   }
 
+  // Force at least one task switch after being triggered, ensuring that the signal masks are
+  // properly settled before triggering the Google handler.
+  usleep(delay_10ms);
+
+  // Do our ANR processing
+  notify_anr_detected();
+
+  // Trigger Google ANR processing
+  bsg_google_anr_call();
+
+  // Give a little time for the Google handler to dump state, then exit this thread.
+  usleep(delay_2sec);
   return NULL;
+}
+
+static void handle_sigquit(int signum, siginfo_t* info, void* user_context) {
+  // Re-block SIGQUIT so that the Google handler can trigger
+  sigset_t sigmask;
+  sigemptyset(&sigmask);
+  sigaddset(&sigmask, SIGQUIT);
+  pthread_sigmask(SIG_BLOCK, &sigmask, NULL);
+  sigaction(SIGQUIT, &original_sigquit_handler, NULL);
+
+  // Instruct our watchdog thread to report the ANR and also call Google
+  should_report_anr = true;
+}
+
+static void install_signal_handler() {
+  if(!bsg_google_anr_init()) {
+    BUGSNAG_LOG("Failed to initialize Google ANR caller. ANRs won't be sent to Google.");
+  }
+
+  // Start the watchdog thread
+  pthread_create(&watchdog_thread, NULL, sigquit_watchdog_thread_main, NULL);
+
+  // Install our signal handler
+  struct sigaction handler;
+  sigemptyset(&handler.sa_mask);
+  handler.sa_sigaction = handle_sigquit;
+  handler.sa_flags = SA_SIGINFO;
+  int success = sigaction(SIGQUIT, &handler, &original_sigquit_handler);
+  if (success != 0) {
+    BUGSNAG_LOG("Failed to install SIGQUIT handler: %s", strerror(errno));
+    return;
+  }
+
+  // Unblock SIGQUIT so that our handler will be called
+  sigset_t anr_sigmask;
+  sigemptyset(&anr_sigmask);
+  sigaddset(&anr_sigmask, SIGQUIT);
+  pthread_sigmask(SIG_UNBLOCK, &anr_sigmask, NULL);
 }
 
 bool bsg_handler_install_anr(JNIEnv *env, jobject plugin,
                              jboolean callPreviousSigquitHandler) {
   pthread_mutex_lock(&bsg_anr_handler_config);
-  invokePrevHandler = callPreviousSigquitHandler;
 
-  if (!installed && bsg_configure_anr_jni(env)) {
+  if (!installed && configure_anr_jni(env)) {
     obj_plugin = (*env)->NewGlobalRef(env, plugin);
-    sigemptyset(&bsg_anr_sigmask);
-    sigaddset(&bsg_anr_sigmask, SIGQUIT);
-
-    int mask_status = pthread_sigmask(SIG_BLOCK, &bsg_anr_sigmask, NULL);
-    if (mask_status != 0) {
-      BUGSNAG_LOG("Failed to mask SIGQUIT: %s", strerror(mask_status));
-    } else {
-      pthread_create(&bsg_watchdog_thread, NULL, bsg_monitor_anrs, NULL);
-      // unblock the current thread
-      pthread_sigmask(SIG_UNBLOCK, &bsg_anr_sigmask, NULL);
-    }
+    install_signal_handler();
     installed = true;
   }
   enabled = true;


### PR DESCRIPTION
## Goal

PLAT-4956 and PLAT-5607

## Design

- Re-block SIGQUIT and then signal the Google ANR thread directly.
- Call Java from an async-safe thread.

## Testing

Manual testing on multiple OS and device types, checking that both Bugsnag and Google get ANR reports.
