### PR TITLE
Trim stack gathering frames out of native ANR traces

### DIFF
--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -18,6 +18,13 @@ internal class AnrPlugin : Plugin {
             // The only check that will work across all Android versions is the isNativeMethod call.
             return javaTrace.first().isNativeMethod
         }
+
+        private const val stackUnwindOverhead = 5
+
+        // Trim the stack trace generation components from the native trace
+        internal fun trimNativeTrace(nativeTrace: List<NativeStackframe>): List<NativeStackframe> {
+            return nativeTrace.subList(stackUnwindOverhead, nativeTrace.size)
+        }
     }
 
     private val loader = LibraryLoader()
@@ -97,7 +104,7 @@ internal class AnrPlugin : Plugin {
             // append native stackframes to error/thread stacktrace
             if (hasNativeComponent) {
                 // update error stacktrace
-                val nativeFrames = nativeTrace.map { Stackframe(it) }
+                val nativeFrames = trimNativeTrace(nativeTrace).map { Stackframe(it) }
                 err.stacktrace.addAll(0, nativeFrames)
 
                 // update thread stacktrace

--- a/features/full_tests/batch_1/detect_anr_jvm.feature
+++ b/features/full_tests/batch_1/detect_anr_jvm.feature
@@ -14,25 +14,6 @@ Scenario: ANR triggered in JVM loop code is captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
-# Other scenarios use a deadlock to generate an ANR, which works on Samsung devices. This scenario remains skipped
-# on Samsung as it is explicitly design to test ANRs caused by a sleeping thread.
-@skip_samsung
-Scenario: ANR triggered in JVM sleep code is captured
-    When I run "JvmAnrSleepScenario"
-    And I wait for 2 seconds
-    And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
-    Then I wait to receive an error
-    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-    And the exception "errorClass" equals "ANR"
-    And the exception "message" starts with " Input dispatching timed out"
-    And the error "Bugsnag-Stacktrace-Types" header equals "android"
-    And the error payload field "events.0.exceptions.0.type" equals "android"
-    And the error payload field "events.0.exceptions.0.stacktrace.0.type" is null
-    And the error payload field "events.0.threads.0.type" equals "android"
-    And the error payload field "events.0.threads.0.stacktrace.0.type" is null
-
 Scenario: ANR triggered in JVM code is not captured when detectAnrs = false
     When I run "JvmAnrDisabledScenario"
     And I wait for 2 seconds


### PR DESCRIPTION
## Goal

We don't want to have the stack unwinding functions in the native portion of ANR traces; we want it to point to the actual culprit.

## Design

Trim the top 5 entries from the native trace (there are 5 stack levels in the unwind functions).

## Testing

Manual testing, and also ran e2e tests.
