### PR TITLE
Only use isNative for detecting native stack transitions

### DIFF
--- a/bugsnag-plugin-android-anr/src/main/jni/anr_google.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_google.c
@@ -2,30 +2,34 @@
 // Author: Karl Stenerud
 // Date:   January 13, 2021
 //
-// Before starting an app, the Android runtime library first sets up its own SIGQUIT handler
-// (art/runtime/signal_catcher.cc, art/runtime/signal_set.h), which listens for SIGQUIT messages
-// that the OS sends to it when it detects an ANR. The handler uses sigwait() instead of the more
-// common sigaction() mechanism, which complicates things:
+// Before starting an app, the Android runtime library first sets up its own
+// SIGQUIT handler (art/runtime/signal_catcher.cc, art/runtime/signal_set.h),
+// which listens for SIGQUIT messages that the OS sends to it when it detects an
+// ANR. The handler uses sigwait() instead of the more common sigaction()
+// mechanism, which complicates things:
 //
-// - sigwait() only triggers when a signal becomes PENDING, which can only happen if the signal is
-//   blocked on all threads. As soon as a signal handler gets called, the signal is no longer
-//   pending. Also, an unblocked signal never becomes pending.
+// - sigwait() only triggers when a signal becomes PENDING, which can only
+//   happen if the signal is blocked on all threads. As soon as a signal
+//   handler gets called, the signal is no longer pending. Also, an unblocked
+//   signal never becomes pending.
 //
-// - Blocked signals will never reach a signal handler registered via sigaction(), which is why the
-//   old BSG implementation had to unblock SIGQUIT to work (while at the same time breaking the
-//   Google handler).
+// - Blocked signals will never reach a signal handler registered via
+//   sigaction(), which is why the old BSG implementation had to unblock
+//   SIGQUIT to work (while at the same time breaking the Google handler).
 //
-// - Registering multiple handlers via sigwait() doesn't work because only the first registered
-//   handler gets called. Once the first handler runs, the signal is no longer pending. And since
-//   the first handler in this case is registered by the runtime library before our code even has
-//   a chance to run, we'd never get called.
+// - Registering multiple handlers via sigwait() doesn't work because only the
+//   first registered handler gets called. Once the first handler runs, the
+//   signal is no longer pending. And since the first handler in this case is
+//   registered by the runtime library before our code even has a chance to
+//   run, we'd never get called.
 //
-// - Even though the runtime library has callback hooks for ANRs (art/runtime/runtime.cc), it's
-//   not a public API, so we can't use it.
+// - Even though the runtime library has callback hooks for ANRs
+//   (art/runtime/runtime.cc), it's not a public API, so we can't use it.
 //
-// So we need a workaround. Calling raise() and signal() won't work, because the signal ends up
-// getting routed incorrectly. The only way to successfully signal the runtime handler is by use
-// of a syscall() of SYS_tgkill with SIGQUIT that targets the Google handler thread ID directly.
+// So we need a workaround. Calling raise() and signal() won't work, because the
+// signal ends up getting routed incorrectly. The only way to successfully
+// signal the runtime handler is by use of a syscall() of SYS_tgkill with
+// SIGQUIT that targets the Google handler thread ID directly.
 //
 //
 // How to work around it:
@@ -34,28 +38,29 @@
 //
 // - Register a SIGQUIT handler via sigaction()
 //
-// - Our handler callback blocks SIGQUIT (allowing the Google handler to work again) and sets a
-//   flag like "should_report_anr"
+// - Our handler callback blocks SIGQUIT (allowing the Google handler to work
+//   again) and sets a flag like "should_report_anr"
 //
-// - We have another thread waiting on the "should_report_anr" flag, which then calls
-//   bsg_google_anr_call() after a short delay to raise a SIGQUIT on Google's handler thread.
-//   Re-raising the signal on the signal handler thread won't work because the signaling system
-//   in the OS won't finish updating the new blocking state until the current signal handler
-//   returns.
+// - We have another thread waiting on the "should_report_anr" flag, which then
+//   calls bsg_google_anr_call() after a short delay to raise a SIGQUIT on
+//   Google's handler thread. Re-raising the signal on the signal handler
+//   thread won't work because the signaling system in the OS won't finish
+//   updating the new blocking state until the current signal handler returns.
 //
-// - Do our handler stuff, delay a short while (like 2 seconds) for Google's handlers to finish,
-//   then exit our watchdog thread. It's important that our watchdog thread stops before the
-//   runtime's timeout (currently 20 seconds), or else we'll be force-killed, which breaks Google
-//   reporting and the ANR popup in some cases.
+// - Do our handler stuff, delay a short while (like 2 seconds) for Google's
+//   handlers to finish, then exit our watchdog thread. It's important that
+//   our watchdog thread stops before the runtime's timeout (currently 20
+//   seconds), or else we'll be force-killed, which breaks Google reporting
+//   and the ANR popup in some cases.
 //
 //
 // Functionality in this file:
 //
-// - bsg_google_anr_init (NOT async-safe): Find and save the Google ANR handler thread ID and the
-//   process ID, which are needed to make the syscall.
+// - bsg_google_anr_init (NOT async-safe): Find and save the Google ANR handler
+//   thread ID and the process ID, which are needed to make the syscall.
 //
-// - bsg_google_anr_call (async-safe): Make the syscall to send a SIGQUIT directly to the runtime
-//   library's ANR handler thread.
+// - bsg_google_anr_call (async-safe): Make the syscall to send a SIGQUIT
+//   directly to the runtime library's ANR handler thread.
 
 #include "anr_google.h"
 
@@ -71,19 +76,20 @@ static pid_t process_id = -1;
 static pid_t google_thread_id = -1;
 
 static bool is_thread_named_signal_catcher(pid_t tid) {
-  static const char*const SIGNAL_CATCHER_THREAD_NAME = "Signal Catcher";
+  static const char *const SIGNAL_CATCHER_THREAD_NAME = "Signal Catcher";
 
   bool success = false;
   char buff[256];
 
   snprintf(buff, sizeof(buff), "/proc/%d/comm", tid);
-  FILE* fp = fopen(buff, "r");
-  if(fp == NULL) {
+  FILE *fp = fopen(buff, "r");
+  if (fp == NULL) {
     return false;
   }
 
-  if(fgets(buff, sizeof(buff), fp) != NULL) {
-    success = strncmp(buff, SIGNAL_CATCHER_THREAD_NAME, strlen(SIGNAL_CATCHER_THREAD_NAME)) == 0;
+  if (fgets(buff, sizeof(buff), fp) != NULL) {
+    success = strncmp(buff, SIGNAL_CATCHER_THREAD_NAME,
+                      strlen(SIGNAL_CATCHER_THREAD_NAME)) == 0;
   }
 
   fclose(fp);
@@ -92,19 +98,19 @@ static bool is_thread_named_signal_catcher(pid_t tid) {
 
 static bool is_thread_signal_catcher_sigblk(pid_t tid) {
   static const uint64_t SIGNAL_CATCHER_THREAD_SIGBLK = 0x1000;
-  static const char* SIGBLK_HEADER = "SigBlk:\t";
+  static const char *SIGBLK_HEADER = "SigBlk:\t";
   const size_t SIGBLK_HEADER_LENGTH = strlen(SIGBLK_HEADER);
 
   char buff[256];
   uint64_t sigblk = 0;
 
   snprintf(buff, sizeof(buff), "/proc/%d/status", tid);
-  FILE* fp = fopen(buff, "r");
-  if(fp == NULL) {
+  FILE *fp = fopen(buff, "r");
+  if (fp == NULL) {
     return false;
   }
 
-  while(fgets(buff, sizeof(buff), fp) != NULL) {
+  while (fgets(buff, sizeof(buff), fp) != NULL) {
     if (strncmp(buff, SIGBLK_HEADER, SIGBLK_HEADER_LENGTH) == 0) {
       sigblk = strtoull(buff + SIGBLK_HEADER_LENGTH, NULL, 16);
       break;
@@ -120,26 +126,27 @@ bool bsg_google_anr_init() {
 
   char path[256];
   snprintf(path, sizeof(path), "/proc/%d/task", pid);
-  DIR* dir = opendir(path);
-  if(dir == NULL) {
+  DIR *dir = opendir(path);
+  if (dir == NULL) {
     return false;
   }
 
   struct dirent *dent;
-  while((dent = readdir(dir)) != NULL) {
-    if(dent->d_name[0] < '0' || dent->d_name[0] > '9') {
+  while ((dent = readdir(dir)) != NULL) {
+    if (dent->d_name[0] < '0' || dent->d_name[0] > '9') {
       continue;
     }
 
     tid = strtol(dent->d_name, NULL, 10);
-    if(is_thread_named_signal_catcher(tid) && is_thread_signal_catcher_sigblk(tid)) {
+    if (is_thread_named_signal_catcher(tid) &&
+        is_thread_signal_catcher_sigblk(tid)) {
       break;
     }
     tid = -1;
   }
   closedir(dir);
 
-  if(tid < 0) {
+  if (tid < 0) {
     return false;
   }
 
@@ -149,7 +156,7 @@ bool bsg_google_anr_init() {
 }
 
 void bsg_google_anr_call() {
-  if(process_id >= 0 && google_thread_id >= 0) {
+  if (process_id >= 0 && google_thread_id >= 0) {
     syscall(SYS_tgkill, process_id, google_thread_id, SIGQUIT);
   }
 }

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_google.h
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_google.h
@@ -4,8 +4,9 @@
 #include <stdbool.h>
 
 /**
- * Initialize the Google ANR caller. This must be called before any other functions in this file.
- * If the call fails, all other calls in this file will be no-ops.
+ * Initialize the Google ANR caller. This must be called before any other
+ * functions in this file. If the call fails, all other calls in this file will
+ * be no-ops.
  *
  * Note: This function is NOT async-safe.
  *
@@ -14,11 +15,12 @@
 bool bsg_google_anr_init(void);
 
 /**
- * Raises a SIGQUIT signal directly on Google's "Signal Catcher" thread in the runtime library.
- * This function will no-op if bsg_google_anr_init() was not called, or the call failed.
+ * Raises a SIGQUIT signal directly on Google's "Signal Catcher" thread in the
+ * runtime library. This function will no-op if bsg_google_anr_init() was not
+ * called, or the call failed.
  *
- * Note: This MUST be called from a non-signal-handler thread (create a separate thread that waits
- *       to call this function).
+ * Note: This MUST be called from a non-signal-handler thread (create a separate
+ * thread that waits to call this function).
  *
  * Note: This function is async-safe.
  */

--- a/bugsnag-plugin-android-anr/src/main/jni/bsg_unwind.h
+++ b/bugsnag-plugin-android-anr/src/main/jni/bsg_unwind.h
@@ -1,1 +1,16 @@
-../../../../bugsnag-plugin-android-ndk/src/main/jni/bsg_unwind.h
+#ifndef BSG_UNWIND_H
+#define BSG_UNWIND_H
+
+#include "../assets/include/event.h"
+
+// These are isolated because the ANR plugin symlinks to this file and to
+// ../assets/include/event.h
+
+#ifndef BUGSNAG_FRAMES_MAX
+/**
+ *  Number of frames in a stacktrace. Configures a default if not defined.
+ */
+#define BUGSNAG_FRAMES_MAX 192
+#endif
+
+#endif

--- a/bugsnag-plugin-android-anr/src/main/jni/bugsnag_anr.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/bugsnag_anr.c
@@ -1,7 +1,7 @@
 #include "anr_handler.h"
+#include "unwind_func.h"
 #include <android/log.h>
 #include <jni.h>
-#include "unwind_func.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,7 +18,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_AnrPlugin_disableAnrReporting(
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_AnrPlugin_setUnwindFunction(
-        JNIEnv *env, jobject thiz, jlong unwind_function) {
+    JNIEnv *env, jobject thiz, jlong unwind_function) {
   local_bsg_unwind_stack = (unwind_func)unwind_function;
 }
 

--- a/bugsnag-plugin-android-anr/src/main/jni/unwind_func.h
+++ b/bugsnag-plugin-android-anr/src/main/jni/unwind_func.h
@@ -9,8 +9,9 @@
 extern "C" {
 #endif
 
-typedef ssize_t (*unwind_func)(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                               siginfo_t *info, void *user_context);
+typedef ssize_t (*unwind_func)(
+    bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX], siginfo_t *info,
+    void *user_context);
 
 extern unwind_func local_bsg_unwind_stack;
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bsg_unwind.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bsg_unwind.h
@@ -3,7 +3,8 @@
 
 #include "../assets/include/event.h"
 
-// These are isolated because the ANR plugin symlinks to this file and to ../assets/include/event.h
+// These are isolated because the ANR plugin symlinks to this file and to
+// ../assets/include/event.h
 
 #ifndef BUGSNAG_FRAMES_MAX
 /**

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -374,8 +374,11 @@ exit:
 }
 
 // Unwind the stack using the default unwind style.
-// This function gets exposed via Java_com_bugsnag_android_ndk_NativeBridge_getUnwindStackFunction()
-ssize_t bsg_unwind_stack_default(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                                 siginfo_t *info, void *user_context) __asyncsafe {
-  return bsg_unwind_stack(bsg_configured_unwind_style(), stacktrace, info, user_context);
+// This function gets exposed via
+// Java_com_bugsnag_android_ndk_NativeBridge_getUnwindStackFunction()
+ssize_t
+bsg_unwind_stack_default(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+                         siginfo_t *info, void *user_context) __asyncsafe {
+  return bsg_unwind_stack(bsg_configured_unwind_style(), stacktrace, info,
+                          user_context);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -567,11 +567,13 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateMetadata(
   bsg_release_env_write_lock();
 }
 
-ssize_t bsg_unwind_stack_default(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                                 siginfo_t *info, void *user_context) __asyncsafe;
+ssize_t
+bsg_unwind_stack_default(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
+                         siginfo_t *info, void *user_context) __asyncsafe;
 
 JNIEXPORT jlong JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_getUnwindStackFunction(JNIEnv *env, jobject thiz) {
+Java_com_bugsnag_android_ndk_NativeBridge_getUnwindStackFunction(JNIEnv *env,
+                                                                 jobject thiz) {
   return (jlong)bsg_unwind_stack_default;
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -2,9 +2,9 @@
 #define BUGSNAG_EVENT_H
 
 #include "../assets/include/event.h"
+#include "bsg_unwind.h"
 #include <stdbool.h>
 #include <sys/types.h>
-#include "bsg_unwind.h"
 #ifndef BUGSNAG_METADATA_MAX
 /**
  * Maximum number of values stored in metadata. Configures a default if not

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrLoopScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrLoopScenario.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
+import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.mazerunner.createDeadlock
 
@@ -20,6 +21,11 @@ internal class JvmAnrLoopScenario(
 
     override fun startScenario() {
         super.startScenario()
+        Bugsnag.addMetadata("custom", "global", "present in global metadata")
+        Bugsnag.addOnError { event ->
+            event.addMetadata("custom", "local", "present in local metadata")
+            true
+        }
         createDeadlock()
     }
 }


### PR DESCRIPTION
## Goal

The current method of native trace detection doesn't work anymore on Android 11.

## Design

Use only the built-in `isNative` call to detect native frames.

## Testing

Re-ran e2e tests
