### PR TITLE
Detail how to test against sonatype staging artefact

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -75,6 +75,7 @@ If you are a project maintainer, you can build and release a new version of
 - Once merged:
   - Checkout `master` and pull the latest changes
   - [ ] Upload artefacts to Maven Central and Bintray with `./gradlew clean assembleRelease publish bintrayUpload`
+  - [ ] Test the Sonatype artefacts in the example app by adding the newly created 'combugsnag-XXXX' repository to the build.gradle:  `maven {url "https://oss.sonatype.org/service/local/repositories/combugsnag-XXXX/content/"}`
   - [ ] "Promote" the release build on Maven Central:
     - Go to the [sonatype open source dashboard](https://oss.sonatype.org/index.html#stagingRepositories)
     - Click the search box at the top right, and type “com.bugsnag”


### PR DESCRIPTION
## Goal

It seems to be possible to test against the artefacts uploaded to Sonatype, although the official docs and Android guides are quite unclear on how do this. This changeset adds a note to the release steps on how this can be achieved.