### PR TITLE
Replace strncpy() usage with safe function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [#1142](https://github.com/bugsnag/bugsnag-android/pull/1142)
 * Move free() call to exit block
   [#1140](https://github.com/bugsnag/bugsnag-android/pull/1140)
+* Replace strncpy() usage with safe function call
+  [#1149](https://github.com/bugsnag/bugsnag-android/pull/1149)
 
 ## 5.6.2 (2021-02-15)
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -296,8 +296,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
 
   if (name != NULL && type != NULL && timestamp != NULL) {
     bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
-    strncpy(crumb->name, name, sizeof(crumb->name));
-    strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
+    bsg_strncpy_safe(crumb->name, name, sizeof(crumb->name));
+    bsg_strncpy_safe(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
     if (strcmp(type, "user") == 0) {
       crumb->type = BSG_CRUMB_USER;
     } else if (strcmp(type, "error") == 0) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -574,7 +574,7 @@ void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
   if (_context != NULL) {
     const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_context);
     if (value != NULL) {
-      strncpy(event->context, value, sizeof(event->context) - 1);
+      bsg_strncpy_safe(event->context, value, sizeof(event->context) - 1);
       bsg_safe_release_string_utf_chars(env, _context, value);
     }
   } else {


### PR DESCRIPTION
## Goal

Wraps all usages of `strncpy()` in a safe function call. This was first identified in #1143 and needs porting to `next`.