### PR TITLE
Enable full obfuscation in test fixture

### DIFF
--- a/features/fixtures/mazerunner/app/proguard-rules.pro
+++ b/features/fixtures/mazerunner/app/proguard-rules.pro
@@ -1,2 +1,1 @@
--dontobfuscate
--keep class com.bugsnag.android.mazerunner.scenarios.** {*;}
+-keep class com.bugsnag.android.mazerunner.** {*;}

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -19,7 +19,8 @@ Scenario: Notify caught Java exception with default configuration
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event "exceptions.0.stacktrace.0.method" ends with "HandledJavaSmokeScenario.startScenario"
     And the exception "stacktrace.0.file" equals "HandledJavaSmokeScenario.java"
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 51
+    # R8 minification alters the lineNumber, see the mapping file/source code for the original value
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 6
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     # App data
@@ -107,7 +108,8 @@ Scenario: Notify Kotlin exception with overwritten configuration
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event "exceptions.0.stacktrace.0.method" ends with "generateException"
     And the exception "stacktrace.0.file" equals "Scenario.kt"
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 93
+    # R8 minification alters the lineNumber, see the mapping file/source code for the original value
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 1
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     # Overwritten App data

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -20,7 +20,8 @@ Scenario: Unhandled Java Exception with loaded configuration
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event "exceptions.0.stacktrace.0.method" ends with "UnhandledJavaLoadedConfigScenario.startScenario"
     And the exception "stacktrace.0.file" equals "UnhandledJavaLoadedConfigScenario.java"
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 28
+    # R8 minification alters the lineNumber, see the mapping file/source code for the original value
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 5
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     # App data


### PR DESCRIPTION
## Goal

Enables obfuscation in the test fixture and updates assertions around lineNumbers where necessary. This ensures that the tests run against a minified and obfuscated bugsnag SDK, which should highlight any failures in ProGuard keep rules for the SDK.

## Testing

This can be verified by inspecting the classes.dex of the fixture APK on Buildkite in Android Studio's APK analyzer.