### PR TITLE
Move free() call to exit block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Check additional JNI calls for pending exceptions and no-op
   [#1142](https://github.com/bugsnag/bugsnag-android/pull/1142)
+* Move free() call to exit block
+  [#1140](https://github.com/bugsnag/bugsnag-android/pull/1140)
 
 ## 5.6.2 (2021-02-15)
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -200,7 +200,6 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
     } else {
       BUGSNAG_LOG("Failed to serialize event as JSON: %s", event_path);
     }
-    free(event);
   } else {
     BUGSNAG_LOG("Failed to read event at file: %s", event_path);
   }
@@ -209,6 +208,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
 
 exit:
   pthread_mutex_unlock(&bsg_native_delivery_mutex);
+  if (event != NULL) {
+    free(event);
+  }
   bsg_safe_release_byte_array_elements(env, jpayload, (jbyte *)payload);
   if (payload != NULL) {
     free(payload);


### PR DESCRIPTION
## Goal

Moves a `free()` to the exit block so that it is always called when cleaning up the `deliverReportAtPath` function.