### PR TITLE
Fix flaky session smoke test

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -180,6 +180,8 @@ class SessionTracker extends BaseObservable {
                                     logger.w("Dropping invalid session tracking payload");
                                     break;
                                 case DELIVERED:
+                                    logger.d("Sent 1 new session to Bugsnag");
+                                    break;
                                 default:
                                     break;
                             }
@@ -280,6 +282,7 @@ class SessionTracker extends BaseObservable {
         switch (deliveryStatus) {
             case DELIVERED:
                 sessionStore.deleteStoredFiles(Collections.singletonList(storedFile));
+                logger.d("Sent 1 new session to Bugsnag");
                 break;
             case UNDELIVERED:
                 sessionStore.cancelQueuedFiles(Collections.singletonList(storedFile));

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
@@ -17,27 +17,32 @@ internal class ManualSessionSmokeScenario(
 
     init {
         config.autoTrackSessions = false
-        val baseDelivery = createDefaultDelivery()
-        var state = 0
-        config.delivery = InterceptingDelivery(baseDelivery) {
-            when (state) {
-                0 -> Bugsnag.notify(generateException())
-                1 -> {
-                    Bugsnag.pauseSession()
-                    Bugsnag.notify(generateException())
+
+        if (eventMetadata != "non-crashy") {
+            val baseDelivery = createDefaultDelivery()
+            var state = 0
+            config.delivery = InterceptingDelivery(baseDelivery) {
+                when (state) {
+                    0 -> Bugsnag.notify(generateException())
+                    1 -> {
+                        Bugsnag.pauseSession()
+                        Bugsnag.notify(generateException())
+                    }
+                    2 -> {
+                        Bugsnag.resumeSession()
+                        throw generateException()
+                    }
                 }
-                2 -> {
-                    Bugsnag.resumeSession()
-                    throw generateException()
-                }
+                state++
             }
-            state++
         }
     }
 
     override fun startScenario() {
         super.startScenario()
-        Bugsnag.setUser("123", "ABC.CBA.CA", "ManualSessionSmokeScenario")
-        Bugsnag.startSession()
+        if (eventMetadata != "non-crashy") {
+            Bugsnag.setUser("123", "ABC.CBA.CA", "ManualSessionSmokeScenario")
+            Bugsnag.startSession()
+        }
     }
 }

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -53,8 +53,8 @@ Scenario: Automated sessions send
 
 Scenario: Manual session control works
     When I run "ManualSessionSmokeScenario"
-    And I wait for 8 seconds
     And I relaunch the app after a crash
+    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "ManualSessionSmokeScenario"
     And I wait to receive a session
 
@@ -104,3 +104,4 @@ Scenario: Manual session control works
     And the event "user.id" equals "123"
     And the event "user.email" equals "ABC.CBA.CA"
     And the event "user.name" equals "ManualSessionSmokeScenario"
+


### PR DESCRIPTION
## Goal

Removes a source of flakiness from the `ManualSessionSmokeScenario`, which suddenly started failing on Android 4.4 devices only.

The source of flakiness was introduced by setting an `InterceptingDelivery` in the constructor parameter. The `Scenario` is always constructed before Bugsnag is initialized, which meant on the second launch that although the crashy code should not be invoked, the `InterceptingDelivery` will notify/start sessions when cached payloads are sent from disk.

The fix has been to remove the wait from the mazerunner steps and to disable delivery interception on the second launch.

It's unclear why this has suddenly started failing on Android 4 - I'd hypothesise that these older devices are more sluggish and therefore take longer to respond to Appium commands, giving enough time for extra network requests to make it through.