### PR TITLE
Setup gwp-asan for CI fixture

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -308,6 +308,10 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
+  # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory to
+  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
+  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
+  # by inspecting the devices logs.
   - label: ':android: Android 11 NDK r21 end-to-end tests - batch 1'
     depends_on:
       - "fixture-r21"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -165,6 +165,10 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
+  # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory to
+  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
+  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
+  # by inspecting the devices logs.
   - label: ':android: Android 11 NDK r21 smoke tests'
     key: 'android-11-smoke'
     depends_on: "fixture-r21"

--- a/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
@@ -2,9 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.bugsnag.android.mazerunner">
 
+    <!-- always enable GWP ASAN tool to detect native memory bugs. see
+        https://developer.android.com/ndk/guides/gwp-asan-->
     <application
         android:label="MazeRunner"
         android:networkSecurityConfig="@xml/network_security_config"
+        android:gwpAsanMode="always"
         >
         <activity android:name=".MainActivity">
             <intent-filter>


### PR DESCRIPTION
## Goal

Sets up [GWP-ASan](https://developer.android.com/ndk/guides/gwp-asan) so that is enabled in our mazerunner test fixture. If memory is misused in the NDK layer this tool should detect this by randomly sampling memory usage, and raise SIGABRT. 

This should provide us insight into whether there are use-after free/buffer overflows problems in the use of our NDK code when the Android 11 tests are run. By extension this should find any latent issues in the implementation of v4 too.