### PR TITLE
Do not use the resilient appium driver

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -58,7 +58,6 @@ steps:
   - label: ':android: Android 7 Instrumentation tests'
     depends_on:
       - "android-ci"
-      - "NDK-smoke-test"
     timeout_in_minutes: 30
     command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
     plugins:
@@ -72,7 +71,6 @@ steps:
   - label: ':android: Android 9 Instrumentation tests'
     depends_on:
       - "android-ci"
-      - "NDK-smoke-test"
     timeout_in_minutes: 30
     command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
     plugins:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -384,9 +384,11 @@ steps:
     concurrency_group: 'browserstack-app'
 
   #
-  # Flaky features
+  # Flaky scenarios.  These should be skipped if there are no scenarios annotated with the @Flaky tag (as we should
+  # always be aiming for) to avoid unnecessary CI wait times and potential flakes from resource unavailability.
   #
   - label: ':hankey: Flaky Android 4.4 NDK r16 end-to-end tests'
+    skip: There are no @Flaky scenarios at present
     depends_on:
       - "fixture-r16"
     timeout_in_minutes: 90
@@ -408,6 +410,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':hankey: Flaky Android 5 NDK r16 end-to-end tests'
+    skip: There are no @Flaky scenarios at present
     depends_on:
       - "fixture-r16"
     timeout_in_minutes: 90
@@ -429,6 +432,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':hankey: Flaky Android 6 NDK r16 end-to-end tests'
+    skip: There are no @Flaky scenarios at present
     depends_on:
       - "fixture-r16"
     timeout_in_minutes: 90
@@ -450,6 +454,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':hankey: Flaky Android 7 NDK r19 end-to-end tests'
+    skip: There are no @Flaky scenarios at present
     depends_on:
       - "fixture-r19"
     timeout_in_minutes: 60
@@ -471,6 +476,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':hankey: Flaky Android 8.1 NDK r19 end-to-end tests'
+    skip: There are no @Flaky scenarios at present
     depends_on:
       - "fixture-r19"
     timeout_in_minutes: 60
@@ -492,6 +498,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':hankey: Flaky Android 10 NDK r21 end-to-end tests'
+    skip: There are no @Flaky scenarios at present
     depends_on:
       - "fixture-r21"
     timeout_in_minutes: 60
@@ -513,6 +520,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':hankey: Flaky Android 11 NDK r21 end-to-end tests'
+    skip: There are no @Flaky scenarios at present
     depends_on:
       - "fixture-r21"
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -45,7 +45,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -102,7 +101,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     # TODO: 2021/01/20 Currently experiencing issues with Appium session stability
@@ -127,7 +125,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     # TODO: 2021/01/20 Currently experiencing issues with Appium session stability
@@ -152,7 +149,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -174,7 +170,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -196,7 +191,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -218,7 +212,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -240,7 +233,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -262,7 +254,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -284,7 +275,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -306,7 +296,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -328,7 +317,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -350,7 +338,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -372,7 +359,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -394,7 +380,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -419,7 +404,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_4_4"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -441,7 +425,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_5_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -463,7 +446,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_6_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -485,7 +467,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_7_1"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -507,7 +488,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_8_1"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -529,7 +509,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_10_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -551,6 +530,5 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_11_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -153,7 +153,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -135,7 +135,12 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
+  #
+  # Flaky scenarios.  Theis should be skipped if there are no scenarios annotated with the @Flaky tag (as we should
+  # always be aiming for) to avoid unnecessary CI wait times and potential flakes from resource unavailability.
+  #
   - label: ':hankey: Flaky Android 9 NDK r21 end-to-end tests'
+    skip: There are no @Flaky scenarios at present
     depends_on:
       - "fixture-r21"
     timeout_in_minutes: 60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    # TODO: Update to latest-v4-cli
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-corrections-for-notifiers-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v4-cli
     environment:
       DEBUG:
       BUILDKITE:

--- a/features/full_tests/batch_2/native_api.feature
+++ b/features/full_tests/batch_2/native_api.feature
@@ -9,7 +9,6 @@ Feature: Native API
         And the exception "message" equals "9 out of 10 adults do not get their 5-a-day"
         And the event "unhandled" is false
 
-    @Flaky
     Scenario: Starting a session, notifying, followed by a C crash
         When I run "CXXSessionInfoCrashScenario" and relaunch the app
         And I configure the app to run in the "non-crashy" state


### PR DESCRIPTION
## Goal

Remove use of the Resilient Appium driver.

## Design

There's a bug in MazeRunner's Resilient Appium Driver that makes it incompatible with the way that the Android test run.  It erroneously treats a `NoSuchElement` exception, which is "normal" in the Android setup, as a broken Appium session.  The simplest thing to do at this stage is to just stop using the flag.

## Changeset

- Stop using the resilient drive
- Use the official MazeRunner release image
- Remove `@Flaky` tag from scenario, as it was down to the resilient driver and not the scenario.

## Testing

Covered by running a full CI.