### PR TITLE
Correct MazeRunner reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source "https://rubygems.org"
 
 # You can run against local Maze Runner branches and uncommitted changes:
-gem 'bugsnag-maze-runner', path: '../maze-runner'
+#gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.7.2'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.3.0'
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,9 @@
-PATH
-  remote: ../maze-runner
+GIT
+  remote: https://github.com/bugsnag/maze-runner
+  revision: e850ec9483b5cf3a7553f964ca0df9b5c5638b6e
+  tag: v4.3.0
   specs:
-    bugsnag-maze-runner (4.0.0)
+    bugsnag-maze-runner (4.3.0)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -61,7 +63,7 @@ GEM
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)
-    power_assert (1.2.0)
+    power_assert (2.0.0)
     racc (1.5.2)
     rake (12.3.3)
     rubyzip (2.3.0)


### PR DESCRIPTION
## Goal

Correct the Gemfile entry for MazeRunner to use a tagged release rather than local reference.