### PR TITLE
Improve handling of system dialogs in end-to-end tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.3.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.5.0'
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: e850ec9483b5cf3a7553f964ca0df9b5c5638b6e
-  tag: v4.3.0
+  revision: 312212a8e31a7c23a569524299b5ff6a56befd16
+  tag: v4.5.0
   specs:
-    bugsnag-maze-runner (4.3.0)
+    bugsnag-maze-runner (4.5.0)
       appium_lib (~> 10.2)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -27,7 +27,7 @@ GEM
     appium_lib_core (3.11.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    backports (3.20.1)
+    backports (3.20.2)
     boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -3,16 +3,18 @@
 #
 # @step_input element_id [String] The element to wait for
 When('any dialog is cleared and the element {string} is present') do |element_id|
-  present = Maze.driver.wait_for_element(element_id, timeout = 5)
-  next if present
+  count = 0
+  present = false
+  until present || count > 15
+    present = Maze.driver.wait_for_element(element_id, timeout = 1)
+    break if present
+    count += 1
+    clicked = click_if_present('android:id/button1') ||
+              click_if_present('android:id/aerr_close') ||
+              click_if_present('android:id/aerr_restart')
+    $logger.info "System dialog cleared, reattempting wait_for_element" if clicked
+  end
 
-  clicked = click_if_present('android:id/button1') ||
-            click_if_present('android:id/aerr_close') ||
-            click_if_present('android:id/aerr_restart')
-
-  $logger.info "System dialog cleared, reattempting wait_for_element" if clicked
-
-  present = Maze.driver.wait_for_element(element_id)
   assert(present, "The element #{element_id} could not be found")
 end
 


### PR DESCRIPTION
## Goal

Reduce end-to-end test run times by handling system error dialogs smarter.

## Design

Reworks the Cucumber step that's run after a crash so that it times out much quicker (1s), making the assumption that if an element is not visible in that time it's because of a system error dialog taking the focus.  This process will be repeated up to 15 times, equivalent to the default timeout for `find_element`.

## Changeset

Cucumber step reworked, MazeRunner version bumped for local running.

## Testing

I ran 6 full builds overnight and clearing of the error dialog can be seen working well.  Looking at a couple of Android 5/6 runs, the dialog was dismissed ~40 times, saving at least a couple of minutes on each.

It's worth noting that the Android 5 tests are currently set to `soft_fail` and there is a strange (but existing) issue where the app appears to crash at points where we could not expect (e.g. simply by entering text into a field).  This could be an issue with Appium, but needs further investigation for which I have raised an internal ticket.