### PR TITLE
Ensure ANR handler calls JNI code safely

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../maze-runner
+GIT
+  remote: https://github.com/bugsnag/maze-runner
+  revision: b12f25a65267a99162a40abf28fe02c3048a097f
+  tag: v4.10.1
   specs:
     bugsnag-maze-runner (4.10.1)
       appium_lib (~> 11.2.0)


### PR DESCRIPTION
## Goal

Adds safe wrapper calls to the ANR handler code which invokes the JNI.

Because the ANR handler is in a separate module to the NDK code, the relevant methods have been temporarily duplicated until the project can be restructured to the point where it can share C code between modules. A ticket has been raised to do this but it will likely require a major version bump.