### PR TITLE
Fix ANR detection for all Android versions

### DIFF
--- a/features/full_tests/batch_1/detect_anr_cxx.feature
+++ b/features/full_tests/batch_1/detect_anr_cxx.feature
@@ -13,13 +13,9 @@ Scenario: ANR triggered in CXX code is captured
     And the exception "message" starts with " Input dispatching timed out"
     And the error "Bugsnag-Stacktrace-Types" header equals "android,c"
     And the error payload field "events.0.exceptions.0.type" equals "android"
-    And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.exceptions.0.stacktrace.0.type" equals "c"
-    And the error payload field "events.0.exceptions.0.stacktrace.1.type" equals "c"
-    And the error payload field "events.0.exceptions.0.stacktrace.19.type" is null
+    And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
-    And the error payload field "events.0.threads.0.stacktrace.1.type" is null
-    And the error payload field "events.0.threads.0.stacktrace.19.type" is null
 
 @skip_android_8_1
 Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled


### PR DESCRIPTION
## Goal

PLAT-5853

## Design

Older Android systems made much more complicated jumps through native code, often fooling the native code detection heuristics. The only heuristics that work across all versions are:

- Java stack traces leading to native calls will respond true to `isNative`, but this is also true of system-based native bridges out of Java land.
- User-generated JNI functions always start with "Java_", whereas system-generated bridges never do.

## Changeset

Modified the native detection heuristics

## Testing

Re-ran e2e ANR tests for all supported Android versions
