### PR TITLE
Fix rare crash when loading device ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Check additional JNI calls for pending exceptions and no-op
   [#1133](https://github.com/bugsnag/bugsnag-android/pull/1133)
 
+* Fix rare crash when loading device ID
+  [#1137](https://github.com/bugsnag/bugsnag-android/pull/1137)
+
 ## 5.6.0 (2021-02-08)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceIdStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceIdStore.kt
@@ -31,7 +31,7 @@ internal class DeviceIdStore @JvmOverloads constructor(
             if (!file.exists()) {
                 file.createNewFile()
             }
-        } catch (exc: IOException) {
+        } catch (exc: Throwable) {
             logger.w("Failed to created device ID file", exc)
         }
         this.synchronizedStreamableStore = SynchronizedStreamableStore(file)
@@ -64,7 +64,7 @@ internal class DeviceIdStore @JvmOverloads constructor(
             } else {
                 return persistNewDeviceUuid(uuidProvider)
             }
-        } catch (exc: Exception) {
+        } catch (exc: Throwable) {
             logger.w("Failed to load device ID", exc)
             null
         }
@@ -79,7 +79,7 @@ internal class DeviceIdStore @JvmOverloads constructor(
         if (file.length() > 0) {
             try {
                 return synchronizedStreamableStore.load(DeviceId.Companion::fromReader)
-            } catch (exc: IOException) {
+            } catch (exc: Throwable) {
                 logger.w("Failed to load device ID", exc)
             }
         }


### PR DESCRIPTION
## Goal

The `DeviceIdStore` can throw an `AssertionError` from [JsonReader#peek()](https://developer.android.com/reference/android/util/JsonReader#peek()) if the file contents are empty. Because `DeviceIdStore` only catches `Exception`, this can result in a crash when initializing Bugsnag.

## Changeset

Catching `Throwable` rather than `Exception` fixes the problem.

Looking at the implementation of `JsonReader`, it appears that the error can get thrown when reading from an empty file. This could be caused by some an I/O or JSON serialization error - e.g. when there is no space left on the device.

The implementation can't currently recover from this scenario but should be able to do so with this fix. This fix allows the notifier to attempt to persist a new device ID each initialization if one was not present, and in the worst case returns an empty string for device ID.