### PR TITLE
Prevent NPE when delivering internal error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   [#1140](https://github.com/bugsnag/bugsnag-android/pull/1140)
 * Replace strncpy() usage with safe function call
   [#1149](https://github.com/bugsnag/bugsnag-android/pull/1149)
+* Prevent NPE when delivering internal error reports
+  [#1150](https://github.com/bugsnag/bugsnag-android/pull/1150)
 
 ## 5.6.2 (2021-02-15)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryHeaders.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryHeaders.kt
@@ -21,7 +21,7 @@ internal const val HEADER_INTERNAL_ERROR = "Bugsnag-Internal-Error"
 internal fun errorApiHeaders(payload: EventPayload): Map<String, String?> {
     val mutableHeaders = mutableMapOf(
         HEADER_API_PAYLOAD_VERSION to "4.0",
-        HEADER_API_KEY to payload.apiKey!!,
+        HEADER_API_KEY to (payload.apiKey ?: ""),
         HEADER_BUGSNAG_SENT_AT to DateUtils.toIso8601(Date()),
         HEADER_CONTENT_TYPE to "application/json"
     )


### PR DESCRIPTION
## Goal

Prevents an NPE when the `apiKey` is null - as in the case of internal error reports. This prevents internal error reports from being sent, and was discovered in #1144, which reenables these E2E tests. It does not affect normal functioning of Bugsnag for the end-user.

## Testing

Ran locally against new tests added in #1144 to confirm issue is no longer present.