### PR TITLE
Tweak release command to include 'clean'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Change `VERSION_NAME` in `gradle.properties` to a version higher than the curren
 released bugsnag-android, then run:
 
 ```shell
-./gradlew assembleRelease publishToMavenLocal
+./gradlew clean assembleRelease publishToMavenLocal
 ```
 
 This installs bugsnag-android to a local maven repository. To use it in the example app, you'll need to modify its `build.gradle` to set the `com.bugsnag:bugsnag-android` dependency version to match (near the bottom of the file).

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 
 TEST_FIXTURE_NDK_VERSION ?= 16.1.4479499
 test-fixture:
-	@./gradlew -PVERSION_NAME=9.9.9 assembleRelease publishToMavenLocal
+	@./gradlew -PVERSION_NAME=9.9.9 clean assembleRelease publishToMavenLocal
 	@./gradlew -PTEST_FIXTURE_NDK_VERSION=$(TEST_FIXTURE_NDK_VERSION) -p=features/fixtures/mazerunner/ assembleRelease
 	@cp features/fixtures/mazerunner/app/build/outputs/apk/release/fixture.apk build/fixture.apk
 
@@ -54,5 +54,5 @@ endif
 	@git commit -m "Release v$(VERSION)"
 	@git tag v$(VERSION)
 	@git push origin master v$(VERSION)
-	@./gradlew assembleRelease publish bintrayUpload -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64 \
-	 && ./gradlew assembleRelease publish bintrayUpload -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64 -PreleaseNdkArtefact=true
+	@./gradlew clean assembleRelease publish bintrayUpload -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64 \
+	 && ./gradlew clean assembleRelease publish bintrayUpload -PABI_FILTERS=arm64-v8a,armeabi,armeabi-v7a,x86,x86_64 -PreleaseNdkArtefact=true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -74,11 +74,11 @@ If you are a project maintainer, you can build and release a new version of
   - [ ] Update the version number and dex count badge by running `make VERSION=[number] bump`
   - [ ] Inspect the updated CHANGELOG, README, and version files to ensure they are correct
 - Once merged:
-  - Pull the latest changes (checking out master if necessary) and build by running `./gradlew assembleRelease`
+  - Pull the latest changes (checking out master if necessary) and build by running `./gradlew clean assembleRelease`
   - Release to GitHub:
     - [ ] Run `git tag vX.X.X && git push origin --tags`
     - [ ] Create a release from your new tag on [GitHub Releases](https://github.com/bugsnag/bugsnag-android/releases)
-  - [ ] Release to Maven Central and Bintray by running `./gradlew assembleRelease publish bintrayUpload`
+  - [ ] Release to Maven Central and Bintray by running `./gradlew clean assembleRelease publish bintrayUpload`
   - [ ] "Promote" the release build on Maven Central:
     - Go to the [sonatype open source dashboard](https://oss.sonatype.org/index.html#stagingRepositories)
     - Click the search box at the top right, and type “com.bugsnag”


### PR DESCRIPTION
## Goal

Enforces that the 'clean' task should always be run before generating artefacts. This ensures that the build is always in a consistent state when building or testing a release.