### PR TITLE
Allow assembling with Android Studio 4.1.1

### DIFF
--- a/bugsnag-plugin-android-anr/build.gradle
+++ b/bugsnag-plugin-android-anr/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         externalNativeBuild.cmake.arguments "-DANDROID_CPP_FEATURES=exceptions", "-DANDROID_STL=c++_static"
         ndk.abiFilters = project.hasProperty("ABI_FILTERS") ? project.ABI_FILTERS.split(",") :
-            ["arm64-v8a", "armeabi-v7a", "armeabi", "x86", "x86_64"]
+            ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
     }
     externalNativeBuild.cmake.path = "CMakeLists.txt"
 }

--- a/bugsnag-plugin-android-ndk/build.gradle
+++ b/bugsnag-plugin-android-ndk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         externalNativeBuild.cmake.arguments "-DANDROID_CPP_FEATURES=exceptions", "-DANDROID_STL=c++_static"
         ndk.abiFilters = project.hasProperty("ABI_FILTERS") ? project.ABI_FILTERS.split(",") :
-            ["arm64-v8a", "armeabi-v7a", "armeabi", "x86", "x86_64"]
+            ["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]
     }
     externalNativeBuild.cmake.path = "CMakeLists.txt"
 }


### PR DESCRIPTION
## Goal

The build script on Unity fails as modern versions of Android Studio (4.1.1) are unable to build the armeabi ABI. This fixes the buildscript by removing armeabi from the targets. This brings Unity into line with Android on the architectures it supports.