### PR TITLE
Check internal JNI calls for pending exceptions and no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Check internal JNI calls for pending exceptions and no-op
+  [#1088](https://github.com/bugsnag/bugsnag-android/pull/1088)
+
 ## 5.5.1 (2021-01-21)
 
 * Alter ANR SIGQUIT handler to stop interfering with Google's ANR reporting, and to avoid unsafe JNI calls from within a signal handler

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library( # Specifies the name of the library.
     jni/bugsnag_ndk.c
     jni/bugsnag.c
     jni/metadata.c
+    jni/safejni.c
     jni/event.c
     jni/handlers/signal_handler.c
     jni/handlers/cpp_handler.cpp

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -1,4 +1,5 @@
 #include "metadata.h"
+#include "safejni.h"
 #include "utils/string.h"
 #include <malloc.h>
 #include <string.h>
@@ -40,55 +41,203 @@ void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
                                  bsg_jni_cache *jni_cache, char *section,
                                  char *name, jobject _value);
 
+/**
+ * Creates a cache of JNI methods/classes that are commonly used.
+ *
+ * Class and method objects can be kept safely since they aren't moved or
+ * removed from the JVM - care should be taken not to load objects as local
+ * references here.
+ */
 bsg_jni_cache *bsg_populate_jni_cache(JNIEnv *env) {
   bsg_jni_cache *jni_cache = malloc(sizeof(bsg_jni_cache));
-  jni_cache->integer = (*env)->FindClass(env, "java/lang/Integer");
-  jni_cache->boolean = (*env)->FindClass(env, "java/lang/Boolean");
-  jni_cache->long_class = (*env)->FindClass(env, "java/lang/Long");
-  jni_cache->float_class = (*env)->FindClass(env, "java/lang/Float");
-  jni_cache->number = (*env)->FindClass(env, "java/lang/Number");
-  jni_cache->string = (*env)->FindClass(env, "java/lang/String");
+
+  // lookup java/lang/Integer
+  jni_cache->integer = bsg_safe_find_class(env, "java/lang/Integer");
+  if (jni_cache->integer == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/Boolean
+  jni_cache->boolean = bsg_safe_find_class(env, "java/lang/Boolean");
+  if (jni_cache->boolean == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/Long
+  jni_cache->long_class = bsg_safe_find_class(env, "java/lang/Long");
+  if (jni_cache->long_class == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/Float
+  jni_cache->float_class = bsg_safe_find_class(env, "java/lang/Float");
+  if (jni_cache->float_class == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/Number
+  jni_cache->number = bsg_safe_find_class(env, "java/lang/Number");
+  if (jni_cache->number == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/String
+  jni_cache->string = bsg_safe_find_class(env, "java/lang/String");
+  if (jni_cache->string == NULL) {
+    return NULL;
+  }
+
+  // lookup Integer.intValue()
   jni_cache->integer_int_value =
-      (*env)->GetMethodID(env, jni_cache->integer, "intValue", "()I");
+      bsg_safe_get_method_id(env, jni_cache->integer, "intValue", "()I");
+  if (jni_cache->integer_int_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Integer.floatValue()
   jni_cache->float_float_value =
-      (*env)->GetMethodID(env, jni_cache->float_class, "floatValue", "()F");
+      bsg_safe_get_method_id(env, jni_cache->float_class, "floatValue", "()F");
+  if (jni_cache->float_float_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Double.doubleValue()
   jni_cache->number_double_value =
-      (*env)->GetMethodID(env, jni_cache->number, "doubleValue", "()D");
+      bsg_safe_get_method_id(env, jni_cache->number, "doubleValue", "()D");
+  if (jni_cache->number_double_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Long.longValue()
   jni_cache->long_long_value =
-      (*env)->GetMethodID(env, jni_cache->integer, "longValue", "()J");
+      bsg_safe_get_method_id(env, jni_cache->integer, "longValue", "()J");
+  if (jni_cache->long_long_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Boolean.booleanValue()
   jni_cache->boolean_bool_value =
-      (*env)->GetMethodID(env, jni_cache->boolean, "booleanValue", "()Z");
-  jni_cache->arraylist = (*env)->FindClass(env, "java/util/ArrayList");
-  jni_cache->arraylist_init_with_obj = (*env)->GetMethodID(
+      bsg_safe_get_method_id(env, jni_cache->boolean, "booleanValue", "()Z");
+  if (jni_cache->boolean_bool_value == NULL) {
+    return NULL;
+  }
+
+  // lookup java/util/ArrayList
+  jni_cache->arraylist = bsg_safe_find_class(env, "java/util/ArrayList");
+  if (jni_cache->arraylist == NULL) {
+    return NULL;
+  }
+
+  // lookup ArrayList constructor
+  jni_cache->arraylist_init_with_obj = bsg_safe_get_method_id(
       env, jni_cache->arraylist, "<init>", "(Ljava/util/Collection;)V");
-  jni_cache->arraylist_get = (*env)->GetMethodID(
+  if (jni_cache->arraylist_init_with_obj == NULL) {
+    return NULL;
+  }
+
+  // lookup ArrayList.get()
+  jni_cache->arraylist_get = bsg_safe_get_method_id(
       env, jni_cache->arraylist, "get", "(I)Ljava/lang/Object;");
-  jni_cache->hash_map = (*env)->FindClass(env, "java/util/HashMap");
-  jni_cache->map = (*env)->FindClass(env, "java/util/Map");
-  jni_cache->hash_map_key_set = (*env)->GetMethodID(
+  if (jni_cache->arraylist_get == NULL) {
+    return NULL;
+  }
+
+  // lookup java/util/HashMap
+  jni_cache->hash_map = bsg_safe_find_class(env, "java/util/HashMap");
+  if (jni_cache->hash_map == NULL) {
+    return NULL;
+  }
+
+  // lookup java/util/Map
+  jni_cache->map = bsg_safe_find_class(env, "java/util/Map");
+  if (jni_cache->map == NULL) {
+    return NULL;
+  }
+
+  // lookup java/util/Set
+  jni_cache->hash_map_key_set = bsg_safe_get_method_id(
       env, jni_cache->hash_map, "keySet", "()Ljava/util/Set;");
+  if (jni_cache->hash_map_key_set == NULL) {
+    return NULL;
+  }
+
+  // lookup HashMap.size()
   jni_cache->hash_map_size =
-      (*env)->GetMethodID(env, jni_cache->hash_map, "size", "()I");
+      bsg_safe_get_method_id(env, jni_cache->hash_map, "size", "()I");
+  if (jni_cache->hash_map_size == NULL) {
+    return NULL;
+  }
+
+  // lookup HashMap.get()
   jni_cache->hash_map_get =
-      (*env)->GetMethodID(env, jni_cache->hash_map, "get",
-                          "(Ljava/lang/Object;)Ljava/lang/Object;");
-  jni_cache->map_key_set =
-      (*env)->GetMethodID(env, jni_cache->map, "keySet", "()Ljava/util/Set;");
-  jni_cache->map_size = (*env)->GetMethodID(env, jni_cache->map, "size", "()I");
-  jni_cache->map_get = (*env)->GetMethodID(
+      bsg_safe_get_method_id(env, jni_cache->hash_map, "get",
+                             "(Ljava/lang/Object;)Ljava/lang/Object;");
+  if (jni_cache->hash_map_get == NULL) {
+    return NULL;
+  }
+
+  // lookup Map.keySet()
+  jni_cache->map_key_set = bsg_safe_get_method_id(env, jni_cache->map, "keySet",
+                                                  "()Ljava/util/Set;");
+  if (jni_cache->map_key_set == NULL) {
+    return NULL;
+  }
+
+  // lookup Map.size()
+  jni_cache->map_size =
+      bsg_safe_get_method_id(env, jni_cache->map, "size", "()I");
+  if (jni_cache->map_size == NULL) {
+    return NULL;
+  }
+
+  // lookup Map.get()
+  jni_cache->map_get = bsg_safe_get_method_id(
       env, jni_cache->map, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
+  if (jni_cache->map_get == NULL) {
+    return NULL;
+  }
+
+  // lookup com/bugsnag/android/NativeInterface
   jni_cache->native_interface =
-      (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-  jni_cache->get_app_data = (*env)->GetStaticMethodID(
+      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
+  if (jni_cache->native_interface == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getApp()
+  jni_cache->get_app_data = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getApp", "()Ljava/util/Map;");
-  jni_cache->get_device_data = (*env)->GetStaticMethodID(
+  if (jni_cache->get_app_data == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getDevice()
+  jni_cache->get_device_data = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getDevice", "()Ljava/util/Map;");
-  jni_cache->get_user_data = (*env)->GetStaticMethodID(
+  if (jni_cache->get_device_data == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getUser()
+  jni_cache->get_user_data = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getUser", "()Ljava/util/Map;");
-  jni_cache->get_metadata = (*env)->GetStaticMethodID(
+  if (jni_cache->get_user_data == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getMetadata()
+  jni_cache->get_metadata = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getMetadata", "()Ljava/util/Map;");
-  jni_cache->get_context = (*env)->GetStaticMethodID(
+  if (jni_cache->get_metadata == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getContext()
+  jni_cache->get_context = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getContext", "()Ljava/lang/String;");
+  if (jni_cache->get_context == NULL) {
+    return NULL;
+  }
   return jni_cache;
 }
 
@@ -186,6 +335,10 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
     return;
   }
   bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
+  if (jni_cache == NULL) {
+    return;
+  }
+
   int map_size = (int)(*env)->CallIntMethod(env, metadata, jni_cache->map_size);
   jobject keyset =
       (*env)->CallObjectMethod(env, metadata, jni_cache->map_key_set);
@@ -381,6 +534,9 @@ void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
 
 void bsg_populate_event(JNIEnv *env, bugsnag_event *event) {
   bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
+  if (jni_cache == NULL) {
+    return;
+  }
   bsg_populate_context(env, jni_cache, event);
   bsg_populate_app_data(env, jni_cache, event);
   bsg_populate_device_data(env, jni_cache, event);
@@ -409,6 +565,9 @@ void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
 void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst,
                            jobject metadata) {
   bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
+  if (jni_cache == NULL) {
+    return;
+  }
   if (metadata == NULL) {
     metadata = (*env)->CallStaticObjectMethod(env, jni_cache->native_interface,
                                               jni_cache->get_metadata);

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -1,0 +1,27 @@
+#include "safejni.h"
+
+jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
+  jclass clz = (*env)->FindClass(env, clz_name);
+  if ((*env)->ExceptionCheck(env)) {
+    (*env)->ExceptionClear(env);
+  }
+  return clz;
+}
+
+jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
+                                 const char *sig) {
+  jmethodID methodId = (*env)->GetMethodID(env, clz, name, sig);
+  if ((*env)->ExceptionCheck(env)) {
+    (*env)->ExceptionClear(env);
+  }
+  return methodId;
+}
+
+jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
+                                        const char *name, const char *sig) {
+  jmethodID methodId = (*env)->GetStaticMethodID(env, clz, name, sig);
+  if ((*env)->ExceptionCheck(env)) {
+    (*env)->ExceptionClear(env);
+  }
+  return methodId;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -1,0 +1,50 @@
+#ifndef BUGSNAG_SAFEJNI_H
+#define BUGSNAG_SAFEJNI_H
+
+#include <jni.h>
+
+/**
+ * A safe wrapper for the JNI's FindClass. This method checks if an exception is
+ * pending and if so clears it so that execution can continue.
+ *
+ * This method should be preferred to using the JNI methods directly. It is the
+ * responsibility of the caller to check whether the return value is NULL and
+ * handle this by no-oping.
+ *
+ * See
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#findclass
+ * @return the class, or NULL if the class could not be found.
+ */
+jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name);
+
+/**
+ * A safe wrapper for the JNI's GetMethodID. This method checks if an exception
+ * is pending and if so clears it so that execution can continue.
+ *
+ * This method should be preferred to using the JNI methods directly. It is the
+ * responsibility of the caller to check whether the return value is NULL and
+ * handle this by no-oping.
+ *
+ * See
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getmethodid
+ * @return the method ID, or NULL if the method could not be found.
+ */
+jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
+                                 const char *sig);
+
+/**
+ * A safe wrapper for the JNI's GetStaticMethodID. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ *
+ * This method should be preferred to using the JNI methods directly. It is the
+ * responsibility of the caller to check whether the return value is NULL and
+ * handle this by no-oping.
+ *
+ * See
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getstaticmethodid
+ * @return the method ID, or NULL if the method could not be found.
+ */
+jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
+                                        const char *name, const char *sig);
+
+#endif


### PR DESCRIPTION
## Goal

Makes safe all invocations of `GetMethodId`, `GetStaticMethodId`, and `FindClass` within the NDK module. This is achieved by calling [ExceptionClear](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#exceptionclear) to remove any pending JVM exceptions that could lead to app termination. The return value of all these invocations is checked for `NULL`, and no-ops if this is the case.

## Changeset

- Replaced `FindClass` with `bsg_safe_find_class` (and equivalents for `GetMethodId/GetStaticMethodId`)
- When loading a class, check if there was an exception in the JVM, and if so clear it and return `NULL`. The following errors can be thrown. As these are not recoverable, Bugsnag should no-op rather than crashing the process:
  - `NoSuchMethodError`
  - `ExceptionInInitializerError`
  - `OutOfMemoryError`
  - `ClassFormatError`
  - `ClassCircularityError`
  - `NoClassDefFoundError`
- Alter all invocations to check the return value for `NULL` and no-op in this case
- Added inline comments to explain what each JNI call is doing, which should improve readability (this comes from a previous review comment and it seemed an opportune moment)

## Testing

Relied on existing test coverage.

## Remaining work

The ANR plugin has not been converted to use these safe calls yet as it cannot directly access the methods. There are also several other JNI calls which can throw errors that Bugsnag does not currently handle. Both these will be addressed in separate changesets.