### PR TITLE
Always pull maze runner image before running

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -36,6 +36,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-minimal.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_1/handled_exception.feature"
@@ -90,6 +91,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_1"
@@ -113,6 +115,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_2"
@@ -136,6 +139,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_1"
@@ -157,6 +161,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_2"
@@ -178,6 +183,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r19.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_1"
@@ -199,6 +205,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r19.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_2"
@@ -220,6 +227,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r19.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_1"
@@ -241,6 +249,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r19.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_2"
@@ -262,6 +271,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_1"
@@ -283,6 +293,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_2"
@@ -304,6 +315,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_1"
@@ -325,6 +337,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_2"
@@ -350,6 +363,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests"
@@ -372,6 +386,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests"
@@ -394,6 +409,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests"
@@ -416,6 +432,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r19.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests"
@@ -438,6 +455,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r19.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests"
@@ -460,6 +478,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests"
@@ -482,6 +501,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests"

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -7,6 +7,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/smoke_tests"
@@ -25,6 +26,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
         - "features/smoke_tests"
@@ -43,6 +45,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r19.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/smoke_tests"
@@ -61,6 +64,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r19.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/smoke_tests"
@@ -79,6 +83,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/smoke_tests"
@@ -98,6 +103,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_1"
@@ -121,6 +127,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests/batch_2"
@@ -148,6 +155,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/full_tests"
@@ -169,6 +177,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/smoke_tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,13 +30,6 @@ steps:
           push:
             - android-ci:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:ci-${BRANCH_NAME}
 
-  - label: ':docker: Build Android maze runner image'
-    key: "maze-runner"
-    timeout_in_minutes: 20
-    plugins:
-      - docker-compose#v3.7.0:
-          build: android-maze-runner
-
   - label: ':android: Build fixture APK r16'
     key: "fixture-r16"
     depends_on: "android-ci"
@@ -161,6 +154,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r16.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "features/smoke_tests"
@@ -179,6 +173,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/release/fixture-r21.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         args:
             - TESTS_DIR=features/smoke_tests


### PR DESCRIPTION
## Goal

Ensure the latest available Maze Runner image is always used.

## Design

The initial `build` step was completely useless and a hangover from how we used to do things.  Adding the `pull:` to every `run:` step should mean that we receive the newest `latest-v4-cli` Maze Runner image every time - for example when a new release is made and the EC2 instances are already up and running (with their local Docker registries).

## Testing

Covered by a full CI run.