### PR TITLE
Disable failing test on Android 5

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -433,7 +433,7 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_4_4"
-          - "--tags='@Flaky'"
+          - "--tags=@Flaky"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -454,7 +454,7 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_5_0"
-          - "--tags='@Flaky'"
+          - "--tags=@Flaky"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -477,7 +477,7 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0"
-          - "--tags='@Flaky'"
+          - "--tags=@Flaky"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -498,7 +498,7 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
-          - "--tags='@Flaky'"
+          - "--tags=@Flaky"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -519,7 +519,7 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_8_0"
-          - "--tags='@Flaky'"
+          - "--tags=@Flaky"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -542,7 +542,7 @@ steps:
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
-          - "--tags='@Flaky'"
+          - "--tags=@Flaky"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -565,7 +565,7 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
-          - "--tags='@Flaky'"
+          - "--tags=@Flaky"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -586,6 +586,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
-          - "--tags='@Flaky'"
+          - "--tags=@Flaky"
     concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/features/full_tests/batch_2/naughty_strings.feature
+++ b/features/full_tests/batch_2/naughty_strings.feature
@@ -24,8 +24,8 @@ Scenario: Test handled JVM error
     And the payload field "events.0.metaData.custom.val_13" equals "𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰"
     And the payload field "events.0.metaData.custom.val_14" equals "گچپژ"
 
-# commented out some failing unicode assertions and skipped Android 4.4 until PLAT-5606 is addressed
-@skip_below_android_5
+# commented out some failing unicode assertions and skipped Android <6 until PLAT-5606 is addressed
+@skip_below_android_6
 Scenario: Test unhandled NDK error
     When I run "CXXNaughtyStringsScenario" and relaunch the app
     And I configure the app to run in the "non-crashy" state

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,6 +26,10 @@ Before('@skip_below_android_8') do |scenario|
   skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version < 8
 end
 
+Before('@skip_below_android_6') do |scenario|
+  skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version < 6
+end
+
 Before('@skip_below_android_5') do |scenario|
   skip_this_scenario("Skipping scenario") if MazeRunner.config.os_version < 5
 end


### PR DESCRIPTION
## Goal

Disables a test which was failing on Android 5, which was missed due to the presence of a soft fail. This will remain disabled until PLAT-5606 is addressed. This seems to be the only genuine failure in a [full CI run](https://buildkite.com/bugsnag/bugsnag-android/builds/3197#_) at the moment.