### PR TITLE
Persist LastRunInfo and populate app.isLaunching for JVM errors

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -648,7 +648,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         int consecutiveLaunchCrashes = lastRunInfo == null ? 0
                 : lastRunInfo.getConsecutiveLaunchCrashes();
         boolean launching = launchCrashTracker.isLaunching();
-        LastRunInfo runInfo = new LastRunInfo(consecutiveLaunchCrashes, true, launching);
+        LastRunInfo runInfo = new LastRunInfo(consecutiveLaunchCrashes + 1, true, launching);
         lastRunInfoStore.persist(runInfo);
     }
 


### PR DESCRIPTION
## Goal

Persists the `LastRunInfo` so that previous launch information can be retrieved by the user. This also sets the value of `app.isLaunching` on JVM events.

The implementation of this behaviour for NDK errors will be done in a separate changeset to ease review.

## Changeset

- Added `LaunchCrashTracker`, which tracks the state of whether the application is currently launching or not
- Created `LastRunInfoStore`, which loads and saves the `LastRunInfo` object from disk in the key-value format
- Reset the `LastRunInfo` to the defaults on `Client` initialization
- Set the `LastRunInfo` whenever an unhandled exception occurred so that the next launch allows the user to check that the app crashed

## Testing

Added unit tests for new classes. Updated JVM events to assert that the `app.isLaunching` field is set to the correct default.

E2E tests for the NDK and when `markLaunchCompleted()` are called will be added in a separate PR.