### PR TITLE
Check additional JNI calls for pending exceptions and no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Check additional JNI calls for pending exceptions and no-op
+  [#1133](https://github.com/bugsnag/bugsnag-android/pull/1133)
+
 ## 5.6.0 (2021-02-08)
 
 ### Enhancements

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
@@ -40,8 +40,9 @@ bool bsg_check_and_clear_exc(JNIEnv *env) {
   return false;
 }
 
-bool configure_anr_jni_impl(JNIEnv *env) {// get a global reference to the AnrPlugin class
-// https://developer.android.com/training/articles/perf-jni#faq:-why-didnt-findclass-find-my-class
+bool configure_anr_jni_impl(
+    JNIEnv *env) { // get a global reference to the AnrPlugin class
+  // https://developer.android.com/training/articles/perf-jni#faq:-why-didnt-findclass-find-my-class
   if (env == NULL) {
     return false;
   }
@@ -87,7 +88,8 @@ static void notify_anr_detected() {
     } else if (result == JNI_EDETACHED) { // attach before calling JNI
       if ((*bsg_jvm)->AttachCurrentThread(bsg_jvm, &env, NULL) == 0) {
         notify_anr_detected_impl(env);
-        (*bsg_jvm)->DetachCurrentThread(bsg_jvm); // detach to restore initial condition
+        (*bsg_jvm)->DetachCurrentThread(
+            bsg_jvm); // detach to restore initial condition
       }
     } // All other results are error codes
   }

--- a/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
@@ -25,19 +25,56 @@ static JavaVM *bsg_jvm = NULL;
 static jmethodID mthd_notify_anr_detected = NULL;
 static jobject obj_plugin = NULL;
 
-static bool configure_anr_jni(JNIEnv *env) {
-  // get a global reference to the AnrPlugin class
-  // https://developer.android.com/training/articles/perf-jni#faq:-why-didnt-findclass-find-my-class
+// duplication required for this method that originally came from
+// bugsnag-plugin-android-ndk. Until a shared C module is available
+// for sharing common code when PLAT-5794 is addressed, this
+// duplication is a necessary evil.
+bool bsg_check_and_clear_exc(JNIEnv *env) {
+  if (env == NULL) {
+    return false;
+  }
+  if ((*env)->ExceptionCheck(env)) {
+    (*env)->ExceptionClear(env);
+    return true;
+  }
+  return false;
+}
+
+bool configure_anr_jni_impl(JNIEnv *env) {// get a global reference to the AnrPlugin class
+// https://developer.android.com/training/articles/perf-jni#faq:-why-didnt-findclass-find-my-class
+  if (env == NULL) {
+    return false;
+  }
   int result = (*env)->GetJavaVM(env, &bsg_jvm);
   if (result != 0) {
-    BUGSNAG_LOG("Failed to fetch Java VM. ANR handler not installed.");
     return false;
   }
 
   jclass clz = (*env)->FindClass(env, "com/bugsnag/android/AnrPlugin");
+  if (bsg_check_and_clear_exc(env) || clz == NULL) {
+    return false;
+  }
   mthd_notify_anr_detected =
       (*env)->GetMethodID(env, clz, "notifyAnrDetected", "()V");
+  if (bsg_check_and_clear_exc(env) || mthd_notify_anr_detected == NULL) {
+    return false;
+  }
   return true;
+}
+
+static bool configure_anr_jni(JNIEnv *env) {
+  bool success = configure_anr_jni_impl(env);
+  if (!success) {
+    BUGSNAG_LOG("Failed to fetch Java VM. ANR handler not installed.");
+  }
+  return success;
+}
+
+void notify_anr_detected_impl(JNIEnv *env) {
+  if (env != NULL && obj_plugin != NULL && mthd_notify_anr_detected != NULL) {
+    (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
+    bsg_check_and_clear_exc(env);
+  }
 }
 
 static void notify_anr_detected() {
@@ -46,12 +83,11 @@ static void notify_anr_detected() {
     int result = (*bsg_jvm)->GetEnv(bsg_jvm, (void **)&env, JNI_VERSION_1_4);
 
     if (result == JNI_OK) { // already attached
-      (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
+      notify_anr_detected_impl(env);
     } else if (result == JNI_EDETACHED) { // attach before calling JNI
       if ((*bsg_jvm)->AttachCurrentThread(bsg_jvm, &env, NULL) == 0) {
-        (*env)->CallVoidMethod(env, obj_plugin, mthd_notify_anr_detected);
-        (*bsg_jvm)->DetachCurrentThread(
-            bsg_jvm); // detach to restore initial condition
+        notify_anr_detected_impl(env);
+        (*bsg_jvm)->DetachCurrentThread(bsg_jvm); // detach to restore initial condition
       }
     } // All other results are error codes
   }
@@ -126,7 +162,7 @@ bool bsg_handler_install_anr(JNIEnv *env, jobject plugin,
                              jboolean callPreviousSigquitHandler) {
   pthread_mutex_lock(&bsg_anr_handler_config);
 
-  if (!installed && configure_anr_jni(env)) {
+  if (!installed && configure_anr_jni(env) && plugin != NULL) {
     obj_plugin = (*env)->NewGlobalRef(env, plugin);
     install_signal_handler();
     installed = true;

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -66,7 +66,8 @@ jfieldID bsg_parse_jseverity(JNIEnv *env, bugsnag_severity severity,
 }
 
 void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
-  bsg_safe_release_byte_array_elements(env, array, (jbyte *)original_text, JNI_COMMIT);
+  bsg_safe_release_byte_array_elements(env, array, (jbyte *)original_text,
+                                       JNI_COMMIT);
 }
 
 void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -66,10 +66,7 @@ jfieldID bsg_parse_jseverity(JNIEnv *env, bugsnag_severity severity,
 }
 
 void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
-  if (array != NULL) {
-    (*env)->ReleaseByteArrayElements(env, array, (jbyte *)original_text,
-                                     JNI_COMMIT);
-  }
+  bsg_safe_release_byte_array_elements(env, array, (jbyte *)original_text, JNI_COMMIT);
 }
 
 void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -108,8 +108,8 @@ void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
     goto exit;
 
   exit:
-    (*env)->DeleteLocalRef(env, filename);
-    (*env)->DeleteLocalRef(env, class);
+    bsg_safe_delete_local_ref(env, filename);
+    bsg_safe_delete_local_ref(env, class);
   }
 }
 
@@ -205,14 +205,14 @@ exit:
   if (jmessage != NULL) {
     bsg_release_byte_ary(env, jmessage, message);
   }
-  (*env)->DeleteLocalRef(env, jname);
-  (*env)->DeleteLocalRef(env, jmessage);
+  bsg_safe_delete_local_ref(env, jname);
+  bsg_safe_delete_local_ref(env, jmessage);
 
-  (*env)->DeleteLocalRef(env, interface_class);
-  (*env)->DeleteLocalRef(env, trace_class);
-  (*env)->DeleteLocalRef(env, severity_class);
-  (*env)->DeleteLocalRef(env, trace);
-  (*env)->DeleteLocalRef(env, jseverity);
+  bsg_safe_delete_local_ref(env, interface_class);
+  bsg_safe_delete_local_ref(env, trace_class);
+  bsg_safe_delete_local_ref(env, severity_class);
+  bsg_safe_delete_local_ref(env, trace);
+  bsg_safe_delete_local_ref(env, jseverity);
 }
 
 void bugsnag_set_binary_arch(JNIEnv *env) {
@@ -244,8 +244,8 @@ void bugsnag_set_binary_arch(JNIEnv *env) {
   goto exit;
 
 exit:
-  (*env)->DeleteLocalRef(env, arch);
-  (*env)->DeleteLocalRef(env, interface_class);
+  bsg_safe_delete_local_ref(env, arch);
+  bsg_safe_delete_local_ref(env, interface_class);
 }
 
 void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
@@ -277,14 +277,14 @@ void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
   bsg_release_byte_ary(env, jemail, email);
   bsg_release_byte_ary(env, jname, name);
 
-  (*env)->DeleteLocalRef(env, jid);
-  (*env)->DeleteLocalRef(env, jemail);
-  (*env)->DeleteLocalRef(env, jname);
+  bsg_safe_delete_local_ref(env, jid);
+  bsg_safe_delete_local_ref(env, jemail);
+  bsg_safe_delete_local_ref(env, jname);
 
   goto exit;
 
 exit:
-  (*env)->DeleteLocalRef(env, interface_class);
+  bsg_safe_delete_local_ref(env, interface_class);
 }
 
 jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bugsnag_breadcrumb_type type,
@@ -359,8 +359,8 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
 
 exit:
   bsg_release_byte_ary(env, jmessage, message);
-  (*env)->DeleteLocalRef(env, interface_class);
-  (*env)->DeleteLocalRef(env, type_class);
-  (*env)->DeleteLocalRef(env, jtype);
-  (*env)->DeleteLocalRef(env, jmessage);
+  bsg_safe_delete_local_ref(env, interface_class);
+  bsg_safe_delete_local_ref(env, type_class);
+  bsg_safe_delete_local_ref(env, jtype);
+  bsg_safe_delete_local_ref(env, jmessage);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -65,11 +65,6 @@ jfieldID bsg_parse_jseverity(JNIEnv *env, bugsnag_severity severity,
   }
 }
 
-void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
-  bsg_safe_release_byte_array_elements(env, array, (jbyte *)original_text,
-                                       JNI_COMMIT);
-}
-
 void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
                                     ssize_t frame_count, jclass trace_class,
                                     jmethodID trace_constructor,
@@ -198,10 +193,11 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
 
 exit:
   if (jname != NULL) {
-    bsg_release_byte_ary(env, jname, name);
+    bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name, JNI_COMMIT);
   }
   if (jmessage != NULL) {
-    bsg_release_byte_ary(env, jmessage, message);
+    bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message,
+                                         JNI_COMMIT);
   }
   bsg_safe_delete_local_ref(env, jname);
   bsg_safe_delete_local_ref(env, jmessage);
@@ -271,9 +267,9 @@ void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
   bsg_safe_call_static_void_method(env, interface_class, set_user_method, jid,
                                    jemail, jname);
 
-  bsg_release_byte_ary(env, jid, id);
-  bsg_release_byte_ary(env, jemail, email);
-  bsg_release_byte_ary(env, jname, name);
+  bsg_safe_release_byte_array_elements(env, jid, (jbyte *)id, JNI_COMMIT);
+  bsg_safe_release_byte_array_elements(env, jemail, (jbyte *)email, JNI_COMMIT);
+  bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name, JNI_COMMIT);
 
   bsg_safe_delete_local_ref(env, jid);
   bsg_safe_delete_local_ref(env, jemail);
@@ -355,8 +351,10 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
 
   goto exit;
 
-exit:
-  bsg_release_byte_ary(env, jmessage, message);
+exit : {
+  bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message,
+                                       JNI_COMMIT);
+}
   bsg_safe_delete_local_ref(env, interface_class);
   bsg_safe_delete_local_ref(env, type_class);
   bsg_safe_delete_local_ref(env, jtype);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -111,7 +111,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   bugsnag_env->report_header.version = BUGSNAG_EVENT_VERSION;
   const char *event_path = (*env)->GetStringUTFChars(env, _event_path, 0);
   sprintf(bugsnag_env->next_event_path, "%s", event_path);
-  (*env)->ReleaseStringUTFChars(env, _event_path, event_path);
+  bsg_safe_release_string_utf_chars(env, _event_path, event_path);
 
   if ((bool)auto_detect_ndk_crashes) {
     bsg_handler_install_signal(bugsnag_env);
@@ -135,7 +135,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   const char *api_key = (*env)->GetStringUTFChars(env, _api_key, 0);
   bsg_strncpy_safe(bugsnag_env->next_event.api_key, (char *)api_key,
                    sizeof(bugsnag_env->next_event.api_key));
-  (*env)->ReleaseStringUTFChars(env, _api_key, api_key);
+  bsg_safe_release_string_utf_chars(env, _api_key, api_key);
 
   bsg_global_env = bugsnag_env;
   BUGSNAG_LOG("Initialization complete!");
@@ -197,19 +197,14 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
     BUGSNAG_LOG("Failed to read event at file: %s", event_path);
   }
   remove(event_path);
-  (*env)->ReleaseStringUTFChars(env, _report_path, event_path);
+  bsg_safe_release_string_utf_chars(env, _report_path, event_path);
   goto exit;
 
 exit:
   pthread_mutex_unlock(&bsg_native_delivery_mutex);
-  if (jpayload != NULL) {
-    (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload,
-                                     0); // <-- frees payload
-  }
-  if (jstage != NULL) {
-    (*env)->ReleaseByteArrayElements(
-        env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
-  }
+  bsg_safe_release_byte_array_elements(env, jpayload, (jbyte *) payload, 0); // <-- frees payload
+  bsg_safe_release_byte_array_elements(
+      env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
   bsg_safe_delete_local_ref(env, jpayload);
   bsg_safe_delete_local_ref(env, jstage);
 }
@@ -254,8 +249,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
                               started_at, handled_count, unhandled_count);
 
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, session_id_, session_id);
-  (*env)->ReleaseStringUTFChars(env, start_date_, started_at);
+  bsg_safe_release_string_utf_chars(env, session_id_, session_id);
+  bsg_safe_release_string_utf_chars(env, start_date_, started_at);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_pausedSession(
@@ -307,9 +302,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
   bsg_release_env_write_lock();
 
   free(crumb);
-  (*env)->ReleaseStringUTFChars(env, name_, name);
-  (*env)->ReleaseStringUTFChars(env, crumb_type, type);
-  (*env)->ReleaseStringUTFChars(env, timestamp_, timestamp);
+  bsg_safe_release_string_utf_chars(env, name_, name);
+  bsg_safe_release_string_utf_chars(env, crumb_type, type);
+  bsg_safe_release_string_utf_chars(env, timestamp_, timestamp);
 }
 
 JNIEXPORT void JNICALL
@@ -324,7 +319,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateAppVersion(JNIEnv *env,
   bsg_request_env_write_lock();
   bugsnag_app_set_version(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, new_value, value);
+  bsg_safe_release_string_utf_chars(env, new_value, value);
 }
 
 JNIEXPORT void JNICALL
@@ -339,7 +334,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateBuildUUID(JNIEnv *env,
   bsg_request_env_write_lock();
   bugsnag_app_set_build_uuid(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, new_value, value);
+  bsg_safe_release_string_utf_chars(env, new_value, value);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateContext(
@@ -353,7 +348,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateContext(
   bugsnag_event_set_context(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
@@ -380,7 +375,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
   }
   bsg_release_env_write_lock();
   if (activity_ != NULL) {
-    (*env)->ReleaseStringUTFChars(env, activity_, activity);
+    bsg_safe_release_string_utf_chars(env, activity_, activity);
   }
 }
 
@@ -410,7 +405,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
   bugsnag_device_set_orientation(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
@@ -426,7 +421,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateReleaseStage(
   bugsnag_app_set_release_stage(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
@@ -443,7 +438,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
                          event.user.name);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
@@ -460,7 +455,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserName(
                          event.user.email, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
@@ -479,7 +474,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateUserEmail(JNIEnv *env,
                          event.user.name);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
@@ -495,9 +490,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataString(
   bugsnag_event_add_metadata_string(&bsg_global_env->next_event, tab, key,
                                     value);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
-  (*env)->ReleaseStringUTFChars(env, key_, key);
-  (*env)->ReleaseStringUTFChars(env, value_, value);
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, key_, key);
+  bsg_safe_release_string_utf_chars(env, value_, value);
 }
 
 JNIEXPORT void JNICALL
@@ -511,8 +506,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataDouble(
   bugsnag_event_add_metadata_double(&bsg_global_env->next_event, tab, key,
                                     (double)value_);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
-  (*env)->ReleaseStringUTFChars(env, key_, key);
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
 JNIEXPORT void JNICALL
@@ -526,8 +521,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataBoolean(
   bugsnag_event_add_metadata_bool(&bsg_global_env->next_event, tab, key,
                                   (bool)value_);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
-  (*env)->ReleaseStringUTFChars(env, key_, key);
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
 JNIEXPORT void JNICALL
@@ -540,7 +535,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_clearMetadataTab(JNIEnv *env,
   bsg_request_env_write_lock();
   bugsnag_event_clear_metadata_section(&bsg_global_env->next_event, tab);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_removeMetadata(
@@ -554,8 +549,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_removeMetadata(
   bugsnag_event_clear_metadata(&bsg_global_env->next_event, tab, key);
   bsg_release_env_write_lock();
 
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
-  (*env)->ReleaseStringUTFChars(env, key_, key);
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateMetadata(

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -209,7 +209,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
 
 exit:
   pthread_mutex_unlock(&bsg_native_delivery_mutex);
-  bsg_safe_release_byte_array_elements(env, jpayload, (jbyte *) payload, 0); // <-- frees payload
+  bsg_safe_release_byte_array_elements(env, jpayload, (jbyte *)payload,
+                                       0); // <-- frees payload
   bsg_safe_release_byte_array_elements(
       env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
   bsg_safe_delete_local_ref(env, jpayload);
@@ -330,7 +331,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateAppVersion(JNIEnv *env,
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
   }
@@ -347,7 +348,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateBuildUUID(JNIEnv *env,
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
   }
@@ -362,7 +363,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateContext(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
   }
@@ -380,7 +381,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *activity = (char *) bsg_safe_get_string_utf_chars(env, activity_);
+  char *activity = (char *)bsg_safe_get_string_utf_chars(env, activity_);
   if (activity == NULL) {
     return;
   }
@@ -424,7 +425,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
     return;
   }
 
-  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
   }
@@ -442,7 +443,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateReleaseStage(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
   }
@@ -459,7 +460,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -212,8 +212,9 @@ exit:
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
                                                           jobject _this) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   bsg_request_env_write_lock();
   bugsnag_event *event = &bsg_global_env->next_event;
 
@@ -226,8 +227,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addUnhandledEvent(JNIEnv *env,
                                                             jobject _this) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   bsg_request_env_write_lock();
   bugsnag_event *event = &bsg_global_env->next_event;
 
@@ -240,8 +242,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_addUnhandledEvent(JNIEnv *env,
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
     JNIEnv *env, jobject _this, jstring session_id_, jstring start_date_,
     jint handled_count, jint unhandled_count) {
-  if (bsg_global_env == NULL || session_id_ == NULL)
+  if (bsg_global_env == NULL || session_id_ == NULL) {
     return;
+  }
   char *session_id = (char *)(*env)->GetStringUTFChars(env, session_id_, 0);
   char *started_at = (char *)(*env)->GetStringUTFChars(env, start_date_, 0);
   bsg_request_env_write_lock();
@@ -270,8 +273,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_pausedSession(
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
     JNIEnv *env, jobject _this, jstring name_, jstring crumb_type,
     jstring timestamp_, jobject metadata) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   const char *name = (*env)->GetStringUTFChars(env, name_, 0);
   const char *type = (*env)->GetStringUTFChars(env, crumb_type, 0);
   const char *timestamp = (*env)->GetStringUTFChars(env, timestamp_, 0);
@@ -311,8 +315,9 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateAppVersion(JNIEnv *env,
                                                            jobject _this,
                                                            jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *value = new_value == NULL
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
@@ -326,8 +331,9 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateBuildUUID(JNIEnv *env,
                                                           jobject _this,
                                                           jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *value = new_value == NULL
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
@@ -339,8 +345,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateBuildUUID(JNIEnv *env,
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateContext(
     JNIEnv *env, jobject _this, jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *value = new_value == NULL
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
@@ -355,8 +362,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateContext(
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
     JNIEnv *env, jobject _this, jboolean new_value, jstring activity_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *activity = activity_ == NULL
                        ? NULL
                        : (char *)(*env)->GetStringUTFChars(env, activity_, 0);
@@ -383,8 +391,9 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateLowMemory(JNIEnv *env,
                                                           jobject _this,
                                                           jboolean new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   bsg_request_env_write_lock();
   bugsnag_event_add_metadata_bool(&bsg_global_env->next_event, "app",
                                   "lowMemory", (bool)new_value);
@@ -395,8 +404,9 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
                                                             jobject _this,
                                                             jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
 
   char *value = new_value == NULL
                     ? NULL
@@ -412,8 +422,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateReleaseStage(
     JNIEnv *env, jobject _this, jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *value = new_value == NULL
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
@@ -427,8 +438,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateReleaseStage(
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
     JNIEnv *env, jobject _this, jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *value = new_value == NULL
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
@@ -444,8 +456,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserName(
     JNIEnv *env, jobject _this, jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *value = new_value == NULL
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
@@ -463,8 +476,9 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateUserEmail(JNIEnv *env,
                                                           jobject _this,
                                                           jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *value = new_value == NULL
                     ? NULL
                     : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
@@ -481,8 +495,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateUserEmail(JNIEnv *env,
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addMetadataString(
     JNIEnv *env, jobject _this, jstring tab_, jstring key_, jstring value_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
   char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
   char *value = (char *)(*env)->GetStringUTFChars(env, value_, 0);
@@ -498,8 +513,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataString(
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addMetadataDouble(
     JNIEnv *env, jobject _this, jstring tab_, jstring key_, jdouble value_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
   char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
   bsg_request_env_write_lock();
@@ -513,8 +529,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataDouble(
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addMetadataBoolean(
     JNIEnv *env, jobject _this, jstring tab_, jstring key_, jboolean value_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
   char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
   bsg_request_env_write_lock();
@@ -529,8 +546,9 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_clearMetadataTab(JNIEnv *env,
                                                            jobject _this,
                                                            jstring tab_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
   bsg_request_env_write_lock();
   bugsnag_event_clear_metadata_section(&bsg_global_env->next_event, tab);
@@ -540,8 +558,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_clearMetadataTab(JNIEnv *env,
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_removeMetadata(
     JNIEnv *env, jobject _this, jstring tab_, jstring key_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
   char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
 
@@ -555,8 +574,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_removeMetadata(
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateMetadata(
     JNIEnv *env, jobject _this, jobject metadata) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   bsg_request_env_write_lock();
   bsg_populate_metadata(env, &bsg_global_env->next_event.metadata, metadata);
   bsg_release_env_write_lock();

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -109,7 +109,10 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   bugsnag_env->report_header.big_endian =
       htonl(47) == 47; // potentially too clever, see man 3 htonl
   bugsnag_env->report_header.version = BUGSNAG_EVENT_VERSION;
-  const char *event_path = (*env)->GetStringUTFChars(env, _event_path, 0);
+  const char *event_path = bsg_safe_get_string_utf_chars(env, _event_path);
+  if (event_path == NULL) {
+    return;
+  }
   sprintf(bugsnag_env->next_event_path, "%s", event_path);
   bsg_safe_release_string_utf_chars(env, _event_path, event_path);
 
@@ -132,10 +135,12 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
                      sizeof(bugsnag_env->report_header.os_build));
   }
 
-  const char *api_key = (*env)->GetStringUTFChars(env, _api_key, 0);
-  bsg_strncpy_safe(bugsnag_env->next_event.api_key, (char *)api_key,
-                   sizeof(bugsnag_env->next_event.api_key));
-  bsg_safe_release_string_utf_chars(env, _api_key, api_key);
+  const char *api_key = bsg_safe_get_string_utf_chars(env, _api_key);
+  if (api_key != NULL) {
+    bsg_strncpy_safe(bugsnag_env->next_event.api_key, (char *)api_key,
+                     sizeof(bugsnag_env->next_event.api_key));
+    bsg_safe_release_string_utf_chars(env, _api_key, api_key);
+  }
 
   bsg_global_env = bugsnag_env;
   BUGSNAG_LOG("Initialization complete!");
@@ -146,7 +151,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
     JNIEnv *env, jobject _this, jstring _report_path) {
   static pthread_mutex_t bsg_native_delivery_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&bsg_native_delivery_mutex);
-  const char *event_path = (*env)->GetStringUTFChars(env, _report_path, 0);
+  const char *event_path = bsg_safe_get_string_utf_chars(env, _report_path);
+  if (event_path == NULL) {
+    return;
+  }
   bugsnag_event *event = bsg_deserialize_event_from_file((char *)event_path);
   jbyteArray jpayload = NULL;
   jbyteArray jstage = NULL;
@@ -197,7 +205,6 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
     BUGSNAG_LOG("Failed to read event at file: %s", event_path);
   }
   remove(event_path);
-  bsg_safe_release_string_utf_chars(env, _report_path, event_path);
   goto exit;
 
 exit:
@@ -207,6 +214,7 @@ exit:
       env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
   bsg_safe_delete_local_ref(env, jpayload);
   bsg_safe_delete_local_ref(env, jstage);
+  bsg_safe_release_string_utf_chars(env, _report_path, event_path);
 }
 
 JNIEXPORT void JNICALL
@@ -245,13 +253,14 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
   if (bsg_global_env == NULL || session_id_ == NULL) {
     return;
   }
-  char *session_id = (char *)(*env)->GetStringUTFChars(env, session_id_, 0);
-  char *started_at = (char *)(*env)->GetStringUTFChars(env, start_date_, 0);
-  bsg_request_env_write_lock();
-  bugsnag_event_start_session(&bsg_global_env->next_event, session_id,
-                              started_at, handled_count, unhandled_count);
-
-  bsg_release_env_write_lock();
+  char *session_id = (char *)bsg_safe_get_string_utf_chars(env, session_id_);
+  char *started_at = (char *)bsg_safe_get_string_utf_chars(env, start_date_);
+  if (session_id != NULL && started_at != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_event_start_session(&bsg_global_env->next_event, session_id,
+                                started_at, handled_count, unhandled_count);
+    bsg_release_env_write_lock();
+  }
   bsg_safe_release_string_utf_chars(env, session_id_, session_id);
   bsg_safe_release_string_utf_chars(env, start_date_, started_at);
 }
@@ -276,36 +285,39 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
   if (bsg_global_env == NULL) {
     return;
   }
-  const char *name = (*env)->GetStringUTFChars(env, name_, 0);
-  const char *type = (*env)->GetStringUTFChars(env, crumb_type, 0);
-  const char *timestamp = (*env)->GetStringUTFChars(env, timestamp_, 0);
-  bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
-  strncpy(crumb->name, name, sizeof(crumb->name));
-  strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
-  if (strcmp(type, "user") == 0) {
-    crumb->type = BSG_CRUMB_USER;
-  } else if (strcmp(type, "error") == 0) {
-    crumb->type = BSG_CRUMB_ERROR;
-  } else if (strcmp(type, "log") == 0) {
-    crumb->type = BSG_CRUMB_LOG;
-  } else if (strcmp(type, "navigation") == 0) {
-    crumb->type = BSG_CRUMB_NAVIGATION;
-  } else if (strcmp(type, "request") == 0) {
-    crumb->type = BSG_CRUMB_REQUEST;
-  } else if (strcmp(type, "state") == 0) {
-    crumb->type = BSG_CRUMB_STATE;
-  } else if (strcmp(type, "process") == 0) {
-    crumb->type = BSG_CRUMB_PROCESS;
-  } else {
-    crumb->type = BSG_CRUMB_MANUAL;
+  const char *name = bsg_safe_get_string_utf_chars(env, name_);
+  const char *type = bsg_safe_get_string_utf_chars(env, crumb_type);
+  const char *timestamp = bsg_safe_get_string_utf_chars(env, timestamp_);
+
+  if (name != NULL && type != NULL && timestamp != NULL) {
+    bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
+    strncpy(crumb->name, name, sizeof(crumb->name));
+    strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
+    if (strcmp(type, "user") == 0) {
+      crumb->type = BSG_CRUMB_USER;
+    } else if (strcmp(type, "error") == 0) {
+      crumb->type = BSG_CRUMB_ERROR;
+    } else if (strcmp(type, "log") == 0) {
+      crumb->type = BSG_CRUMB_LOG;
+    } else if (strcmp(type, "navigation") == 0) {
+      crumb->type = BSG_CRUMB_NAVIGATION;
+    } else if (strcmp(type, "request") == 0) {
+      crumb->type = BSG_CRUMB_REQUEST;
+    } else if (strcmp(type, "state") == 0) {
+      crumb->type = BSG_CRUMB_STATE;
+    } else if (strcmp(type, "process") == 0) {
+      crumb->type = BSG_CRUMB_PROCESS;
+    } else {
+      crumb->type = BSG_CRUMB_MANUAL;
+    }
+
+    bsg_populate_crumb_metadata(env, crumb, metadata);
+    bsg_request_env_write_lock();
+    bugsnag_event_add_breadcrumb(&bsg_global_env->next_event, crumb);
+    bsg_release_env_write_lock();
+
+    free(crumb);
   }
-
-  bsg_populate_crumb_metadata(env, crumb, metadata);
-  bsg_request_env_write_lock();
-  bugsnag_event_add_breadcrumb(&bsg_global_env->next_event, crumb);
-  bsg_release_env_write_lock();
-
-  free(crumb);
   bsg_safe_release_string_utf_chars(env, name_, name);
   bsg_safe_release_string_utf_chars(env, crumb_type, type);
   bsg_safe_release_string_utf_chars(env, timestamp_, timestamp);
@@ -318,9 +330,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateAppVersion(JNIEnv *env,
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_app_set_version(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
@@ -334,9 +347,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateBuildUUID(JNIEnv *env,
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_app_set_build_uuid(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
@@ -348,9 +362,10 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateContext(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_event_set_context(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
@@ -365,9 +380,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *activity = activity_ == NULL
-                       ? NULL
-                       : (char *)(*env)->GetStringUTFChars(env, activity_, 0);
+  char *activity = (char *) bsg_safe_get_string_utf_chars(env, activity_);
+  if (activity == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bool was_in_foreground = bsg_global_env->next_event.app.in_foreground;
   bsg_global_env->next_event.app.in_foreground = (bool)new_value;
@@ -408,9 +424,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
     return;
   }
 
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_device_set_orientation(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
@@ -425,9 +442,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateReleaseStage(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_app_set_release_stage(&bsg_global_env->next_event, value);
   bsg_release_env_write_lock();
@@ -441,9 +459,10 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  char *value = (char *) bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_event event = bsg_global_env->next_event;
   bugsnag_event_set_user(&bsg_global_env->next_event, value, event.user.email,
@@ -459,9 +478,10 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserName(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_event event = bsg_global_env->next_event;
   bugsnag_event_set_user(&bsg_global_env->next_event, event.user.id,
@@ -479,9 +499,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateUserEmail(JNIEnv *env,
   if (bsg_global_env == NULL) {
     return;
   }
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_event event = bsg_global_env->next_event;
   bugsnag_event_set_user(&bsg_global_env->next_event, event.user.id, value,
@@ -498,13 +519,16 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataString(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
-  char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
-  char *value = (char *)(*env)->GetStringUTFChars(env, value_, 0);
-  bsg_request_env_write_lock();
-  bugsnag_event_add_metadata_string(&bsg_global_env->next_event, tab, key,
-                                    value);
-  bsg_release_env_write_lock();
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, value_);
+
+  if (tab != NULL && key != NULL && value != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_event_add_metadata_string(&bsg_global_env->next_event, tab, key,
+                                      value);
+    bsg_release_env_write_lock();
+  }
   bsg_safe_release_string_utf_chars(env, tab_, tab);
   bsg_safe_release_string_utf_chars(env, key_, key);
   bsg_safe_release_string_utf_chars(env, value_, value);
@@ -516,11 +540,13 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataDouble(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
-  char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
-  bsg_request_env_write_lock();
-  bugsnag_event_add_metadata_double(&bsg_global_env->next_event, tab, key,
-                                    (double)value_);
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
+  if (tab != NULL && key != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_event_add_metadata_double(&bsg_global_env->next_event, tab, key,
+                                      (double)value_);
+  }
   bsg_release_env_write_lock();
   bsg_safe_release_string_utf_chars(env, tab_, tab);
   bsg_safe_release_string_utf_chars(env, key_, key);
@@ -532,12 +558,14 @@ Java_com_bugsnag_android_ndk_NativeBridge_addMetadataBoolean(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
-  char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
-  bsg_request_env_write_lock();
-  bugsnag_event_add_metadata_bool(&bsg_global_env->next_event, tab, key,
-                                  (bool)value_);
-  bsg_release_env_write_lock();
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
+  if (tab != NULL && key != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_event_add_metadata_bool(&bsg_global_env->next_event, tab, key,
+                                    (bool)value_);
+    bsg_release_env_write_lock();
+  }
   bsg_safe_release_string_utf_chars(env, tab_, tab);
   bsg_safe_release_string_utf_chars(env, key_, key);
 }
@@ -549,7 +577,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_clearMetadataTab(JNIEnv *env,
   if (bsg_global_env == NULL) {
     return;
   }
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  if (tab == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_event_clear_metadata_section(&bsg_global_env->next_event, tab);
   bsg_release_env_write_lock();
@@ -561,12 +592,14 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_removeMetadata(
   if (bsg_global_env == NULL) {
     return;
   }
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
-  char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
 
-  bsg_request_env_write_lock();
-  bugsnag_event_clear_metadata(&bsg_global_env->next_event, tab, key);
-  bsg_release_env_write_lock();
+  if (tab != NULL && key != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_event_clear_metadata(&bsg_global_env->next_event, tab, key);
+    bsg_release_env_write_lock();
+  }
 
   bsg_safe_release_string_utf_chars(env, tab_, tab);
   bsg_safe_release_string_utf_chars(env, key_, key);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -188,7 +188,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
         bsg_safe_call_static_void_method(env, interface_class, jdeliver_method,
                                          jstage, jpayload, japi_key);
       }
-      (*env)->DeleteLocalRef(env, japi_key);
+      bsg_safe_delete_local_ref(env, japi_key);
     } else {
       BUGSNAG_LOG("Failed to serialize event as JSON: %s", event_path);
     }
@@ -210,8 +210,8 @@ exit:
     (*env)->ReleaseByteArrayElements(
         env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
   }
-  (*env)->DeleteLocalRef(env, jpayload);
-  (*env)->DeleteLocalRef(env, jstage);
+  bsg_safe_delete_local_ref(env, jpayload);
+  bsg_safe_delete_local_ref(env, jstage);
 }
 
 JNIEXPORT void JNICALL

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -15,8 +15,8 @@ int bsg_find_next_free_metadata_index(bugsnag_metadata *const metadata) {
   return -1;
 }
 
-int bsg_allocate_metadata_index(bugsnag_metadata *metadata, char *section,
-                                char *name) {
+int bsg_allocate_metadata_index(bugsnag_metadata *metadata, const char *section,
+                                const char *name) {
   int index = bsg_find_next_free_metadata_index(metadata);
   if (index < 0) {
     return index;
@@ -31,8 +31,8 @@ int bsg_allocate_metadata_index(bugsnag_metadata *metadata, char *section,
   return index;
 }
 
-void bsg_add_metadata_value_double(bugsnag_metadata *metadata, char *section,
-                                   char *name, double value) {
+void bsg_add_metadata_value_double(bugsnag_metadata *metadata, const char *section,
+                                   const char *name, double value) {
   int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_NUMBER_VALUE;
@@ -40,8 +40,8 @@ void bsg_add_metadata_value_double(bugsnag_metadata *metadata, char *section,
   }
 }
 
-void bsg_add_metadata_value_str(bugsnag_metadata *metadata, char *section,
-                                char *name, char *value) {
+void bsg_add_metadata_value_str(bugsnag_metadata *metadata, const char *section,
+                                const char *name, const char *value) {
   int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_CHAR_VALUE;
@@ -50,8 +50,8 @@ void bsg_add_metadata_value_str(bugsnag_metadata *metadata, char *section,
   }
 }
 
-void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, char *section,
-                                 char *name, bool value) {
+void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, const char *section,
+                                 const char *name, bool value) {
   int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_BOOL_VALUE;

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -31,8 +31,9 @@ int bsg_allocate_metadata_index(bugsnag_metadata *metadata, const char *section,
   return index;
 }
 
-void bsg_add_metadata_value_double(bugsnag_metadata *metadata, const char *section,
-                                   const char *name, double value) {
+void bsg_add_metadata_value_double(bugsnag_metadata *metadata,
+                                   const char *section, const char *name,
+                                   double value) {
   int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_NUMBER_VALUE;
@@ -50,8 +51,9 @@ void bsg_add_metadata_value_str(bugsnag_metadata *metadata, const char *section,
   }
 }
 
-void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, const char *section,
-                                 const char *name, bool value) {
+void bsg_add_metadata_value_bool(bugsnag_metadata *metadata,
+                                 const char *section, const char *name,
+                                 bool value) {
   int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_BOOL_VALUE;

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -216,12 +216,12 @@ void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
                                  int unhandled_count);
 bool bugsnag_event_has_session(bugsnag_event *event);
 
-void bsg_add_metadata_value_double(bugsnag_metadata *metadata, char *section,
-                                   char *name, double value);
-void bsg_add_metadata_value_str(bugsnag_metadata *metadata, char *section,
-                                char *name, char *value);
-void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, char *section,
-                                 char *name, bool value);
+void bsg_add_metadata_value_double(bugsnag_metadata *metadata, const char *section,
+                                   const char *name, double value);
+void bsg_add_metadata_value_str(bugsnag_metadata *metadata, const char *section,
+                                const char *name, const char *value);
+void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, const char *section,
+                                 const char *name, bool value);
 
 /*********************************
  * (end) NDK-SPECIFIC BITS

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -216,12 +216,14 @@ void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
                                  int unhandled_count);
 bool bugsnag_event_has_session(bugsnag_event *event);
 
-void bsg_add_metadata_value_double(bugsnag_metadata *metadata, const char *section,
-                                   const char *name, double value);
+void bsg_add_metadata_value_double(bugsnag_metadata *metadata,
+                                   const char *section, const char *name,
+                                   double value);
 void bsg_add_metadata_value_str(bugsnag_metadata *metadata, const char *section,
                                 const char *name, const char *value);
-void bsg_add_metadata_value_bool(bugsnag_metadata *metadata, const char *section,
-                                 const char *name, bool value);
+void bsg_add_metadata_value_bool(bugsnag_metadata *metadata,
+                                 const char *section, const char *name,
+                                 bool value);
 
 /*********************************
  * (end) NDK-SPECIFIC BITS

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -263,7 +263,7 @@ void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
   if (_value != NULL) {
     char *value = (char *)(*env)->GetStringUTFChars(env, (jstring)_value, 0);
     bsg_strncpy_safe(dest, value, len);
-    (*env)->ReleaseStringUTFChars(env, _value, value);
+    bsg_safe_release_string_utf_chars(env, _value, value);
   }
 }
 
@@ -335,7 +335,7 @@ int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
       char *abi = (char *)(*env)->GetStringUTFChars(env, jabi, 0);
       bsg_strncpy_safe(device->cpu_abi[i].value, abi,
                        sizeof(device->cpu_abi[i].value));
-      (*env)->ReleaseStringUTFChars(env, jabi, abi);
+      bsg_safe_release_string_utf_chars(env, jabi, abi);
       device->cpu_abi_count++;
     }
     bsg_safe_delete_local_ref(env, _value);
@@ -388,7 +388,7 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
       char *key = (char *)(*env)->GetStringUTFChars(env, _key, 0);
       bsg_populate_metadata_value(env, &crumb->metadata, jni_cache, "metaData",
                                   key, _value);
-      (*env)->ReleaseStringUTFChars(env, _key, key);
+      bsg_safe_release_string_utf_chars(env, _key, key);
     }
   }
   goto exit;
@@ -568,7 +568,7 @@ void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
   if (_context != NULL) {
     const char *value = (*env)->GetStringUTFChars(env, (jstring)_context, 0);
     strncpy(event->context, value, sizeof(event->context) - 1);
-    (*env)->ReleaseStringUTFChars(env, _context, value);
+    bsg_safe_release_string_utf_chars(env, _context, value);
   } else {
     memset(&event->context, 0, strlen(event->context));
   }
@@ -618,7 +618,7 @@ void bsg_populate_metadata_obj(JNIEnv *env, bugsnag_metadata *dst,
   jobject _value = bsg_safe_call_object_method(env, section, jni_cache->map_get,
                                                section_key);
   bsg_populate_metadata_value(env, dst, jni_cache, section, name, _value);
-  (*env)->ReleaseStringUTFChars(env, section_key, name);
+  bsg_safe_release_string_utf_chars(env, section_key, name);
   bsg_safe_delete_local_ref(env, _value);
 }
 
@@ -665,7 +665,7 @@ void bsg_populate_metadata_section(JNIEnv *env, bugsnag_metadata *dst,
   goto exit;
 
 exit:
-  (*env)->ReleaseStringUTFChars(env, _key, section);
+  bsg_safe_release_string_utf_chars(env, _key, section);
   bsg_safe_delete_local_ref(env, section_keyset);
   bsg_safe_delete_local_ref(env, section_keylist);
   bsg_safe_delete_local_ref(env, _section);

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -251,7 +251,7 @@ jobject bsg_get_map_value_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
 
   jobject obj =
       bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
-  (*env)->DeleteLocalRef(env, key);
+  bsg_safe_delete_local_ref(env, key);
   return obj;
 }
 
@@ -274,7 +274,7 @@ long bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
   if (_value != NULL) {
     long value = bsg_safe_call_double_method(env, _value,
                                              jni_cache->number_double_value);
-    (*env)->DeleteLocalRef(env, _value);
+    bsg_safe_delete_local_ref(env, _value);
     return value;
   }
   return 0;
@@ -287,7 +287,7 @@ float bsg_get_map_value_float(JNIEnv *env, bsg_jni_cache *jni_cache,
   if (_value != NULL) {
     float value =
         bsg_safe_call_float_method(env, _value, jni_cache->float_float_value);
-    (*env)->DeleteLocalRef(env, _value);
+    bsg_safe_delete_local_ref(env, _value);
     return value;
   }
   return 0;
@@ -300,7 +300,7 @@ int bsg_get_map_value_int(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
   if (_value != NULL) {
     jint value =
         bsg_safe_call_int_method(env, _value, jni_cache->integer_int_value);
-    (*env)->DeleteLocalRef(env, _value);
+    bsg_safe_delete_local_ref(env, _value);
     return value;
   }
   return 0;
@@ -338,7 +338,7 @@ int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
       (*env)->ReleaseStringUTFChars(env, jabi, abi);
       device->cpu_abi_count++;
     }
-    (*env)->DeleteLocalRef(env, _value);
+    bsg_safe_delete_local_ref(env, _value);
     return count;
   }
   return 0;
@@ -382,8 +382,8 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
         bsg_safe_call_object_method(env, metadata, jni_cache->map_get, _key);
 
     if (_key == NULL || _value == NULL) {
-      (*env)->DeleteLocalRef(env, _key);
-      (*env)->DeleteLocalRef(env, _value);
+      bsg_safe_delete_local_ref(env, _key);
+      bsg_safe_delete_local_ref(env, _value);
     } else {
       char *key = (char *)(*env)->GetStringUTFChars(env, _key, 0);
       bsg_populate_metadata_value(env, &crumb->metadata, jni_cache, "metaData",
@@ -395,8 +395,8 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
 
 exit:
   free(jni_cache);
-  (*env)->DeleteLocalRef(env, keyset);
-  (*env)->DeleteLocalRef(env, keylist);
+  bsg_safe_delete_local_ref(env, keyset);
+  bsg_safe_delete_local_ref(env, keylist);
 }
 
 char *bsg_binary_arch() {
@@ -451,7 +451,7 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   event->app.version_code =
       bsg_get_map_value_int(env, jni_cache, data, "versionCode");
 
-  (*env)->DeleteLocalRef(env, data);
+  bsg_safe_delete_local_ref(env, data);
 }
 
 char *bsg_os_name() { return "android"; }
@@ -535,14 +535,14 @@ void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
 
     event->device.api_level = bsg_get_map_value_int(
         env, jni_cache, _runtime_versions, "androidApiLevel");
-    (*env)->DeleteLocalRef(env, _runtime_versions);
+    bsg_safe_delete_local_ref(env, _runtime_versions);
   }
   event->device.total_memory =
       bsg_get_map_value_long(env, jni_cache, data, "totalMemory");
 
   // add fields to device metadata
   populate_device_metadata(env, jni_cache, event, data);
-  (*env)->DeleteLocalRef(env, data);
+  bsg_safe_delete_local_ref(env, data);
 }
 
 void bsg_populate_user_data(JNIEnv *env, bsg_jni_cache *jni_cache,
@@ -558,7 +558,7 @@ void bsg_populate_user_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                             sizeof(event->user.name));
   bsg_copy_map_value_string(env, jni_cache, data, "email", event->user.email,
                             sizeof(event->user.email));
-  (*env)->DeleteLocalRef(env, data);
+  bsg_safe_delete_local_ref(env, data);
 }
 
 void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
@@ -619,7 +619,7 @@ void bsg_populate_metadata_obj(JNIEnv *env, bugsnag_metadata *dst,
                                                section_key);
   bsg_populate_metadata_value(env, dst, jni_cache, section, name, _value);
   (*env)->ReleaseStringUTFChars(env, section_key, name);
-  (*env)->DeleteLocalRef(env, _value);
+  bsg_safe_delete_local_ref(env, _value);
 }
 
 void bsg_populate_metadata_section(JNIEnv *env, bugsnag_metadata *dst,
@@ -666,9 +666,9 @@ void bsg_populate_metadata_section(JNIEnv *env, bugsnag_metadata *dst,
 
 exit:
   (*env)->ReleaseStringUTFChars(env, _key, section);
-  (*env)->DeleteLocalRef(env, section_keyset);
-  (*env)->DeleteLocalRef(env, section_keylist);
-  (*env)->DeleteLocalRef(env, _section);
+  bsg_safe_delete_local_ref(env, section_keyset);
+  bsg_safe_delete_local_ref(env, section_keylist);
+  bsg_safe_delete_local_ref(env, _section);
 }
 
 void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst,
@@ -715,6 +715,6 @@ exit:
   if (jni_cache != NULL) {
     free(jni_cache);
   }
-  (*env)->DeleteLocalRef(env, keyset);
-  (*env)->DeleteLocalRef(env, keylist);
+  bsg_safe_delete_local_ref(env, keyset);
+  bsg_safe_delete_local_ref(env, keylist);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -391,8 +391,8 @@ void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
     } else {
       const char *key = bsg_safe_get_string_utf_chars(env, _key);
       if (key != NULL) {
-        bsg_populate_metadata_value(env, &crumb->metadata, jni_cache, "metaData",
-                                    key, _value);
+        bsg_populate_metadata_value(env, &crumb->metadata, jni_cache,
+                                    "metaData", key, _value);
         bsg_safe_release_string_utf_chars(env, _key, key);
       }
     }
@@ -611,7 +611,7 @@ void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
     const char *value = bsg_safe_get_string_utf_chars(env, _value);
     if (value != NULL) {
       bsg_add_metadata_value_str(dst, section, name, value);
-      free((char *) value);
+      free((char *)value);
     }
   }
 }
@@ -676,7 +676,8 @@ void bsg_populate_metadata_section(JNIEnv *env, bugsnag_metadata *dst,
     goto exit;
   }
   for (int j = 0; j < section_size; j++) {
-    bsg_populate_metadata_obj(env, dst, jni_cache, _section, section_keylist, j);
+    bsg_populate_metadata_obj(env, dst, jni_cache, _section, section_keylist,
+                              j);
   }
   goto exit;
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -323,7 +323,7 @@ int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
   jobjectArray _value =
       bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
   if (_value != NULL) {
-    int count = (*env)->GetArrayLength(env, _value);
+    int count = bsg_safe_get_array_length(env, _value);
 
     // get the ABI as a Java string and copy it to bsg_device_info
     for (int i = 0; i < count && i < sizeof(device->cpu_abi); i++) {
@@ -589,17 +589,17 @@ void bsg_populate_event(JNIEnv *env, bugsnag_event *event) {
 void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
                                  bsg_jni_cache *jni_cache, char *section,
                                  char *name, jobject _value) {
-  if ((*env)->IsInstanceOf(env, _value, jni_cache->number)) {
+  if (bsg_safe_is_instance_of(env, _value, jni_cache->number)) {
     // add a double metadata value
     double value = bsg_safe_call_double_method(env, _value,
                                                jni_cache->number_double_value);
     bsg_add_metadata_value_double(dst, section, name, value);
-  } else if ((*env)->IsInstanceOf(env, _value, jni_cache->boolean)) {
+  } else if (bsg_safe_is_instance_of(env, _value, jni_cache->boolean)) {
     // add a boolean metadata value
     bool value = bsg_safe_call_boolean_method(env, _value,
                                               jni_cache->boolean_bool_value);
     bsg_add_metadata_value_bool(dst, section, name, value);
-  } else if ((*env)->IsInstanceOf(env, _value, jni_cache->string)) {
+  } else if (bsg_safe_is_instance_of(env, _value, jni_cache->string)) {
     char *value = (char *)(*env)->GetStringUTFChars(env, _value, 0);
     bsg_add_metadata_value_str(dst, section, name, value);
     free(value);

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -212,13 +212,15 @@ const char *bsg_safe_get_string_utf_chars(JNIEnv *env, jstring string) {
   return NULL;
 }
 
-void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string, const char *utf) {
+void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string,
+                                       const char *utf) {
   if (env != NULL && string != NULL && utf != NULL) {
     (*env)->ReleaseStringUTFChars(env, string, utf);
   }
 }
 
-void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array, jbyte *elems, jint mode) {
+void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array,
+                                          jbyte *elems, jint mode) {
   if (env != NULL && array != NULL) {
     (*env)->ReleaseByteArrayElements(env, array, elems, mode);
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -3,6 +3,9 @@
 #include <utils/string.h>
 
 bool bsg_check_and_clear_exc(JNIEnv *env) {
+  if (env == NULL) {
+    return false;
+  }
   if ((*env)->ExceptionCheck(env)) {
     (*env)->ExceptionClear(env);
     return true;
@@ -11,6 +14,9 @@ bool bsg_check_and_clear_exc(JNIEnv *env) {
 }
 
 jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
+  if (env == NULL) {
+    return NULL;
+  }
   if (clz_name == NULL) {
     return NULL;
   }
@@ -21,7 +27,7 @@ jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
 
 jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
                                  const char *sig) {
-  if (clz == NULL || name == NULL || sig == NULL) {
+  if (env == NULL || clz == NULL || name == NULL || sig == NULL) {
     return NULL;
   }
   jmethodID methodId = (*env)->GetMethodID(env, clz, name, sig);
@@ -31,7 +37,7 @@ jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
 
 jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
                                         const char *name, const char *sig) {
-  if (clz == NULL || name == NULL || sig == NULL) {
+  if (env == NULL || clz == NULL || name == NULL || sig == NULL) {
     return NULL;
   }
   jmethodID methodId = (*env)->GetStaticMethodID(env, clz, name, sig);
@@ -40,7 +46,7 @@ jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
 }
 
 jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
-  if (str == NULL) {
+  if (env == NULL || str == NULL) {
     return NULL;
   }
   jstring jstr = (*env)->NewStringUTF(env, str);
@@ -50,7 +56,7 @@ jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
 
 jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
                                       jmethodID method) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return false;
   }
   jboolean value = (*env)->CallBooleanMethod(env, _value, method);
@@ -61,7 +67,7 @@ jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
 }
 
 jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return -1;
   }
   jint value = (*env)->CallIntMethod(env, _value, method);
@@ -73,7 +79,7 @@ jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
 
 jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
                                   jmethodID method) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return -1;
   }
   jfloat value = (*env)->CallFloatMethod(env, _value, method);
@@ -85,7 +91,7 @@ jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
 
 jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
                                     jmethodID method) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return -1;
   }
   jdouble value = (*env)->CallDoubleMethod(env, _value, method);
@@ -96,7 +102,7 @@ jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
 }
 
 jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return NULL;
   }
   jobjectArray trace = (*env)->NewObjectArray(env, size, clz, NULL);
@@ -106,7 +112,7 @@ jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
 
 jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
                                           jsize size) {
-  if (array == NULL) {
+  if (env == NULL || array == NULL) {
     return NULL;
   }
   jobject obj = (*env)->GetObjectArrayElement(env, array, size);
@@ -116,7 +122,7 @@ jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
 
 void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
                                        jsize size, jobject object) {
-  if (array == NULL) {
+  if (env == NULL || array == NULL) {
     return;
   }
   (*env)->SetObjectArrayElement(env, array, size, object);
@@ -125,7 +131,7 @@ void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
 
 jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
                                       const char *sig) {
-  if (clz == NULL || name == NULL || sig == NULL) {
+  if (env == NULL || clz == NULL || name == NULL || sig == NULL) {
     return NULL;
   }
   jfieldID field_id = (*env)->GetStaticFieldID(env, clz, name, sig);
@@ -135,7 +141,7 @@ jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
 
 jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
                                          jfieldID field) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return NULL;
   }
   jobject obj = (*env)->GetStaticObjectField(env, clz, field);
@@ -144,7 +150,7 @@ jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
 }
 
 jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return NULL;
   }
   va_list args;
@@ -157,7 +163,7 @@ jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...) {
 
 jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
                                     jmethodID method, ...) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return NULL;
   }
   va_list args;
@@ -170,7 +176,7 @@ jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
 
 void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
                                       ...) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return;
   }
   va_list args;
@@ -182,7 +188,7 @@ void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
 
 jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
                                            jmethodID method, ...) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return NULL;
   }
   va_list args;
@@ -191,6 +197,45 @@ jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
   va_end(args);
   bsg_check_and_clear_exc(env);
   return obj;
+}
+
+void bsg_safe_delete_local_ref(JNIEnv *env, jobject obj) {
+  if (env != NULL) {
+    (*env)->DeleteLocalRef(env, obj);
+  }
+}
+
+const char *bsg_safe_get_string_utf_chars(JNIEnv *env, jstring string) {
+  if (env != NULL && string != NULL) {
+    return (*env)->GetStringUTFChars(env, string, NULL);
+  }
+  return NULL;
+}
+
+void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string, const char *utf) {
+  if (env != NULL && string != NULL && utf != NULL) {
+    (*env)->ReleaseStringUTFChars(env, string, utf);
+  }
+}
+
+void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array, jbyte *elems, jint mode) {
+  if (env != NULL && array != NULL) {
+    (*env)->ReleaseByteArrayElements(env, array, elems, mode);
+  }
+}
+
+jsize bsg_safe_get_array_length(JNIEnv *env, jarray array) {
+  if (env != NULL && array != NULL) {
+    return (*env)->GetArrayLength(env, array);
+  }
+  return -1;
+}
+
+jboolean bsg_safe_is_instance_of(JNIEnv *env, jobject object, jclass clz) {
+  if (env != NULL && clz != NULL) {
+    return (*env)->IsInstanceOf(env, object, clz);
+  }
+  return false;
 }
 
 jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -175,7 +175,7 @@ void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array,
                                           jbyte *elems, jint mode);
 
 /**
- * A safe wrapper for the JNI's ReleaseStringUTFChars. This method checks if the
+ * A safe wrapper for the JNI's GetArrayLength. This method checks if the
  * parameters are NULL and no-ops if so. The caller is responsible for handling
  * the invalid return value of -1.
  */

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -154,34 +154,36 @@ jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
 void bsg_safe_delete_local_ref(JNIEnv *env, jobject obj);
 
 /**
- * A safe wrapper for the JNI's GetStringUTFChars. This method checks if the parameters
- * are NULL and returns NULL if so. The caller is responsible for checking for NULL
- * return values.
+ * A safe wrapper for the JNI's GetStringUTFChars. This method checks if the
+ * parameters are NULL and returns NULL if so. The caller is responsible for
+ * checking for NULL return values.
  */
 const char *bsg_safe_get_string_utf_chars(JNIEnv *env, jstring string);
 
 /**
- * A safe wrapper for the JNI's ReleaseStringUTFChars. This method checks if the parameters
- * are NULL and no-ops if so.
+ * A safe wrapper for the JNI's ReleaseStringUTFChars. This method checks if the
+ * parameters are NULL and no-ops if so.
  */
-void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string, const char *utf);
+void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string,
+                                       const char *utf);
 
 /**
- * A safe wrapper for the JNI's ReleaseByteArrayElements. This method checks if an
- * exception is pending and if so clears it so that execution can continue.
+ * A safe wrapper for the JNI's ReleaseByteArrayElements. This method checks if
+ * an exception is pending and if so clears it so that execution can continue.
  */
-void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array, jbyte *elems, jint mode);
+void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array,
+                                          jbyte *elems, jint mode);
 
 /**
- * A safe wrapper for the JNI's ReleaseStringUTFChars. This method checks if the parameters
- * are NULL and no-ops if so. The caller is responsible for handling the invalid return value
- * of -1.
+ * A safe wrapper for the JNI's ReleaseStringUTFChars. This method checks if the
+ * parameters are NULL and no-ops if so. The caller is responsible for handling
+ * the invalid return value of -1.
  */
 jsize bsg_safe_get_array_length(JNIEnv *env, jarray array);
 
 /**
- * A safe wrapper for the JNI's IsInstanceOf. This method checks if the parameters
- * are NULL and returns false if so.
+ * A safe wrapper for the JNI's IsInstanceOf. This method checks if the
+ * parameters are NULL and returns false if so.
  */
 jboolean bsg_safe_is_instance_of(JNIEnv *env, jobject object, jclass clz);
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -148,6 +148,44 @@ jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
                                            jmethodID method, ...);
 
 /**
+ * A safe wrapper for the JNI's DeleteLocalRef. This method checks if the env
+ * is NULL and no-ops if so.
+ */
+void bsg_safe_delete_local_ref(JNIEnv *env, jobject obj);
+
+/**
+ * A safe wrapper for the JNI's GetStringUTFChars. This method checks if the parameters
+ * are NULL and returns NULL if so. The caller is responsible for checking for NULL
+ * return values.
+ */
+const char *bsg_safe_get_string_utf_chars(JNIEnv *env, jstring string);
+
+/**
+ * A safe wrapper for the JNI's ReleaseStringUTFChars. This method checks if the parameters
+ * are NULL and no-ops if so.
+ */
+void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string, const char *utf);
+
+/**
+ * A safe wrapper for the JNI's ReleaseByteArrayElements. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ */
+void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array, jbyte *elems, jint mode);
+
+/**
+ * A safe wrapper for the JNI's ReleaseStringUTFChars. This method checks if the parameters
+ * are NULL and no-ops if so. The caller is responsible for handling the invalid return value
+ * of -1.
+ */
+jsize bsg_safe_get_array_length(JNIEnv *env, jarray array);
+
+/**
+ * A safe wrapper for the JNI's IsInstanceOf. This method checks if the parameters
+ * are NULL and returns false if so.
+ */
+jboolean bsg_safe_is_instance_of(JNIEnv *env, jobject object, jclass clz);
+
+/**
  * Constructs a byte array from a string.
  */
 jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -30,7 +30,7 @@ size_t bsg_strlen(const char *str) {
   }
 }
 
-void bsg_strncpy_safe(char *dst, char *src, int dst_size) {
+void bsg_strncpy_safe(char *dst, const char *src, int dst_size) {
   if (dst_size == 0)
     return;
   dst[0] = '\0';

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -26,7 +26,7 @@ void bsg_strncpy(char *dst, char *src, size_t len) __asyncsafe;
 /**
  * Copy a string from src to dst, null padding the rest
  */
-void bsg_strncpy_safe(char *dst, char *src, int dst_size);
+void bsg_strncpy_safe(char *dst, const char *src, int dst_size);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Goal

Performs additional checking of JNI calls for pending exceptions, and no-ops if these are detected. This changeset also wraps all JNI calls in a `bsg_safe` wrapper, which checks for disallowed parameter values such as `NULL` and no-ops.

## Changeset

The changeset is roughly broken up into individual commits for each affected JNI method:

```
DeleteLocalRef
ReleaseByteArrayElements
ReleaseStringUTFChars
GetStringUTFChars
IsInstanceOf
GetArrayLength
```

Each affected method has been added to `safejni.h` and its parameters checked according to the [JNI docs](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html). For `GetStringUTFChars` the calling method has been updated to handle a `NULL` return value where necessary.

JNI calls in the ANR plugin have also been updated to perform equivalent safety checks.

Some internal method signatures have been updated where possible to use `const char *` rather than `char *`, as this is what `GetStringUTFChars` actually returns - a lot of invocations have been incorrectly casting it to `char *`.

## Testing

Relied on existing E2E test coverage, also performed smoke testing with example app on emulator to cover x86 architectures.