### PR TITLE
Plat 5957/additional backports

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -62,12 +62,6 @@ jfieldID bsg_parse_jseverity(JNIEnv *env, bsg_severity_t severity,
   }
 }
 
-void bsg_release_byte_ary(JNIEnv *env, jbyteArray array, char *original_text) {
-  if (array != NULL) {
-    (*env)->ReleaseByteArrayElements(env, array, (jbyte *)original_text, JNI_COMMIT);
-  }
-}
-
 void bsg_populate_notify_stacktrace(JNIEnv *env, bsg_stackframe *stacktrace,
                                    ssize_t frame_count, jclass trace_class,
                                    jmethodID trace_constructor,
@@ -104,8 +98,8 @@ void bsg_populate_notify_stacktrace(JNIEnv *env, bsg_stackframe *stacktrace,
     goto exit;
 
     exit:
-    (*env)->DeleteLocalRef(env, filename);
-    (*env)->DeleteLocalRef(env, class);
+    bsg_safe_delete_local_ref(env, filename);
+    bsg_safe_delete_local_ref(env, class);
   }
 }
 
@@ -196,19 +190,19 @@ void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
 
   exit:
   if (jname != NULL) {
-    bsg_release_byte_ary(env, jname, name);
+    bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name);
   }
   if (jmessage != NULL) {
-    bsg_release_byte_ary(env, jmessage, message);
+    bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message);
   }
-  (*env)->DeleteLocalRef(env, jname);
-  (*env)->DeleteLocalRef(env, jmessage);
+  bsg_safe_delete_local_ref(env, jname);
+  bsg_safe_delete_local_ref(env, jmessage);
 
-  (*env)->DeleteLocalRef(env, interface_class);
-  (*env)->DeleteLocalRef(env, trace_class);
-  (*env)->DeleteLocalRef(env, severity_class);
-  (*env)->DeleteLocalRef(env, trace);
-  (*env)->DeleteLocalRef(env, jseverity);
+  bsg_safe_delete_local_ref(env, interface_class);
+  bsg_safe_delete_local_ref(env, trace_class);
+  bsg_safe_delete_local_ref(env, severity_class);
+  bsg_safe_delete_local_ref(env, trace);
+  bsg_safe_delete_local_ref(env, jseverity);
 }
 
 void bugsnag_set_binary_arch(JNIEnv *env) {
@@ -240,8 +234,8 @@ void bugsnag_set_binary_arch(JNIEnv *env) {
   goto exit;
 
   exit:
-  (*env)->DeleteLocalRef(env, arch);
-  (*env)->DeleteLocalRef(env, interface_class);
+  bsg_safe_delete_local_ref(env, arch);
+  bsg_safe_delete_local_ref(env, interface_class);
 }
 
 void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
@@ -269,18 +263,18 @@ void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
   bsg_safe_call_static_void_method(env, interface_class, set_user_method, jid,
                                    jemail, jname);
 
-  bsg_release_byte_ary(env, jid, id);
-  bsg_release_byte_ary(env, jemail, email);
-  bsg_release_byte_ary(env, jname, name);
+  bsg_safe_release_byte_array_elements(env, jid, (jbyte *)id);
+  bsg_safe_release_byte_array_elements(env, jemail, (jbyte *)email);
+  bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name);
 
-  (*env)->DeleteLocalRef(env, jid);
-  (*env)->DeleteLocalRef(env, jemail);
-  (*env)->DeleteLocalRef(env, jname);
+  bsg_safe_delete_local_ref(env, jid);
+  bsg_safe_delete_local_ref(env, jemail);
+  bsg_safe_delete_local_ref(env, jname);
 
   goto exit;
 
   exit:
-  (*env)->DeleteLocalRef(env, interface_class);
+  bsg_safe_delete_local_ref(env, interface_class);
 }
 
 jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bsg_breadcrumb_t type,
@@ -354,9 +348,9 @@ void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
   goto exit;
 
   exit:
-  bsg_release_byte_ary(env, jmessage, message);
-  (*env)->DeleteLocalRef(env, interface_class);
-  (*env)->DeleteLocalRef(env, type_class);
-  (*env)->DeleteLocalRef(env, jtype);
-  (*env)->DeleteLocalRef(env, jmessage);
+  bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message);
+  bsg_safe_delete_local_ref(env, interface_class);
+  bsg_safe_delete_local_ref(env, type_class);
+  bsg_safe_delete_local_ref(env, jtype);
+  bsg_safe_delete_local_ref(env, jmessage);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -270,8 +270,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
 
   if (name != NULL && type != NULL && timestamp != NULL) {
     bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
-    strncpy(crumb->name, name, sizeof(crumb->name));
-    strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
+    bsg_strncpy_safe(crumb->name, name, sizeof(crumb->name));
+    bsg_strncpy_safe(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
     if (strcmp(type, "user") == 0) {
       crumb->type = BSG_CRUMB_USER;
     } else if (strcmp(type, "error") == 0) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -85,8 +85,13 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   bugsnag_env->report_header.big_endian =
       htonl(47) == 47; // potentially too clever, see man 3 htonl
   bugsnag_env->report_header.version = BUGSNAG_REPORT_VERSION;
-  const char *report_path = (*env)->GetStringUTFChars(env, _report_path, 0);
+  const char *report_path = bsg_safe_get_string_utf_chars(env, _report_path);
+  if (report_path == NULL) {
+    return;
+  }
+
   sprintf(bugsnag_env->next_report_path, "%s", report_path);
+  bsg_safe_release_string_utf_chars(env, _report_path, report_path);
 
   if ((bool)auto_notify) {
     bsg_handler_install_signal(bugsnag_env);
@@ -107,7 +112,6 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
                      sizeof(bugsnag_env->report_header.os_build));
   }
 
-  (*env)->ReleaseStringUTFChars(env, _report_path, report_path);
   bsg_global_env = bugsnag_env;
   BUGSNAG_LOG("Initialization complete!");
 }
@@ -117,7 +121,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
     JNIEnv *env, jobject _this, jstring _report_path) {
   static pthread_mutex_t bsg_native_delivery_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&bsg_native_delivery_mutex);
-  const char *report_path = (*env)->GetStringUTFChars(env, _report_path, 0);
+  const char *report_path = bsg_safe_get_string_utf_chars(env, _report_path);
+  if (report_path == NULL) {
+    return;
+  }
   bugsnag_report *report =
       bsg_deserialize_report_from_file((char *)report_path);
   jbyteArray jpayload = NULL;
@@ -164,7 +171,6 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
     BUGSNAG_LOG("Failed to read report at file: %s", report_path);
   }
   remove(report_path);
-  (*env)->ReleaseStringUTFChars(env, _report_path, report_path);
   goto exit;
 
   exit:
@@ -172,16 +178,15 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   if (report != NULL) {
     free(report);
   }
-  if (jpayload != NULL) {
-    (*env)->ReleaseByteArrayElements(env, jpayload, (jbyte *)payload,
-                                     0); // <-- frees payload
+  bsg_safe_release_byte_array_elements(env, jpayload, (jbyte *)payload);
+  if (payload != NULL) {
+    free(payload);
   }
-  if (jstage != NULL) {
-    (*env)->ReleaseByteArrayElements(
-        env, jstage, (jbyte *)report->app.release_stage, JNI_COMMIT);
-  }
-  (*env)->DeleteLocalRef(env, jpayload);
-  (*env)->DeleteLocalRef(env, jstage);
+  bsg_safe_release_byte_array_elements(env, jstage,
+                                       (jbyte *)report->app.release_stage);
+  bsg_safe_delete_local_ref(env, jpayload);
+  bsg_safe_delete_local_ref(env, jstage);
+  bsg_safe_release_string_utf_chars(env, _report_path, report_path);
 }
 
 JNIEXPORT void JNICALL
@@ -217,15 +222,17 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
     jint handled_count, jint unhandled_count) {
   if (bsg_global_env == NULL || session_id_ == NULL)
     return;
-  char *session_id = (char *)(*env)->GetStringUTFChars(env, session_id_, 0);
-  char *started_at = (char *)(*env)->GetStringUTFChars(env, start_date_, 0);
-  bsg_request_env_write_lock();
-  bugsnag_report_start_session(&bsg_global_env->next_report, session_id,
-                               started_at, handled_count, unhandled_count);
+  char *session_id = (char *)bsg_safe_get_string_utf_chars(env, session_id_);
+  char *started_at = (char *)bsg_safe_get_string_utf_chars(env, start_date_);
+  if (session_id != NULL && started_at != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_report_start_session(&bsg_global_env->next_report, session_id,
+                                 started_at, handled_count, unhandled_count);
 
-  bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, session_id_, session_id);
-  (*env)->ReleaseStringUTFChars(env, start_date_, started_at);
+    bsg_release_env_write_lock();
+  }
+  bsg_safe_release_string_utf_chars(env, session_id_, session_id);
+  bsg_safe_release_string_utf_chars(env, start_date_, started_at);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_stoppedSession(
@@ -257,94 +264,105 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
     jstring timestamp_, jobject metadata) {
   if (bsg_global_env == NULL)
     return;
-  const char *name = (*env)->GetStringUTFChars(env, name_, 0);
-  const char *type = (*env)->GetStringUTFChars(env, crumb_type, 0);
-  const char *timestamp = (*env)->GetStringUTFChars(env, timestamp_, 0);
-  bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
-  strncpy(crumb->name, name, sizeof(crumb->name));
-  strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
-  if (strcmp(type, "user") == 0) {
-    crumb->type = BSG_CRUMB_USER;
-  } else if (strcmp(type, "error") == 0) {
-    crumb->type = BSG_CRUMB_ERROR;
-  } else if (strcmp(type, "log") == 0) {
-    crumb->type = BSG_CRUMB_LOG;
-  } else if (strcmp(type, "navigation") == 0) {
-    crumb->type = BSG_CRUMB_NAVIGATION;
-  } else if (strcmp(type, "request") == 0) {
-    crumb->type = BSG_CRUMB_REQUEST;
-  } else if (strcmp(type, "state") == 0) {
-    crumb->type = BSG_CRUMB_STATE;
-  } else if (strcmp(type, "process") == 0) {
-    crumb->type = BSG_CRUMB_PROCESS;
-  } else {
-    crumb->type = BSG_CRUMB_MANUAL;
+  const char *name = bsg_safe_get_string_utf_chars(env, name_);
+  const char *type = bsg_safe_get_string_utf_chars(env, crumb_type);
+  const char *timestamp = bsg_safe_get_string_utf_chars(env, timestamp_);
+
+  if (name != NULL && type != NULL && timestamp != NULL) {
+    bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
+    strncpy(crumb->name, name, sizeof(crumb->name));
+    strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
+    if (strcmp(type, "user") == 0) {
+      crumb->type = BSG_CRUMB_USER;
+    } else if (strcmp(type, "error") == 0) {
+      crumb->type = BSG_CRUMB_ERROR;
+    } else if (strcmp(type, "log") == 0) {
+      crumb->type = BSG_CRUMB_LOG;
+    } else if (strcmp(type, "navigation") == 0) {
+      crumb->type = BSG_CRUMB_NAVIGATION;
+    } else if (strcmp(type, "request") == 0) {
+      crumb->type = BSG_CRUMB_REQUEST;
+    } else if (strcmp(type, "state") == 0) {
+      crumb->type = BSG_CRUMB_STATE;
+    } else if (strcmp(type, "process") == 0) {
+      crumb->type = BSG_CRUMB_PROCESS;
+    } else {
+      crumb->type = BSG_CRUMB_MANUAL;
+    }
+
+    bsg_populate_crumb_metadata(env, crumb, metadata);
+    bsg_request_env_write_lock();
+    bugsnag_report_add_breadcrumb(&bsg_global_env->next_report, crumb);
+    bsg_release_env_write_lock();
+
+    free(crumb);
   }
-
-  bsg_populate_crumb_metadata(env, crumb, metadata);
-  bsg_request_env_write_lock();
-  bugsnag_report_add_breadcrumb(&bsg_global_env->next_report, crumb);
-  bsg_release_env_write_lock();
-
-  free(crumb);
-  (*env)->ReleaseStringUTFChars(env, name_, name);
-  (*env)->ReleaseStringUTFChars(env, crumb_type, type);
-  (*env)->ReleaseStringUTFChars(env, timestamp_, timestamp);
+  bsg_safe_release_string_utf_chars(env, name_, name);
+  bsg_safe_release_string_utf_chars(env, crumb_type, type);
+  bsg_safe_release_string_utf_chars(env, timestamp_, timestamp);
 }
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateAppVersion(JNIEnv *env,
                                                            jobject _this,
                                                            jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  }
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_report_set_app_version(&bsg_global_env->next_report, value);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, new_value, value);
+  bsg_safe_release_string_utf_chars(env, new_value, value);
 }
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateBuildUUID(JNIEnv *env,
                                                           jobject _this,
                                                           jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  }
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_report_set_build_uuid(&bsg_global_env->next_report, value);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, new_value, value);
+  bsg_safe_release_string_utf_chars(env, new_value, value);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateContext(
     JNIEnv *env, jobject _this, jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  }
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_report_set_context(&bsg_global_env->next_report, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
     JNIEnv *env, jobject _this, jboolean new_value, jstring activity_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *activity = activity_ == NULL
-                       ? NULL
-                       : (char *)(*env)->GetStringUTFChars(env, activity_, 0);
+  }
+  char *activity = (char *)bsg_safe_get_string_utf_chars(env, activity_);
+  if (activity == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bool was_in_foreground = bsg_global_env->next_report.app.in_foreground;
   bsg_global_env->next_report.app.in_foreground = (bool)new_value;
@@ -360,7 +378,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
   }
   bsg_release_env_write_lock();
   if (activity_ != NULL) {
-    (*env)->ReleaseStringUTFChars(env, activity_, activity);
+    bsg_safe_release_string_utf_chars(env, activity_, activity);
   }
 }
 
@@ -390,46 +408,52 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateReleaseStage(
     JNIEnv *env, jobject _this, jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  }
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_report_set_release_stage(&bsg_global_env->next_report, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
     JNIEnv *env, jobject _this, jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  }
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_report_set_user_id(&bsg_global_env->next_report, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserName(
     JNIEnv *env, jobject _this, jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  }
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_report_set_user_name(&bsg_global_env->next_report, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
@@ -437,98 +461,117 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_updateUserEmail(JNIEnv *env,
                                                           jobject _this,
                                                           jstring new_value) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *value = new_value == NULL
-                    ? NULL
-                    : (char *)(*env)->GetStringUTFChars(env, new_value, 0);
+  }
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
+  if (value == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_report_set_user_email(&bsg_global_env->next_report, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
-    (*env)->ReleaseStringUTFChars(env, new_value, value);
+    bsg_safe_release_string_utf_chars(env, new_value, value);
   }
 }
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addMetadataString(
     JNIEnv *env, jobject _this, jstring tab_, jstring key_, jstring value_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
-  char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
-  char *value = (char *)(*env)->GetStringUTFChars(env, value_, 0);
-  bsg_request_env_write_lock();
-  bugsnag_report_add_metadata_string(&bsg_global_env->next_report, tab, key,
-                                     value);
-  bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
-  (*env)->ReleaseStringUTFChars(env, key_, key);
-  (*env)->ReleaseStringUTFChars(env, value_, value);
+  }
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
+  char *value = (char *)bsg_safe_get_string_utf_chars(env, value_);
+  if (tab != NULL && key != NULL && value != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_report_add_metadata_string(&bsg_global_env->next_report, tab, key,
+                                       value);
+    bsg_release_env_write_lock();
+  }
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, key_, key);
+  bsg_safe_release_string_utf_chars(env, value_, value);
 }
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addMetadataDouble(
     JNIEnv *env, jobject _this, jstring tab_, jstring key_, jdouble value_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
-  char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
-  bsg_request_env_write_lock();
-  bugsnag_report_add_metadata_double(&bsg_global_env->next_report, tab, key,
-                                     (double)value_);
-  bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
-  (*env)->ReleaseStringUTFChars(env, key_, key);
+  }
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
+  if (tab != NULL && key != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_report_add_metadata_double(&bsg_global_env->next_report, tab, key,
+                                       (double) value_);
+    bsg_release_env_write_lock();
+  }
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_addMetadataBoolean(
     JNIEnv *env, jobject _this, jstring tab_, jstring key_, jboolean value_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
-  char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
-  bsg_request_env_write_lock();
-  bugsnag_report_add_metadata_bool(&bsg_global_env->next_report, tab, key,
-                                   (bool)value_);
-  bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
-  (*env)->ReleaseStringUTFChars(env, key_, key);
+  }
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
+  if (tab != NULL && key != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_report_add_metadata_bool(&bsg_global_env->next_report, tab, key,
+                                     (bool) value_);
+    bsg_release_env_write_lock();
+  }
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_clearMetadataTab(JNIEnv *env,
                                                            jobject _this,
                                                            jstring tab_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
+  }
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  if (tab == NULL) {
+    return;
+  }
   bsg_request_env_write_lock();
   bugsnag_report_remove_metadata_tab(&bsg_global_env->next_report, tab);
   bsg_release_env_write_lock();
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_removeMetadata(
     JNIEnv *env, jobject _this, jstring tab_, jstring key_) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
-  char *tab = (char *)(*env)->GetStringUTFChars(env, tab_, 0);
-  char *key = (char *)(*env)->GetStringUTFChars(env, key_, 0);
+  }
+  char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
+  char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
 
-  bsg_request_env_write_lock();
-  bugsnag_report_remove_metadata(&bsg_global_env->next_report, tab, key);
-  bsg_release_env_write_lock();
+  if (tab != NULL && key != NULL) {
+    bsg_request_env_write_lock();
+    bugsnag_report_remove_metadata(&bsg_global_env->next_report, tab, key);
+    bsg_release_env_write_lock();
+  }
 
-  (*env)->ReleaseStringUTFChars(env, tab_, tab);
-  (*env)->ReleaseStringUTFChars(env, key_, key);
+  bsg_safe_release_string_utf_chars(env, tab_, tab);
+  bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateMetadata(
     JNIEnv *env, jobject _this, jobject metadata) {
-  if (bsg_global_env == NULL)
+  if (bsg_global_env == NULL) {
     return;
+  }
   bsg_request_env_write_lock();
   bsg_populate_metadata(env, &bsg_global_env->next_report, metadata);
   bsg_release_env_write_lock();

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -360,9 +360,6 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
     return;
   }
   char *activity = (char *)bsg_safe_get_string_utf_chars(env, activity_);
-  if (activity == NULL) {
-    return;
-  }
   bsg_request_env_write_lock();
   bool was_in_foreground = bsg_global_env->next_report.app.in_foreground;
   bsg_global_env->next_report.app.in_foreground = (bool)new_value;

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -551,7 +551,7 @@ void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
   if (_context != NULL) {
     const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_context);
     if (value != NULL) {
-      strncpy(report->context, value, sizeof(report->context) - 1);
+      bsg_strncpy_safe(report->context, value, sizeof(report->context) - 1);
       bsg_safe_release_string_utf_chars(env, _context, value);
     }
   } else {

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -3,6 +3,9 @@
 #include <utils/string.h>
 
 bool bsg_check_and_clear_exc(JNIEnv *env) {
+  if (env == NULL) {
+    return false;
+  }
   if ((*env)->ExceptionCheck(env)) {
     (*env)->ExceptionClear(env);
     return true;
@@ -11,6 +14,9 @@ bool bsg_check_and_clear_exc(JNIEnv *env) {
 }
 
 jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
+  if (env == NULL) {
+    return NULL;
+  }
   if (clz_name == NULL) {
     return NULL;
   }
@@ -21,7 +27,7 @@ jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
 
 jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
                                  const char *sig) {
-  if (clz == NULL || name == NULL || sig == NULL) {
+  if (env == NULL || clz == NULL || name == NULL || sig == NULL) {
     return NULL;
   }
   jmethodID methodId = (*env)->GetMethodID(env, clz, name, sig);
@@ -31,7 +37,7 @@ jmethodID bsg_safe_get_method_id(JNIEnv *env, jclass clz, const char *name,
 
 jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
                                         const char *name, const char *sig) {
-  if (clz == NULL || name == NULL || sig == NULL) {
+  if (env == NULL || clz == NULL || name == NULL || sig == NULL) {
     return NULL;
   }
   jmethodID methodId = (*env)->GetStaticMethodID(env, clz, name, sig);
@@ -40,7 +46,7 @@ jmethodID bsg_safe_get_static_method_id(JNIEnv *env, jclass clz,
 }
 
 jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
-  if (str == NULL) {
+  if (env == NULL || str == NULL) {
     return NULL;
   }
   jstring jstr = (*env)->NewStringUTF(env, str);
@@ -50,7 +56,7 @@ jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
 
 jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
                                       jmethodID method) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return false;
   }
   jboolean value = (*env)->CallBooleanMethod(env, _value, method);
@@ -61,7 +67,7 @@ jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
 }
 
 jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return -1;
   }
   jint value = (*env)->CallIntMethod(env, _value, method);
@@ -73,7 +79,7 @@ jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
 
 jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
                                   jmethodID method) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return -1;
   }
   jfloat value = (*env)->CallFloatMethod(env, _value, method);
@@ -85,7 +91,7 @@ jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
 
 jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
                                     jmethodID method) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return -1;
   }
   jdouble value = (*env)->CallDoubleMethod(env, _value, method);
@@ -96,7 +102,7 @@ jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
 }
 
 jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return NULL;
   }
   jobjectArray trace = (*env)->NewObjectArray(env, size, clz, NULL);
@@ -106,7 +112,7 @@ jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
 
 jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
                                           jsize size) {
-  if (array == NULL) {
+  if (env == NULL || array == NULL) {
     return NULL;
   }
   jobject obj = (*env)->GetObjectArrayElement(env, array, size);
@@ -116,7 +122,7 @@ jobject bsg_safe_get_object_array_element(JNIEnv *env, jobjectArray array,
 
 void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
                                        jsize size, jobject object) {
-  if (array == NULL) {
+  if (env == NULL || array == NULL) {
     return;
   }
   (*env)->SetObjectArrayElement(env, array, size, object);
@@ -125,7 +131,7 @@ void bsg_safe_set_object_array_element(JNIEnv *env, jobjectArray array,
 
 jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
                                       const char *sig) {
-  if (clz == NULL || name == NULL || sig == NULL) {
+  if (env == NULL || clz == NULL || name == NULL || sig == NULL) {
     return NULL;
   }
   jfieldID field_id = (*env)->GetStaticFieldID(env, clz, name, sig);
@@ -135,7 +141,7 @@ jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
 
 jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
                                          jfieldID field) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return NULL;
   }
   jobject obj = (*env)->GetStaticObjectField(env, clz, field);
@@ -144,7 +150,7 @@ jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
 }
 
 jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return NULL;
   }
   va_list args;
@@ -157,7 +163,7 @@ jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...) {
 
 jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
                                     jmethodID method, ...) {
-  if (_value == NULL) {
+  if (env == NULL || _value == NULL) {
     return NULL;
   }
   va_list args;
@@ -170,7 +176,7 @@ jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
 
 void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
                                       ...) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return;
   }
   va_list args;
@@ -182,7 +188,7 @@ void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
 
 jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
                                            jmethodID method, ...) {
-  if (clz == NULL) {
+  if (env == NULL || clz == NULL) {
     return NULL;
   }
   va_list args;
@@ -191,6 +197,53 @@ jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
   va_end(args);
   bsg_check_and_clear_exc(env);
   return obj;
+}
+
+void bsg_safe_delete_local_ref(JNIEnv *env, jobject obj) {
+  if (env != NULL) {
+    (*env)->DeleteLocalRef(env, obj);
+  }
+}
+
+const char *bsg_safe_get_string_utf_chars(JNIEnv *env, jstring string) {
+  if (env != NULL && string != NULL) {
+    return (*env)->GetStringUTFChars(env, string, NULL);
+  }
+  return NULL;
+}
+
+void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string,
+                                       const char *utf) {
+  if (env != NULL && string != NULL && utf != NULL) {
+    (*env)->ReleaseStringUTFChars(env, string, utf);
+  }
+}
+
+void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array,
+                                          jbyte *elems) {
+  // If mode is anything other than JNI_COMMIT, the JNI method will try and call
+  // delete[] on the elems parameter, which leads to bad things happening (e.g.
+  // aborting will cause it to free, blowing up any custom allocators).
+  // Therefore JNI_COMMIT will always be called and the caller should free the
+  // elems parameter themselves if necessary.
+  // https://android.googlesource.com/platform/art/+/refs/heads/master/runtime/jni/jni_internal.cc#2689
+  if (env != NULL && array != NULL) {
+    (*env)->ReleaseByteArrayElements(env, array, elems, JNI_COMMIT);
+  }
+}
+
+jsize bsg_safe_get_array_length(JNIEnv *env, jarray array) {
+  if (env != NULL && array != NULL) {
+    return (*env)->GetArrayLength(env, array);
+  }
+  return -1;
+}
+
+jboolean bsg_safe_is_instance_of(JNIEnv *env, jobject object, jclass clz) {
+  if (env != NULL && clz != NULL) {
+    return (*env)->IsInstanceOf(env, object, clz);
+  }
+  return false;
 }
 
 jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -148,6 +148,49 @@ jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
                                            jmethodID method, ...);
 
 /**
+ * A safe wrapper for the JNI's DeleteLocalRef. This method checks if the env
+ * is NULL and no-ops if so.
+ */
+void bsg_safe_delete_local_ref(JNIEnv *env, jobject obj);
+
+/**
+ * A safe wrapper for the JNI's GetStringUTFChars. This method checks if the
+ * parameters are NULL and returns NULL if so. The caller is responsible for
+ * checking for NULL return values.
+ */
+const char *bsg_safe_get_string_utf_chars(JNIEnv *env, jstring string);
+
+/**
+ * A safe wrapper for the JNI's ReleaseStringUTFChars. This method checks if the
+ * parameters are NULL and no-ops if so.
+ */
+void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string,
+                                       const char *utf);
+
+/**
+ * A safe wrapper for the JNI's ReleaseByteArrayElements. This method checks if
+ * an exception is pending and if so clears it so that execution can continue.
+ *
+ * The caller is responsible for freeing the elems parameter after invoking this
+ * method, if elems was allocated using malloc or new.
+ */
+void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array,
+                                          jbyte *elems);
+
+/**
+ * A safe wrapper for the JNI's GetArrayLength. This method checks if the
+ * parameters are NULL and no-ops if so. The caller is responsible for handling
+ * the invalid return value of -1.
+ */
+jsize bsg_safe_get_array_length(JNIEnv *env, jarray array);
+
+/**
+ * A safe wrapper for the JNI's IsInstanceOf. This method checks if the
+ * parameters are NULL and returns false if so.
+ */
+jboolean bsg_safe_is_instance_of(JNIEnv *env, jobject object, jclass clz);
+
+/**
  * Constructs a byte array from a string.
  */
 jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -32,7 +32,7 @@ size_t bsg_strlen(const char *str) {
   }
 }
 
-void bsg_strncpy_safe(char *dst, char *src, int dst_size) {
+void bsg_strncpy_safe(char *dst, const char *src, int dst_size) {
   if (dst_size == 0)
     return;
   dst[0] = '\0';

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -26,7 +26,7 @@ void bsg_strncpy(char *dst, char *src, size_t len) __asyncsafe;
 /**
  * Copy a string from src to dst, null padding the rest
  */
-void bsg_strncpy_safe(char *dst, char *src, int dst_size);
+void bsg_strncpy_safe(char *dst, const char *src, int dst_size);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/features/native_api.feature
+++ b/tests/features/native_api.feature
@@ -159,7 +159,7 @@ Feature: Native API
           | SIGILL |
           | SIGTRAP |
         And the event "app.version" equals "22.312.749.78.300.810.24.167.32"
-        And the event "context" equals "ObservableSessionInitializerStringParserStringSessionProxyGloba"
+        And the event "context" equals "ObservableSessionInitializerStringParserStringSessionProxyGlob"
         And the event "unhandled" is true
 
     Scenario: Add custom metadata followed by notifying in C


### PR DESCRIPTION
Backport of #1133 to the v4 branch for bugsnag-unity..

## Goal

Performs additional checking of JNI calls for pending exceptions, and no-ops if these are detected. This changeset also wraps all JNI calls in a `bsg_safe` wrapper, which checks for disallowed parameter values such as `NULL` and no-ops.

## Changeset

The changeset is roughly broken up into individual commits for each affected JNI method:

```
DeleteLocalRef
ReleaseByteArrayElements
ReleaseStringUTFChars
GetStringUTFChars
IsInstanceOf
GetArrayLength
```

Each affected method has been added to `safejni.h` and its parameters checked according to the [JNI docs](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html). For `GetStringUTFChars` the calling method has been updated to handle a `NULL` return value where necessary.

JNI calls in the ANR plugin have also been updated to perform equivalent safety checks.

Some internal method signatures have been updated where possible to use `const char *` rather than `char *`, as this is what `GetStringUTFChars` actually returns - a lot of invocations have been incorrectly casting it to `char *`.

## Testing

Relied on existing E2E test coverage, also performed smoke testing with example app on emulator to cover x86 architectures.