### PR TITLE
Global JNI cache

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -8,12 +8,14 @@ add_library( # Specifies the name of the library.
              # Provides a relative path to your source file(s).
     jni/bugsnag_ndk.c
     jni/bugsnag.c
+    jni/jnicache.c
     jni/metadata.c
     jni/safejni.c
     jni/report.c
     jni/handlers/signal_handler.c
     jni/handlers/cpp_handler.cpp
     jni/utils/crash_info.c
+    jni/utils/jni_utils.c
     jni/utils/stack_unwinder.c
     jni/utils/stack_unwinder_libunwindstack.cpp
     jni/utils/stack_unwinder_libcorkscrew.c

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -15,7 +15,9 @@ static JNIEnv *bsg_global_jni_env = NULL;
 
 void bugsnag_set_binary_arch(JNIEnv *env);
 
-void bugsnag_init(JNIEnv *env) { bsg_global_jni_env = env; }
+void bugsnag_init(JNIEnv *env) {
+  bsg_global_jni_env = env;
+}
 
 void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
                         bsg_severity_t severity);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -13,6 +13,7 @@
 #include "utils/serializer.h"
 #include "utils/string.h"
 #include "safejni.h"
+#include "jnicache.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,6 +79,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_disableCrashRep
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
     JNIEnv *env, jobject _this, jstring _report_path, jboolean auto_notify,
     jint _api_level, jboolean is32bit) {
+  if(!bsg_init_jni_cache(env)) {
+    BUGSNAG_LOG("Could not initialize JNI cache! Some functions will be no-op");
+  }
   bsg_environment *bugsnag_env = calloc(1, sizeof(bsg_environment));
   bsg_set_unwind_types((int)_api_level, (bool)is32bit,
                        &bugsnag_env->signal_unwind_style,

--- a/bugsnag-plugin-android-ndk/src/main/jni/jnicache.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jnicache.c
@@ -1,0 +1,249 @@
+//
+// Created by Karl Stenerud on 22.02.21.
+//
+
+#include "jnicache.h"
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <bugsnag_ndk.h>
+#include "safejni.h"
+
+static bsg_jni_cache jni_cache;
+static bool is_cache_valid = false;
+
+static inline jclass safe_find_class(JNIEnv *env, const char *name) {
+  jclass cls = (*env)->NewGlobalRef(env, bsg_safe_find_class(env, name));
+  if (cls == NULL) {
+    BUGSNAG_LOG("Could not load class %s", name);
+  }
+  return cls;
+}
+
+static inline jclass safe_get_method_id(JNIEnv *env, jclass cls, const char *name, const char *sig) {
+  jmethodID method = bsg_safe_get_method_id(env, cls, name, sig);
+  if (method == NULL) {
+    BUGSNAG_LOG("Could not load method %s with signature %s", name, sig);
+  }
+
+  return method;
+}
+
+static inline jmethodID safe_get_static_method_id(JNIEnv *env, jclass cls, const char *name, const char *sig) {
+  jmethodID method = bsg_safe_get_static_method_id(env, cls, name, sig);
+  if (method == NULL) {
+    BUGSNAG_LOG("Could not load static method %s with signature %s", name, sig);
+  }
+
+  return method;
+}
+
+bool bsg_init_jni_cache(JNIEnv *env) {
+  static atomic_flag initialized = ATOMIC_FLAG_INIT;
+  if (atomic_flag_test_and_set(&initialized)) {
+    return true;
+  }
+
+  // lookup java/lang/Integer
+  jni_cache.integer = safe_find_class(env, "java/lang/Integer");
+  if (jni_cache.integer == NULL) {
+    goto fail;
+  }
+
+  // lookup java/lang/Boolean
+  jni_cache.boolean = safe_find_class(env, "java/lang/Boolean");
+  if (jni_cache.boolean == NULL) {
+    goto fail;
+  }
+
+  // lookup java/lang/Long
+  jni_cache.long_class = safe_find_class(env, "java/lang/Long");
+  if (jni_cache.long_class == NULL) {
+    goto fail;
+  }
+
+  // lookup java/lang/Float
+  jni_cache.float_class = safe_find_class(env, "java/lang/Float");
+  if (jni_cache.float_class == NULL) {
+    goto fail;
+  }
+
+  // lookup java/lang/Number
+  jni_cache.number = safe_find_class(env, "java/lang/Number");
+  if (jni_cache.number == NULL) {
+    goto fail;
+  }
+
+  // lookup java/lang/String
+  jni_cache.string = safe_find_class(env, "java/lang/String");
+  if (jni_cache.string == NULL) {
+    goto fail;
+  }
+
+  // lookup Integer.intValue()
+  jni_cache.integer_int_value =
+          safe_get_method_id(env, jni_cache.integer, "intValue", "()I");
+  if (jni_cache.integer_int_value == NULL) {
+    goto fail;
+  }
+
+  // lookup Integer.floatValue()
+  jni_cache.float_float_value =
+          safe_get_method_id(env, jni_cache.float_class, "floatValue", "()F");
+  if (jni_cache.float_float_value == NULL) {
+    goto fail;
+  }
+
+  // lookup Double.doubleValue()
+  jni_cache.number_double_value =
+          safe_get_method_id(env, jni_cache.number, "doubleValue", "()D");
+  if (jni_cache.number_double_value == NULL) {
+    goto fail;
+  }
+
+  // lookup Long.longValue()
+  jni_cache.long_long_value =
+          safe_get_method_id(env, jni_cache.integer, "longValue", "()J");
+  if (jni_cache.long_long_value == NULL) {
+    goto fail;
+  }
+
+  // lookup Boolean.booleanValue()
+  jni_cache.boolean_bool_value =
+          safe_get_method_id(env, jni_cache.boolean, "booleanValue", "()Z");
+  if (jni_cache.boolean_bool_value == NULL) {
+    goto fail;
+  }
+
+  // lookup java/util/ArrayList
+  jni_cache.arraylist = safe_find_class(env, "java/util/ArrayList");
+  if (jni_cache.arraylist == NULL) {
+    goto fail;
+  }
+
+  // lookup ArrayList constructor
+  jni_cache.arraylist_init_with_obj = safe_get_method_id(
+          env, jni_cache.arraylist, "<init>", "(Ljava/util/Collection;)V");
+  if (jni_cache.arraylist_init_with_obj == NULL) {
+    goto fail;
+  }
+
+  // lookup ArrayList.get()
+  jni_cache.arraylist_get = safe_get_method_id(
+          env, jni_cache.arraylist, "get", "(I)Ljava/lang/Object;");
+  if (jni_cache.arraylist_get == NULL) {
+    goto fail;
+  }
+
+  // lookup java/util/HashMap
+  jni_cache.hash_map = safe_find_class(env, "java/util/HashMap");
+  if (jni_cache.hash_map == NULL) {
+    goto fail;
+  }
+
+  // lookup java/util/Map
+  jni_cache.map = safe_find_class(env, "java/util/Map");
+  if (jni_cache.map == NULL) {
+    goto fail;
+  }
+
+  // lookup java/util/Set
+  jni_cache.hash_map_key_set = safe_get_method_id(
+          env, jni_cache.hash_map, "keySet", "()Ljava/util/Set;");
+  if (jni_cache.hash_map_key_set == NULL) {
+    goto fail;
+  }
+
+  // lookup HashMap.size()
+  jni_cache.hash_map_size =
+          safe_get_method_id(env, jni_cache.hash_map, "size", "()I");
+  if (jni_cache.hash_map_size == NULL) {
+    goto fail;
+  }
+
+  // lookup HashMap.get()
+  jni_cache.hash_map_get =
+          safe_get_method_id(env, jni_cache.hash_map, "get",
+                             "(Ljava/lang/Object;)Ljava/lang/Object;");
+  if (jni_cache.hash_map_get == NULL) {
+    goto fail;
+  }
+
+  // lookup Map.keySet()
+  jni_cache.map_key_set = safe_get_method_id(env, jni_cache.map, "keySet",
+                                             "()Ljava/util/Set;");
+  if (jni_cache.map_key_set == NULL) {
+    goto fail;
+  }
+
+  // lookup Map.size()
+  jni_cache.map_size =
+          safe_get_method_id(env, jni_cache.map, "size", "()I");
+  if (jni_cache.map_size == NULL) {
+    goto fail;
+  }
+
+  // lookup Map.get()
+  jni_cache.map_get = safe_get_method_id(
+          env, jni_cache.map, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
+  if (jni_cache.map_get == NULL) {
+    goto fail;
+  }
+
+  // lookup com/bugsnag/android/NativeInterface
+  jni_cache.native_interface =
+          safe_find_class(env, "com/bugsnag/android/NativeInterface");
+  if (jni_cache.native_interface == NULL) {
+    goto fail;
+  }
+
+  // lookup NativeInterface.getApp()
+  jni_cache.get_app_data = safe_get_static_method_id(
+          env, jni_cache.native_interface, "getAppData", "()Ljava/util/Map;");
+  if (jni_cache.get_app_data == NULL) {
+    goto fail;
+  }
+
+  // lookup NativeInterface.getDevice()
+  jni_cache.get_device_data = safe_get_static_method_id(
+          env, jni_cache.native_interface, "getDeviceData", "()Ljava/util/Map;");
+  if (jni_cache.get_device_data == NULL) {
+    goto fail;
+  }
+
+  // lookup NativeInterface.getUser()
+  jni_cache.get_user_data = safe_get_static_method_id(
+          env, jni_cache.native_interface, "getUserData", "()Ljava/util/Map;");
+  if (jni_cache.get_user_data == NULL) {
+    goto fail;
+  }
+
+  // lookup NativeInterface.getMetadata()
+  jni_cache.get_metadata = safe_get_static_method_id(
+          env, jni_cache.native_interface, "getMetaData", "()Ljava/util/Map;");
+  if (jni_cache.get_metadata == NULL) {
+    goto fail;
+  }
+
+  // lookup NativeInterface.getContext()
+  jni_cache.get_context = safe_get_static_method_id(
+          env, jni_cache.native_interface, "getContext", "()Ljava/lang/String;");
+  if (jni_cache.get_context == NULL) {
+    goto fail;
+  }
+
+  is_cache_valid = true;
+  return true;
+
+  fail:
+  is_cache_valid = false;
+  return false;
+}
+
+bsg_jni_cache *bsg_get_jni_cache() {
+  return &jni_cache;
+}
+
+bool bsg_is_jni_cache_valid() {
+  return is_cache_valid;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/jnicache.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jnicache.h
@@ -1,0 +1,65 @@
+//
+// Created by Karl Stenerud on 22.02.21.
+//
+// Cache for JNI classes and methods.
+//
+// Note: Technically, no JNI objects should be called outside of the JNI
+// context they were fetched from because they could get unloaded at any
+// time, after which accessing the pointer from C would crash.
+//
+// HOWEVER, because we have a controlled environment where we're not unloading
+// Java classes, it is safe to cache the classes and methods that we know
+// won't ever be unloaded.
+//
+
+#ifndef BUGSNAG_ANDROID_JNICACHE_H
+#define BUGSNAG_ANDROID_JNICACHE_H
+
+#include <jni.h>
+#include <stdbool.h>
+
+typedef struct {
+    jclass hash_map;
+    jclass map;
+    jclass arraylist;
+    jclass integer;
+    jclass boolean;
+    jclass metadata;
+    jclass native_interface;
+    jclass long_class;
+    jclass float_class;
+    jclass number;
+    jclass string;
+    jmethodID integer_int_value;
+    jmethodID long_long_value;
+    jmethodID float_float_value;
+    jmethodID boolean_bool_value;
+    jmethodID number_double_value;
+    jmethodID hash_map_get;
+    jmethodID hash_map_size;
+    jmethodID hash_map_key_set;
+    jmethodID map_get;
+    jmethodID map_size;
+    jmethodID map_key_set;
+    jmethodID arraylist_init_with_obj;
+    jmethodID arraylist_get;
+    jmethodID get_app_data;
+    jmethodID get_device_data;
+    jmethodID get_user_data;
+    jmethodID get_breadcrumbs;
+    jmethodID get_metadata;
+    jmethodID get_context;
+} bsg_jni_cache;
+
+// Initialize the cache, returning true if it was successful.
+// Do NOT use the cache before calling this, and do NOT use the cache if this returns false!
+bool bsg_init_jni_cache(JNIEnv *env);
+
+// Global access to the cache.
+bsg_jni_cache *bsg_get_jni_cache();
+
+// Return true if the cache was successfully initialized.
+// Do NOT use the cache if this returns false!
+bool bsg_is_jni_cache_valid();
+
+#endif //BUGSNAG_ANDROID_JNICACHE_H

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -1,5 +1,6 @@
 #include "safejni.h"
 #include <stdbool.h>
+#include <bugsnag_ndk.h>
 #include <utils/string.h>
 
 bool bsg_check_and_clear_exc(JNIEnv *env) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/jni_utils.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/jni_utils.c
@@ -1,0 +1,81 @@
+//
+// Created by Karl Stenerud on 22.02.21.
+//
+
+#include "jni_utils.h"
+#include "jnicache.h"
+#include "safejni.h"
+#include "utils/string.h"
+
+jobject bsg_get_map_value_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
+                              jobject map, const char *_key) {
+  // create Java string object for map key
+  jstring key = bsg_safe_new_string_utf(env, _key);
+  if (key == NULL) {
+    return NULL;
+  }
+
+  jobject obj =
+          bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
+  bsg_safe_delete_local_ref(env, key);
+  return obj;
+}
+
+void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
+                               jobject map, const char *_key, char *dest,
+                               int len) {
+  jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
+
+  if (_value != NULL) {
+    const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_value);
+    if (value != NULL) {
+      bsg_strncpy_safe(dest, value, len);
+      bsg_safe_release_string_utf_chars(env, _value, value);
+    }
+  }
+}
+
+long bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
+                            const char *_key) {
+  jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
+
+  if (_value != NULL) {
+    long value = bsg_safe_call_double_method(env, _value,
+                                             jni_cache->number_double_value);
+    bsg_safe_delete_local_ref(env, _value);
+    return value;
+  }
+  return 0;
+}
+
+float bsg_get_map_value_float(JNIEnv *env, bsg_jni_cache *jni_cache,
+                              jobject map, const char *_key) {
+  jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
+
+  if (_value != NULL) {
+    float value =
+            bsg_safe_call_float_method(env, _value, jni_cache->float_float_value);
+    bsg_safe_delete_local_ref(env, _value);
+    return value;
+  }
+  return 0;
+}
+
+int bsg_get_map_value_int(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
+                          const char *_key) {
+  jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
+
+  if (_value != NULL) {
+    jint value =
+            bsg_safe_call_int_method(env, _value, jni_cache->integer_int_value);
+    bsg_safe_delete_local_ref(env, _value);
+    return value;
+  }
+  return 0;
+}
+
+bool bsg_get_map_value_bool(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
+                            const char *_key) {
+  jobject obj = bsg_get_map_value_obj(env, jni_cache, map, _key);
+  return bsg_safe_call_boolean_method(env, obj, jni_cache->boolean_bool_value);
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/jni_utils.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/jni_utils.h
@@ -1,0 +1,33 @@
+//
+// Created by Karl Stenerud on 22.02.21.
+//
+
+// Utils to deal with common JNI situations.
+
+#ifndef BUGSNAG_ANDROID_JNI_UTILS_H
+#define BUGSNAG_ANDROID_JNI_UTILS_H
+
+#include <jni.h>
+#include <stdbool.h>
+#include "jnicache.h"
+
+jobject bsg_get_map_value_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
+                              jobject map, const char *_key);
+
+void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
+                               jobject map, const char *_key, char *dest,
+                               int len);
+
+long bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
+                            const char *_key);
+
+float bsg_get_map_value_float(JNIEnv *env, bsg_jni_cache *jni_cache,
+                              jobject map, const char *_key);
+
+int bsg_get_map_value_int(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
+                          const char *_key);
+
+bool bsg_get_map_value_bool(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
+                            const char *_key);
+
+#endif //BUGSNAG_ANDROID_JNI_UTILS_H


### PR DESCRIPTION
## Goal

https://bugsnag.atlassian.net/browse/PLAT-6090

## Design

The JNI cache used by the metadata and breadcrumb system is now initialised once at app start, and is made available as a global.

## Testing

Manual testing with the example app, and e2e tests.
