### PR TITLE
Various updates for flaking scenarios

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -105,6 +105,9 @@ steps:
           - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    # TODO: 2021/01/20 Currently experiencing issues with Appium session stability
+    soft_fail:
+      - exit_status: *
 
   - label: ':android: Android 4.4 NDK r16 end-to-end tests - batch 2'
     depends_on:
@@ -127,6 +130,9 @@ steps:
           - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    # TODO: 2021/01/20 Currently experiencing issues with Appium session stability
+    soft_fail:
+      - exit_status: *
 
   - label: ':android: Android 5 NDK r16 end-to-end tests - batch 1'
     depends_on:

--- a/features/full_tests/batch_2/session_stopping.feature
+++ b/features/full_tests/batch_2/session_stopping.feature
@@ -12,7 +12,6 @@ Scenario: When a session is paused the error has no session information
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events.0.session" is null
 
-@Flaky    
 Scenario: When a session is resumed the error uses the previous session information
     When I run "ResumedSessionScenario"
     Then I wait to receive a session
@@ -28,7 +27,6 @@ Scenario: When a session is resumed the error uses the previous session informat
     And the error payload field "events.0.session.events.handled" equals 2
     And the error payload field "events.0.session.id" equals the stored value "resumed_session_id"
 
-@Flaky
 Scenario: When a new session is started the error uses different session information
     When I run "NewSessionScenario"
     Then I wait to receive 2 sessions

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,7 @@ $api_key = "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
 AfterConfiguration do |_config|
   Maze.config.receive_no_requests_wait = 10
+  Maze.config.receive_requests_wait = 60
 end
 
 Before('@skip') do |scenario|


### PR DESCRIPTION
## Goal

Makes a few tweaks in relation to flaking scenarios:
1. Temporary soft fail on Android 4.4 and 5 whilst we wait for support from BrowserStack
2. Increase timeout for receiving requests to 60s (the theoretical maximum)
3. Remove `@Flaky` tag from scenarios that should now be fixed by MazeRunner v4

## Testing

Will be fully covered by CI when we come to merge to `next`.