### PR TITLE
Handle remaining JNI calls error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Check internal JNI calls for pending exceptions and no-op
   [#1088](https://github.com/bugsnag/bugsnag-android/pull/1088)
   [#1091](https://github.com/bugsnag/bugsnag-android/pull/1091)
+  [#1092](https://github.com/bugsnag/bugsnag-android/pull/1092)
 * Add global metadata to ANR error reports
   [#1095](https://github.com/bugsnag/bugsnag-android/pull/1095)  
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -185,8 +185,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
       // call NativeInterface.deliverReport()
       jstring japi_key = bsg_safe_new_string_utf(env, event->api_key);
       if (japi_key != NULL) {
-        (*env)->CallStaticVoidMethod(env, interface_class, jdeliver_method,
-                                     jstage, jpayload, japi_key);
+        bsg_safe_call_static_void_method(env, interface_class, jdeliver_method,
+                                         jstage, jpayload, japi_key);
       }
       (*env)->DeleteLocalRef(env, japi_key);
     } else {
@@ -200,18 +200,18 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   (*env)->ReleaseStringUTFChars(env, _report_path, event_path);
   goto exit;
 
-  exit:
-    pthread_mutex_unlock(&bsg_native_delivery_mutex);
-    if (jpayload != NULL) {
-      (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload,
-                                       0); // <-- frees payload
-    }
-    if (jstage != NULL) {
-      (*env)->ReleaseByteArrayElements(
-          env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
-    }
-    (*env)->DeleteLocalRef(env, jpayload);
-    (*env)->DeleteLocalRef(env, jstage);
+exit:
+  pthread_mutex_unlock(&bsg_native_delivery_mutex);
+  if (jpayload != NULL) {
+    (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload,
+                                     0); // <-- frees payload
+  }
+  if (jstage != NULL) {
+    (*env)->ReleaseByteArrayElements(
+        env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
+  }
+  (*env)->DeleteLocalRef(env, jpayload);
+  (*env)->DeleteLocalRef(env, jstage);
 }
 
 JNIEXPORT void JNICALL

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -11,6 +11,9 @@ bool bsg_check_and_clear_exc(JNIEnv *env) {
 }
 
 jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
+  if (clz_name == NULL) {
+    return NULL;
+  }
   jclass clz = (*env)->FindClass(env, clz_name);
   bsg_check_and_clear_exc(env);
   return clz;
@@ -18,6 +21,9 @@ jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
 
 jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
                                  const char *sig) {
+  if (clz == NULL || name == NULL || sig == NULL) {
+    return NULL;
+  }
   jmethodID methodId = (*env)->GetMethodID(env, clz, name, sig);
   bsg_check_and_clear_exc(env);
   return methodId;
@@ -25,12 +31,18 @@ jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
 
 jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
                                         const char *name, const char *sig) {
+  if (clz == NULL || name == NULL || sig == NULL) {
+    return NULL;
+  }
   jmethodID methodId = (*env)->GetStaticMethodID(env, clz, name, sig);
   bsg_check_and_clear_exc(env);
   return methodId;
 }
 
 jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
+  if (str == NULL) {
+    return NULL;
+  }
   jstring jstr = (*env)->NewStringUTF(env, str);
   bsg_check_and_clear_exc(env);
   return jstr;
@@ -38,6 +50,9 @@ jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
 
 jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
                                       jmethodID method) {
+  if (_value == NULL) {
+    return false;
+  }
   jboolean value = (*env)->CallBooleanMethod(env, _value, method);
   if (bsg_check_and_clear_exc(env)) {
     return false; // default to false
@@ -46,6 +61,9 @@ jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
 }
 
 jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
+  if (_value == NULL) {
+    return -1;
+  }
   jint value = (*env)->CallIntMethod(env, _value, method);
   if (bsg_check_and_clear_exc(env)) {
     return -1; // default to -1
@@ -55,6 +73,9 @@ jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
 
 jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
                                   jmethodID method) {
+  if (_value == NULL) {
+    return -1;
+  }
   jfloat value = (*env)->CallFloatMethod(env, _value, method);
   if (bsg_check_and_clear_exc(env)) {
     return -1; // default to -1
@@ -64,6 +85,9 @@ jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
 
 jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
                                     jmethodID method) {
+  if (_value == NULL) {
+    return -1;
+  }
   jdouble value = (*env)->CallDoubleMethod(env, _value, method);
   if (bsg_check_and_clear_exc(env)) {
     return -1; // default to -1
@@ -72,6 +96,9 @@ jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
 }
 
 jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
+  if (clz == NULL) {
+    return NULL;
+  }
   jobjectArray trace = (*env)->NewObjectArray(env, size, clz, NULL);
   bsg_check_and_clear_exc(env);
   return trace;
@@ -79,6 +106,9 @@ jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
 
 jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
                                           jsize size) {
+  if (array == NULL) {
+    return NULL;
+  }
   jobject obj = (*env)->GetObjectArrayElement(env, array, size);
   bsg_check_and_clear_exc(env);
   return obj;
@@ -86,8 +116,81 @@ jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
 
 void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
                                        jsize size, jobject object) {
+  if (array == NULL) {
+    return;
+  }
   (*env)->SetObjectArrayElement(env, array, size, object);
   bsg_check_and_clear_exc(env);
+}
+
+jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
+                                      const char *sig) {
+  if (clz == NULL || name == NULL || sig == NULL) {
+    return NULL;
+  }
+  jfieldID field_id = (*env)->GetStaticFieldID(env, clz, name, sig);
+  bsg_check_and_clear_exc(env);
+  return field_id;
+}
+
+jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
+                                         jfieldID field) {
+  if (clz == NULL) {
+    return NULL;
+  }
+  jobject obj = (*env)->GetStaticObjectField(env, clz, field);
+  bsg_check_and_clear_exc(env);
+  return obj;
+}
+
+jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...) {
+  if (clz == NULL) {
+    return NULL;
+  }
+  va_list args;
+  va_start(args, method);
+  jobject obj = (*env)->NewObjectV(env, clz, method, args);
+  va_end(args);
+  bsg_check_and_clear_exc(env);
+  return obj;
+}
+
+jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
+                                    jmethodID method, ...) {
+  if (_value == NULL) {
+    return NULL;
+  }
+  va_list args;
+  va_start(args, method);
+  jobject value = (*env)->CallObjectMethodV(env, _value, method, args);
+  va_end(args);
+  bsg_check_and_clear_exc(env);
+  return value;
+}
+
+void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
+                                      ...) {
+  if (clz == NULL) {
+    return;
+  }
+  va_list args;
+  va_start(args, method);
+  (*env)->CallStaticVoidMethodV(env, clz, method, args);
+  va_end(args);
+  bsg_check_and_clear_exc(env);
+}
+
+jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
+                                           jmethodID method, ...) {
+  if (clz == NULL) {
+    return NULL;
+  }
+  va_list args;
+  va_start(args, method);
+  jobject obj = (*env)->CallStaticObjectMethodV(env, clz, method, args);
+  va_end(args);
+  bsg_check_and_clear_exc(env);
+  return obj;
 }
 
 jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -4,12 +4,19 @@
 #include <jni.h>
 
 /**
+ * This provides safe JNI calls by wrapping functions and calling
+ * ExceptionClear(). This approach prevents crashes and undefined behaviour,
+ * providing the caller checks the return value of each invocation.
+ *
+ * For an overview of the methods decorated here, please see
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
+ */
+
+/**
  * A safe wrapper for the JNI's FindClass. This method checks if an exception is
  * pending and if so clears it so that execution can continue.
  * The caller is responsible for handling the invalid return value of NULL.
  *
- * See
- * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#findclass
  * @return the class, or NULL if the class could not be found.
  */
 jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name);
@@ -19,8 +26,6 @@ jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name);
  * is pending and if so clears it so that execution can continue.
  * The caller is responsible for handling the invalid return value of NULL.
  *
- * See
- * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getmethodid
  * @return the method ID, or NULL if the method could not be found.
  */
 jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
@@ -31,8 +36,6 @@ jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
  * exception is pending and if so clears it so that execution can continue.
  * The caller is responsible for handling the invalid return value of NULL.
  *
- * See
- * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getstaticmethodid
  * @return the method ID, or NULL if the method could not be found.
  */
 jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
@@ -42,8 +45,6 @@ jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
  * exception is pending and if so clears it so that execution can continue.
  * The caller is responsible for handling the invalid return value of NULL.
  *
- * See
- * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#newstringutf
  * @return the java string or NULL if it could not be created
  */
 jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str);
@@ -52,8 +53,6 @@ jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str);
  * A safe wrapper for the JNI's CallBooleanMethod. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
  * If an exception was thrown this method returns false.
- *
- * See https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
  */
 jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
                                       jmethodID method);
@@ -62,8 +61,6 @@ jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
  * A safe wrapper for the JNI's CallIntMethod. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
  * If an exception was thrown this method returns -1.
- *
- * See https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
  */
 jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method);
 
@@ -71,8 +68,6 @@ jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method);
  * A safe wrapper for the JNI's CallFloatMethod. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
  * If an exception was thrown this method returns -1.
- *
- * See https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
  */
 jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
                                   jmethodID method);
@@ -81,8 +76,6 @@ jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
  * A safe wrapper for the JNI's CallDoubleMethod. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
  * If an exception was thrown this method returns -1.
- *
- * See https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
  */
 jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
                                     jmethodID method);
@@ -91,9 +84,6 @@ jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
  * A safe wrapper for the JNI's NewObjectArray. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
  * The caller is responsible for handling the invalid return value of NULL.
- *
- * See
- * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#newobjectarray
  */
 jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz);
 
@@ -101,9 +91,6 @@ jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz);
  * A safe wrapper for the JNI's GetObjectArrayElement. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
  * The caller is responsible for handling the invalid return value of NULL.
- *
- * See
- * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getobjectarrayelement
  */
 jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
                                           jsize size);
@@ -111,12 +98,54 @@ jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
 /**
  * A safe wrapper for the JNI's SetObjectArrayElement. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
- *
- * See
- * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#setobjectarrayelement
  */
 void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
                                        jsize size, jobject object);
+
+/**
+ * A safe wrapper for the JNI's GetStaticFieldId. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ */
+jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
+                                      const char *sig);
+
+/**
+ * A safe wrapper for the JNI's GetStaticObjectField. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
+                                         jfieldID field);
+
+/**
+ * A safe wrapper for the JNI's NewObject. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...);
+
+/**
+ * A safe wrapper for the JNI's CallObjectMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
+                                    jmethodID method, ...);
+
+/**
+ * A safe wrapper for the JNI's CallStaticVoidMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ */
+void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
+                                      ...);
+
+/**
+ * A safe wrapper for the JNI's CallStaticObjectMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
+                                           jmethodID method, ...);
 
 /**
  * Constructs a byte array from a string.


### PR DESCRIPTION
## Goal

Checks additional JNI calls in the NDK module for pending exceptions and no-ops, building on #1088. This is achieved by calling [ExceptionClear](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#exceptionclear) to remove any pending JVM exceptions that could lead to app termination.

## Changeset

Added safe versions of the following methods and updated code to check the return value where appropriate:

```
GetStaticFieldID
GetStaticObjectField
NewObject
CallObjectMethod
CallStaticVoidMethod
CallStaticObjectMethod
```

## Testing

Relied on existing test coverage.