### PR TITLE
Use atomic wrappers for primitives in E2E scenarios

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedNotifyScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedNotifyScenario.java
@@ -8,6 +8,8 @@ import android.os.Handler;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 public class CXXDelayedNotifyScenario extends Scenario {
 
     static {
@@ -16,8 +18,8 @@ public class CXXDelayedNotifyScenario extends Scenario {
 
     public native void activate();
 
-    private boolean didActivate = false;
-    private Handler handler = new Handler();
+    private final AtomicBoolean didActivate = new AtomicBoolean(false);
+    private final Handler handler = new Handler();
 
     public CXXDelayedNotifyScenario(@NonNull Configuration config,
                                     @NonNull Context context,
@@ -28,10 +30,9 @@ public class CXXDelayedNotifyScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        if (didActivate) {
+        if (didActivate.getAndSet(true)) {
             return;
         }
-        didActivate = true;
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaBreadcrumbNativeBreadcrumbScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaBreadcrumbNativeBreadcrumbScenario.java
@@ -4,7 +4,6 @@ import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
 
 import android.content.Context;
-import android.os.Handler;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -17,8 +16,6 @@ public class CXXJavaBreadcrumbNativeBreadcrumbScenario extends Scenario {
     }
 
     public native void activate();
-
-    private Handler handler = new Handler();
 
     public CXXJavaBreadcrumbNativeBreadcrumbScenario(@NonNull Configuration config,
                                                      @NonNull Context context,

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.lang.Runnable;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CXXDelayedCrashScenario extends Scenario {
 
@@ -18,8 +19,8 @@ public class CXXDelayedCrashScenario extends Scenario {
 
     public native int activate(int value);
 
-    private boolean didActivate = false;
-    private Handler handler = new Handler();
+    private final AtomicBoolean didActivate = new AtomicBoolean(false);
+    private final Handler handler = new Handler();
 
     public CXXDelayedCrashScenario(@NonNull Configuration config,
                                    @NonNull Context context,
@@ -31,10 +32,9 @@ public class CXXDelayedCrashScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        if (didActivate) {
+        if (didActivate.getAndSet(true)) {
             return;
         }
-        didActivate = true;
         String metadata = getEventMetadata();
         if (metadata != null && metadata.equals("non-crashy")) {
             return;

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionSmokeScenario.kt
@@ -6,6 +6,7 @@ import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.createDefaultDelivery
 import com.bugsnag.android.mazerunner.InterceptingDelivery
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Sends an automated session payload to Bugsnag.
@@ -18,10 +19,9 @@ internal class AutoSessionSmokeScenario(
 
     init {
         val baseDelivery = createDefaultDelivery()
-        var intercept = true
+        val intercept = AtomicBoolean(true)
         config.delivery = InterceptingDelivery(baseDelivery) {
-            if (intercept) {
-                intercept = false
+            if (intercept.getAndSet(false)) {
                 Bugsnag.notify(generateException())
             }
         }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
@@ -5,6 +5,7 @@ import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.createDefaultDelivery
 import com.bugsnag.android.mazerunner.InterceptingDelivery
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Sends an exception after pausing the session
@@ -20,9 +21,9 @@ internal class ManualSessionSmokeScenario(
 
         if (eventMetadata != "non-crashy") {
             val baseDelivery = createDefaultDelivery()
-            var state = 0
+            val state = AtomicInteger(0)
             config.delivery = InterceptingDelivery(baseDelivery) {
-                when (state) {
+                when (state.incrementAndGet()) {
                     0 -> Bugsnag.notify(generateException())
                     1 -> {
                         Bugsnag.pauseSession()
@@ -33,7 +34,6 @@ internal class ManualSessionSmokeScenario(
                         throw generateException()
                     }
                 }
-                state++
             }
         }
     }


### PR DESCRIPTION
## Goal

Uses atomic wrappers for primitives in the E2E scenarios. The scenarios are typically called from multiple threads, so variables accessed from multiple threads to track state should really use `volatile` or an `AtomicReference` to ensure that an up-to-date value is observed on each thread. This is hypothesised to be a potential source of flakes on some scenarios - and should have no ill effect on the tests.