### PR TITLE
Add global metadata to ANR error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Check internal JNI calls for pending exceptions and no-op
   [#1088](https://github.com/bugsnag/bugsnag-android/pull/1088)
   [#1091](https://github.com/bugsnag/bugsnag-android/pull/1091)
+* Add global metadata to ANR error reports
+  [#1095](https://github.com/bugsnag/bugsnag-android/pull/1095)  
 
 ## 5.5.2 (2021-01-27)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -934,4 +934,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     Notifier getNotifier() {
         return notifier;
     }
+
+    MetadataState getMetadataState() {
+        return metadataState;
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -389,7 +389,8 @@ public class NativeInterface {
     public static Event createEvent(@Nullable Throwable exc,
                                     @NonNull Client client,
                                     @NonNull SeverityReason severityReason) {
-        return new Event(exc, client.getConfig(), severityReason, client.logger);
+        Metadata metadata = client.getMetadataState().getMetadata();
+        return new Event(exc, client.getConfig(), severityReason, metadata, client.logger);
     }
 
     @NonNull

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/AnrDetailsCollectorTest.kt
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/AnrDetailsCollectorTest.kt
@@ -64,6 +64,7 @@ class AnrDetailsCollectorTest {
     @Test
     fun anrDetailsAltered() {
         Mockito.`when`(client.config).thenReturn(BugsnagTestUtils.generateImmutableConfig())
+        Mockito.`when`(client.getMetadataState()).thenReturn(BugsnagTestUtils.generateMetadataState())
         val event = NativeInterface.createEvent(
             RuntimeException("whoops"),
             client,

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -28,6 +28,9 @@ final class BugsnagTestUtils {
         return convert(generateConfiguration());
     }
 
+    static MetadataState generateMetadataState() {
+        return new MetadataState();
+    }
 
     static ImmutableConfig convert(Configuration config) {
         return ImmutableConfigKt.convertToImmutableConfig(config, null);

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -41,6 +41,7 @@ class EventDeserializerTest {
 
         `when`(client.config).thenReturn(TestData.generateConfig())
         `when`(client.getLogger()).thenReturn(object : Logger {})
+        `when`(client.getMetadataState()).thenReturn(TestHooks.generateMetadataState())
     }
 
     private fun breadcrumbMap() = hashMapOf(

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestHooks.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestHooks.java
@@ -4,4 +4,8 @@ class TestHooks {
     static boolean getUnhandledOverridden(Event event) {
         return event.impl.getUnhandledOverridden();
     }
+
+    static MetadataState generateMetadataState() {
+        return new MetadataState();
+    }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppNotRespondingScenario.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 
 /**
@@ -21,6 +22,11 @@ internal class AppNotRespondingScenario(
 
     override fun startScenario() {
         super.startScenario()
+        Bugsnag.addMetadata("custom", "global", "present in global metadata")
+        Bugsnag.addOnError { event ->
+            event.addMetadata("custom", "local", "present in local metadata")
+            true
+        }
         val main = Handler(Looper.getMainLooper())
         main.postDelayed(
             Runnable {

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -230,3 +230,7 @@ Scenario: ANR detection
     And the event "threads.0.stacktrace.0.method" is not null
     And the event "threads.0.stacktrace.0.file" is not null
     And the event "threads.0.stacktrace.0.lineNumber" is not null
+
+    # Metadata validation
+    And the event "metaData.custom.global" equals "present in global metadata"
+    And the event "metaData.custom.local" equals "present in local metadata"


### PR DESCRIPTION
## Goal

Ensures that global metadata is added to ANR error reports. These were previously omitted.

## Changeset

When creating an event in `NativeInterface`, call `client.getMetadataState().getMetadata();` to pass into the `metadata` parameter

## Testing

Unit test coverage has been updated to mock `client.getMetadataState().getMetadata();` where necessary. The ANR smoke scenario has also been updated to confirm that local & global metadata can be added to ANRs.