### PR TITLE
Improve build stability for v4 back-ports

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -119,6 +119,7 @@ steps:
         command:
           - "-e"
           - "features/[n-z].*.feature"
+          - "--retry=2"
     env:
       DEVICE_TYPE: "ANDROID_9"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -136,6 +137,7 @@ steps:
         command:
           - "-e"
           - "features/[a-m].*.feature"
+          - "--retry=2"
     env:
       DEVICE_TYPE: "ANDROID_9"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -183,6 +185,7 @@ steps:
         command:
           - "-e"
           - "features/[n-z].*.feature"
+          - "--retry=2"
     env:
       DEVICE_TYPE: "ANDROID_6"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -200,6 +203,7 @@ steps:
         command:
           - "-e"
           - "features/[a-m].*.feature"
+          - "--retry=2"
     env:
       DEVICE_TYPE: "ANDROID_6"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -217,6 +221,7 @@ steps:
         command:
           - "-e"
           - "features/[n-z].*.feature"
+          - "--retry=2"
     env:
       DEVICE_TYPE: "ANDROID_7"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -234,6 +239,7 @@ steps:
         command:
           - "-e"
           - "features/[a-m].*.feature"
+          - "--retry=2"
     env:
       DEVICE_TYPE: "ANDROID_7"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -251,6 +257,7 @@ steps:
         command:
           - "-e"
           - "features/[n-z].*.feature"
+          - "--retry=2"
     env:
       DEVICE_TYPE: "ANDROID_8"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -268,6 +275,7 @@ steps:
         command:
           - "-e"
           - "features/[a-m].*.feature"
+          - "--retry=2"
     env:
       DEVICE_TYPE: "ANDROID_8"
       APP_LOCATION: "/app/build/fixture.apk"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,6 +120,8 @@ steps:
           - "-e"
           - "features/[n-z].*.feature"
           - "--retry=2"
+          - "--strict-undefined"
+          - "--strict-pending"
     env:
       DEVICE_TYPE: "ANDROID_9"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -138,6 +140,8 @@ steps:
           - "-e"
           - "features/[a-m].*.feature"
           - "--retry=2"
+          - "--strict-undefined"
+          - "--strict-pending"
     env:
       DEVICE_TYPE: "ANDROID_9"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -186,6 +190,8 @@ steps:
           - "-e"
           - "features/[n-z].*.feature"
           - "--retry=2"
+          - "--strict-undefined"
+          - "--strict-pending"
     env:
       DEVICE_TYPE: "ANDROID_6"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -204,6 +210,8 @@ steps:
           - "-e"
           - "features/[a-m].*.feature"
           - "--retry=2"
+          - "--strict-undefined"
+          - "--strict-pending"
     env:
       DEVICE_TYPE: "ANDROID_6"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -222,6 +230,8 @@ steps:
           - "-e"
           - "features/[n-z].*.feature"
           - "--retry=2"
+          - "--strict-undefined"
+          - "--strict-pending"
     env:
       DEVICE_TYPE: "ANDROID_7"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -240,6 +250,8 @@ steps:
           - "-e"
           - "features/[a-m].*.feature"
           - "--retry=2"
+          - "--strict-undefined"
+          - "--strict-pending"
     env:
       DEVICE_TYPE: "ANDROID_7"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -258,6 +270,8 @@ steps:
           - "-e"
           - "features/[n-z].*.feature"
           - "--retry=2"
+          - "--strict-undefined"
+          - "--strict-pending"
     env:
       DEVICE_TYPE: "ANDROID_8"
       APP_LOCATION: "/app/build/fixture.apk"
@@ -276,6 +290,8 @@ steps:
           - "-e"
           - "features/[a-m].*.feature"
           - "--retry=2"
+          - "--strict-undefined"
+          - "--strict-pending"
     env:
       DEVICE_TYPE: "ANDROID_8"
       APP_LOCATION: "/app/build/fixture.apk"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,6 +115,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "-e"
@@ -135,6 +136,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "-e"
@@ -171,6 +173,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
     env:
       DEVICE_TYPE: "ANDROID_5"
@@ -185,6 +188,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "-e"
@@ -205,6 +209,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "-e"
@@ -225,6 +230,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "-e"
@@ -245,6 +251,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "-e"
@@ -265,6 +272,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "-e"
@@ -285,6 +293,7 @@ steps:
       artifacts#v1.2.0:
         download: "build/fixture.apk"
       docker-compose#v3.7.0:
+        pull: android-maze-runner
         run: android-maze-runner
         command:
           - "-e"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     environment:
       VERBOSE:
       DEBUG:
+      BUILDKITE:
       BROWSER_STACK_USERNAME:
       BROWSER_STACK_ACCESS_KEY:
       BROWSER_STACK_LOCAL_IDENTIFIER: ${BUILDKITE_JOB_ID:-maze-runner}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.emulator
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-backport-timeout-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-v2-improve-logging-cli
     environment:
       VERBOSE:
       DEBUG:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.emulator
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v2.8.1-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli
     environment:
       VERBOSE:
       DEBUG:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.emulator
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-backport-timeout-cli
     environment:
       VERBOSE:
       DEBUG:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.emulator
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:tms-v2-improve-logging-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli
     environment:
       VERBOSE:
       DEBUG:

--- a/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/tests/features/fixtures/mazerunner/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner
 
 import android.app.Activity
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -18,8 +19,11 @@ class MainActivity : Activity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        val bugsnagStarter = findViewById<Button>(R.id.startBugsnagButton)
+        // Attempt to dismiss any system dialogs (such as "MazeRunner crashed")
+        val closeDialog = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
+        sendBroadcast(closeDialog)
 
+        val bugsnagStarter = findViewById<Button>(R.id.startBugsnagButton)
         bugsnagStarter.setOnClickListener {
             val scenarioPicker = findViewById<EditText>(R.id.scenarioText)
             val scenario = scenarioPicker.text.toString()

--- a/tests/features/support/env.rb
+++ b/tests/features/support/env.rb
@@ -29,6 +29,7 @@ Before('@skip_above_android_7') do |scenario|
 end
 
 AfterConfiguration do |config|
+  MazeRunner.configuration.receive_requests_wait = 60
   AppAutomateDriver.new(bs_username, bs_access_key, bs_local_id, bs_device, app_location)
   $driver.start_driver
 end


### PR DESCRIPTION
## Goal

Improve stability of builds for v4 back-ported changes.

## Design

Applies some techniques that we've learnt since v4, as well as allowing retries on e2e test scenarios (for these v4-basd changes only).

## Changeset

- Update Buildkite pipeline pipeline to allow retries
- Use latest v2 Maze Runner
- Dismiss error dialogs when app launches

## Testing

Covered by CI.