### PR TITLE
Fix Clangformat script and violations

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,7 +116,7 @@ steps:
           run: android-ci
     command: 'bash ./scripts/run-cpp-check.sh'
 
-  - label: ':android: Lint mazerunner scenarios'
+  - label: ':android: ClangFormat'
     depends_on: "android-ci"
     timeout_in_minutes: 10
     plugins:
@@ -124,7 +124,7 @@ steps:
           run: android-ci
     command: 'bash ./scripts/run-clang-format-ci-check.sh'
 
-  - label: ':android: ClangFormat'
+  - label: ':android: Lint mazerunner scenarios'
     depends_on: "android-ci"
     timeout_in_minutes: 10
     plugins:

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_google.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_google.c
@@ -2,30 +2,37 @@
 // Author: Karl Stenerud
 // Date:   January 13, 2021
 //
-// Before starting an app, the Android runtime library first sets up its own SIGQUIT handler
-// (art/runtime/signal_catcher.cc, art/runtime/signal_set.h), which listens for SIGQUIT messages
-// that the OS sends to it when it detects an ANR. The handler uses sigwait() instead of the more
-// common sigaction() mechanism, which complicates things:
+// Before starting an app, the Android runtime library first sets up its own
+// SIGQUIT handler (art/runtime/signal_catcher.cc, art/runtime/signal_set.h),
+// which listens for SIGQUIT messages that the OS sends to it when it detects an
+// ANR. The handler uses sigwait() instead of the more common sigaction()
+// mechanism, which complicates things:
 //
-// - sigwait() only triggers when a signal becomes PENDING, which can only happen if the signal is
-//   blocked on all threads. As soon as a signal handler gets called, the signal is no longer
-//   pending. Also, an unblocked signal never becomes pending.
+// - sigwait() only triggers when a signal becomes PENDING, which can only
+// happen if the signal is
+//   blocked on all threads. As soon as a signal handler gets called, the signal
+//   is no longer pending. Also, an unblocked signal never becomes pending.
 //
-// - Blocked signals will never reach a signal handler registered via sigaction(), which is why the
-//   old BSG implementation had to unblock SIGQUIT to work (while at the same time breaking the
-//   Google handler).
+// - Blocked signals will never reach a signal handler registered via
+// sigaction(), which is why the
+//   old BSG implementation had to unblock SIGQUIT to work (while at the same
+//   time breaking the Google handler).
 //
-// - Registering multiple handlers via sigwait() doesn't work because only the first registered
-//   handler gets called. Once the first handler runs, the signal is no longer pending. And since
-//   the first handler in this case is registered by the runtime library before our code even has
-//   a chance to run, we'd never get called.
+// - Registering multiple handlers via sigwait() doesn't work because only the
+// first registered
+//   handler gets called. Once the first handler runs, the signal is no longer
+//   pending. And since the first handler in this case is registered by the
+//   runtime library before our code even has a chance to run, we'd never get
+//   called.
 //
-// - Even though the runtime library has callback hooks for ANRs (art/runtime/runtime.cc), it's
+// - Even though the runtime library has callback hooks for ANRs
+// (art/runtime/runtime.cc), it's
 //   not a public API, so we can't use it.
 //
-// So we need a workaround. Calling raise() and signal() won't work, because the signal ends up
-// getting routed incorrectly. The only way to successfully signal the runtime handler is by use
-// of a syscall() of SYS_tgkill with SIGQUIT that targets the Google handler thread ID directly.
+// So we need a workaround. Calling raise() and signal() won't work, because the
+// signal ends up getting routed incorrectly. The only way to successfully
+// signal the runtime handler is by use of a syscall() of SYS_tgkill with
+// SIGQUIT that targets the Google handler thread ID directly.
 //
 //
 // How to work around it:
@@ -34,27 +41,33 @@
 //
 // - Register a SIGQUIT handler via sigaction()
 //
-// - Our handler callback blocks SIGQUIT (allowing the Google handler to work again) and sets a
+// - Our handler callback blocks SIGQUIT (allowing the Google handler to work
+// again) and sets a
 //   flag like "should_report_anr"
 //
-// - We have another thread waiting on the "should_report_anr" flag, which then calls
-//   bsg_google_anr_call() after a short delay to raise a SIGQUIT on Google's handler thread.
-//   Re-raising the signal on the signal handler thread won't work because the signaling system
-//   in the OS won't finish updating the new blocking state until the current signal handler
-//   returns.
+// - We have another thread waiting on the "should_report_anr" flag, which then
+// calls
+//   bsg_google_anr_call() after a short delay to raise a SIGQUIT on Google's
+//   handler thread. Re-raising the signal on the signal handler thread won't
+//   work because the signaling system in the OS won't finish updating the new
+//   blocking state until the current signal handler returns.
 //
-// - Do our handler stuff, delay a short while (like 2 seconds) for Google's handlers to finish,
-//   then exit our watchdog thread. It's important that our watchdog thread stops before the
-//   runtime's timeout (currently 20 seconds), or else we'll be force-killed, which breaks Google
-//   reporting and the ANR popup in some cases.
+// - Do our handler stuff, delay a short while (like 2 seconds) for Google's
+// handlers to finish,
+//   then exit our watchdog thread. It's important that our watchdog thread
+//   stops before the runtime's timeout (currently 20 seconds), or else we'll be
+//   force-killed, which breaks Google reporting and the ANR popup in some
+//   cases.
 //
 //
 // Functionality in this file:
 //
-// - bsg_google_anr_init (NOT async-safe): Find and save the Google ANR handler thread ID and the
+// - bsg_google_anr_init (NOT async-safe): Find and save the Google ANR handler
+// thread ID and the
 //   process ID, which are needed to make the syscall.
 //
-// - bsg_google_anr_call (async-safe): Make the syscall to send a SIGQUIT directly to the runtime
+// - bsg_google_anr_call (async-safe): Make the syscall to send a SIGQUIT
+// directly to the runtime
 //   library's ANR handler thread.
 
 #include "anr_google.h"
@@ -71,19 +84,20 @@ static pid_t process_id = -1;
 static pid_t google_thread_id = -1;
 
 static bool is_thread_named_signal_catcher(pid_t tid) {
-  static const char*const SIGNAL_CATCHER_THREAD_NAME = "Signal Catcher";
+  static const char *const SIGNAL_CATCHER_THREAD_NAME = "Signal Catcher";
 
   bool success = false;
   char buff[256];
 
   snprintf(buff, sizeof(buff), "/proc/%d/comm", tid);
-  FILE* fp = fopen(buff, "r");
-  if(fp == NULL) {
+  FILE *fp = fopen(buff, "r");
+  if (fp == NULL) {
     return false;
   }
 
-  if(fgets(buff, sizeof(buff), fp) != NULL) {
-    success = strncmp(buff, SIGNAL_CATCHER_THREAD_NAME, strlen(SIGNAL_CATCHER_THREAD_NAME)) == 0;
+  if (fgets(buff, sizeof(buff), fp) != NULL) {
+    success = strncmp(buff, SIGNAL_CATCHER_THREAD_NAME,
+                      strlen(SIGNAL_CATCHER_THREAD_NAME)) == 0;
   }
 
   fclose(fp);
@@ -92,19 +106,19 @@ static bool is_thread_named_signal_catcher(pid_t tid) {
 
 static bool is_thread_signal_catcher_sigblk(pid_t tid) {
   static const uint64_t SIGNAL_CATCHER_THREAD_SIGBLK = 0x1000;
-  static const char* SIGBLK_HEADER = "SigBlk:\t";
+  static const char *SIGBLK_HEADER = "SigBlk:\t";
   const size_t SIGBLK_HEADER_LENGTH = strlen(SIGBLK_HEADER);
 
   char buff[256];
   uint64_t sigblk = 0;
 
   snprintf(buff, sizeof(buff), "/proc/%d/status", tid);
-  FILE* fp = fopen(buff, "r");
-  if(fp == NULL) {
+  FILE *fp = fopen(buff, "r");
+  if (fp == NULL) {
     return false;
   }
 
-  while(fgets(buff, sizeof(buff), fp) != NULL) {
+  while (fgets(buff, sizeof(buff), fp) != NULL) {
     if (strncmp(buff, SIGBLK_HEADER, SIGBLK_HEADER_LENGTH) == 0) {
       sigblk = strtoull(buff + SIGBLK_HEADER_LENGTH, NULL, 16);
       break;
@@ -120,26 +134,27 @@ bool bsg_google_anr_init() {
 
   char path[256];
   snprintf(path, sizeof(path), "/proc/%d/task", pid);
-  DIR* dir = opendir(path);
-  if(dir == NULL) {
+  DIR *dir = opendir(path);
+  if (dir == NULL) {
     return false;
   }
 
   struct dirent *dent;
-  while((dent = readdir(dir)) != NULL) {
-    if(dent->d_name[0] < '0' || dent->d_name[0] > '9') {
+  while ((dent = readdir(dir)) != NULL) {
+    if (dent->d_name[0] < '0' || dent->d_name[0] > '9') {
       continue;
     }
 
     tid = strtol(dent->d_name, NULL, 10);
-    if(is_thread_named_signal_catcher(tid) && is_thread_signal_catcher_sigblk(tid)) {
+    if (is_thread_named_signal_catcher(tid) &&
+        is_thread_signal_catcher_sigblk(tid)) {
       break;
     }
     tid = -1;
   }
   closedir(dir);
 
-  if(tid < 0) {
+  if (tid < 0) {
     return false;
   }
 
@@ -149,7 +164,7 @@ bool bsg_google_anr_init() {
 }
 
 void bsg_google_anr_call() {
-  if(process_id >= 0 && google_thread_id >= 0) {
+  if (process_id >= 0 && google_thread_id >= 0) {
     syscall(SYS_tgkill, process_id, google_thread_id, SIGQUIT);
   }
 }

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_google.h
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_google.h
@@ -4,8 +4,9 @@
 #include <stdbool.h>
 
 /**
- * Initialize the Google ANR caller. This must be called before any other functions in this file.
- * If the call fails, all other calls in this file will be no-ops.
+ * Initialize the Google ANR caller. This must be called before any other
+ * functions in this file. If the call fails, all other calls in this file will
+ * be no-ops.
  *
  * Note: This function is NOT async-safe.
  *
@@ -14,11 +15,12 @@
 bool bsg_google_anr_init(void);
 
 /**
- * Raises a SIGQUIT signal directly on Google's "Signal Catcher" thread in the runtime library.
- * This function will no-op if bsg_google_anr_init() was not called, or the call failed.
+ * Raises a SIGQUIT signal directly on Google's "Signal Catcher" thread in the
+ * runtime library. This function will no-op if bsg_google_anr_init() was not
+ * called, or the call failed.
  *
- * Note: This MUST be called from a non-signal-handler thread (create a separate thread that waits
- *       to call this function).
+ * Note: This MUST be called from a non-signal-handler thread (create a separate
+ * thread that waits to call this function).
  *
  * Note: This function is async-safe.
  */

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
@@ -36,14 +36,14 @@ static bool configure_anr_jni(JNIEnv *env) {
 
   jclass clz = (*env)->FindClass(env, "com/bugsnag/android/AnrPlugin");
   mthd_notify_anr_detected =
-          (*env)->GetMethodID(env, clz, "notifyAnrDetected", "()V");
+      (*env)->GetMethodID(env, clz, "notifyAnrDetected", "()V");
   return true;
 }
 
 static void notify_anr_detected() {
   if (enabled) {
     JNIEnv *env;
-    int result = (*bsg_jvm)->GetEnv(bsg_jvm, (void **) &env, JNI_VERSION_1_4);
+    int result = (*bsg_jvm)->GetEnv(bsg_jvm, (void **)&env, JNI_VERSION_1_4);
 
     if (result == JNI_OK) { // already attached
       (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
@@ -51,24 +51,24 @@ static void notify_anr_detected() {
       if ((*bsg_jvm)->AttachCurrentThread(bsg_jvm, &env, NULL) == 0) {
         (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
         (*bsg_jvm)->DetachCurrentThread(
-                bsg_jvm); // detach to restore initial condition
+            bsg_jvm); // detach to restore initial condition
       }
     } // All other results are error codes
   }
 }
 
-static void* sigquit_watchdog_thread_main(void* _) {
+static void *sigquit_watchdog_thread_main(void *_) {
   static const useconds_t delay_2sec = 2000000;
   static const useconds_t delay_100ms = 100000;
   static const useconds_t delay_10ms = 10000;
 
   // Wait until our SIGQUIT handler is ready for us to start
-  while(!should_report_anr) {
+  while (!should_report_anr) {
     usleep(delay_100ms);
   }
 
-  // Force at least one task switch after being triggered, ensuring that the signal masks are
-  // properly settled before triggering the Google handler.
+  // Force at least one task switch after being triggered, ensuring that the
+  // signal masks are properly settled before triggering the Google handler.
   usleep(delay_10ms);
 
   // Do our ANR processing
@@ -77,12 +77,13 @@ static void* sigquit_watchdog_thread_main(void* _) {
   // Trigger Google ANR processing
   bsg_google_anr_call();
 
-  // Give a little time for the Google handler to dump state, then exit this thread.
+  // Give a little time for the Google handler to dump state, then exit this
+  // thread.
   usleep(delay_2sec);
   return NULL;
 }
 
-static void handle_sigquit(int signum, siginfo_t* info, void* user_context) {
+static void handle_sigquit(int signum, siginfo_t *info, void *user_context) {
   // Re-block SIGQUIT so that the Google handler can trigger
   sigset_t sigmask;
   sigemptyset(&sigmask);
@@ -95,8 +96,9 @@ static void handle_sigquit(int signum, siginfo_t* info, void* user_context) {
 }
 
 static void install_signal_handler() {
-  if(!bsg_google_anr_init()) {
-    BUGSNAG_LOG("Failed to initialize Google ANR caller. ANRs won't be sent to Google.");
+  if (!bsg_google_anr_init()) {
+    BUGSNAG_LOG("Failed to initialize Google ANR caller. ANRs won't be sent to "
+                "Google.");
   }
 
   // Start the watchdog thread

--- a/scripts/run-clang-format-ci-check.sh
+++ b/scripts/run-clang-format-ci-check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-find bugsnag-plugin-android-anr/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format --dry-run -Werror
-find bugsnag-plugin-android-ndk/src/main -iname *.h -o -iname *.cpp -o -iname *.c | grep -v src/main/jni/external/ | grep -v src/main/jni/deps/ | xargs clang-format --dry-run -Werror
+find bugsnag-plugin-android-anr/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format --dry-run -Werror &&
+find bugsnag-plugin-android-ndk/src/main -iname *.h -o -iname *.cpp -o -iname *.c | grep -v src/main/jni/external/ | grep -v src/main/jni/deps/ | xargs clang-format --dry-run -Werror &&
 find examples/sdk-app-example/app/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format --dry-run -Werror

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-find bugsnag-plugin-android-anr/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format -i
-find bugsnag-plugin-android-ndk/src/main -iname *.h -o -iname *.cpp -o -iname *.c | grep -v src/main/jni/external/ | grep -v src/main/jni/deps/ | xargs clang-format -i
+find bugsnag-plugin-android-anr/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format -i &&
+find bugsnag-plugin-android-ndk/src/main -iname *.h -o -iname *.cpp -o -iname *.c | grep -v src/main/jni/external/ | grep -v src/main/jni/deps/ | xargs clang-format -i &&
 find examples/sdk-app-example/app/src/main -iname *.h -o -iname *.cpp -o -iname *.c | xargs clang-format -i


### PR DESCRIPTION
## Goal

Fixes the script for running Clangformat checks on CI so that errors from any line result in the build step failing.  Also fixes existing format violation in the code base.
