### PR TITLE
Check internal JNI calls for pending exceptions and no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Check internal JNI calls for pending exceptions and no-op
   [#1088](https://github.com/bugsnag/bugsnag-android/pull/1088)
+  [#1091](https://github.com/bugsnag/bugsnag-android/pull/1091)
 
 ## 5.5.2 (2021-01-27)
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -148,45 +148,47 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   pthread_mutex_lock(&bsg_native_delivery_mutex);
   const char *event_path = (*env)->GetStringUTFChars(env, _report_path, 0);
   bugsnag_event *event = bsg_deserialize_event_from_file((char *)event_path);
+  jbyteArray jpayload = NULL;
+  jbyteArray jstage = NULL;
+  char *payload = NULL;
 
   if (event != NULL) {
-    char *payload = bsg_serialize_event_to_json_string(event);
+    payload = bsg_serialize_event_to_json_string(event);
     if (payload != NULL) {
 
       // lookup com/bugsnag/android/NativeInterface
       jclass interface_class =
           bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
       if (interface_class == NULL) {
-        return;
+        goto exit;
       }
 
       // lookup NativeInterface.deliverReport()
       jmethodID jdeliver_method = bsg_safe_get_static_method_id(
           env, interface_class, "deliverReport", "([B[BLjava/lang/String;)V");
       if (jdeliver_method == NULL) {
-        return;
+        goto exit;
       }
 
-      size_t payload_length = bsg_strlen(payload);
-      jbyteArray jpayload = (*env)->NewByteArray(env, payload_length);
-      (*env)->SetByteArrayRegion(env, jpayload, 0, payload_length,
-                                 (jbyte *)payload);
+      // generate payload bytearray
+      jpayload = bsg_byte_ary_from_string(env, payload);
+      if (jpayload == NULL) {
+        goto exit;
+      }
 
-      size_t stage_length = bsg_strlen(event->app.release_stage);
-      jbyteArray jstage = (*env)->NewByteArray(env, stage_length);
-      (*env)->SetByteArrayRegion(env, jstage, 0, stage_length,
-                                 (jbyte *)event->app.release_stage);
+      // generate releaseStage bytearray
+      jstage = bsg_byte_ary_from_string(env, event->app.release_stage);
+      if (jstage == NULL) {
+        goto exit;
+      }
 
-      jstring japi_key = (*env)->NewStringUTF(env, event->api_key);
-      (*env)->CallStaticVoidMethod(env, interface_class, jdeliver_method,
-                                   jstage, jpayload, japi_key);
+      // call NativeInterface.deliverReport()
+      jstring japi_key = bsg_safe_new_string_utf(env, event->api_key);
+      if (japi_key != NULL) {
+        (*env)->CallStaticVoidMethod(env, interface_class, jdeliver_method,
+                                     jstage, jpayload, japi_key);
+      }
       (*env)->DeleteLocalRef(env, japi_key);
-      (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload,
-                                       0); // <-- frees payload
-      (*env)->ReleaseByteArrayElements(
-          env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
-      (*env)->DeleteLocalRef(env, jpayload);
-      (*env)->DeleteLocalRef(env, jstage);
     } else {
       BUGSNAG_LOG("Failed to serialize event as JSON: %s", event_path);
     }
@@ -196,7 +198,20 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   }
   remove(event_path);
   (*env)->ReleaseStringUTFChars(env, _report_path, event_path);
-  pthread_mutex_unlock(&bsg_native_delivery_mutex);
+  goto exit;
+
+  exit:
+    pthread_mutex_unlock(&bsg_native_delivery_mutex);
+    if (jpayload != NULL) {
+      (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload,
+                                       0); // <-- frees payload
+    }
+    if (jstage != NULL) {
+      (*env)->ReleaseByteArrayElements(
+          env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
+    }
+    (*env)->DeleteLocalRef(env, jpayload);
+    (*env)->DeleteLocalRef(env, jstage);
 }
 
 JNIEXPORT void JNICALL

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -1,27 +1,109 @@
 #include "safejni.h"
+#include <stdbool.h>
+#include <utils/string.h>
+
+bool bsg_check_and_clear_exc(JNIEnv *env) {
+  if ((*env)->ExceptionCheck(env)) {
+    (*env)->ExceptionClear(env);
+    return true;
+  }
+  return false;
+}
 
 jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
   jclass clz = (*env)->FindClass(env, clz_name);
-  if ((*env)->ExceptionCheck(env)) {
-    (*env)->ExceptionClear(env);
-  }
+  bsg_check_and_clear_exc(env);
   return clz;
 }
 
 jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
                                  const char *sig) {
   jmethodID methodId = (*env)->GetMethodID(env, clz, name, sig);
-  if ((*env)->ExceptionCheck(env)) {
-    (*env)->ExceptionClear(env);
-  }
+  bsg_check_and_clear_exc(env);
   return methodId;
 }
 
 jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
                                         const char *name, const char *sig) {
   jmethodID methodId = (*env)->GetStaticMethodID(env, clz, name, sig);
-  if ((*env)->ExceptionCheck(env)) {
-    (*env)->ExceptionClear(env);
-  }
+  bsg_check_and_clear_exc(env);
   return methodId;
+}
+
+jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
+  jstring jstr = (*env)->NewStringUTF(env, str);
+  bsg_check_and_clear_exc(env);
+  return jstr;
+}
+
+jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
+                                      jmethodID method) {
+  jboolean value = (*env)->CallBooleanMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return false; // default to false
+  }
+  return value;
+}
+
+jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
+  jint value = (*env)->CallIntMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return -1; // default to -1
+  }
+  return value;
+}
+
+jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
+                                  jmethodID method) {
+  jfloat value = (*env)->CallFloatMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return -1; // default to -1
+  }
+  return value;
+}
+
+jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
+                                    jmethodID method) {
+  jdouble value = (*env)->CallDoubleMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return -1; // default to -1
+  }
+  return value;
+}
+
+jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
+  jobjectArray trace = (*env)->NewObjectArray(env, size, clz, NULL);
+  bsg_check_and_clear_exc(env);
+  return trace;
+}
+
+jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
+                                          jsize size) {
+  jobject obj = (*env)->GetObjectArrayElement(env, array, size);
+  bsg_check_and_clear_exc(env);
+  return obj;
+}
+
+void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
+                                       jsize size, jobject object) {
+  (*env)->SetObjectArrayElement(env, array, size, object);
+  bsg_check_and_clear_exc(env);
+}
+
+jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text) {
+  if (text == NULL) {
+    return NULL;
+  }
+  size_t text_length = bsg_strlen(text);
+  jbyteArray jtext = (*env)->NewByteArray(env, text_length);
+
+  if (bsg_check_and_clear_exc(env)) {
+    return NULL;
+  }
+  (*env)->SetByteArrayRegion(env, jtext, 0, text_length, (jbyte *)text);
+
+  if (bsg_check_and_clear_exc(env)) {
+    return NULL;
+  }
+  return jtext;
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -6,10 +6,7 @@
 /**
  * A safe wrapper for the JNI's FindClass. This method checks if an exception is
  * pending and if so clears it so that execution can continue.
- *
- * This method should be preferred to using the JNI methods directly. It is the
- * responsibility of the caller to check whether the return value is NULL and
- * handle this by no-oping.
+ * The caller is responsible for handling the invalid return value of NULL.
  *
  * See
  * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#findclass
@@ -20,10 +17,7 @@ jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name);
 /**
  * A safe wrapper for the JNI's GetMethodID. This method checks if an exception
  * is pending and if so clears it so that execution can continue.
- *
- * This method should be preferred to using the JNI methods directly. It is the
- * responsibility of the caller to check whether the return value is NULL and
- * handle this by no-oping.
+ * The caller is responsible for handling the invalid return value of NULL.
  *
  * See
  * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getmethodid
@@ -35,10 +29,7 @@ jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
 /**
  * A safe wrapper for the JNI's GetStaticMethodID. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
- *
- * This method should be preferred to using the JNI methods directly. It is the
- * responsibility of the caller to check whether the return value is NULL and
- * handle this by no-oping.
+ * The caller is responsible for handling the invalid return value of NULL.
  *
  * See
  * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getstaticmethodid
@@ -46,5 +37,90 @@ jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
  */
 jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
                                         const char *name, const char *sig);
+/**
+ * A safe wrapper for the JNI's NewStringUtf. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ *
+ * See
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#newstringutf
+ * @return the java string or NULL if it could not be created
+ */
+jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str);
+
+/**
+ * A safe wrapper for the JNI's CallBooleanMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns false.
+ *
+ * See https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
+ */
+jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
+                                      jmethodID method);
+
+/**
+ * A safe wrapper for the JNI's CallIntMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns -1.
+ *
+ * See https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
+ */
+jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method);
+
+/**
+ * A safe wrapper for the JNI's CallFloatMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns -1.
+ *
+ * See https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
+ */
+jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
+                                  jmethodID method);
+
+/**
+ * A safe wrapper for the JNI's CallDoubleMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns -1.
+ *
+ * See https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
+ */
+jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
+                                    jmethodID method);
+
+/**
+ * A safe wrapper for the JNI's NewObjectArray. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ *
+ * See
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#newobjectarray
+ */
+jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz);
+
+/**
+ * A safe wrapper for the JNI's GetObjectArrayElement. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ *
+ * See
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getobjectarrayelement
+ */
+jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
+                                          jsize size);
+
+/**
+ * A safe wrapper for the JNI's SetObjectArrayElement. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ *
+ * See
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#setobjectarrayelement
+ */
+void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
+                                       jsize size, jobject object);
+
+/**
+ * Constructs a byte array from a string.
+ */
+jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text);
 
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -17,7 +17,7 @@ void bsg_strncpy(char *dst, char *src, size_t len) {
   }
 }
 
-size_t bsg_strlen(char *str) {
+size_t bsg_strlen(const char *str) {
   size_t i = 0;
   while (true) {
     char current = str[i];

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -16,7 +16,7 @@ void bsg_strcpy(char *dst, char *src) __asyncsafe;
 /**
  * Return the length of a string
  */
-size_t bsg_strlen(char *str) __asyncsafe;
+size_t bsg_strlen(const char *str) __asyncsafe;
 
 /**
  * Copy a maximum number of bytes from src to dst


### PR DESCRIPTION
## Goal

Checks additional JNI calls in the NDK module for pending exceptions and no-ops, building on #1088. This is achieved by calling [ExceptionClear](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#exceptionclear) to remove any pending JVM exceptions that could lead to app termination.

## Changeset

Added safe versions of the following methods and updated code to check the return value where appropriate:

```
NewStringUTF
CallBooleanMethod
CallDoubleMethod
CallFloatMethod
CallIntMethod
NewByteArray
SetByteArrayRegion
NewObjectArray
SetObjectArrayElement
GetObjectArrayElement
```

Additionally fixes a (unlikely) deadlock introduced in #1088 in `Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath`

## Testing

Relied on existing test coverage.