### PR TITLE
Remove use of "non-crashy" metadata in test scenarios

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -110,9 +110,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
-          - "--retry=1"
-          - "--strict-undefined"
-          - "--strict-pending"
           - "--tags"
           - "not @Flaky"
     concurrency: 9
@@ -134,9 +131,6 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
-          - "--retry=1"
-          - "--strict-undefined"
-          - "--strict-pending"
           - "--tags"
           - "not @Flaky"
     concurrency: 9

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.7.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.10.0'
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.10.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.10.1'
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: c35845c10a7c35165c1468c4f098f41b3f3955f7
-  tag: v4.7.0
+  revision: 18b5136f8d006893e7775f984153d09bde1af032
+  tag: v4.10.0
   specs:
-    bugsnag-maze-runner (4.7.0)
+    bugsnag-maze-runner (4.10.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -24,7 +24,7 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.3.1)
+    appium_lib_core (4.4.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     backports (3.20.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,7 @@
-GIT
-  remote: https://github.com/bugsnag/maze-runner
-  revision: 18b5136f8d006893e7775f984153d09bde1af032
-  tag: v4.10.0
+PATH
+  remote: ../maze-runner
   specs:
-    bugsnag-maze-runner (4.10.0)
+    bugsnag-maze-runner (4.10.1)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/dockerfiles/Dockerfile.android-common
+++ b/dockerfiles/Dockerfile.android-common
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
-RUN apt-get update > /dev/null
-RUN apt-get install -y wget maven gnupg1 cppcheck libncurses5 jq clang-format unzip curl git > /dev/null
+RUN apt-get update > /dev/n
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget maven gnupg1 cppcheck libncurses5 jq clang-format unzip curl git
 RUN apt-get clean > /dev/null
 
 ENV ANDROID_SDK_ROOT="/sdk"

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -31,7 +31,6 @@ class MainActivity : Activity() {
         findViewById<Button>(R.id.start_bugsnag).setOnClickListener {
             scenario = loadScenarioFromUi()
             scenario?.startBugsnag(true)
-
         }
 
         // execute the pre-loaded scenario, or load it then execute it if needed

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -28,13 +28,13 @@ class MainActivity : Activity() {
         sendBroadcast(closeDialog)
 
         // load the scenario first, which initialises bugsnag without running any crashy code
-        findViewById<Button>(R.id.startBugsnagButton).setOnClickListener {
+        findViewById<Button>(R.id.start_bugsnag).setOnClickListener {
             scenario = loadScenarioFromUi()
             scenario?.startBugsnag()
         }
 
         // execute the pre-loaded scenario, or load it then execute it if needed
-        findViewById<Button>(R.id.startScenarioButton).setOnClickListener {
+        findViewById<Button>(R.id.run_scenario).setOnClickListener {
             if (scenario == null) {
                 scenario = loadScenarioFromUi()
                 scenario?.startBugsnag()
@@ -71,9 +71,9 @@ class MainActivity : Activity() {
     }
 
     private fun loadScenarioFromUi(): Scenario {
-        val scenarioPicker = findViewById<EditText>(R.id.scenarioText)
+        val scenarioPicker = findViewById<EditText>(R.id.scenario_name)
         val eventType = scenarioPicker.text.toString()
-        val eventMetadata = findViewById<EditText>(R.id.scenarioMetaData)
+        val eventMetadata = findViewById<EditText>(R.id.scenario_metadata)
         val metadata = eventMetadata.text.toString()
 
         val config = loadConfigFromUi()
@@ -82,8 +82,8 @@ class MainActivity : Activity() {
 
     private fun loadConfigFromUi(): Configuration {
         val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
-        val notifyEndpointField = findViewById<EditText>(R.id.notifyEndpoint)
-        val sessionEndpointField = findViewById<EditText>(R.id.sessionEndpoint)
+        val notifyEndpointField = findViewById<EditText>(R.id.notify_endpoint)
+        val sessionEndpointField = findViewById<EditText>(R.id.session_endpoint)
 
         val manualMode = apiKeyField.text.isNotEmpty()
         val apiKey = when {

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -30,14 +30,15 @@ class MainActivity : Activity() {
         // load the scenario first, which initialises bugsnag without running any crashy code
         findViewById<Button>(R.id.start_bugsnag).setOnClickListener {
             scenario = loadScenarioFromUi()
-            scenario?.startBugsnag()
+            scenario?.startBugsnag(true)
+
         }
 
         // execute the pre-loaded scenario, or load it then execute it if needed
         findViewById<Button>(R.id.run_scenario).setOnClickListener {
             if (scenario == null) {
                 scenario = loadScenarioFromUi()
-                scenario?.startBugsnag()
+                scenario?.startBugsnag(false)
             }
 
             /**

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -9,57 +9,67 @@
     android:layout_height="wrap_content"
     android:layout_weight="6" />
 
+  <EditText
+          android:id="@+id/scenario_name"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:ems="10"
+          android:hint="Scenario name"
+          android:inputType="text" />
+
+  <EditText
+          android:id="@+id/scenario_metadata"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:ems="10"
+          android:hint="Scenario metadata"
+          android:inputType="text" />
+
+  <Space
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="6" />
+
+  <EditText
+          android:id="@+id/notify_endpoint"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:ems="10"
+          android:hint="Notify endpoint"
+          android:inputType="text"
+          android:text="http://bs-local.com:9339/notify" />
+
+  <EditText
+          android:id="@+id/session_endpoint"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:ems="10"
+          android:hint="Session endpoint"
+          android:inputType="text"
+          android:text="http://bs-local.com:9339/sessions" />
+
+  <Space
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="6" />
+
   <Button
-    android:id="@+id/startBugsnagButton"
+    android:id="@+id/start_bugsnag"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_weight="0"
     android:text="Start Bugsnag" />
 
   <Button
-    android:id="@+id/startScenarioButton"
+    android:id="@+id/run_scenario"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_weight="0"
     android:text="Execute" />
-
-  <EditText
-    android:id="@+id/notifyEndpoint"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="0"
-    android:ems="10"
-    android:hint="Notify endpoint"
-    android:inputType="text"
-    android:text="http://bs-local.com:9339/notify" />
-
-  <EditText
-    android:id="@+id/sessionEndpoint"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="0"
-    android:ems="10"
-    android:hint="Session endpoint"
-    android:inputType="text"
-    android:text="http://bs-local.com:9339/sessions" />
-
-  <EditText
-    android:id="@+id/scenarioText"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="0"
-    android:ems="10"
-    android:hint="Enter scenario name"
-    android:inputType="text" />
-
-  <EditText
-    android:id="@+id/scenarioMetaData"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="0"
-    android:ems="10"
-    android:hint="Enter scenario metadata"
-    android:inputType="text" />
 
   <Space
     android:layout_width="match_parent"

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -4,11 +4,6 @@
   android:layout_height="match_parent"
   android:orientation="vertical">
 
-  <Space
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="6" />
-
   <EditText
           android:id="@+id/scenario_name"
           android:layout_width="match_parent"
@@ -27,10 +22,19 @@
           android:hint="Scenario metadata"
           android:inputType="text" />
 
-  <Space
+  <Button
+          android:id="@+id/start_bugsnag"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_weight="6" />
+          android:layout_weight="0"
+          android:text="Start Bugsnag" />
+
+  <Button
+          android:id="@+id/run_scenario"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:text="Execute" />
 
   <EditText
           android:id="@+id/notify_endpoint"
@@ -51,25 +55,6 @@
           android:hint="Session endpoint"
           android:inputType="text"
           android:text="http://bs-local.com:9339/sessions" />
-
-  <Space
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_weight="6" />
-
-  <Button
-    android:id="@+id/start_bugsnag"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="0"
-    android:text="Start Bugsnag" />
-
-  <Button
-    android:id="@+id/run_scenario"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="0"
-    android:text="Execute" />
 
   <Space
     android:layout_width="match_parent"

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 class CXXExceptionOnErrorFalseScenario(
     config: Configuration,
@@ -20,10 +19,6 @@ class CXXExceptionOnErrorFalseScenario(
 
     override fun startScenario() {
         super.startScenario()
-        if ("non-crashy" != eventMetadata) {
-            crash()
-        }
+        crash()
     }
-
-    override fun getInterceptedLogMessages() = getZeroEventsLogMessages(eventMetadata)
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.kt
@@ -27,4 +27,3 @@ class CXXExceptionOnErrorFalseScenario(
         return getZeroEventsLogMessages(startBugsnagOnly)
     }
 }
-

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 class CXXExceptionOnErrorFalseScenario(
     config: Configuration,
@@ -21,4 +22,9 @@ class CXXExceptionOnErrorFalseScenario(
         super.startScenario()
         crash()
     }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
+    }
 }
+

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorTrueScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorTrueScenario.kt
@@ -19,8 +19,6 @@ class CXXExceptionOnErrorTrueScenario(
 
     override fun startScenario() {
         super.startScenario()
-        if (eventMetadata != "non-crashy") {
-            crash()
-        }
+        crash()
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXHandledOverrideScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXHandledOverrideScenario.kt
@@ -21,9 +21,7 @@ internal class CXXHandledOverrideScenario(
     override fun startScenario() {
         super.startScenario()
 
-        if (eventMetadata != "non-crashy") {
-            Bugsnag.startSession()
-            activate()
-        }
+        Bugsnag.startSession()
+        activate()
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNaughtyStringsScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNaughtyStringsScenario.kt
@@ -22,8 +22,6 @@ internal class CXXNaughtyStringsScenario(
         addNaughtyStringMetadata(javaClass)
         Thread.sleep(200) // allow metadata to sync across JNI layer
 
-        if (eventMetadata != "non-crashy") {
-            crash()
-        }
+        crash()
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 class CXXSignalOnErrorFalseScenario(
     config: Configuration,
@@ -20,10 +19,6 @@ class CXXSignalOnErrorFalseScenario(
 
     override fun startScenario() {
         super.startScenario()
-        if ("non-crashy" != eventMetadata) {
-            crash()
-        }
+        crash()
     }
-
-    override fun getInterceptedLogMessages() = getZeroEventsLogMessages(eventMetadata)
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 class CXXSignalOnErrorFalseScenario(
     config: Configuration,
@@ -20,5 +21,9 @@ class CXXSignalOnErrorFalseScenario(
     override fun startScenario() {
         super.startScenario()
         crash()
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkDisabledScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkDisabledScenario.java
@@ -28,10 +28,6 @@ public class AutoDetectNdkDisabledScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash();
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAbortScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAbortScenario.java
@@ -25,10 +25,6 @@ public class CXXAbortScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash();
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.java
@@ -35,10 +35,6 @@ public class CXXDelayedCrashScenario extends Scenario {
             return;
         }
         didActivate = true;
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDoubleFreeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDoubleFreeScenario.java
@@ -25,10 +25,6 @@ public class CXXDoubleFreeScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash();
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionScenario.java
@@ -25,10 +25,6 @@ public class CXXExceptionScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash();
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExternalStackElementScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExternalStackElementScenario.java
@@ -26,10 +26,6 @@ public class CXXExternalStackElementScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(34);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExtraordinaryLongStringScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExtraordinaryLongStringScenario.java
@@ -34,10 +34,6 @@ public class CXXExtraordinaryLongStringScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(39383);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXImproperTypecastScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXImproperTypecastScenario.java
@@ -25,10 +25,6 @@ public class CXXImproperTypecastScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash();
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaBreadcrumbNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaBreadcrumbNativeCrashScenario.java
@@ -26,10 +26,6 @@ public class CXXJavaBreadcrumbNativeCrashScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         Bugsnag.leaveBreadcrumb("Bridge connector activated");
         activate();
     }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaUserInfoNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaUserInfoNativeCrashScenario.java
@@ -26,10 +26,6 @@ public class CXXJavaUserInfoNativeCrashScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         Bugsnag.setUser("9816734", "j@example.com", "Strulyegha  Ghaumon  "
                 + "Rabelban  Snefkal  Angengtai  Samperris  Dreperwar Raygariss  Haytther "
                 + " Ackworkin  Turdrakin  Clardon");

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNullPointerScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNullPointerScenario.java
@@ -25,10 +25,6 @@ public class CXXNullPointerScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash();
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXPausedSessionScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXPausedSessionScenario.java
@@ -30,18 +30,14 @@ public class CXXPausedSessionScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-
-        if (metadata == null || !metadata.equals("non-crashy")) {
-            Bugsnag.getClient().startSession();
-            Bugsnag.getClient().pauseSession();
-            TestHarnessHooksKt.flushAllSessions();
-            handler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    crash(0);
-                }
-            }, 500);
-        }
+        Bugsnag.getClient().startSession();
+        Bugsnag.getClient().pauseSession();
+        TestHarnessHooksKt.flushAllSessions();
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                crash(0);
+            }
+        }, 500);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSessionInfoCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSessionInfoCrashScenario.java
@@ -32,17 +32,15 @@ public class CXXSessionInfoCrashScenario extends Scenario {
         super.startScenario();
         String metadata = getEventMetadata();
 
-        if (metadata == null || !metadata.equals("non-crashy")) {
-            Bugsnag.startSession();
-            TestHarnessHooksKt.flushAllSessions();
-            Bugsnag.notify(new Exception("For the first"));
-            Bugsnag.notify(new Exception("For the second"));
-            handler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    crash(3837);
-                }
-            }, 2500);
-        }
+        Bugsnag.startSession();
+        TestHarnessHooksKt.flushAllSessions();
+        Bugsnag.notify(new Exception("For the first"));
+        Bugsnag.notify(new Exception("For the second"));
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                crash(3837);
+            }
+        }, 2500);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigabrtScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigabrtScenario.java
@@ -25,10 +25,6 @@ public class CXXSigabrtScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(2726);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigbusScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigbusScenario.java
@@ -25,10 +25,6 @@ public class CXXSigbusScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(2726);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigfpeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigfpeScenario.java
@@ -25,10 +25,6 @@ public class CXXSigfpeScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(2726);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigillScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigillScenario.java
@@ -25,10 +25,6 @@ public class CXXSigillScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(2726);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigsegvScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigsegvScenario.java
@@ -25,10 +25,6 @@ public class CXXSigsegvScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(2726);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigtrapScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigtrapScenario.java
@@ -25,10 +25,6 @@ public class CXXSigtrapScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(2726);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStackoverflowScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStackoverflowScenario.java
@@ -25,10 +25,6 @@ public class CXXStackoverflowScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(1209, "some moderately long text, longer than 7 characters at least.");
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.java
@@ -32,15 +32,13 @@ public class CXXStartSessionScenario extends Scenario {
         super.startScenario();
         String metadata = getEventMetadata();
 
-        if (metadata == null || !metadata.equals("non-crashy")) {
-            Bugsnag.getClient().startSession();
-            TestHarnessHooksKt.flushAllSessions();
-            handler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    crash(0);
-                }
-            }, 2500);
-        }
+        Bugsnag.getClient().startSession();
+        TestHarnessHooksKt.flushAllSessions();
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                crash(0);
+            }
+        }, 2500);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingOutsideReleaseStagesScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingOutsideReleaseStagesScenario.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 class CXXThrowSomethingOutsideReleaseStagesScenario(
     config: Configuration,
@@ -25,6 +24,4 @@ class CXXThrowSomethingOutsideReleaseStagesScenario(
         super.startScenario()
         crash(23)
     }
-
-    override fun getInterceptedLogMessages() = getZeroEventsLogMessages(eventMetadata)
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingOutsideReleaseStagesScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingOutsideReleaseStagesScenario.kt
@@ -23,9 +23,7 @@ class CXXThrowSomethingOutsideReleaseStagesScenario(
 
     override fun startScenario() {
         super.startScenario()
-        if ("non-crashy" != eventMetadata) {
-            crash(23)
-        }
+        crash(23)
     }
 
     override fun getInterceptedLogMessages() = getZeroEventsLogMessages(eventMetadata)

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingOutsideReleaseStagesScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingOutsideReleaseStagesScenario.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 class CXXThrowSomethingOutsideReleaseStagesScenario(
     config: Configuration,
@@ -23,5 +24,9 @@ class CXXThrowSomethingOutsideReleaseStagesScenario(
     override fun startScenario() {
         super.startScenario()
         crash(23)
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingScenario.java
@@ -25,10 +25,6 @@ public class CXXThrowSomethingScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash(23);
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapOutsideReleaseStagesScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapOutsideReleaseStagesScenario.kt
@@ -20,9 +20,7 @@ class CXXTrapOutsideReleaseStagesScenario(
 
     override fun startScenario() {
         super.startScenario()
-        if (eventMetadata != "non-crashy") {
-            crash()
-        }
+        crash()
     }
 
     override fun getInterceptedLogMessages() = getZeroEventsLogMessages(eventMetadata)

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapOutsideReleaseStagesScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapOutsideReleaseStagesScenario.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 class CXXTrapOutsideReleaseStagesScenario(
     config: Configuration,
@@ -22,6 +21,4 @@ class CXXTrapOutsideReleaseStagesScenario(
         super.startScenario()
         crash()
     }
-
-    override fun getInterceptedLogMessages() = getZeroEventsLogMessages(eventMetadata)
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapOutsideReleaseStagesScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapOutsideReleaseStagesScenario.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 class CXXTrapOutsideReleaseStagesScenario(
     config: Configuration,
@@ -20,5 +21,9 @@ class CXXTrapOutsideReleaseStagesScenario(
     override fun startScenario() {
         super.startScenario()
         crash()
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapScenario.java
@@ -25,10 +25,6 @@ public class CXXTrapScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash();
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXUpdateContextCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXUpdateContextCrashScenario.java
@@ -28,9 +28,6 @@ public class CXXUpdateContextCrashScenario extends Scenario {
     public void startScenario() {
         super.startScenario();
         String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         Context context = getContext();
         Bugsnag.setContext("Everest");
 

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXWriteReadOnlyMemoryScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXWriteReadOnlyMemoryScenario.java
@@ -25,10 +25,6 @@ public class CXXWriteReadOnlyMemoryScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         crash();
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
@@ -10,14 +10,12 @@ fun log(msg: String) {
  * Gets the log messages expected when zero events should be sent to Bugsnag.
  */
 fun getZeroEventsLogMessages(startBugsnagOnly: Boolean): List<String> {
-    log("getZeroEventsLogMessages called with: " + startBugsnagOnly)
     return if (startBugsnagOnly) {
-        listOf (
+        listOf(
             "No startupcrash events to flush to Bugsnag.",
             "No regular events to flush to Bugsnag."
         )
-    }
-    else {
+    } else {
         emptyList()
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
@@ -7,15 +7,11 @@ fun log(msg: String) {
 }
 
 /**
- * Gets the log messages expected when zero events should be sent to Bugsna.
+ * Gets the log messages expected when zero events should be sent to Bugsnag.
  */
 fun getZeroEventsLogMessages(eventMetadata: String?): List<String> {
-    return if ("non-crashy" == eventMetadata) {
-        listOf(
-            "No startupcrash events to flush to Bugsnag.",
-            "No regular events to flush to Bugsnag."
-        )
-    } else {
-        emptyList()
-    }
+    return listOf(
+        "No startupcrash events to flush to Bugsnag.",
+        "No regular events to flush to Bugsnag."
+    )
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
@@ -9,9 +9,15 @@ fun log(msg: String) {
 /**
  * Gets the log messages expected when zero events should be sent to Bugsnag.
  */
-fun getZeroEventsLogMessages(eventMetadata: String?): List<String> {
-    return listOf(
-        "No startupcrash events to flush to Bugsnag.",
-        "No regular events to flush to Bugsnag."
-    )
+fun getZeroEventsLogMessages(startBugsnagOnly: Boolean): List<String> {
+    log("getZeroEventsLogMessages called with: " + startBugsnagOnly)
+    return if (startBugsnagOnly) {
+        listOf (
+            "No startupcrash events to flush to Bugsnag.",
+            "No regular events to flush to Bugsnag."
+        )
+    }
+    else {
+        emptyList()
+    }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomHttpClientFlushScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomHttpClientFlushScenario.kt
@@ -15,22 +15,21 @@ internal class CustomHttpClientFlushScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
         config.autoTrackSessions = false
 
-        if ("non-crashy" == eventMetadata) {
+        if (startBugsnagOnly) {
             config.delivery = createCustomHeaderDelivery()
         } else {
             disableAllDelivery(config)
         }
+        super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {
         super.startScenario()
 
-        if ("non-crashy" != eventMetadata) {
-            Bugsnag.startSession()
-            throw RuntimeException("ReportCacheScenario")
-        }
+        Bugsnag.startSession()
+        throw RuntimeException("ReportCacheScenario")
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedReportScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedReportScenario.kt
@@ -17,12 +17,10 @@ internal class DeletedReportScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
         config.autoTrackSessions = false
 
-        if (eventMetadata != "non-crashy") {
-            disableAllDelivery(config)
-        } else {
+        if (startBugsnagOnly) {
             val baseDelivery = createDefaultDelivery()
             val errDir = File(context.cacheDir, "bugsnag-errors")
 
@@ -40,7 +38,11 @@ internal class DeletedReportScenario(
                     return baseDelivery.deliver(payload, deliveryParams)
                 }
             }
+        } else {
+            disableAllDelivery(config)
         }
+
+        super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedReportScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedReportScenario.kt
@@ -45,9 +45,6 @@ internal class DeletedReportScenario(
 
     override fun startScenario() {
         super.startScenario()
-
-        if (eventMetadata != "non-crashy") {
-            Bugsnag.notify(java.lang.RuntimeException("Whoops"))
-        }
+        Bugsnag.notify(java.lang.RuntimeException("Whoops"))
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedSessionScenario.kt
@@ -29,8 +29,8 @@ internal class DeletedSessionScenario(
 
             config.delivery = object : Delivery {
                 override fun deliver(
-                        payload: Session,
-                        deliveryParams: DeliveryParams
+                    payload: Session,
+                    deliveryParams: DeliveryParams
                 ): DeliveryStatus {
                     // delete files before they can be delivered
                     val files = errDir.listFiles()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeletedSessionScenario.kt
@@ -20,19 +20,17 @@ internal class DeletedSessionScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
         config.autoTrackSessions = false
 
-        if (eventMetadata != "non-crashy") {
-            disableAllDelivery(config)
-        } else {
+        if (startBugsnagOnly) {
             val baseDelivery = createDefaultDelivery()
             val errDir = File(context.cacheDir, "bugsnag-sessions")
 
             config.delivery = object : Delivery {
                 override fun deliver(
-                    payload: Session,
-                    deliveryParams: DeliveryParams
+                        payload: Session,
+                        deliveryParams: DeliveryParams
                 ): DeliveryStatus {
                     // delete files before they can be delivered
                     val files = errDir.listFiles()
@@ -46,15 +44,16 @@ internal class DeletedSessionScenario(
                     return baseDelivery.deliver(payload, deliveryParams)
                 }
             }
+        } else {
+            disableAllDelivery(config)
         }
+        super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {
         super.startScenario()
 
-        if (eventMetadata != "non-crashy") {
-            Bugsnag.startSession()
-        }
+        Bugsnag.startSession()
 
         val thread = HandlerThread("HandlerThread")
         thread.start()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
@@ -21,9 +21,7 @@ internal class DisableAutoDetectErrorsScenario(
 
     override fun startScenario() {
         super.startScenario()
-        if ("non-crashy" != eventMetadata) {
-            throw RuntimeException("Should never appear")
-        }
+        throw RuntimeException("Should never appear")
     }
 
     override fun getInterceptedLogMessages() = getZeroEventsLogMessages(eventMetadata)

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 /**
  * Attempts to send a handled exception to Bugsnag, when the exception handler is disabled,
@@ -23,6 +22,4 @@ internal class DisableAutoDetectErrorsScenario(
         super.startScenario()
         throw RuntimeException("Should never appear")
     }
-
-    override fun getInterceptedLogMessages() = getZeroEventsLogMessages(eventMetadata)
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 /**
  * Attempts to send a handled exception to Bugsnag, when the exception handler is disabled,
@@ -21,5 +22,9 @@ internal class DisableAutoDetectErrorsScenario(
     override fun startScenario() {
         super.startScenario()
         throw RuntimeException("Should never appear")
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
@@ -11,23 +11,15 @@ internal class EmptyReportScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-        val errDir = File(context.cacheDir, "bugsnag-errors")
-
-        if (eventMetadata != "non-crashy") {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
+        if (startBugsnagOnly) {
             disableAllDelivery(config)
-        } else {
-            val files = errDir.listFiles()
-            files.forEach { it.writeText("") }
         }
     }
 
     override fun startScenario() {
         super.startScenario()
 
-        if (eventMetadata != "non-crashy") {
-            Bugsnag.notify(java.lang.RuntimeException("Whoops"))
-        }
+        Bugsnag.notify(java.lang.RuntimeException("Whoops"))
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import java.io.File
 
 internal class EmptyReportScenario(
     config: Configuration,

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyReportScenario.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import java.io.File
 
 internal class EmptyReportScenario(
     config: Configuration,
@@ -11,9 +12,16 @@ internal class EmptyReportScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     override fun startBugsnag(startBugsnagOnly: Boolean) {
+        config.autoTrackSessions = false
+
         if (startBugsnagOnly) {
             disableAllDelivery(config)
+        } else {
+            val errDir = File(context.cacheDir, "bugsnag-errors")
+            val files = errDir.listFiles()
+            files.forEach { it.writeText("") }
         }
+        super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptySessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptySessionScenario.kt
@@ -15,26 +15,24 @@ internal class EmptySessionScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
         config.autoTrackSessions = false
 
         val dir = File(context.cacheDir, "bugsnag-sessions")
 
-        if (eventMetadata != "non-crashy") {
-            disableAllDelivery(config)
-        } else {
+        if (startBugsnagOnly) {
             val files = dir.listFiles()
             Log.d("Bugsnag", "Empty sessions: $files")
             files.forEach { it.writeText("") }
+        } else {
+            disableAllDelivery(config)
         }
     }
 
     override fun startScenario() {
         super.startScenario()
 
-        if (eventMetadata != "non-crashy") {
-            Bugsnag.startSession()
-        }
+        Bugsnag.startSession()
 
         val thread = HandlerThread("HandlerThread")
         thread.start()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptySessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptySessionScenario.kt
@@ -27,6 +27,7 @@ internal class EmptySessionScenario(
         } else {
             disableAllDelivery(config)
         }
+        super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalReportScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalReportScenario.kt
@@ -27,20 +27,12 @@ internal class InternalReportScenario(
             storageManager.setCacheBehaviorGroup(errDir, true)
             storageManager.setCacheBehaviorTombstone(errDir, true)
         }
-
-        if (eventMetadata != "non-crashy") {
-            disableAllDelivery(config)
-        } else {
-            val files = errDir.listFiles()
-            files.forEach { it.writeText("{[]}") }
-        }
     }
 
     override fun startScenario() {
         super.startScenario()
 
-        if (eventMetadata != "non-crashy") {
-            Bugsnag.notify(java.lang.RuntimeException("Whoops"))
-        }
+        disableAllDelivery(config)
+        Bugsnag.notify(java.lang.RuntimeException("Whoops"))
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalReportScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalReportScenario.kt
@@ -29,10 +29,19 @@ internal class InternalReportScenario(
         }
     }
 
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
+        if (startBugsnagOnly) {
+            val errDir = File(context.cacheDir, "bugsnag-errors")
+            val files = errDir.listFiles()
+            files.forEach { it.writeText("{[]}") }
+        } else {
+            disableAllDelivery(config)
+        }
+    }
+
     override fun startScenario() {
         super.startScenario()
 
-        disableAllDelivery(config)
         Bugsnag.notify(java.lang.RuntimeException("Whoops"))
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationFromManifestScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationFromManifestScenario.kt
@@ -12,7 +12,8 @@ internal class LoadConfigurationFromManifestScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    override fun startBugsnag() {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
+        this.startBugsnagOnly = startBugsnagOnly
         val testConfig = Configuration.load(this.context)
         testConfig.addOnError(
             OnErrorCallback { event ->

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
@@ -14,7 +14,8 @@ internal class LoadConfigurationKotlinScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    override fun startBugsnag() {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
+        this.startBugsnagOnly = startBugsnagOnly
         val testConfig = Configuration("78978978978978978978978978978978")
         testConfig.apiKey = "45645645645645645645645645645645"
         testConfig.appVersion = "0.9.8"

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationNullsScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationNullsScenario.java
@@ -28,7 +28,8 @@ public class LoadConfigurationNullsScenario extends Scenario {
     }
 
     @Override
-    public void startBugsnag() {
+    public void startBugsnag(boolean startBugsnagOnly) {
+        setStartBugsnagOnly(startBugsnagOnly);
         Configuration testConfig = new Configuration("12312312312312312312312312312312");
         // Setup
         testConfig.setAutoDetectErrors(true);

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
@@ -18,31 +18,27 @@ internal class ManualSessionSmokeScenario(
     init {
         config.autoTrackSessions = false
 
-        if (eventMetadata != "non-crashy") {
-            val baseDelivery = createDefaultDelivery()
-            var state = 0
-            config.delivery = InterceptingDelivery(baseDelivery) {
-                when (state) {
-                    0 -> Bugsnag.notify(generateException())
-                    1 -> {
-                        Bugsnag.pauseSession()
-                        Bugsnag.notify(generateException())
-                    }
-                    2 -> {
-                        Bugsnag.resumeSession()
-                        throw generateException()
-                    }
+        val baseDelivery = createDefaultDelivery()
+        var state = 0
+        config.delivery = InterceptingDelivery(baseDelivery) {
+            when (state) {
+                0 -> Bugsnag.notify(generateException())
+                1 -> {
+                    Bugsnag.pauseSession()
+                    Bugsnag.notify(generateException())
                 }
-                state++
+                2 -> {
+                    Bugsnag.resumeSession()
+                    throw generateException()
+                }
             }
+            state++
         }
     }
 
     override fun startScenario() {
         super.startScenario()
-        if (eventMetadata != "non-crashy") {
-            Bugsnag.setUser("123", "ABC.CBA.CA", "ManualSessionSmokeScenario")
-            Bugsnag.startSession()
-        }
+        Bugsnag.setUser("123", "ABC.CBA.CA", "ManualSessionSmokeScenario")
+        Bugsnag.startSession()
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
@@ -15,25 +15,28 @@ internal class ManualSessionSmokeScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
         config.autoTrackSessions = false
 
-        val baseDelivery = createDefaultDelivery()
-        var state = 0
-        config.delivery = InterceptingDelivery(baseDelivery) {
-            when (state) {
-                0 -> Bugsnag.notify(generateException())
-                1 -> {
-                    Bugsnag.pauseSession()
-                    Bugsnag.notify(generateException())
+        if (!startBugsnagOnly) {
+            val baseDelivery = createDefaultDelivery()
+            var state = 0
+            config.delivery = InterceptingDelivery(baseDelivery) {
+                when (state) {
+                    0 -> Bugsnag.notify(generateException())
+                    1 -> {
+                        Bugsnag.pauseSession()
+                        Bugsnag.notify(generateException())
+                    }
+                    2 -> {
+                        Bugsnag.resumeSession()
+                        throw generateException()
+                    }
                 }
-                2 -> {
-                    Bugsnag.resumeSession()
-                    throw generateException()
-                }
+                state++
             }
-            state++
         }
+        super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToHandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToHandledExceptionScenario.kt
@@ -28,8 +28,6 @@ internal class OverrideToHandledExceptionScenario(
     override fun startScenario() {
         super.startScenario()
         Bugsnag.startSession()
-        if (eventMetadata != "non-crashy") {
-            throw generateException()
-        }
+        throw generateException()
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/PartialSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/PartialSessionScenario.kt
@@ -14,25 +14,24 @@ internal class PartialSessionScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
         config.autoTrackSessions = false
 
-        val dir = File(context.cacheDir, "bugsnag-sessions")
-
-        if (eventMetadata != "non-crashy") {
-            disableAllDelivery(config)
-        } else {
+        if (startBugsnagOnly) {
+            val dir = File(context.cacheDir, "bugsnag-sessions")
             val files = dir.listFiles()
             files.forEach { it.writeText("{[]}") }
+        } else {
+            disableAllDelivery(config)
         }
+
+        super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {
         super.startScenario()
 
-        if (eventMetadata != "non-crashy") {
-            Bugsnag.startSession()
-        }
+        Bugsnag.startSession()
 
         val thread = HandlerThread("HandlerThread")
         thread.start()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -19,6 +19,7 @@ import com.bugsnag.android.EventPayload
 import com.bugsnag.android.Session
 import com.bugsnag.android.createDefaultDelivery
 import com.bugsnag.android.mazerunner.BugsnagIntentParams
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 import com.bugsnag.android.mazerunner.log
 import com.bugsnag.android.mazerunner.multiprocess.MultiProcessService
 import com.bugsnag.android.mazerunner.multiprocess.findCurrentProcessName
@@ -30,18 +31,25 @@ abstract class Scenario(
 ) : Application.ActivityLifecycleCallbacks {
 
     /**
+     * Tracks whether the scenario is starting Bugsnag only, or running the scenario.
+     */
+    protected var startBugsnagOnly: Boolean = false
+
+    /**
      * Determines what log messages should be intercepted from Bugsnag and sent to Mazerunner
      * using a HTTP requests to the /logs endpoint. This is used to assert that Bugsnag is
      * behaving correctly in situations where sending an error/session payload is not
      * possible.
      */
-    open fun getInterceptedLogMessages() = emptyList<String>()
+    open fun getInterceptedLogMessages() = getZeroEventsLogMessages(startBugsnagOnly)
 
     /**
      * Initializes Bugsnag. It is possible to override this method if the scenario requires
      * it - e.g., if the config needs to be loaded from the manifest.
      */
-    open fun startBugsnag() {
+    open fun startBugsnag(startBugsnagOnly: Boolean) {
+        log("startBugsnag called with: " + startBugsnagOnly)
+        this.startBugsnagOnly = startBugsnagOnly
         Bugsnag.start(context, config)
     }
 
@@ -49,6 +57,8 @@ abstract class Scenario(
      * Runs code which should result in Bugsnag capturing an error or session.
      */
     open fun startScenario() {
+        log("startScenario startBugsnagOnly now false")
+        startBugsnagOnly = false
     }
 
     /**

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -48,7 +48,6 @@ abstract class Scenario(
      * it - e.g., if the config needs to be loaded from the manifest.
      */
     open fun startBugsnag(startBugsnagOnly: Boolean) {
-        log("startBugsnag called with: " + startBugsnagOnly)
         this.startBugsnagOnly = startBugsnagOnly
         Bugsnag.start(context, config)
     }
@@ -57,7 +56,6 @@ abstract class Scenario(
      * Runs code which should result in Bugsnag capturing an error or session.
      */
     open fun startScenario() {
-        log("startScenario startBugsnagOnly now false")
         startBugsnagOnly = false
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -19,7 +19,6 @@ import com.bugsnag.android.EventPayload
 import com.bugsnag.android.Session
 import com.bugsnag.android.createDefaultDelivery
 import com.bugsnag.android.mazerunner.BugsnagIntentParams
-import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 import com.bugsnag.android.mazerunner.log
 import com.bugsnag.android.mazerunner.multiprocess.MultiProcessService
 import com.bugsnag.android.mazerunner.multiprocess.findCurrentProcessName
@@ -41,7 +40,9 @@ abstract class Scenario(
      * behaving correctly in situations where sending an error/session payload is not
      * possible.
      */
-    open fun getInterceptedLogMessages() = getZeroEventsLogMessages(startBugsnagOnly)
+    open fun getInterceptedLogMessages(): List<String> {
+        return emptyList<String>()
+    }
 
     /**
      * Initializes Bugsnag. It is possible to override this method if the scenario requires

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SharedPrefMigrationScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SharedPrefMigrationScenario.kt
@@ -20,9 +20,9 @@ internal class SharedPrefMigrationScenario(
         config.persistUser = true
     }
 
-    override fun startBugsnag() {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
         persistLegacyPrefs()
-        super.startBugsnag()
+        super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnsatisfiedLinkErrorScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnsatisfiedLinkErrorScenario.java
@@ -21,10 +21,6 @@ public class UnsatisfiedLinkErrorScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
-        if (metadata != null && metadata.equals("non-crashy")) {
-            return;
-        }
         doesNotExist();
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/multiprocess/MultiProcessService.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/multiprocess/MultiProcessService.kt
@@ -49,7 +49,7 @@ class MultiProcessService : Service() {
         val config = prepareServiceConfig(params)
 
         scenario = Scenario.load(this, config, params.eventType!!, params.eventMetadata).apply {
-            startBugsnag()
+            startBugsnag(false)
             log("Executing scenario")
             startScenario()
         }

--- a/features/full_tests/batch_1/cached_error_reports.feature
+++ b/features/full_tests/batch_1/cached_error_reports.feature
@@ -2,7 +2,6 @@ Feature: Cached Error Reports
 
 Scenario: If an empty file is in the cache directory then zero requests should be made
     When I run "EmptyReportScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "EmptyReportScenario"
     Then I should receive no requests
 
@@ -11,7 +10,6 @@ Scenario: If an empty file is in the cache directory then zero requests should b
 @skip_above_android_7
 Scenario: Sending internal error reports on API <26
     When I run "InternalReportScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "InternalReportScenario"
     Then I should receive no requests
 
@@ -20,7 +18,6 @@ Scenario: Sending internal error reports on API <26
 @skip_below_android_8
 Scenario: Sending internal error reports on API >=26
     When I run "InternalReportScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "InternalReportScenario"
     Then I should receive no requests
 
@@ -30,7 +27,6 @@ Scenario: Sending internal error reports on API >=26
 Scenario: Sending internal error reports with cache tombstone + groups enabled
     And I configure the app to run in the "tombstone" state
     When I run "InternalReportScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "InternalReportScenario"
     Then I should receive no requests
 
@@ -38,6 +34,5 @@ Scenario: Sending internal error reports with cache tombstone + groups enabled
 @skip
 Scenario: If a file in the cache directory is deleted before a request completes, zero further requests should be made
     When I run "DeletedReportScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "DeletedReportScenario"
     Then I should receive no requests

--- a/features/full_tests/batch_1/cached_error_reports.feature
+++ b/features/full_tests/batch_1/cached_error_reports.feature
@@ -2,7 +2,7 @@ Feature: Cached Error Reports
 
 Scenario: If an empty file is in the cache directory then zero requests should be made
     When I run "EmptyReportScenario" and relaunch the app
-    And I run "EmptyReportScenario"
+    And I configure Bugsnag for "EmptyReportScenario"
     Then I should receive no requests
 
 # TODO: Skip pending PLAT-5488
@@ -10,7 +10,7 @@ Scenario: If an empty file is in the cache directory then zero requests should b
 @skip_above_android_7
 Scenario: Sending internal error reports on API <26
     When I run "InternalReportScenario" and relaunch the app
-    And I run "InternalReportScenario"
+    And I configure Bugsnag for "InternalReportScenario"
     Then I should receive no requests
 
 # TODO: Skip pending PLAT-5488
@@ -18,7 +18,7 @@ Scenario: Sending internal error reports on API <26
 @skip_below_android_8
 Scenario: Sending internal error reports on API >=26
     When I run "InternalReportScenario" and relaunch the app
-    And I run "InternalReportScenario"
+    And I configure Bugsnag for "InternalReportScenario"
     Then I should receive no requests
 
 # TODO: Skip pending PLAT-5488
@@ -27,12 +27,12 @@ Scenario: Sending internal error reports on API >=26
 Scenario: Sending internal error reports with cache tombstone + groups enabled
     And I configure the app to run in the "tombstone" state
     When I run "InternalReportScenario" and relaunch the app
-    And I run "InternalReportScenario"
+    And I configure Bugsnag for "InternalReportScenario"
     Then I should receive no requests
 
 # TODO: Skip pending PLAT-5488
 @skip
 Scenario: If a file in the cache directory is deleted before a request completes, zero further requests should be made
     When I run "DeletedReportScenario" and relaunch the app
-    And I run "DeletedReportScenario"
+    And I configure Bugsnag for "DeletedReportScenario"
     Then I should receive no requests

--- a/features/full_tests/batch_1/cached_session_reports.feature
+++ b/features/full_tests/batch_1/cached_session_reports.feature
@@ -2,19 +2,19 @@ Feature: Cached Session Reports
 
 Scenario: If an empty file is in the cache directory then zero requests should be made
     When I run "EmptySessionScenario" and relaunch the app
-    And I run "EmptySessionScenario"
+    And I configure Bugsnag for "EmptySessionScenario"
     Then I should receive no requests
 
 # TODO: Skip pending PLAT-5488
 @skip
 Scenario: Sending internal error reports on API <26
     When I run "PartialSessionScenario" and relaunch the app
-    And I run "PartialSessionScenario"
+    And I configure Bugsnag for "PartialSessionScenario"
     Then I should receive no requests
 
 # TODO: Skip pending PLAT-5488
 @skip
 Scenario: If a file in the cache directory is deleted before a request completes, zero further requests should be made
     When I run "DeletedSessionScenario" and relaunch the app
-    And I run "DeletedSessionScenario"
+    And I configure Bugsnag for "DeletedSessionScenario"
     Then I should receive no requests

--- a/features/full_tests/batch_1/cached_session_reports.feature
+++ b/features/full_tests/batch_1/cached_session_reports.feature
@@ -2,7 +2,6 @@ Feature: Cached Session Reports
 
 Scenario: If an empty file is in the cache directory then zero requests should be made
     When I run "EmptySessionScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "EmptySessionScenario"
     Then I should receive no requests
 
@@ -10,7 +9,6 @@ Scenario: If an empty file is in the cache directory then zero requests should b
 @skip
 Scenario: Sending internal error reports on API <26
     When I run "PartialSessionScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "PartialSessionScenario"
     Then I should receive no requests
 
@@ -18,6 +16,5 @@ Scenario: Sending internal error reports on API <26
 @skip
 Scenario: If a file in the cache directory is deleted before a request completes, zero further requests should be made
     When I run "DeletedSessionScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "DeletedSessionScenario"
     Then I should receive no requests

--- a/features/full_tests/batch_1/custom_http_client.feature
+++ b/features/full_tests/batch_1/custom_http_client.feature
@@ -3,8 +3,7 @@ Feature: Using custom API clients for reporting errors
 Scenario: Set a custom HTTP client and flush a stored error + session
     When I configure the app to run in the "offline" state
     And I run "CustomHttpClientFlushScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
-    And I run "CustomHttpClientFlushScenario"
+    And I configure Bugsnag for "CustomHttpClientFlushScenario"
 
     # error received
     And I wait to receive an error

--- a/features/full_tests/batch_1/ignored_reports.feature
+++ b/features/full_tests/batch_1/ignored_reports.feature
@@ -7,18 +7,15 @@ Scenario: Exception classname ignored
 
 Scenario: Disabled Exception Handler
     When I run "DisableAutoDetectErrorsScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "DisableAutoDetectErrorsScenario"
     Then Bugsnag confirms it has no errors to send
 
 Scenario: Changing release stage to exclude the current stage settings before a POSIX signal
     When I run "CXXTrapOutsideReleaseStagesScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "CXXTrapOutsideReleaseStagesScenario"
     Then Bugsnag confirms it has no errors to send
 
 Scenario: Changing release stage settings to exclude the current stage before a native C++ crash
     When I run "CXXThrowSomethingOutsideReleaseStagesScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "CXXThrowSomethingOutsideReleaseStagesScenario"
     Then Bugsnag confirms it has no errors to send

--- a/features/full_tests/batch_1/multi_process.feature
+++ b/features/full_tests/batch_1/multi_process.feature
@@ -34,7 +34,6 @@ Scenario: Unhandled JVM error
     When I run "MultiProcessUnhandledExceptionScenario" and relaunch the app
     And I configure the app to run in the "multi-process-service" state
     And I run "MultiProcessUnhandledExceptionScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "MultiProcessUnhandledExceptionScenario"
     Then I wait to receive 2 errors
     And I sort the errors by "events.0.metaData.process.name"
@@ -55,7 +54,7 @@ Scenario: Unhandled JVM error
 
 Scenario: Handled NDK error
     When I run "MultiProcessHandledCXXErrorScenario"
-        Then I wait to receive 2 errors
+    Then I wait to receive 2 errors
     And I sort the errors by "events.0.metaData.process.name"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload contains a completed handled native report
@@ -85,7 +84,6 @@ Scenario: Unhandled NDK error
     When I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the app
     And I configure the app to run in the "multi-process-service" state
     And I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I run "MultiProcessUnhandledCXXErrorScenario"
     Then I wait to receive 2 errors
     And I sort the errors by "events.0.metaData.process.name"

--- a/features/full_tests/batch_2/native_api.feature
+++ b/features/full_tests/batch_2/native_api.feature
@@ -2,7 +2,6 @@ Feature: Native API
 
     Scenario: Set extraordinarily long app information
         When I run "CXXExtraordinaryLongStringScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXExtraordinaryLongStringScenario"
         And I wait to receive an error
         And the error payload contains a completed handled native report

--- a/features/full_tests/batch_2/native_breadcrumbs.feature
+++ b/features/full_tests/batch_2/native_breadcrumbs.feature
@@ -2,7 +2,6 @@ Feature: Native Breadcrumbs API
 
     Scenario: Leaving breadcrumbs in C followed by a Java crash
         When I run "CXXNativeBreadcrumbJavaCrashScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXNativeBreadcrumbJavaCrashScenario"
         And I wait to receive an error
         And the error payload contains a completed handled native report

--- a/features/full_tests/batch_2/native_context.feature
+++ b/features/full_tests/batch_2/native_context.feature
@@ -12,7 +12,6 @@ Feature: Native Context API
 
     Scenario: Update context in Java followed by crashing in C
         When I run "CXXUpdateContextCrashScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXUpdateContextCrashScenario"
         And I wait to receive an error
         Then the error payload contains a completed handled native report

--- a/features/full_tests/batch_2/native_crash_handling.feature
+++ b/features/full_tests/batch_2/native_crash_handling.feature
@@ -2,7 +2,6 @@ Feature: Native crash reporting
 
 Scenario: Dereference a null pointer
         When I run "CXXNullPointerScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXNullPointerScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -29,7 +28,6 @@ Scenario: Dereference a null pointer
     @skip_below_api18
     Scenario: Stack buffer overflow
         When I run "CXXStackoverflowScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXStackoverflowScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -40,7 +38,6 @@ Scenario: Dereference a null pointer
 
     Scenario: Program trap()
         When I run "CXXTrapScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXTrapScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -56,7 +53,6 @@ Scenario: Dereference a null pointer
 
     Scenario: Write to read-only memory
         When I run "CXXWriteReadOnlyMemoryScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXWriteReadOnlyMemoryScenario"
         And I wait to receive an error
         And the exception "errorClass" equals "SIGSEGV"
@@ -69,7 +65,6 @@ Scenario: Dereference a null pointer
     @skip_android_10 @skip_android_11
     Scenario: Double free() allocated memory
         When I run "CXXDoubleFreeScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXDoubleFreeScenario"
         And I wait to receive an error
         And the exception "type" equals "c"
@@ -81,7 +76,6 @@ Scenario: Dereference a null pointer
 
     Scenario: Improper object type cast
         When I run "CXXImproperTypecastScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXImproperTypecastScenario"
         And I wait to receive an error
         And the exception "errorClass" equals "SIGSEGV"
@@ -92,7 +86,6 @@ Scenario: Dereference a null pointer
 
     Scenario: Program abort()
         When I run "CXXAbortScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXAbortScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -108,7 +101,6 @@ Scenario: Dereference a null pointer
 
     Scenario: Undefined JNI method
         When I run "UnsatisfiedLinkErrorScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "UnsatisfiedLinkErrorScenario"
         And I wait to receive an error
         And the report contains the required fields
@@ -119,7 +111,6 @@ Scenario: Dereference a null pointer
 
     Scenario: Causing a crash in a separate library
         When I run "CXXExternalStackElementScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXExternalStackElementScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report

--- a/features/full_tests/batch_2/native_on_error.feature
+++ b/features/full_tests/batch_2/native_on_error.feature
@@ -2,13 +2,11 @@ Feature: Native on error callbacks are invoked
 
     Scenario: on_error returning false prevents C signal being reported
         When I run "CXXSignalOnErrorFalseScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXSignalOnErrorFalseScenario"
         Then Bugsnag confirms it has no errors to send
 
     Scenario: on_error returning false prevents C++ exception being reported
         When I run "CXXExceptionOnErrorFalseScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXExceptionOnErrorFalseScenario"
         Then Bugsnag confirms it has no errors to send
 

--- a/features/full_tests/batch_2/native_session_tracking.feature
+++ b/features/full_tests/batch_2/native_session_tracking.feature
@@ -2,7 +2,6 @@ Feature: NDK Session Tracking
 
 Scenario: Paused session is not in payload of unhandled NDK error
     And I run "CXXPausedSessionScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "CXXPausedSessionScenario"
     And I wait to receive a session
     Then the session is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
@@ -13,7 +12,6 @@ Scenario: Paused session is not in payload of unhandled NDK error
 
 Scenario: Started session is in payload of unhandled NDK error
     And I run "CXXStartSessionScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "CXXStartSessionScenario"
     And I wait to receive a session
     Then the session is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
@@ -24,7 +22,6 @@ Scenario: Started session is in payload of unhandled NDK error
 
 Scenario: Starting a session, notifying, followed by a C crash
     When I run "CXXSessionInfoCrashScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "CXXSessionInfoCrashScenario"
     And I wait to receive a session
     And I wait to receive 3 errors

--- a/features/full_tests/batch_2/native_signal_raise.feature
+++ b/features/full_tests/batch_2/native_signal_raise.feature
@@ -2,7 +2,6 @@ Feature: Raising native signals
 
     Scenario: Raise SIGILL
         When I run "CXXSigillScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXSigillScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -16,7 +15,6 @@ Feature: Raising native signals
 
     Scenario: Raise SIGSEGV
         When I run "CXXSigsegvScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXSigsegvScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -28,7 +26,6 @@ Feature: Raising native signals
 
     Scenario: Raise SIGABRT
         When I run "CXXSigabrtScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXSigabrtScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -40,7 +37,6 @@ Feature: Raising native signals
 
     Scenario: Raise SIGBUS
         When I run "CXXSigbusScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXSigbusScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -52,7 +48,6 @@ Feature: Raising native signals
 
     Scenario: Raise SIGFPE
         When I run "CXXSigfpeScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXSigfpeScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -64,7 +59,6 @@ Feature: Raising native signals
 
     Scenario: Raise SIGTRAP
         When I run "CXXSigtrapScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXSigtrapScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report

--- a/features/full_tests/batch_2/native_throw_crash.feature
+++ b/features/full_tests/batch_2/native_throw_crash.feature
@@ -2,7 +2,6 @@ Feature: Native crash reporting with thrown objects
 
     Scenario: Throwing an exception in C++
         When I run "CXXExceptionScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXExceptionScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report
@@ -13,7 +12,6 @@ Feature: Native crash reporting with thrown objects
 
     Scenario: Throwing an object in C++
         When I run "CXXThrowSomethingScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXThrowSomethingScenario"
         And I wait to receive an error
         And the error payload contains a completed unhandled native report

--- a/features/full_tests/batch_2/native_user.feature
+++ b/features/full_tests/batch_2/native_user.feature
@@ -2,7 +2,6 @@ Feature: Native User API
 
     Scenario: Adding user information in Java followed by a C crash
         And I run "CXXJavaUserInfoNativeCrashScenario" and relaunch the app
-        And I configure the app to run in the "non-crashy" state
         And I configure Bugsnag for "CXXJavaUserInfoNativeCrashScenario"
         And I wait to receive an error
         Then the error payload contains a completed handled native report

--- a/features/full_tests/batch_2/naughty_strings.feature
+++ b/features/full_tests/batch_2/naughty_strings.feature
@@ -27,7 +27,6 @@ Scenario: Test handled JVM error
 @skip_below_android_6
 Scenario: Test unhandled NDK error
     When I run "CXXNaughtyStringsScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "CXXNaughtyStringsScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/batch_2/override_unhandled.feature
+++ b/features/full_tests/batch_2/override_unhandled.feature
@@ -15,7 +15,6 @@ Scenario: Non-fatal exception overridden to unhandled
 
 Scenario: Fatal exception overridden to handled
     When I run "OverrideToHandledExceptionScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "OverrideToHandledExceptionScenario"
     And I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -30,7 +29,6 @@ Scenario: Fatal exception overridden to handled
 
 Scenario: CXX error overridden to handled
     When I run "CXXHandledOverrideScenario" and relaunch the app
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "CXXHandledOverrideScenario"
     And I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -54,7 +54,6 @@ Scenario: Automated sessions send
 Scenario: Manual session control works
     When I run "ManualSessionSmokeScenario"
     And I relaunch the app after a crash
-    And I configure the app to run in the "non-crashy" state
     And I configure Bugsnag for "ManualSessionSmokeScenario"
     And I wait to receive a session
 

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -52,8 +52,7 @@ Scenario: Automated sessions send
     And the event "severityReason.unhandledOverridden" is false
 
 Scenario: Manual session control works
-    When I run "ManualSessionSmokeScenario"
-    And I relaunch the app after a crash
+    When I run "ManualSessionSmokeScenario" and relaunch the app
     And I configure Bugsnag for "ManualSessionSmokeScenario"
     And I wait to receive a session
 

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -20,9 +20,9 @@ end
 
 When("I run {string}") do |event_type|
   steps %Q{
-    Given any dialog is cleared and the element "scenarioText" is present
-    When I send the keys "#{event_type}" to the element "scenarioText"
-    And I click the element "startScenarioButton"
+    Given any dialog is cleared and the element "scenario_name" is present
+    When I send the keys "#{event_type}" to the element "scenario_name"
+    And I click the element "run_scenario"
   }
 end
 
@@ -41,9 +41,9 @@ end
 
 When("I configure Bugsnag for {string}") do |event_type|
   steps %Q{
-    Given any dialog is cleared and the element "scenarioText" is present
-    When I send the keys "#{event_type}" to the element "scenarioText"
-    And I click the element "startBugsnagButton"
+    Given any dialog is cleared and the element "scenario_name" is present
+    When I send the keys "#{event_type}" to the element "scenario_name"
+    And I click the element "start_bugsnag"
   }
 end
 
@@ -68,10 +68,11 @@ When("I tap the screen {int} times") do |count|
   }
 end
 
+
 When("I configure the app to run in the {string} state") do |event_metadata|
   steps %Q{
-    Given any dialog is cleared and the element "scenarioMetaData" is present
-    And I send the keys "#{event_metadata}" to the element "scenarioMetaData"
+    Given any dialog is cleared and the element "scenario_metadata" is present
+    And I send the keys "#{event_metadata}" to the element "scenario_metadata"
   }
 end
 


### PR DESCRIPTION
## Goal

Remove use of "non-crashy" metadata from e2e test scenarios, simplifying the test code base and removing several Appium interactions (approx 0.5s each).

## Design

Rather than than passing "non-crashy" through as metadata for the scenario, knowledge of whether the app is "crashy" or reopening after a crash is now built into the test fixture buttons.  Pressing "Start Bugsnag" will, by default, only start Bugsnag and is typically used to send any errors after relaunching a crashed app.  "Run Scenario" will start Bugsnag and perform any notify/crashes coded into the scenario.  

This default behaviour is sufficient for most scenarios, but can be overridden as necessary.  When it is, the `startBugsnag` function is overridden with conditional logic based on the `startBugsnagOnly` parameter (calling `super.StartBugsnag` at the end).

The Cucumber steps of interest are:
- `I configure Bugsnag for {string}` ("Start Bugsnag only")
- `I run {string} and relaunch the app` 

## Changeset

Whilst refactoring the test fixture, I took to opportunity to update the layout to be more consistent with our other notifiers and in line with internally published conventions.

## Testing

Covered by a full CI run.  A few scenarios are currently `@skip`ped and it's harder to see if these have been updated completely correctly.  However, any errors or omissions should naturally come out in the wash when the relevant ticket is processed.