### PR TITLE
Improve how NDK payload is freed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Check additional JNI calls for pending exceptions and no-op
+  [#1142](https://github.com/bugsnag/bugsnag-android/pull/1142)
+
 ## 5.6.2 (2021-02-15)
 
 ### Bug fixes

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -193,11 +193,10 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
 
 exit:
   if (jname != NULL) {
-    bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name, JNI_COMMIT);
+    bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name);
   }
   if (jmessage != NULL) {
-    bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message,
-                                         JNI_COMMIT);
+    bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message);
   }
   bsg_safe_delete_local_ref(env, jname);
   bsg_safe_delete_local_ref(env, jmessage);
@@ -267,9 +266,9 @@ void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
   bsg_safe_call_static_void_method(env, interface_class, set_user_method, jid,
                                    jemail, jname);
 
-  bsg_safe_release_byte_array_elements(env, jid, (jbyte *)id, JNI_COMMIT);
-  bsg_safe_release_byte_array_elements(env, jemail, (jbyte *)email, JNI_COMMIT);
-  bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name, JNI_COMMIT);
+  bsg_safe_release_byte_array_elements(env, jid, (jbyte *)id);
+  bsg_safe_release_byte_array_elements(env, jemail, (jbyte *)email);
+  bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name);
 
   bsg_safe_delete_local_ref(env, jid);
   bsg_safe_delete_local_ref(env, jemail);
@@ -352,8 +351,7 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
   goto exit;
 
 exit : {
-  bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message,
-                                       JNI_COMMIT);
+  bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message);
 }
   bsg_safe_delete_local_ref(env, interface_class);
   bsg_safe_delete_local_ref(env, type_class);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -209,10 +209,12 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
 
 exit:
   pthread_mutex_unlock(&bsg_native_delivery_mutex);
-  bsg_safe_release_byte_array_elements(env, jpayload, (jbyte *)payload,
-                                       0); // <-- frees payload
-  bsg_safe_release_byte_array_elements(
-      env, jstage, (jbyte *)event->app.release_stage, JNI_COMMIT);
+  bsg_safe_release_byte_array_elements(env, jpayload, (jbyte *)payload);
+  if (payload != NULL) {
+    free(payload);
+  }
+  bsg_safe_release_byte_array_elements(env, jstage,
+                                       (jbyte *)event->app.release_stage);
   bsg_safe_delete_local_ref(env, jpayload);
   bsg_safe_delete_local_ref(env, jstage);
   bsg_safe_release_string_utf_chars(env, _report_path, event_path);

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -220,9 +220,15 @@ void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string,
 }
 
 void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array,
-                                          jbyte *elems, jint mode) {
+                                          jbyte *elems) {
+  // If mode is anything other than JNI_COMMIT, the JNI method will try and call
+  // delete[] on the elems parameter, which leads to bad things happening (e.g.
+  // aborting will cause it to free, blowing up any custom allocators).
+  // Therefore JNI_COMMIT will always be called and the caller should free the
+  // elems parameter themselves if necessary.
+  // https://android.googlesource.com/platform/art/+/refs/heads/master/runtime/jni/jni_internal.cc#2689
   if (env != NULL && array != NULL) {
-    (*env)->ReleaseByteArrayElements(env, array, elems, mode);
+    (*env)->ReleaseByteArrayElements(env, array, elems, JNI_COMMIT);
   }
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -170,9 +170,12 @@ void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string,
 /**
  * A safe wrapper for the JNI's ReleaseByteArrayElements. This method checks if
  * an exception is pending and if so clears it so that execution can continue.
+ *
+ * The caller is responsible for freeing the elems parameter after invoking this
+ * method, if elems was allocated using malloc or new.
  */
 void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array,
-                                          jbyte *elems, jint mode);
+                                          jbyte *elems);
 
 /**
  * A safe wrapper for the JNI's GetArrayLength. This method checks if the


### PR DESCRIPTION
## Goal

Ensures that `JNI_COMMIT` is always used when calling `ReleaseByteArrayElements`, and that any variables allocated via malloc/new are freed manually. This is preferable to the default mode which calls `delete []` on elems, leading to undesirable behaviour.