### PR TITLE
Avoid calling DeleteLocalRef for jmethodID and jfieldID pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.6.0 (2021-02-04)
+## 5.6.0 (2021-02-05)
 
 ### Enhancements
 
@@ -14,6 +14,7 @@
   [#1088](https://github.com/bugsnag/bugsnag-android/pull/1088)
   [#1091](https://github.com/bugsnag/bugsnag-android/pull/1091)
   [#1092](https://github.com/bugsnag/bugsnag-android/pull/1092)
+  [#1117](https://github.com/bugsnag/bugsnag-android/pull/1117)
 
 * Add global metadata to ANR error reports
   [#1095](https://github.com/bugsnag/bugsnag-android/pull/1095)  

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -110,7 +110,6 @@ void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
   exit:
     (*env)->DeleteLocalRef(env, filename);
     (*env)->DeleteLocalRef(env, class);
-    (*env)->DeleteLocalRef(env, method);
   }
 }
 
@@ -210,12 +209,9 @@ exit:
   (*env)->DeleteLocalRef(env, jmessage);
 
   (*env)->DeleteLocalRef(env, interface_class);
-  (*env)->DeleteLocalRef(env, notify_method);
   (*env)->DeleteLocalRef(env, trace_class);
   (*env)->DeleteLocalRef(env, severity_class);
-  (*env)->DeleteLocalRef(env, trace_constructor);
   (*env)->DeleteLocalRef(env, trace);
-  (*env)->DeleteLocalRef(env, severity_field);
   (*env)->DeleteLocalRef(env, jseverity);
 }
 
@@ -249,7 +245,6 @@ void bugsnag_set_binary_arch(JNIEnv *env) {
 
 exit:
   (*env)->DeleteLocalRef(env, arch);
-  (*env)->DeleteLocalRef(env, set_arch_method);
   (*env)->DeleteLocalRef(env, interface_class);
 }
 
@@ -290,7 +285,6 @@ void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
 
 exit:
   (*env)->DeleteLocalRef(env, interface_class);
-  (*env)->DeleteLocalRef(env, set_user_method);
 }
 
 jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bugsnag_breadcrumb_type type,
@@ -366,9 +360,7 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
 exit:
   bsg_release_byte_ary(env, jmessage, message);
   (*env)->DeleteLocalRef(env, interface_class);
-  (*env)->DeleteLocalRef(env, leave_breadcrumb_method);
   (*env)->DeleteLocalRef(env, type_class);
-  (*env)->DeleteLocalRef(env, crumb_type);
   (*env)->DeleteLocalRef(env, jtype);
   (*env)->DeleteLocalRef(env, jmessage);
 }


### PR DESCRIPTION
## Goal

Avoids calling `DeleteLocalRef` for `jmethodID` and `jfieldID` pointers, which are regular [C-style pointers](https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/types.html#wp9502). Invoking this method on an Android emulator results in a SIGABRT when triggering a handled C++ error report in Bugsnag. This behaviour is not triggered on BrowserStack or physical devices, even when loading the same APK.

## Testing

Ran the example app on an emulator and triggered the C++ error report, confirming that no SIGABRT was raised. This interacts with all the Bugsnag C APIs that use the JNI.

### Stacktrace

```
SIGABRT Abort program 
    [vdso]:2756 __kernel_vsyscall
    /system/lib/libc.so:482109 tgkill
    /system/lib/libc.so:127055 abort
    /system/lib/libart.so:5442750 0xaa348cbe
    /system/lib/libart.so:5445018 art::Runtime::Aborter(char const*)
    /system/lib/libart.so:1119188 std::__1::__function::__func<void (*)(char const*), std::__1::allocator<void (*)(char const*)>, void (char const*)>::operator()(char const*&&)
    /system/lib/libart.so:6579851 android::base::LogMessage::~LogMessage()
    /system/lib/libart.so:3651923 art::JavaVMExt::JniAbort(char const*, char const*)
    /system/lib/libart.so:3652742 art::JavaVMExt::JniAbortF(char const*, char const*, ...)
    /system/lib/libart.so:5677576 art::Thread::DecodeJObject(_jobject*) const
    /system/lib/libart.so:1322721 art::ScopedCheck::CheckInstance(art::ScopedObjectAccess&, art::ScopedCheck::InstanceKind, _jobject*, bool)
    /system/lib/libart.so:1319719 art::ScopedCheck::CheckPossibleHeapValue(art::ScopedObjectAccess&, char, art::JniValueType)
    /system/lib/libart.so:1317044 art::ScopedCheck::Check(art::ScopedObjectAccess&, bool, char const*, art::JniValueType*)
    /system/lib/libart.so:1332117 art::CheckJNI::DeleteRef(char const*, _JNIEnv*, _jobject*, art::IndirectRefKind)
    /system/lib/libart.so:1230458 art::CheckJNI::DeleteLocalRef(_JNIEnv*, _jobject*)
    /data/app/com.example.bugsnag.android-ANziLEUMmj2LefWUs739eg==/lib/x86/libbugsnag-ndk.so:174337 bugsnag_leave_breadcrumb_env
    /data/app/com.example.bugsnag.android-ANziLEUMmj2LefWUs739eg==/lib/x86/libentrypoint.so:2675 Java_com_example_bugsnag_android_BaseCrashyActivity_notifyFromCXX
```