### PR TITLE
Update ANR tests to run on Samsung devices

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -5,6 +5,8 @@
     <ID>EmptyWhileBlock:JvmAnrDisabledScenario.kt$JvmAnrDisabledScenario${ }</ID>
     <ID>EmptyWhileBlock:JvmAnrLoopScenario.kt$JvmAnrLoopScenario${ }</ID>
     <ID>EmptyWhileBlock:JvmAnrMinimalFixtureScenario.kt$JvmAnrMinimalFixtureScenario${ }</ID>
+    <ID>MagicNumber:AnrHelper.kt$&lt;no name provided&gt;$60000</ID>
+    <ID>MagicNumber:AnrHelper.kt$1000</ID>
     <ID>MagicNumber:BugsnagInitScenario.kt$BugsnagInitScenario$25</ID>
     <ID>MagicNumber:HandledKotlinSmokeScenario.kt$HandledKotlinSmokeScenario$999</ID>
     <ID>MagicNumber:JvmAnrDisabledScenario.kt$JvmAnrDisabledScenario$2000</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/AnrHelper.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/AnrHelper.kt
@@ -1,0 +1,32 @@
+package com.bugsnag.android.mazerunner
+
+import android.os.Handler
+
+val mutex = Any()
+
+fun createDeadlock() {
+    java.lang.Thread(
+        object : java.lang.Runnable {
+            override fun run() {
+                synchronized(mutex) {
+                    while (true) {
+                        try {
+                            java.lang.Thread.sleep(60000)
+                        } catch (e: java.lang.InterruptedException) {
+                            e.printStackTrace()
+                        }
+                    }
+                }
+            }
+        }
+    ).start()
+
+    Handler().postDelayed(
+        object : java.lang.Runnable {
+            override fun run() {
+                synchronized(mutex) { throw java.lang.IllegalStateException() }
+            }
+        },
+        1000
+    )
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrDisabledScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrDisabledScenario.kt
@@ -1,11 +1,9 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import java.util.Timer
+import com.bugsnag.android.mazerunner.createDeadlock
 import kotlin.concurrent.schedule
 
 /**
@@ -23,17 +21,7 @@ internal class JvmAnrDisabledScenario(
 
     override fun startScenario() {
         super.startScenario()
-        val main = Handler(Looper.getMainLooper())
-        main.postDelayed(
-            Runnable {
-                while (true) { }
-            },
-            1
-        ) // A moment of delay so there is something to 'tap' onscreen
-
-        // Generate a handled event after 2 seconds as a sanity check that the process didn't crash.
-        Timer("HandledException", false).schedule(2000) {
-            Bugsnag.notify(generateException())
-        }
+        Bugsnag.notify(generateException())
+        createDeadlock()
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrDisabledScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrDisabledScenario.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.mazerunner.createDeadlock
-import kotlin.concurrent.schedule
 
 /**
  * Stops the app from responding for a time period with ANR detection disabled

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrLoopScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrLoopScenario.kt
@@ -1,9 +1,8 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.createDeadlock
 
 /**
  * Stops the app from responding for a time period
@@ -21,12 +20,6 @@ internal class JvmAnrLoopScenario(
 
     override fun startScenario() {
         super.startScenario()
-        val main = Handler(Looper.getMainLooper())
-        main.postDelayed(
-            Runnable {
-                while (true) { }
-            },
-            1
-        ) // A moment of delay so there is something to 'tap' onscreen
+        createDeadlock()
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrMinimalFixtureScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrMinimalFixtureScenario.kt
@@ -1,10 +1,9 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.createDeadlock
 
 /**
  * Stops the app from responding for a time period
@@ -23,12 +22,6 @@ internal class JvmAnrMinimalFixtureScenario(
     override fun startScenario() {
         super.startScenario()
         Bugsnag.notify(generateException())
-        val main = Handler(Looper.getMainLooper())
-        main.postDelayed(
-            Runnable {
-                while (true) { }
-            },
-            1
-        ) // A moment of delay so there is something to 'tap' onscreen
+        createDeadlock()
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
@@ -1,7 +1,8 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
-import com.bugsnag.android.Configuration;
 import static com.bugsnag.android.mazerunner.AnrHelperKt.createDeadlock;
+
+import com.bugsnag.android.Configuration;
 
 import android.content.Context;
 
@@ -9,7 +10,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Collections;
-
 
 public class JvmAnrOutsideReleaseStagesScenario extends Scenario {
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
@@ -1,10 +1,9 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
 import com.bugsnag.android.Configuration;
+import static com.bugsnag.android.mazerunner.AnrHelperKt.createDeadlock;
 
 import android.content.Context;
-import android.os.Handler;
-import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -28,16 +27,6 @@ public class JvmAnrOutsideReleaseStagesScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        Handler main = new Handler(Looper.getMainLooper());
-        main.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    while (true) { }
-                } catch (Exception exc) {
-                    // Catch possible thread interruption exception
-                }
-            }
-        }, 1); // Delayed to allow the UI to appear so there is something to tap
+        createDeadlock();
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrSleepScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrSleepScenario.kt
@@ -1,9 +1,8 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.createDeadlock
 
 /**
  * Stops the app from responding for a time period
@@ -21,12 +20,6 @@ internal class JvmAnrSleepScenario(
 
     override fun startScenario() {
         super.startScenario()
-        val main = Handler(Looper.getMainLooper())
-        main.postDelayed(
-            Runnable {
-                Thread.sleep(100000)
-            },
-            1
-        ) // A moment of delay so there is something to 'tap' onscreen
+        createDeadlock()
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrSleepScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrSleepScenario.kt
@@ -1,8 +1,9 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.mazerunner.createDeadlock
 
 /**
  * Stops the app from responding for a time period
@@ -20,6 +21,14 @@ internal class JvmAnrSleepScenario(
 
     override fun startScenario() {
         super.startScenario()
-        createDeadlock()
+        // Note: Whilst other ANR scenarios use a deadlock to generate the ANR, this scenario is specifically designed
+        // to test how we deal with stack traces of syscall-generating Java methods like Thread.sleep().
+        val main = Handler(Looper.getMainLooper())
+        main.postDelayed(
+            Runnable {
+                Thread.sleep(100000)
+            },
+            1
+        ) // A moment of delay so there is something to 'tap' onscreen
     }
 }

--- a/features/full_tests/batch_1/detect_anr_cxx.feature
+++ b/features/full_tests/batch_1/detect_anr_cxx.feature
@@ -1,12 +1,9 @@
 Feature: ANRs triggered in CXX code are captured
 
-@skip_android_8_1
 Scenario: ANR triggered in CXX code is captured
     When I run "CXXAnrScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -17,13 +14,10 @@ Scenario: ANR triggered in CXX code is captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
-@skip_android_8_1
 Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled
     When I run "CXXAnrNdkDisabledScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"

--- a/features/full_tests/batch_1/detect_anr_jvm.feature
+++ b/features/full_tests/batch_1/detect_anr_jvm.feature
@@ -14,10 +14,15 @@ Scenario: ANR triggered in JVM loop code is captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
+# Other scenarios use a deadlock to generate an ANR, which works on Samsung devices. This scenario remains skipped
+# on Samsung as it is explicitly design to test ANRs caused by a sleeping thread.
+@skip_samsung
 Scenario: ANR triggered in JVM sleep code is captured
     When I run "JvmAnrSleepScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
+    And I wait for 4 seconds
+    And I clear any error dialogue
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"

--- a/features/full_tests/batch_1/detect_anr_jvm.feature
+++ b/features/full_tests/batch_1/detect_anr_jvm.feature
@@ -1,12 +1,9 @@
 Feature: ANRs triggered in JVM code are captured
 
-@skip_android_8_1
 Scenario: ANR triggered in JVM loop code is captured
     When I run "JvmAnrLoopScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -17,13 +14,10 @@ Scenario: ANR triggered in JVM loop code is captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
-@skip_android_8_1
 Scenario: ANR triggered in JVM sleep code is captured
     When I run "JvmAnrSleepScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -34,24 +28,18 @@ Scenario: ANR triggered in JVM sleep code is captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
-@skip_android_8_1
 Scenario: ANR triggered in JVM code is not captured when detectAnrs = false
     When I run "JvmAnrDisabledScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "JvmAnrDisabledScenario"
 
-@skip_android_8_1
 Scenario: ANR triggered in JVM code is not captured when outside of release stage
     When I run "JvmAnrOutsideReleaseStagesScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     Then I should receive no requests

--- a/features/full_tests/batch_2/native_crash_handling.feature
+++ b/features/full_tests/batch_2/native_crash_handling.feature
@@ -8,13 +8,6 @@ Scenario: Dereference a null pointer
         And the error payload contains a completed unhandled native report
         And the exception "errorClass" equals "SIGSEGV"
         And the exception "message" equals "Segmentation violation (invalid memory reference)"
-# TODO: Or it might be:
-#        And the exception "errorClass" equals one of:
-#          | SIGILL |
-#          | SIGTRAP |
-#        And the exception "message" equals one of:
-#            | Illegal instruction   |
-#            | Trace/breakpoint trap |
         And the exception "type" equals "c"
         And the event "severity" equals "error"
         And the event "unhandled" is true

--- a/features/minimal/detect_anr_minimal.feature
+++ b/features/minimal/detect_anr_minimal.feature
@@ -1,6 +1,5 @@
 Feature: ANRs triggered in a fixture with only bugsnag-android-core are captured
 
-@skip_android_8_1
 Scenario: Triggering ANR does not crash the minimal app
     When I run "JvmAnrMinimalFixtureScenario"
     And I wait for 2 seconds

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -153,7 +153,6 @@ Scenario: Signal exception with overwritten config
     # Breadcrumbs
     And the event has a "manual" breadcrumb named "CXXSignalSmokeScenario"
 
-@skip_android_8_1
 Scenario: ANR detection
     When I run "JvmAnrLoopScenario"
     And I wait for 2 seconds

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -35,10 +35,6 @@ Before('@skip_below_android_5') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version < 5
 end
 
-Before('@skip_android_8_1') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version == 8.1
-end
-
 Before('@skip_android_10') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version == 10
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -42,3 +42,8 @@ end
 Before('@skip_android_11') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version == 11
 end
+
+Before('@skip_samsung') do |scenario|
+  skip_this_scenario("Skipping scenario") if Maze.driver.capabilities['device']&.downcase&.include? 'samsung'
+end
+


### PR DESCRIPTION
## Goal

Update the mechanism by which ANRs are generated in tests, in order that they run successfully on Samsung devices (which the previous mechanism did not).

## Design

The idea and code for generating ANRs using a deadlock is taken directly from [this post](https://stackoverflow.com/a/45587343/15097391).  With the scenarios running on Samsung devices we no longer need to skip Android 8.1 (it was only coincidence that our 8.1 device is a Samsung).  It also opens the door to running scenarios on alternative Android 5/6 devices, increasing our diversity and resilience to things like unavailable devices.

## Changeset

- New `AnrKelper.kt` to centralize the ANR mechanism.
- Tests no longer skipped on Android 8.1
- Clearing of error popups removed - it's unnecessary and I found that trying to press buttons during an ANR can cause Appium failures and flaking tests.

## Testing

Covered by a full CI run and I've tested it locally several times on Android 5 and 8 Samsung devices.