### PR TITLE
e2e tests: Use click_element_if_present

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.10.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.12.0'
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b12f25a65267a99162a40abf28fe02c3048a097f
-  tag: v4.10.1
+  revision: b590f1c94366349729f1b4413a9e6c050730a9fb
+  tag: v4.12.0
   specs:
-    bugsnag-maze-runner (4.10.1)
+    bugsnag-maze-runner (4.12.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -55,7 +55,7 @@ GEM
       websocket-driver (>= 0.5.1)
     gherkin (5.1.0)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     multi_json (1.15.0)
     multi_test (0.1.2)
     nokogiri (1.11.1)
@@ -84,4 +84,4 @@ DEPENDENCIES
   bugsnag-maze-runner!
 
 BUNDLED WITH
-   2.1.4
+   2.2.13

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:v4.7.0-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v4-cli
     environment:
       DEBUG:
       BUILDKITE:

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -223,11 +223,7 @@ end
 def click_if_present(element)
   return false unless Maze.driver.wait_for_element(element, 1)
 
-  Maze.driver.click_element(element)
-  true
-rescue Selenium::WebDriver::Error::NoSuchElementError
-  # Ignore - we have seen clicks fail like this despite having just checked for the element's presence
-  false
+  Maze.driver.click_element_if_present(element)
 end
 
 Then("I sort the errors by {string}") do |comparator|


### PR DESCRIPTION
## Goal

Use the newly introduce `click_element_if_present` method on the Maze Runner Appium driver class instead of handling raised `NoSuchElementError`s.

## Design

The previous method of calling `driver.click_element`, which can raise a `NoSuchElementError` meant that Android could not use Maze Runner's resilient driver.  Because `NoSuchElementError` extends `WebDriverError`, the resilient driver would catch it before it reached the Android step code, causing a retry loop that would never succeed.

This change has no overall effect in itself, but should allow the resilient driver to be used should be find ourselves needing to.

## Testing

Covered by CI.