### PR TITLE
Improve stability of Android 5 testing

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -101,6 +101,7 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
+          - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -125,6 +126,7 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
+          - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -397,6 +399,7 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_5_0"
           - "--tags=@Flaky"
+          - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -15,6 +15,7 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_5_0"
           - "--fail-fast"
+          - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -5,8 +5,10 @@
 When('any dialog is cleared and the element {string} is present') do |element_id|
   count = 0
   present = false
+  # Give Android 5 more time to find elements in an attempt to combat flakes
+  timeout = (Maze.config.os_version == 5 ? 15 : 3)
   until present || count > 5
-    present = Maze.driver.wait_for_element(element_id, timeout = 3)
+    present = Maze.driver.wait_for_element(element_id, timeout = timeout)
     break if present
     count += 1
     clicked = click_if_present('android:id/button1') ||

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -5,8 +5,8 @@
 When('any dialog is cleared and the element {string} is present') do |element_id|
   count = 0
   present = false
-  until present || count > 15
-    present = Maze.driver.wait_for_element(element_id, timeout = 1)
+  until present || count > 5
+    present = Maze.driver.wait_for_element(element_id, timeout = 3)
     break if present
     count += 1
     clicked = click_if_present('android:id/button1') ||


### PR DESCRIPTION
## Goal

Attempts to improve the stability of Android 5 testing by increasing the timeout when waiting for elements and upping the Appium version to the latest possible at this time. 

## Design

We were seeing some failures to find the `scenario_name` element, despite the field being visible in the screenshot that was taken for the failure.  This change seems to improve the situation, but it's not perfect and we should explore using the very latest version of Appium now available.  Trying this now uncovered another problem, in that at least one of our scenarios fails consistently with a newer version (more investigation needed and internal ticket raised).

## Changeset

Use Appium 1.8.0 on Android 5 (1.9.1 causes scenario failures at present) and increase timeout when finding elements.

## Testing

Covered by CI.