### PR TITLE
Backport JNI error handling fixes to v4

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,11 +8,9 @@ steps:
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - wait
 
@@ -24,13 +22,10 @@ steps:
             - android-jvm
           cache-from:
             - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
             - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - label: ':docker: Build Android instrumentation image'
     timeout_in_minutes: 40
@@ -39,13 +34,10 @@ steps:
           build: android-instrumentation-tests
           cache-from:
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
 
   - label: ':docker: Build Android apk builder image'
     timeout_in_minutes: 40
@@ -54,13 +46,10 @@ steps:
           build: android-builder
           cache-from:
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
     env:
       MAVEN_VERSION: "3.6.1"
 
@@ -102,13 +91,10 @@ steps:
           build: android-sizer
           cache-from:
             - android-sizer:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-sizer-${BRANCH_NAME}
-            - android-sizer:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-sizer-latest
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-            - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-latest
       - docker-compose#v2.6.0:
           push:
             - android-sizer:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-sizer-${BRANCH_NAME}
-            - android-sizer:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-sizer-latest
     env:
       MAVEN_VERSION: "3.6.1"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -130,7 +130,7 @@ steps:
     env:
       DEVICE_TYPE: "ANDROID_9"
       APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
@@ -142,7 +142,7 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
       NDK_VERSION: "r16b"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - block: "Trigger full test suite"
@@ -158,7 +158,7 @@ steps:
     env:
       DEVICE_TYPE: "ANDROID_5"
       APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 6 end-to-end tests'
@@ -171,7 +171,7 @@ steps:
     env:
       DEVICE_TYPE: "ANDROID_6"
       APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 7 end-to-end tests'
@@ -184,7 +184,7 @@ steps:
     env:
       DEVICE_TYPE: "ANDROID_7"
       APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 8 end-to-end tests'
@@ -197,7 +197,7 @@ steps:
     env:
       DEVICE_TYPE: "ANDROID_8"
       APP_LOCATION: "/app/build/fixture.apk"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
@@ -209,7 +209,7 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
       NDK_VERSION: "r16b"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
@@ -221,7 +221,7 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
       NDK_VERSION: "r16b"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
@@ -233,7 +233,7 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
       NDK_VERSION: "r12b"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
@@ -245,7 +245,7 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
       NDK_VERSION: "r12b"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
@@ -257,7 +257,7 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
       NDK_VERSION: "r12b"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
@@ -269,7 +269,7 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Nexus 5-4.4"]'
       NDK_VERSION: "r19"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
@@ -281,7 +281,7 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
       NDK_VERSION: "r19"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
@@ -293,5 +293,5 @@ steps:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
       INSTRUMENTATION_DEVICES: '["Google Pixel 3-9.0"]'
       NDK_VERSION: "r19"
-    concurrency: 5
+    concurrency: 9
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -189,6 +189,23 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
+  - label: ':android: Android 6 end-to-end tests - 2'
+    depends_on: "build-fixture"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v2.6.0:
+        run: android-maze-runner
+        command:
+          - "-e"
+          - "features/[a-m].*.feature"
+    env:
+      DEVICE_TYPE: "ANDROID_6"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
   - label: ':android: Android 7 end-to-end tests - 1'
     depends_on: "build-fixture"
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,13 +3,13 @@ steps:
     timeout_in_minutes: 30
     key: "build-android-base"
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           build:
             - android-base
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           push:
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
 
@@ -18,13 +18,13 @@ steps:
     key: "build-android-jvm"
     depends_on: "build-android-base"
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           build:
             - android-jvm
           cache-from:
             - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           push:
             - android-jvm:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
 
@@ -33,12 +33,12 @@ steps:
     key: "build-android-instrumentation-tests"
     depends_on: "build-android-base"
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           build: android-instrumentation-tests
           cache-from:
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           push:
             - android-instrumentation-tests:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
 
@@ -47,12 +47,12 @@ steps:
     key: "build-android-builder"
     depends_on: "build-android-base"
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           build: android-builder
           cache-from:
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           push:
             - android-builder:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
     env:
@@ -62,7 +62,7 @@ steps:
     depends_on: "build-android-jvm"
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-jvm
     command: 'bash ./scripts/run-linter.sh'
 
@@ -70,7 +70,7 @@ steps:
     depends_on: "build-android-jvm"
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-jvm
     command: './gradlew test'
 
@@ -80,7 +80,7 @@ steps:
     timeout_in_minutes: 30
     artifact_paths: build/fixture.apk
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-builder
     env:
       MAVEN_VERSION: "3.6.1"
@@ -90,12 +90,12 @@ steps:
     depends_on: "build-android-base"
     timeout_in_minutes: 40
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           build: android-sizer
           cache-from:
             - android-sizer:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-sizer-${BRANCH_NAME}
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           push:
             - android-sizer:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-sizer-${BRANCH_NAME}
     env:
@@ -105,7 +105,7 @@ steps:
     depends_on: "build-android-sizer"
     timeout_in_minutes: 30
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-sizer
 
   - label: ':android: Android 9 end-to-end tests - 1'
@@ -114,7 +114,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
         command:
           - "-e"
@@ -131,7 +131,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
         command:
           - "-e"
@@ -146,7 +146,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
@@ -164,7 +164,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
     env:
       DEVICE_TYPE: "ANDROID_5"
@@ -178,7 +178,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
         command:
           - "-e"
@@ -195,7 +195,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
         command:
           - "-e"
@@ -212,7 +212,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
         command:
           - "-e"
@@ -229,7 +229,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
         command:
           - "-e"
@@ -246,7 +246,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
         command:
           - "-e"
@@ -263,7 +263,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
-      docker-compose#v2.6.0:
+      docker-compose#v3.7.0:
         run: android-maze-runner
         command:
           - "-e"
@@ -278,7 +278,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
@@ -291,7 +291,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
@@ -304,7 +304,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
@@ -317,7 +317,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
@@ -330,7 +330,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
@@ -343,7 +343,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
@@ -356,7 +356,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"
@@ -369,7 +369,7 @@ steps:
     depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
-      - docker-compose#v2.6.0:
+      - docker-compose#v3.7.0:
           run: android-instrumentation-tests
     env:
       APP_LOCATION: "/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,7 @@
 steps:
   - label: ':docker: Build Android base image'
     timeout_in_minutes: 30
+    key: "build-android-base"
     plugins:
       - docker-compose#v2.6.0:
           build:
@@ -12,10 +13,10 @@ steps:
           push:
             - android-base:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:android-${BRANCH_NAME}
 
-  - wait
-
   - label: ':docker: Build Android jvm test image'
     timeout_in_minutes: 40
+    key: "build-android-jvm"
+    depends_on: "build-android-base"
     plugins:
       - docker-compose#v2.6.0:
           build:
@@ -29,6 +30,8 @@ steps:
 
   - label: ':docker: Build Android instrumentation image'
     timeout_in_minutes: 40
+    key: "build-android-instrumentation-tests"
+    depends_on: "build-android-base"
     plugins:
       - docker-compose#v2.6.0:
           build: android-instrumentation-tests
@@ -41,6 +44,8 @@ steps:
 
   - label: ':docker: Build Android apk builder image'
     timeout_in_minutes: 40
+    key: "build-android-builder"
+    depends_on: "build-android-base"
     plugins:
       - docker-compose#v2.6.0:
           build: android-builder
@@ -53,15 +58,8 @@ steps:
     env:
       MAVEN_VERSION: "3.6.1"
 
-  - label: ':docker: Build Android maze runner image'
-    timeout_in_minutes: 20
-    plugins:
-      - docker-compose#v2.6.0:
-          build: android-maze-runner
-
-  - wait
-
   - label: ':android: Linter'
+    depends_on: "build-android-jvm"
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v2.6.0:
@@ -69,6 +67,7 @@ steps:
     command: 'bash ./scripts/run-linter.sh'
 
   - label: ':android: JVM tests'
+    depends_on: "build-android-jvm"
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v2.6.0:
@@ -76,6 +75,8 @@ steps:
     command: './gradlew test'
 
   - label: ':android: Build fixture APK'
+    key: "build-fixture"
+    depends_on: "build-android-builder"
     timeout_in_minutes: 30
     artifact_paths: build/fixture.apk
     plugins:
@@ -85,6 +86,8 @@ steps:
       MAVEN_VERSION: "3.6.1"
 
   - label: ':docker: Build Android sizer image'
+    key: "build-android-sizer"
+    depends_on: "build-android-base"
     timeout_in_minutes: 40
     plugins:
       - docker-compose#v2.6.0:
@@ -98,15 +101,15 @@ steps:
     env:
       MAVEN_VERSION: "3.6.1"
 
-  - wait
-
   - label: ':android: Android size reporting'
+    depends_on: "build-android-sizer"
     timeout_in_minutes: 30
     plugins:
       - docker-compose#v2.6.0:
           run: android-sizer
 
   - label: ':android: Android 9 end-to-end tests'
+    depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -120,6 +123,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 16b SDK 9.0 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:
@@ -135,6 +139,7 @@ steps:
 
   - label: ':android: Android 5 end-to-end tests'
     skip: Temporarily disabled due to flakiness with BrowserStack tunneling
+    depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -148,6 +153,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 6 end-to-end tests'
+    depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -161,6 +167,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 7 end-to-end tests'
+    depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -174,6 +181,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: Android 8 end-to-end tests'
+    depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
       artifacts#v1.2.0:
@@ -187,6 +195,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 16b SDK 4.4 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:
@@ -199,6 +208,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 16b SDK 7.1 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:
@@ -211,6 +221,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 12b SDK 4.4 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:
@@ -223,6 +234,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 12b SDK 7.1 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:
@@ -235,6 +247,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 12b SDK 9.0 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:
@@ -247,6 +260,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 19 SDK 4.4 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:
@@ -259,6 +273,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 19 SDK 7.1 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:
@@ -271,6 +286,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   - label: ':android: NDK 19 SDK 9.0 Instrumentation tests'
+    depends_on: "build-android-instrumentation-tests"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v2.6.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -108,7 +108,7 @@ steps:
       - docker-compose#v2.6.0:
           run: android-sizer
 
-  - label: ':android: Android 9 end-to-end tests'
+  - label: ':android: Android 9 end-to-end tests - 1'
     depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
@@ -116,6 +116,26 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v2.6.0:
         run: android-maze-runner
+        command:
+          - "-e"
+          - "features/[n-z].*.feature"
+    env:
+      DEVICE_TYPE: "ANDROID_9"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 9 end-to-end tests - 2'
+    depends_on: "build-fixture"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v2.6.0:
+        run: android-maze-runner
+        command:
+          - "-e"
+          - "features/[a-m].*.feature"
     env:
       DEVICE_TYPE: "ANDROID_9"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -152,7 +172,7 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Android 6 end-to-end tests'
+  - label: ':android: Android 6 end-to-end tests - 1'
     depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
@@ -160,13 +180,16 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v2.6.0:
         run: android-maze-runner
+        command:
+          - "-e"
+          - "features/[n-z].*.feature"
     env:
       DEVICE_TYPE: "ANDROID_6"
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Android 7 end-to-end tests'
+  - label: ':android: Android 7 end-to-end tests - 1'
     depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
@@ -174,13 +197,16 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v2.6.0:
         run: android-maze-runner
+        command:
+          - "-e"
+          - "features/[n-z].*.feature"
     env:
       DEVICE_TYPE: "ANDROID_7"
       APP_LOCATION: "/app/build/fixture.apk"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Android 8 end-to-end tests'
+  - label: ':android: Android 7 end-to-end tests - 2'
     depends_on: "build-fixture"
     timeout_in_minutes: 60
     plugins:
@@ -188,6 +214,43 @@ steps:
         download: "build/fixture.apk"
       docker-compose#v2.6.0:
         run: android-maze-runner
+        command:
+          - "-e"
+          - "features/[a-m].*.feature"
+    env:
+      DEVICE_TYPE: "ANDROID_7"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 8 end-to-end tests - 1'
+    depends_on: "build-fixture"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v2.6.0:
+        run: android-maze-runner
+        command:
+          - "-e"
+          - "features/[n-z].*.feature"
+    env:
+      DEVICE_TYPE: "ANDROID_8"
+      APP_LOCATION: "/app/build/fixture.apk"
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+
+  - label: ':android: Android 8 end-to-end tests - 2'
+    depends_on: "build-fixture"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/fixture.apk"
+      docker-compose#v2.6.0:
+        run: android-maze-runner
+        command:
+          - "-e"
+          - "features/[a-m].*.feature"
     env:
       DEVICE_TYPE: "ANDROID_8"
       APP_LOCATION: "/app/build/fixture.apk"

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library( # Specifies the name of the library.
     jni/bugsnag_ndk.c
     jni/bugsnag.c
     jni/metadata.c
+    jni/safejni.c
     jni/report.c
     jni/handlers/signal_handler.c
     jni/handlers/cpp_handler.cpp

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -5,6 +5,7 @@
 #include "utils/stack_unwinder.h"
 #include "utils/string.h"
 #include "metadata.h"
+#include "safejni.h"
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -52,24 +53,13 @@ jfieldID bsg_parse_jseverity(JNIEnv *env, bsg_severity_t severity,
                              jclass severity_class) {
   const char *severity_sig = "Lcom/bugsnag/android/Severity;";
   if (severity == BSG_SEVERITY_ERR) {
-    return (*env)->GetStaticFieldID(env, severity_class, "ERROR", severity_sig);
+    return bsg_safe_get_static_field_id(env, severity_class, "ERROR", severity_sig);
   } else if (severity == BSG_SEVERITY_WARN) {
-    return (*env)->GetStaticFieldID(env, severity_class, "WARNING",
-                                    severity_sig);
+    return bsg_safe_get_static_field_id(env, severity_class, "WARNING",
+                                        severity_sig);
   } else {
-    return (*env)->GetStaticFieldID(env, severity_class, "INFO", severity_sig);
+    return bsg_safe_get_static_field_id(env, severity_class, "INFO", severity_sig);
   }
-}
-
-jbyteArray bsg_byte_ary_from_string(JNIEnv *env, char *text) {
-  if (text == NULL) {
-    return NULL;
-  }
-  size_t text_length = bsg_strlen(text);
-  jbyteArray jtext = (*env)->NewByteArray(env, text_length);
-  (*env)->SetByteArrayRegion(env, jtext, 0, text_length, (jbyte *)text);
-
-  return jtext;
 }
 
 void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
@@ -78,100 +68,206 @@ void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
   }
 }
 
-void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
-                        bsg_severity_t severity) {
-  bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
-  ssize_t frame_count =
-      bsg_unwind_stack(bsg_configured_unwind_style(), stacktrace, NULL, NULL);
-
-  jclass interface_class =
-      (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-  jmethodID notify_method = (*env)->GetStaticMethodID(
-      env, interface_class, "notify",
-      "([B[BLcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
-  jclass trace_class = (*env)->FindClass(env, "java/lang/StackTraceElement");
-  jclass severity_class =
-      (*env)->FindClass(env, "com/bugsnag/android/Severity");
-  jmethodID trace_constructor = (*env)->GetMethodID(
-      env, trace_class, "<init>",
-      "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
-  jobjectArray trace = (*env)->NewObjectArray(
-      env, (jsize)frame_count,
-      (*env)->FindClass(env, "java/lang/StackTraceElement"), NULL);
-
+void bsg_populate_notify_stacktrace(JNIEnv *env, bsg_stackframe *stacktrace,
+                                   ssize_t frame_count, jclass trace_class,
+                                   jmethodID trace_constructor,
+                                   jobjectArray trace) {
   for (int i = 0; i < frame_count; i++) {
     bsg_stackframe frame = stacktrace[i];
-    jstring class = (*env)->NewStringUTF(env, "");
-    jstring filename = (*env)->NewStringUTF(env, frame.filename);
+
+    // create Java string objects for class/filename/method
+    jstring class = bsg_safe_new_string_utf(env, "");
+    if (class == NULL) {
+      goto exit;
+    }
+
+    jstring filename = bsg_safe_new_string_utf(env, frame.filename);
     jstring method;
     if (strlen(frame.method) == 0) {
       char *frame_address = malloc(sizeof(char) * 32);
       sprintf(frame_address, "0x%lx", (unsigned long)frame.frame_address);
-      method = (*env)->NewStringUTF(env, frame_address);
+      method = bsg_safe_new_string_utf(env, frame_address);
       free(frame_address);
     } else {
-      method = (*env)->NewStringUTF(env, frame.method);
+      method = bsg_safe_new_string_utf(env, frame.method);
     }
-    jobject jframe =
-        (*env)->NewObject(env, trace_class, trace_constructor, class, method,
-                          filename, frame.line_number);
 
-    (*env)->SetObjectArrayElement(env, trace, i, jframe);
+    // create StackTraceElement object
+    jobject jframe =
+        bsg_safe_new_object(env, trace_class, trace_constructor, class, method,
+                            filename, frame.line_number);
+    if (jframe == NULL) {
+      goto exit;
+    }
+
+    bsg_safe_set_object_array_element(env, trace, i, jframe);
+    goto exit;
+
+    exit:
     (*env)->DeleteLocalRef(env, filename);
     (*env)->DeleteLocalRef(env, class);
-    (*env)->DeleteLocalRef(env, method);
+  }
+}
+
+void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
+                        bsg_severity_t severity) {
+  jclass interface_class = NULL;
+  jmethodID notify_method = NULL;
+  jclass trace_class = NULL;
+  jclass severity_class = NULL;
+  jmethodID trace_constructor = NULL;
+  jobjectArray trace = NULL;
+  jfieldID severity_field = NULL;
+  jobject jseverity = NULL;
+  jbyteArray jname = NULL;
+  jbyteArray jmessage = NULL;
+
+  bsg_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+  ssize_t frame_count =
+      bsg_unwind_stack(bsg_configured_unwind_style(), stacktrace, NULL, NULL);
+
+  // lookup com/bugsnag/android/NativeInterface
+  interface_class =
+      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
+  if (interface_class == NULL) {
+    goto exit;
   }
 
-  // Create a severity Error
-  jobject jseverity = (*env)->GetStaticObjectField(
-      env, severity_class, bsg_parse_jseverity(env, severity, severity_class));
+  // lookup NativeInterface.notify()
+  notify_method = bsg_safe_get_static_method_id(
+      env, interface_class, "notify",
+      "([B[BLcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
+  if (notify_method == NULL) {
+    goto exit;
+  }
 
-  jbyteArray jname = bsg_byte_ary_from_string(env, name);
-  jbyteArray jmessage = bsg_byte_ary_from_string(env, message);
+  // lookup java/lang/StackTraceElement
+  trace_class = bsg_safe_find_class(env, "java/lang/StackTraceElement");
+  if (trace_class == NULL) {
+    goto exit;
+  }
+
+  // lookup com/bugsnag/android/Severity
+  severity_class = bsg_safe_find_class(env, "com/bugsnag/android/Severity");
+  if (severity_class == NULL) {
+    goto exit;
+  }
+
+  // lookup StackTraceElement constructor
+  trace_constructor = bsg_safe_get_method_id(
+      env, trace_class, "<init>",
+      "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
+  if (trace_constructor == NULL) {
+    goto exit;
+  }
+
+  // create StackTraceElement array
+  trace = bsg_safe_new_object_array(env, frame_count, trace_class);
+  if (trace == NULL) {
+    goto exit;
+  }
+
+  // populate stacktrace object
+  bsg_populate_notify_stacktrace(env, stacktrace, frame_count, trace_class,
+                                 trace_constructor, trace);
+
+  // get the severity field
+  severity_field = bsg_parse_jseverity(env, severity, severity_class);
+  if (severity_field == NULL) {
+    goto exit;
+  }
+  // get the error severity object
+  jseverity =
+      bsg_safe_get_static_object_field(env, severity_class, severity_field);
+  if (jseverity == NULL) {
+    goto exit;
+  }
+
+  jname = bsg_byte_ary_from_string(env, name);
+  jmessage = bsg_byte_ary_from_string(env, message);
 
   // set application's binary arch
   bugsnag_set_binary_arch(env);
 
-  (*env)->CallStaticVoidMethod(env, interface_class, notify_method, jname,
-                               jmessage, jseverity, trace);
+  bsg_safe_call_static_void_method(env, interface_class, notify_method, jname,
+                                   jmessage, jseverity, trace);
 
-  bsg_release_byte_ary(env, jname, name);
-  bsg_release_byte_ary(env, jmessage, message);
+  goto exit;
+
+  exit:
+  if (jname != NULL) {
+    bsg_release_byte_ary(env, jname, name);
+  }
+  if (jmessage != NULL) {
+    bsg_release_byte_ary(env, jmessage, message);
+  }
   (*env)->DeleteLocalRef(env, jname);
   (*env)->DeleteLocalRef(env, jmessage);
 
-  (*env)->DeleteLocalRef(env, trace_class);
-  (*env)->DeleteLocalRef(env, trace);
-  (*env)->DeleteLocalRef(env, severity_class);
-  (*env)->DeleteLocalRef(env, jseverity);
   (*env)->DeleteLocalRef(env, interface_class);
+  (*env)->DeleteLocalRef(env, trace_class);
+  (*env)->DeleteLocalRef(env, severity_class);
+  (*env)->DeleteLocalRef(env, trace);
+  (*env)->DeleteLocalRef(env, jseverity);
 }
 
 void bugsnag_set_binary_arch(JNIEnv *env) {
-    jclass interface_class =
-        (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-    jmethodID set_arch_method = (*env)->GetStaticMethodID(
-        env, interface_class, "setBinaryArch", "(Ljava/lang/String;)V");
+  jclass interface_class = NULL;
+  jmethodID set_arch_method = NULL;
+  jstring arch = NULL;
 
-    jstring arch = (*env)->NewStringUTF(env, bsg_binary_arch());
-    (*env)->CallStaticVoidMethod(env, interface_class, set_arch_method, arch);
-    (*env)->DeleteLocalRef(env, arch);
-    (*env)->DeleteLocalRef(env, interface_class);
+  // lookup com/bugsnag/android/NativeInterface
+  interface_class =
+      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
+  if (interface_class == NULL) {
+    goto exit;
+  }
+
+  // lookup NativeInterface.setBinaryArch()
+  set_arch_method = bsg_safe_get_static_method_id(
+      env, interface_class, "setBinaryArch", "(Ljava/lang/String;)V");
+  if (set_arch_method == NULL) {
+    goto exit;
+  }
+
+  // call NativeInterface.setBinaryArch()
+  arch = bsg_safe_new_string_utf(env, bsg_binary_arch());
+  if (arch != NULL) {
+    bsg_safe_call_static_void_method(env, interface_class, set_arch_method,
+                                     arch);
+  }
+
+  goto exit;
+
+  exit:
+  (*env)->DeleteLocalRef(env, arch);
+  (*env)->DeleteLocalRef(env, interface_class);
 }
 
 void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
-  jclass interface_class =
-      (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-  jmethodID set_user_method = (*env)->GetStaticMethodID(
-      env, interface_class, "setUser",
-      "([B[B[B)V");
+  // lookup com/bugsnag/android/NativeInterface
+  jclass interface_class = NULL;
+  jmethodID set_user_method = NULL;
+
+  interface_class =
+      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
+  if (interface_class == NULL) {
+    goto exit;
+  }
+
+  // lookup NativeInterface.setUser()
+  set_user_method = bsg_safe_get_static_method_id(env, interface_class,
+                                                  "setUser", "([B[B[B)V");
+  if (set_user_method == NULL) {
+    goto exit;
+  }
 
   jbyteArray jid = bsg_byte_ary_from_string(env, id);
   jbyteArray jemail = bsg_byte_ary_from_string(env, email);
   jbyteArray jname = bsg_byte_ary_from_string(env, name);
 
-  (*env)->CallStaticVoidMethod(env, interface_class, set_user_method, jid,
-                               jemail, jname);
+  bsg_safe_call_static_void_method(env, interface_class, set_user_method, jid,
+                                   jemail, jname);
 
   bsg_release_byte_ary(env, jid, id);
   bsg_release_byte_ary(env, jemail, email);
@@ -180,6 +276,10 @@ void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
   (*env)->DeleteLocalRef(env, jid);
   (*env)->DeleteLocalRef(env, jemail);
   (*env)->DeleteLocalRef(env, jname);
+
+  goto exit;
+
+  exit:
   (*env)->DeleteLocalRef(env, interface_class);
 }
 
@@ -187,43 +287,76 @@ jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bsg_breadcrumb_t type,
                                jclass type_class) {
   const char *type_sig = "Lcom/bugsnag/android/BreadcrumbType;";
   if (type == BSG_CRUMB_USER) {
-    return (*env)->GetStaticFieldID(env, type_class, "USER", type_sig);
+    return bsg_safe_get_static_field_id(env, type_class, "USER", type_sig);
   } else if (type == BSG_CRUMB_ERROR) {
-    return (*env)->GetStaticFieldID(env, type_class, "ERROR", type_sig);
+    return bsg_safe_get_static_field_id(env, type_class, "ERROR", type_sig);
   } else if (type == BSG_CRUMB_LOG) {
-    return (*env)->GetStaticFieldID(env, type_class, "LOG", type_sig);
+    return bsg_safe_get_static_field_id(env, type_class, "LOG", type_sig);
   } else if (type == BSG_CRUMB_NAVIGATION) {
-    return (*env)->GetStaticFieldID(env, type_class, "NAVIGATION", type_sig);
+    return bsg_safe_get_static_field_id(env, type_class, "NAVIGATION",
+                                        type_sig);
   } else if (type == BSG_CRUMB_PROCESS) {
-    return (*env)->GetStaticFieldID(env, type_class, "PROCESS", type_sig);
+    return bsg_safe_get_static_field_id(env, type_class, "PROCESS", type_sig);
   } else if (type == BSG_CRUMB_REQUEST) {
-    return (*env)->GetStaticFieldID(env, type_class, "REQUEST", type_sig);
+    return bsg_safe_get_static_field_id(env, type_class, "REQUEST", type_sig);
   } else if (type == BSG_CRUMB_STATE) {
-    return (*env)->GetStaticFieldID(env, type_class, "STATE", type_sig);
+    return bsg_safe_get_static_field_id(env, type_class, "STATE", type_sig);
   } else { // MANUAL is the default type
-    return (*env)->GetStaticFieldID(env, type_class, "MANUAL", type_sig);
+    return bsg_safe_get_static_field_id(env, type_class, "MANUAL", type_sig);
   }
 }
 
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *name,
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
                                   bsg_breadcrumb_t type) {
-  jclass interface_class =
-      (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-  jmethodID leave_breadcrumb_method = (*env)->GetStaticMethodID(
+  jclass interface_class = NULL;
+  jmethodID leave_breadcrumb_method = NULL;
+  jclass type_class = NULL;
+  jfieldID crumb_type = NULL;
+  jobject jtype = NULL;
+  jbyteArray jmessage = NULL;
+
+  // lookup com/bugsnag/android/NativeInterface
+  interface_class =
+      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
+  if (interface_class == NULL) {
+    goto exit;
+  }
+
+  // lookup NativeInterface.leaveBreadcrumb()
+  leave_breadcrumb_method = bsg_safe_get_static_method_id(
       env, interface_class, "leaveBreadcrumb",
       "([BLcom/bugsnag/android/BreadcrumbType;)V");
-  jclass type_class =
-      (*env)->FindClass(env, "com/bugsnag/android/BreadcrumbType");
+  if (leave_breadcrumb_method == NULL) {
+    goto exit;
+  }
 
-  jobject jtype = (*env)->GetStaticObjectField(
-      env, type_class, bsg_parse_jcrumb_type(env, type, type_class));
-  jbyteArray jname = bsg_byte_ary_from_string(env, name);
-  (*env)->CallStaticVoidMethod(env, interface_class, leave_breadcrumb_method,
-                               jname, jtype);
-  bsg_release_byte_ary(env, jname, name);
-  (*env)->DeleteLocalRef(env, jtype);
-  (*env)->DeleteLocalRef(env, jname);
+  // lookup com/bugsnag/android/BreadcrumbType
+  type_class = bsg_safe_find_class(env, "com/bugsnag/android/BreadcrumbType");
+  if (type_class == NULL) {
+    goto exit;
+  }
 
-  (*env)->DeleteLocalRef(env, type_class);
+  // get breadcrumb type fieldID
+  crumb_type = bsg_parse_jcrumb_type(env, type, type_class);
+  if (crumb_type == NULL) {
+    goto exit;
+  }
+
+  // get the breadcrumb type
+  jtype = bsg_safe_get_static_object_field(env, type_class, crumb_type);
+  if (jtype == NULL) {
+    goto exit;
+  }
+  jmessage = bsg_byte_ary_from_string(env, message);
+  bsg_safe_call_static_void_method(env, interface_class,
+                                   leave_breadcrumb_method, jmessage, jtype);
+
+  goto exit;
+
+  exit:
+  bsg_release_byte_ary(env, jmessage, message);
   (*env)->DeleteLocalRef(env, interface_class);
+  (*env)->DeleteLocalRef(env, type_class);
+  (*env)->DeleteLocalRef(env, jtype);
+  (*env)->DeleteLocalRef(env, jmessage);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -160,7 +160,6 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
     } else {
       BUGSNAG_LOG("Failed to serialize report as JSON: %s", report_path);
     }
-    free(report);
   } else {
     BUGSNAG_LOG("Failed to read report at file: %s", report_path);
   }
@@ -170,6 +169,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
 
   exit:
   pthread_mutex_unlock(&bsg_native_delivery_mutex);
+  if (report != NULL) {
+    free(report);
+  }
   if (jpayload != NULL) {
     (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload,
                                      0); // <-- frees payload

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -1,4 +1,5 @@
 #include "metadata.h"
+#include "safejni.h"
 #include "report.h"
 #include "utils/string.h"
 #include <malloc.h>
@@ -37,64 +38,218 @@ typedef struct {
   jmethodID get_context;
 } bsg_jni_cache;
 
+/**
+ * Creates a cache of JNI methods/classes that are commonly used.
+ *
+ * Class and method objects can be kept safely since they aren't moved or
+ * removed from the JVM - care should be taken not to load objects as local
+ * references here.
+ */
 bsg_jni_cache *bsg_populate_jni_cache(JNIEnv *env) {
   bsg_jni_cache *jni_cache = malloc(sizeof(bsg_jni_cache));
-  jni_cache->integer = (*env)->FindClass(env, "java/lang/Integer");
-  jni_cache->boolean = (*env)->FindClass(env, "java/lang/Boolean");
-  jni_cache->long_class = (*env)->FindClass(env, "java/lang/Long");
-  jni_cache->float_class = (*env)->FindClass(env, "java/lang/Float");
-  jni_cache->number = (*env)->FindClass(env, "java/lang/Number");
-  jni_cache->string = (*env)->FindClass(env, "java/lang/String");
+
+  // lookup java/lang/Integer
+  jni_cache->integer = bsg_safe_find_class(env, "java/lang/Integer");
+  if (jni_cache->integer == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/Boolean
+  jni_cache->boolean = bsg_safe_find_class(env, "java/lang/Boolean");
+  if (jni_cache->boolean == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/Long
+  jni_cache->long_class = bsg_safe_find_class(env, "java/lang/Long");
+  if (jni_cache->long_class == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/Float
+  jni_cache->float_class = bsg_safe_find_class(env, "java/lang/Float");
+  if (jni_cache->float_class == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/Number
+  jni_cache->number = bsg_safe_find_class(env, "java/lang/Number");
+  if (jni_cache->number == NULL) {
+    return NULL;
+  }
+
+  // lookup java/lang/String
+  jni_cache->string = bsg_safe_find_class(env, "java/lang/String");
+  if (jni_cache->string == NULL) {
+    return NULL;
+  }
+
+  // lookup Integer.intValue()
   jni_cache->integer_int_value =
-      (*env)->GetMethodID(env, jni_cache->integer, "intValue", "()I");
+      bsg_safe_get_method_id(env, jni_cache->integer, "intValue", "()I");
+  if (jni_cache->integer_int_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Integer.floatValue()
   jni_cache->float_float_value =
-      (*env)->GetMethodID(env, jni_cache->float_class, "floatValue", "()F");
+      bsg_safe_get_method_id(env, jni_cache->float_class, "floatValue", "()F");
+  if (jni_cache->float_float_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Double.doubleValue()
   jni_cache->number_double_value =
-      (*env)->GetMethodID(env, jni_cache->number, "doubleValue", "()D");
+      bsg_safe_get_method_id(env, jni_cache->number, "doubleValue", "()D");
+  if (jni_cache->number_double_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Long.longValue()
   jni_cache->long_long_value =
-      (*env)->GetMethodID(env, jni_cache->integer, "longValue", "()J");
+      bsg_safe_get_method_id(env, jni_cache->integer, "longValue", "()J");
+  if (jni_cache->long_long_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Boolean.booleanValue()
   jni_cache->boolean_bool_value =
-      (*env)->GetMethodID(env, jni_cache->boolean, "booleanValue", "()Z");
-  jni_cache->arraylist = (*env)->FindClass(env, "java/util/ArrayList");
-  jni_cache->arraylist_init_with_obj = (*env)->GetMethodID(
+      bsg_safe_get_method_id(env, jni_cache->boolean, "booleanValue", "()Z");
+  if (jni_cache->boolean_bool_value == NULL) {
+    return NULL;
+  }
+
+  // lookup java/util/ArrayList
+  jni_cache->arraylist = bsg_safe_find_class(env, "java/util/ArrayList");
+  if (jni_cache->arraylist == NULL) {
+    return NULL;
+  }
+
+  // lookup ArrayList constructor
+  jni_cache->arraylist_init_with_obj = bsg_safe_get_method_id(
       env, jni_cache->arraylist, "<init>", "(Ljava/util/Collection;)V");
-  jni_cache->arraylist_get = (*env)->GetMethodID(
+  if (jni_cache->arraylist_init_with_obj == NULL) {
+    return NULL;
+  }
+
+  // lookup ArrayList.get()
+  jni_cache->arraylist_get = bsg_safe_get_method_id(
       env, jni_cache->arraylist, "get", "(I)Ljava/lang/Object;");
-  jni_cache->hash_map = (*env)->FindClass(env, "java/util/HashMap");
-  jni_cache->map = (*env)->FindClass(env, "java/util/Map");
-  jni_cache->hash_map_key_set = (*env)->GetMethodID(
+  if (jni_cache->arraylist_get == NULL) {
+    return NULL;
+  }
+
+  // lookup java/util/HashMap
+  jni_cache->hash_map = bsg_safe_find_class(env, "java/util/HashMap");
+  if (jni_cache->hash_map == NULL) {
+    return NULL;
+  }
+
+  // lookup java/util/Map
+  jni_cache->map = bsg_safe_find_class(env, "java/util/Map");
+  if (jni_cache->map == NULL) {
+    return NULL;
+  }
+
+  // lookup java/util/Set
+  jni_cache->hash_map_key_set = bsg_safe_get_method_id(
       env, jni_cache->hash_map, "keySet", "()Ljava/util/Set;");
+  if (jni_cache->hash_map_key_set == NULL) {
+    return NULL;
+  }
+
+  // lookup HashMap.size()
   jni_cache->hash_map_size =
-      (*env)->GetMethodID(env, jni_cache->hash_map, "size", "()I");
+      bsg_safe_get_method_id(env, jni_cache->hash_map, "size", "()I");
+  if (jni_cache->hash_map_size == NULL) {
+    return NULL;
+  }
+
+  // lookup HashMap.get()
   jni_cache->hash_map_get =
-      (*env)->GetMethodID(env, jni_cache->hash_map, "get",
-                          "(Ljava/lang/Object;)Ljava/lang/Object;");
-  jni_cache->map_key_set =
-      (*env)->GetMethodID(env, jni_cache->map, "keySet", "()Ljava/util/Set;");
-  jni_cache->map_size = (*env)->GetMethodID(env, jni_cache->map, "size", "()I");
-  jni_cache->map_get = (*env)->GetMethodID(
+      bsg_safe_get_method_id(env, jni_cache->hash_map, "get",
+                             "(Ljava/lang/Object;)Ljava/lang/Object;");
+  if (jni_cache->hash_map_get == NULL) {
+    return NULL;
+  }
+
+  // lookup Map.keySet()
+  jni_cache->map_key_set = bsg_safe_get_method_id(env, jni_cache->map, "keySet",
+                                                  "()Ljava/util/Set;");
+  if (jni_cache->map_key_set == NULL) {
+    return NULL;
+  }
+
+  // lookup Map.size()
+  jni_cache->map_size =
+      bsg_safe_get_method_id(env, jni_cache->map, "size", "()I");
+  if (jni_cache->map_size == NULL) {
+    return NULL;
+  }
+
+  // lookup Map.get()
+  jni_cache->map_get = bsg_safe_get_method_id(
       env, jni_cache->map, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
+  if (jni_cache->map_get == NULL) {
+    return NULL;
+  }
+
+  // lookup com/bugsnag/android/NativeInterface
   jni_cache->native_interface =
-      (*env)->FindClass(env, "com/bugsnag/android/NativeInterface");
-  jni_cache->get_app_data = (*env)->GetStaticMethodID(
+      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
+  if (jni_cache->native_interface == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getApp()
+  jni_cache->get_app_data = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getAppData", "()Ljava/util/Map;");
-  jni_cache->get_device_data = (*env)->GetStaticMethodID(
+  if (jni_cache->get_app_data == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getDevice()
+  jni_cache->get_device_data = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getDeviceData", "()Ljava/util/Map;");
-  jni_cache->get_user_data = (*env)->GetStaticMethodID(
+  if (jni_cache->get_device_data == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getUser()
+  jni_cache->get_user_data = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getUserData", "()Ljava/util/Map;");
-  jni_cache->get_metadata = (*env)->GetStaticMethodID(
+  if (jni_cache->get_user_data == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getMetadata()
+  jni_cache->get_metadata = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getMetaData", "()Ljava/util/Map;");
-  jni_cache->get_context = (*env)->GetStaticMethodID(
+  if (jni_cache->get_metadata == NULL) {
+    return NULL;
+  }
+
+  // lookup NativeInterface.getContext()
+  jni_cache->get_context = bsg_safe_get_static_method_id(
       env, jni_cache->native_interface, "getContext", "()Ljava/lang/String;");
+  if (jni_cache->get_context == NULL) {
+    return NULL;
+  }
   return jni_cache;
 }
 
 jobject bsg_get_map_value_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
                               jobject map, const char *_key) {
-    jstring key = (*env)->NewStringUTF(env, _key);
-    jobject obj = (*env)->CallObjectMethod(env, map, jni_cache->hash_map_get, key);
-    (*env)->DeleteLocalRef(env, key);
-    return obj;
+  // create Java string object for map key
+  jstring key = bsg_safe_new_string_utf(env, _key);
+  if (key == NULL) {
+    return NULL;
+  }
+
+  jobject obj =
+      bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
+  (*env)->DeleteLocalRef(env, key);
+  return obj;
 }
 
 void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
@@ -114,8 +269,8 @@ long bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
   jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
 
   if (_value != NULL) {
-    long value = (long)(*env)->CallDoubleMethod(env, _value,
-                                                jni_cache->number_double_value);
+    long value = bsg_safe_call_double_method(env, _value,
+                                             jni_cache->number_double_value);
     (*env)->DeleteLocalRef(env, _value);
     return value;
   }
@@ -127,8 +282,8 @@ float bsg_get_map_value_float(JNIEnv *env, bsg_jni_cache *jni_cache,
   jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
 
   if (_value != NULL) {
-    float value = (float)(*env)->CallFloatMethod(env, _value,
-                                                 jni_cache->float_float_value);
+    float value =
+        bsg_safe_call_float_method(env, _value, jni_cache->float_float_value);
     (*env)->DeleteLocalRef(env, _value);
     return value;
   }
@@ -141,7 +296,7 @@ int bsg_get_map_value_int(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
 
   if (_value != NULL) {
     jint value =
-        (int)(*env)->CallIntMethod(env, _value, jni_cache->integer_int_value);
+        bsg_safe_call_int_method(env, _value, jni_cache->integer_int_value);
     (*env)->DeleteLocalRef(env, _value);
     return value;
   }
@@ -151,23 +306,33 @@ int bsg_get_map_value_int(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
 bool bsg_get_map_value_bool(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
                             const char *_key) {
   jobject obj = bsg_get_map_value_obj(env, jni_cache, map, _key);
-  return (*env)->CallBooleanMethod(env, obj, jni_cache->boolean_bool_value);
+  return bsg_safe_call_boolean_method(env, obj, jni_cache->boolean_bool_value);
 }
 
 int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
                                   jobject map, bsg_device_info *device) {
-  jstring key = (*env)->NewStringUTF(env, "cpuAbi");
+  // create Java string object for map key
+  jstring key = bsg_safe_new_string_utf(env, "cpuAbi");
+  if (key == NULL) {
+    return 0;
+  }
+
   jobjectArray _value =
-      (*env)->CallObjectMethod(env, map, jni_cache->hash_map_get, key);
+      bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
   if (_value != NULL) {
     int count = (*env)->GetArrayLength(env, _value);
 
+    // get the ABI as a Java string and copy it to bsg_device_info
     for (int i = 0; i < count && i < sizeof(device->cpu_abi); i++) {
-      jstring abi_ = (jstring)((*env)->GetObjectArrayElement(env, _value, i));
-      char *abi = (char *)(*env)->GetStringUTFChars(env, abi_, 0);
+      jstring jabi = bsg_safe_get_object_array_element(env, _value, i);
+      if (jabi == NULL) {
+        break;
+      }
+
+      char *abi = (char *)(*env)->GetStringUTFChars(env, jabi, 0);
       bsg_strncpy_safe(device->cpu_abi[i].value, abi,
                        sizeof(device->cpu_abi[i].value));
-      (*env)->ReleaseStringUTFChars(env, abi_, abi);
+      (*env)->ReleaseStringUTFChars(env, jabi, abi);
       device->cpu_abi_count++;
     }
     (*env)->DeleteLocalRef(env, _value);
@@ -178,23 +343,41 @@ int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
 
 void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
                                  jobject metadata) {
+  bsg_jni_cache *jni_cache = NULL;
+  jobject keyset = NULL;
+  jobject keylist = NULL;
+
   if (metadata == NULL) {
-    return;
+    goto exit;
+  }
+  jni_cache = bsg_populate_jni_cache(env);
+  if (jni_cache == NULL) {
+    goto exit;
   }
 
-  bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
-  int map_size = (int)(*env)->CallIntMethod(env, metadata, jni_cache->map_size);
-  jobject keyset =
-      (*env)->CallObjectMethod(env, metadata, jni_cache->map_key_set);
-  jobject keylist = (*env)->NewObject(
-      env, jni_cache->arraylist, jni_cache->arraylist_init_with_obj, keyset);
-  size_t metadata_size = sizeof(crumb->metadata) / sizeof(bsg_char_metadata_pair);
+  // get size of metadata map
+  jint map_size = bsg_safe_call_int_method(env, metadata, jni_cache->map_size);
+  if (map_size == -1) {
+    goto exit;
+  }
 
-  for (int i = 0; i < map_size && i < metadata_size; i++) {
-    jstring _key = (*env)->CallObjectMethod(env, keylist,
-                                            jni_cache->arraylist_get, (jint)i);
+  // create a list of metadata keys
+  keyset = bsg_safe_call_object_method(env, metadata, jni_cache->map_key_set);
+  if (keyset == NULL) {
+    goto exit;
+  }
+  keylist = bsg_safe_new_object(env, jni_cache->arraylist,
+                                jni_cache->arraylist_init_with_obj, keyset);
+  if (keylist == NULL) {
+    goto exit;
+  }
+
+  for (int i = 0; i < map_size; i++) {
+    jstring _key = bsg_safe_call_object_method(
+        env, keylist, jni_cache->arraylist_get, (jint)i);
     jstring _value =
-        (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);
+        bsg_safe_call_object_method(env, metadata, jni_cache->map_get, _key);
+
     if (_key == NULL || _value == NULL) {
       (*env)->DeleteLocalRef(env, _key);
       (*env)->DeleteLocalRef(env, _value);
@@ -206,9 +389,11 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
       bsg_strncpy_safe(crumb->metadata[i].value, value,
                        sizeof(crumb->metadata[i].value));
       (*env)->ReleaseStringUTFChars(env, _key, key);
-      (*env)->ReleaseStringUTFChars(env, _value, value);
     }
   }
+  goto exit;
+
+  exit:
   free(jni_cache);
   (*env)->DeleteLocalRef(env, keyset);
   (*env)->DeleteLocalRef(env, keylist);
@@ -230,8 +415,12 @@ char *bsg_binary_arch() {
 
 void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                            bugsnag_report *report) {
-  jobject data = (*env)->CallStaticObjectMethod(
+  jobject data = bsg_safe_call_static_object_method(
       env, jni_cache->native_interface, jni_cache->get_app_data);
+  if (data == NULL) {
+    return;
+  }
+
   bsg_copy_map_value_string(env, jni_cache, data, "version",
                             report->app.version, sizeof(report->app.version));
   bsg_copy_map_value_string(env, jni_cache, data, "versionName",
@@ -269,8 +458,12 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
 
 void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                               bugsnag_report *report) {
-  jobject data = (*env)->CallStaticObjectMethod(
+  jobject data = bsg_safe_call_static_object_method(
       env, jni_cache->native_interface, jni_cache->get_device_data);
+  if (data == NULL) {
+    return;
+  }
+
   bsg_copy_map_value_string(env, jni_cache, data, "manufacturer",
                             report->device.manufacturer,
                             sizeof(report->device.manufacturer));
@@ -325,8 +518,12 @@ void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
 
 void bsg_populate_user_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                             bugsnag_report *report) {
-  jobject data = (*env)->CallStaticObjectMethod(
+  jobject data = bsg_safe_call_static_object_method(
       env, jni_cache->native_interface, jni_cache->get_user_data);
+  if (data == NULL) {
+    return;
+  }
+
   bsg_copy_map_value_string(env, jni_cache, data, "id", report->user.id,
                             sizeof(report->user.id));
   bsg_copy_map_value_string(env, jni_cache, data, "name", report->user.name,
@@ -335,9 +532,10 @@ void bsg_populate_user_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                             sizeof(report->user.email));
   (*env)->DeleteLocalRef(env, data);
 }
+
 void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
                           bugsnag_report *report) {
-  jstring _context = (*env)->CallStaticObjectMethod(
+  jstring _context = bsg_safe_call_static_object_method(
       env, jni_cache->native_interface, jni_cache->get_context);
   if (_context != NULL) {
     const char *value = (*env)->GetStringUTFChars(env, (jstring)_context, 0);
@@ -347,71 +545,148 @@ void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
     memset(&report->context, 0, strlen(report->context));
   }
 }
+
 void bsg_populate_report(JNIEnv *env, bugsnag_report *report) {
   bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
+  if (jni_cache == NULL) {
+    return;
+  }
   bsg_populate_context(env, jni_cache, report);
   bsg_populate_app_data(env, jni_cache, report);
   bsg_populate_device_data(env, jni_cache, report);
   bsg_populate_user_data(env, jni_cache, report);
   free(jni_cache);
 }
+
+void bsg_populate_metadata_value(JNIEnv *env, bugsnag_report *dst,
+                                 bsg_jni_cache *jni_cache, char *section,
+                                 char *name, jobject _value) {
+  if ((*env)->IsInstanceOf(env, _value, jni_cache->number)) {
+    // add a double metadata value
+    double value = bsg_safe_call_double_method(env, _value,
+                                               jni_cache->number_double_value);
+    bugsnag_report_add_metadata_double(dst, section, name, value);
+  } else if ((*env)->IsInstanceOf(env, _value, jni_cache->boolean)) {
+    // add a boolean metadata value
+    bool value = bsg_safe_call_boolean_method(env, _value,
+                                              jni_cache->boolean_bool_value);
+    bugsnag_report_add_metadata_bool(dst, section, name, value);
+  } else if ((*env)->IsInstanceOf(env, _value, jni_cache->string)) {
+    char *value = (char *)(*env)->GetStringUTFChars(env, _value, 0);
+    bugsnag_report_add_metadata_string(dst, section, name, value);
+    free(value);
+  }
+}
+
+void bsg_populate_metadata_obj(JNIEnv *env, bugsnag_report *dst,
+                               bsg_jni_cache *jni_cache, char *section,
+                               void *section_keylist, int index) {
+  jstring section_key = bsg_safe_call_object_method(
+      env, section_keylist, jni_cache->arraylist_get, (jint)index);
+  if (section_key == NULL) {
+    return;
+  }
+  char *name = (char *)(*env)->GetStringUTFChars(env, section_key, 0);
+  jobject _value = bsg_safe_call_object_method(env, section, jni_cache->map_get,
+                                               section_key);
+  bsg_populate_metadata_value(env, dst, jni_cache, section, name, _value);
+  (*env)->ReleaseStringUTFChars(env, section_key, name);
+  (*env)->DeleteLocalRef(env, _value);
+}
+
+void bsg_populate_metadata_section(JNIEnv *env, bugsnag_report *report,
+                                   jobject metadata, bsg_jni_cache *jni_cache,
+                                   jobject keylist, int i) {
+  jstring _key = NULL;
+  char *section = NULL;
+  jobject _section = NULL;
+  jobject section_keyset = NULL;
+  jobject section_keylist = NULL;
+
+  _key = bsg_safe_call_object_method(env, keylist, jni_cache->arraylist_get,
+                                     (jint)i);
+  if (_key == NULL) {
+    goto exit;
+  }
+  section = (char *)(*env)->GetStringUTFChars(env, _key, 0);
+  _section =
+      bsg_safe_call_object_method(env, metadata, jni_cache->map_get, _key);
+  if (_section == NULL) {
+    goto exit;
+  }
+  jint section_size =
+      bsg_safe_call_int_method(env, _section, jni_cache->map_size);
+  if (section_size == -1) {
+    goto exit;
+  }
+  section_keyset =
+      bsg_safe_call_object_method(env, _section, jni_cache->map_key_set);
+  if (section_keyset == NULL) {
+    goto exit;
+  }
+
+  section_keylist =
+      bsg_safe_new_object(env, jni_cache->arraylist,
+                          jni_cache->arraylist_init_with_obj, section_keyset);
+  if (section_keylist == NULL) {
+    goto exit;
+  }
+  for (int j = 0; j < section_size; j++) {
+    bsg_populate_metadata_obj(env, report, jni_cache, section, section_keylist, j);
+  }
+  goto exit;
+
+  exit:
+  (*env)->ReleaseStringUTFChars(env, _key, section);
+  (*env)->DeleteLocalRef(env, section_keyset);
+  (*env)->DeleteLocalRef(env, section_keylist);
+  (*env)->DeleteLocalRef(env, _section);
+}
+
 void bsg_populate_metadata(JNIEnv *env, bugsnag_report *report,
                            jobject metadata) {
+  jobject keyset = NULL;
+  jobject keylist = NULL;
   bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
+
+  if (jni_cache == NULL) {
+    goto exit;
+  }
   if (metadata == NULL) {
-    metadata = (*env)->CallStaticObjectMethod(env, jni_cache->native_interface,
-                                              jni_cache->get_metadata);
+    metadata = bsg_safe_call_static_object_method(
+        env, jni_cache->native_interface, jni_cache->get_metadata);
   }
   if (metadata != NULL) {
-    int size = (int)(*env)->CallIntMethod(env, metadata, jni_cache->map_size);
-    jobject keyset =
-        (*env)->CallObjectMethod(env, metadata, jni_cache->map_key_set);
-    jobject keylist = (*env)->NewObject(
-        env, jni_cache->arraylist, jni_cache->arraylist_init_with_obj, keyset);
-    for (int i = 0; i < size; i++) {
-      jstring _key = (*env)->CallObjectMethod(
-          env, keylist, jni_cache->arraylist_get, (jint)i);
-      char *section = (char *)(*env)->GetStringUTFChars(env, _key, 0);
-      jobject _section =
-          (*env)->CallObjectMethod(env, metadata, jni_cache->map_get, _key);
-      int section_size =
-          (int)(*env)->CallIntMethod(env, _section, jni_cache->map_size);
-      jobject section_keyset =
-          (*env)->CallObjectMethod(env, _section, jni_cache->map_key_set);
-      jobject section_keylist =
-          (*env)->NewObject(env, jni_cache->arraylist,
-                            jni_cache->arraylist_init_with_obj, section_keyset);
-      for (int j = 0; j < section_size; j++) {
-        jstring section_key = (*env)->CallObjectMethod(
-            env, section_keylist, jni_cache->arraylist_get, (jint)j);
-        char *name = (char *)(*env)->GetStringUTFChars(env, section_key, 0);
-        jobject _value = (*env)->CallObjectMethod(
-            env, section, jni_cache->map_get, section_key);
-        if ((*env)->IsInstanceOf(env, _value, jni_cache->number)) {
-          double value = (*env)->CallDoubleMethod(
-              env, _value, jni_cache->number_double_value);
-          bugsnag_report_add_metadata_double(report, section, name, value);
-        } else if ((*env)->IsInstanceOf(env, _value, jni_cache->boolean)) {
-          bool value = (*env)->CallBooleanMethod(env, _value,
-                                                 jni_cache->boolean_bool_value);
-          bugsnag_report_add_metadata_bool(report, section, name, value);
-        } else if ((*env)->IsInstanceOf(env, _value, jni_cache->string)) {
-          char *value = (char *)(*env)->GetStringUTFChars(env, _value, 0);
-          bugsnag_report_add_metadata_string(report, section, name, value);
-          free(value);
-        }
-        (*env)->ReleaseStringUTFChars(env, section_key, name);
-        (*env)->DeleteLocalRef(env, _value);
-      }
-      (*env)->ReleaseStringUTFChars(env, _key, section);
-      (*env)->DeleteLocalRef(env, section_keyset);
-      (*env)->DeleteLocalRef(env, section_keylist);
-      (*env)->DeleteLocalRef(env, _section);
+    int size = bsg_safe_call_int_method(env, metadata, jni_cache->map_size);
+    if (size == -1) {
+      goto exit;
     }
-    (*env)->DeleteLocalRef(env, keyset);
-    (*env)->DeleteLocalRef(env, keylist);
+
+    // create a list of metadata keys
+    keyset = bsg_safe_call_static_object_method(env, metadata,
+                                                jni_cache->map_key_set);
+    if (keyset == NULL) {
+      goto exit;
+    }
+    keylist = bsg_safe_new_object(env, jni_cache->arraylist,
+                                  jni_cache->arraylist_init_with_obj, keyset);
+    if (keylist == NULL) {
+      goto exit;
+    }
+
+    for (int i = 0; i < size; i++) {
+      bsg_populate_metadata_section(env, report, metadata, jni_cache, keylist, i);
+    }
   } else {
     report->metadata.value_count = 0;
   }
-  free(jni_cache);
+  goto exit;
+
+// cleanup
+  exit:
+  if (jni_cache != NULL) {
+    free(jni_cache);
+  }
+  (*env)->DeleteLocalRef(env, keyset);
+  (*env)->DeleteLocalRef(env, keylist);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -1,0 +1,212 @@
+#include "safejni.h"
+#include <stdbool.h>
+#include <utils/string.h>
+
+bool bsg_check_and_clear_exc(JNIEnv *env) {
+  if ((*env)->ExceptionCheck(env)) {
+    (*env)->ExceptionClear(env);
+    return true;
+  }
+  return false;
+}
+
+jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
+  if (clz_name == NULL) {
+    return NULL;
+  }
+  jclass clz = (*env)->FindClass(env, clz_name);
+  bsg_check_and_clear_exc(env);
+  return clz;
+}
+
+jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
+                                 const char *sig) {
+  if (clz == NULL || name == NULL || sig == NULL) {
+    return NULL;
+  }
+  jmethodID methodId = (*env)->GetMethodID(env, clz, name, sig);
+  bsg_check_and_clear_exc(env);
+  return methodId;
+}
+
+jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
+                                        const char *name, const char *sig) {
+  if (clz == NULL || name == NULL || sig == NULL) {
+    return NULL;
+  }
+  jmethodID methodId = (*env)->GetStaticMethodID(env, clz, name, sig);
+  bsg_check_and_clear_exc(env);
+  return methodId;
+}
+
+jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
+  if (str == NULL) {
+    return NULL;
+  }
+  jstring jstr = (*env)->NewStringUTF(env, str);
+  bsg_check_and_clear_exc(env);
+  return jstr;
+}
+
+jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
+                                      jmethodID method) {
+  if (_value == NULL) {
+    return false;
+  }
+  jboolean value = (*env)->CallBooleanMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return false; // default to false
+  }
+  return value;
+}
+
+jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
+  if (_value == NULL) {
+    return -1;
+  }
+  jint value = (*env)->CallIntMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return -1; // default to -1
+  }
+  return value;
+}
+
+jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
+                                  jmethodID method) {
+  if (_value == NULL) {
+    return -1;
+  }
+  jfloat value = (*env)->CallFloatMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return -1; // default to -1
+  }
+  return value;
+}
+
+jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
+                                    jmethodID method) {
+  if (_value == NULL) {
+    return -1;
+  }
+  jdouble value = (*env)->CallDoubleMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return -1; // default to -1
+  }
+  return value;
+}
+
+jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
+  if (clz == NULL) {
+    return NULL;
+  }
+  jobjectArray trace = (*env)->NewObjectArray(env, size, clz, NULL);
+  bsg_check_and_clear_exc(env);
+  return trace;
+}
+
+jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
+                                          jsize size) {
+  if (array == NULL) {
+    return NULL;
+  }
+  jobject obj = (*env)->GetObjectArrayElement(env, array, size);
+  bsg_check_and_clear_exc(env);
+  return obj;
+}
+
+void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
+                                       jsize size, jobject object) {
+  if (array == NULL) {
+    return;
+  }
+  (*env)->SetObjectArrayElement(env, array, size, object);
+  bsg_check_and_clear_exc(env);
+}
+
+jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
+                                      const char *sig) {
+  if (clz == NULL || name == NULL || sig == NULL) {
+    return NULL;
+  }
+  jfieldID field_id = (*env)->GetStaticFieldID(env, clz, name, sig);
+  bsg_check_and_clear_exc(env);
+  return field_id;
+}
+
+jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
+                                         jfieldID field) {
+  if (clz == NULL) {
+    return NULL;
+  }
+  jobject obj = (*env)->GetStaticObjectField(env, clz, field);
+  bsg_check_and_clear_exc(env);
+  return obj;
+}
+
+jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...) {
+  if (clz == NULL) {
+    return NULL;
+  }
+  va_list args;
+  va_start(args, method);
+  jobject obj = (*env)->NewObjectV(env, clz, method, args);
+  va_end(args);
+  bsg_check_and_clear_exc(env);
+  return obj;
+}
+
+jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
+                                    jmethodID method, ...) {
+  if (_value == NULL) {
+    return NULL;
+  }
+  va_list args;
+  va_start(args, method);
+  jobject value = (*env)->CallObjectMethodV(env, _value, method, args);
+  va_end(args);
+  bsg_check_and_clear_exc(env);
+  return value;
+}
+
+void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
+                                      ...) {
+  if (clz == NULL) {
+    return;
+  }
+  va_list args;
+  va_start(args, method);
+  (*env)->CallStaticVoidMethodV(env, clz, method, args);
+  va_end(args);
+  bsg_check_and_clear_exc(env);
+}
+
+jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
+                                           jmethodID method, ...) {
+  if (clz == NULL) {
+    return NULL;
+  }
+  va_list args;
+  va_start(args, method);
+  jobject obj = (*env)->CallStaticObjectMethodV(env, clz, method, args);
+  va_end(args);
+  bsg_check_and_clear_exc(env);
+  return obj;
+}
+
+jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text) {
+  if (text == NULL) {
+    return NULL;
+  }
+  size_t text_length = bsg_strlen(text);
+  jbyteArray jtext = (*env)->NewByteArray(env, text_length);
+
+  if (bsg_check_and_clear_exc(env)) {
+    return NULL;
+  }
+  (*env)->SetByteArrayRegion(env, jtext, 0, text_length, (jbyte *)text);
+
+  if (bsg_check_and_clear_exc(env)) {
+    return NULL;
+  }
+  return jtext;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -1,0 +1,155 @@
+#ifndef BUGSNAG_SAFEJNI_H
+#define BUGSNAG_SAFEJNI_H
+
+#include <jni.h>
+
+/**
+ * This provides safe JNI calls by wrapping functions and calling
+ * ExceptionClear(). This approach prevents crashes and undefined behaviour,
+ * providing the caller checks the return value of each invocation.
+ *
+ * For an overview of the methods decorated here, please see
+ * https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html
+ */
+
+/**
+ * A safe wrapper for the JNI's FindClass. This method checks if an exception is
+ * pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ *
+ * @return the class, or NULL if the class could not be found.
+ */
+jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name);
+
+/**
+ * A safe wrapper for the JNI's GetMethodID. This method checks if an exception
+ * is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ *
+ * @return the method ID, or NULL if the method could not be found.
+ */
+jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
+                                 const char *sig);
+
+/**
+ * A safe wrapper for the JNI's GetStaticMethodID. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ *
+ * @return the method ID, or NULL if the method could not be found.
+ */
+jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
+                                        const char *name, const char *sig);
+/**
+ * A safe wrapper for the JNI's NewStringUtf. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ *
+ * @return the java string or NULL if it could not be created
+ */
+jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str);
+
+/**
+ * A safe wrapper for the JNI's CallBooleanMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns false.
+ */
+jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
+                                      jmethodID method);
+
+/**
+ * A safe wrapper for the JNI's CallIntMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns -1.
+ */
+jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method);
+
+/**
+ * A safe wrapper for the JNI's CallFloatMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns -1.
+ */
+jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
+                                  jmethodID method);
+
+/**
+ * A safe wrapper for the JNI's CallDoubleMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns -1.
+ */
+jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
+                                    jmethodID method);
+
+/**
+ * A safe wrapper for the JNI's NewObjectArray. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz);
+
+/**
+ * A safe wrapper for the JNI's GetObjectArrayElement. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
+                                          jsize size);
+
+/**
+ * A safe wrapper for the JNI's SetObjectArrayElement. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ */
+void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
+                                       jsize size, jobject object);
+
+/**
+ * A safe wrapper for the JNI's GetStaticFieldId. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ */
+jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
+                                      const char *sig);
+
+/**
+ * A safe wrapper for the JNI's GetStaticObjectField. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
+                                         jfieldID field);
+
+/**
+ * A safe wrapper for the JNI's NewObject. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...);
+
+/**
+ * A safe wrapper for the JNI's CallObjectMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
+                                    jmethodID method, ...);
+
+/**
+ * A safe wrapper for the JNI's CallStaticVoidMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ */
+void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
+                                      ...);
+
+/**
+ * A safe wrapper for the JNI's CallStaticObjectMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * The caller is responsible for handling the invalid return value of NULL.
+ */
+jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
+                                           jmethodID method, ...);
+
+/**
+ * Constructs a byte array from a string.
+ */
+jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text);
+
+#endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -19,7 +19,7 @@ void bsg_strncpy(char *dst, char *src, size_t len) {
     }
 }
 
-size_t bsg_strlen(char *str) {
+size_t bsg_strlen(const char *str) {
   size_t i = 0;
   while (true) {
     char current = str[i];

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -16,7 +16,7 @@ void bsg_strcpy(char *dst, char *src) __asyncsafe;
 /**
  * Return the length of a string
  */
-size_t bsg_strlen(char *str) __asyncsafe;
+size_t bsg_strlen(const char *str) __asyncsafe;
 
 /**
  * Copy a maximum number of bytes from src to dst

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.emulator
 
   android-maze-runner:
-    build:
-      context: .
-      dockerfile: dockerfiles/Dockerfile.android
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli
     environment:
       VERBOSE:
       DEBUG:
@@ -60,6 +58,7 @@ services:
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output
+      - ./features/:/app/features/
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.emulator
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v2.8.1-cli
     environment:
       VERBOSE:
       DEBUG:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output
-      - ./features/:/app/features/
+      - ./tests/features/:/app/features/
 
 networks:
   default:

--- a/dockerfiles/Dockerfile.android
+++ b/dockerfiles/Dockerfile.android
@@ -1,5 +1,5 @@
 # CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:v2-cli as android-maze-runner
+FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as android-maze-runner
 RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
 
 COPY tests/features features

--- a/dockerfiles/Dockerfile.android
+++ b/dockerfiles/Dockerfile.android
@@ -1,5 +1,0 @@
-# CI test image for unit/lint/type tests
-FROM 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli as android-maze-runner
-RUN apk add --no-cache ruby-dev build-base libffi-dev curl-dev curl
-
-COPY tests/features features

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -43,7 +43,7 @@ project.afterEvaluate {
 }
 
 dependencies {
-    implementation "com.bugsnag:bugsnag-android:+"
+    implementation "com.bugsnag:bugsnag-android:4.22.2"
 
     implementation "androidx.appcompat:appcompat:1.0.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/tests/features/plugin_interface.feature
+++ b/tests/features/plugin_interface.feature
@@ -7,10 +7,10 @@ Feature: Add custom behavior through a plugin interface
 
     Scenario: Changing payload notifier description
         When I run "CustomPluginNotifierDescriptionScenario"
-        Then I should receive a request
+        Then I wait to receive a request
         Then the payload field "notifier.name" equals "Foo Handler Library"
         And the payload field "notifier.version" equals "2.1.0"
         And the payload field "notifier.url" equals "https://example.com"
-        And the payload field "events" is an array with 1 element
+        And the payload field "events" is an array with 1 elements
         And the exception "errorClass" equals "java.lang.RuntimeException"
 


### PR DESCRIPTION
## Goal

Backports the following PRs to the v4 branch for use in bugsnag-unity: #1088 #1091 #1092 #1117

These enhance the error handling around JNI calls by ensuring that exceptions are checked and cleared.

## Changeset

The PR consists of 4 commits, which add the new `safejni.h` functions, then applies them to the source files in the NDK module.

Broadly speaking this was mostly a case of just copying functions over. There were a few structs that were renamed between v4 and v5 (e.g. `bsg_metadata_t` to `bugsnag_metadata`) that required alterations, and some method names on the `NativeInterface` class were renamed. The `bugsnag_notify_env` and `bugsnag_populate_crumb_metadata` functions have also been split into multiple functions in v5 - this change has been carried across.

## Testing

Performed a smoke test by comparing an NDK error report from the Unity app before and after these changes. Full regression testing will be carried out before release.