### PR TITLE
Ensure proguard files are included in AAR

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -45,7 +45,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -84,56 +83,6 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Android 4.4 NDK r16 end-to-end tests - batch 1'
-    depends_on:
-      - "fixture-r16"
-      - "android-4-4-smoke"
-    timeout_in_minutes: 90
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/release/fixture-r16.apk"
-      docker-compose#v3.7.0:
-        run: android-maze-runner
-        command:
-          - "features/full_tests/batch_1"
-          - "--app=/app/build/release/fixture-r16.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_4_4"
-          - "--fail-fast"
-          - "--tags"
-          - "not @Flaky"
-          - "--resilient"
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-    # TODO: 2021/01/20 Currently experiencing issues with Appium session stability
-    soft_fail:
-      - exit_status: "*"
-
-  - label: ':android: Android 4.4 NDK r16 end-to-end tests - batch 2'
-    depends_on:
-      - "fixture-r16"
-      - "android-4-4-smoke"
-    timeout_in_minutes: 90
-    plugins:
-      artifacts#v1.2.0:
-        download: "build/release/fixture-r16.apk"
-      docker-compose#v3.7.0:
-        run: android-maze-runner
-        command:
-          - "features/full_tests/batch_2"
-          - "--app=/app/build/release/fixture-r16.apk"
-          - "--farm=bs"
-          - "--device=ANDROID_4_4"
-          - "--fail-fast"
-          - "--tags"
-          - "not @Flaky"
-          - "--resilient"
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-    # TODO: 2021/01/20 Currently experiencing issues with Appium session stability
-    soft_fail:
-      - exit_status: "*"
-
   - label: ':android: Android 5 NDK r16 end-to-end tests - batch 1'
     depends_on:
       - "fixture-r16"
@@ -152,9 +101,10 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 5 NDK r16 end-to-end tests - batch 2'
     depends_on:
@@ -174,9 +124,10 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 6 NDK r16 end-to-end tests - batch 1'
     depends_on:
@@ -196,7 +147,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -218,7 +168,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -240,7 +189,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -262,7 +210,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -284,7 +231,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -306,7 +252,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -328,7 +273,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -350,7 +294,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -372,7 +315,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -394,7 +336,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -419,7 +360,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_4_4"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -441,7 +381,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_5_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -463,7 +402,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_6_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -485,7 +423,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_7_1"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -507,7 +444,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_8_1"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -529,7 +465,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_10_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
@@ -551,6 +486,5 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_11_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -153,7 +153,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "--tags=@Flaky"
-          - "--resilient"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.5.2 (2021-01-27)
+
+* Ensure proguard files are included in AAR
+  [#1096](https://github.com/bugsnag/bugsnag-android/pull/1096)
+
 ## 5.5.1 (2021-01-21)
 
 * Alter ANR SIGQUIT handler to stop interfering with Google's ANR reporting, and to avoid unsafe JNI calls from within a signal handler

--- a/bugsnag-android-core/build.gradle
+++ b/bugsnag-android-core/build.gradle
@@ -10,6 +10,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig.minSdkVersion rootProject.ext.minSdkVersion
     ndkVersion rootProject.ext.ndkVersion
+    defaultConfig.consumerProguardFiles = ["proguard-rules.pro"]
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,7 +7,7 @@ import java.io.IOException
  */
 class Notifier @JvmOverloads constructor(
     var name: String = "Android Bugsnag Notifier",
-    var version: String = "5.5.1",
+    var version: String = "5.5.2",
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 

--- a/bugsnag-android-ndk/build.gradle
+++ b/bugsnag-android-ndk/build.gradle
@@ -7,6 +7,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig.minSdkVersion rootProject.ext.minSdkVersion
     ndkVersion rootProject.ext.ndkVersion
+    defaultConfig.consumerProguardFiles = ["proguard-rules.pro"]
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7

--- a/bugsnag-android/build.gradle
+++ b/bugsnag-android/build.gradle
@@ -8,6 +8,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig.minSdkVersion rootProject.ext.minSdkVersion
     ndkVersion rootProject.ext.ndkVersion
+    defaultConfig.consumerProguardFiles = ["proguard-rules.pro"]
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7

--- a/bugsnag-plugin-android-anr/build.gradle
+++ b/bugsnag-plugin-android-anr/build.gradle
@@ -9,6 +9,7 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     ndkVersion rootProject.ext.ndkVersion
+    defaultConfig.consumerProguardFiles = ["proguard-rules.pro"]
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/bugsnag-plugin-android-ndk/build.gradle
+++ b/bugsnag-plugin-android-ndk/build.gradle
@@ -9,6 +9,7 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     ndkVersion rootProject.ext.ndkVersion
+    defaultConfig.consumerProguardFiles = ["proguard-rules.pro"]
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/bugsnag-plugin-react-native/build.gradle
+++ b/bugsnag-plugin-react-native/build.gradle
@@ -11,6 +11,7 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig.minSdkVersion rootProject.ext.minSdkVersion
     ndkVersion rootProject.ext.ndkVersion
+    defaultConfig.consumerProguardFiles = ["proguard-rules.pro"]
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ private void configureAndroidProject(Project proj) {
 
     def defaultConfig = proj.android.defaultConfig
     defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    defaultConfig.consumerProguardFiles = ["proguard-rules.pro"]
 
     proj.android.testOptions.unitTests.all {
         testLogging {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    # TODO: Update to latest-v4-cli
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-corrections-for-notifiers-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v4-cli
     environment:
       DEBUG:
       BUILDKITE:

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx4096m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
-VERSION_NAME=5.5.1
+VERSION_NAME=5.5.2
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git


### PR DESCRIPTION
## Goal

Ensures that proguard.txt is added to AARs so that consumers of the library can use ProGuard and R8 for obfuscation.

## Changeset

Alters the gradle script so that each module declares the `consumerProguardFiles`, rather than setting it in an [afterEvaluate](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#afterEvaluate-groovy.lang.Closure-) closure. The AGP version used to build the project has recently changed, so it seems probable that newer versions of AGP read this information before the `afterEvaluate` block triggers, thus ignoring the consumer proguard file.

## Testing

Confirmed that a locally generated AAR contains a proguard.txt file with the appropriate contents, and checked that the [deployed artefact](https://search.maven.org/artifact/com.bugsnag/bugsnag-plugin-android-ndk/5.5.1/aar) does not.
https://developer.android.com/studio/projects/android-library#aar-contents

