### PR TITLE
Add tests that password metadata is redacted by default

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
@@ -233,6 +233,11 @@ bool add_java_data(void *event_ptr) {
                                     (char *) "device",
                                     bugsnag_device_get_model(event_ptr)
   );
+  bugsnag_event_add_metadata_string(event_ptr,
+                                    (char *) "data",
+                                    (char *) "password",
+                                    (char *) "Not telling you"
+  );
   return true;
 }
 

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNotifySmokeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNotifySmokeScenario.java
@@ -37,6 +37,7 @@ public class CXXNotifySmokeScenario extends Scenario {
         Bugsnag.leaveBreadcrumb("Initiate lift");
         Bugsnag.leaveBreadcrumb("Disable lift");
         Bugsnag.addMetadata("TestData", "JVM", "pre notify()");
+        Bugsnag.addMetadata("TestData", "password", "NotTellingYou");
         Bugsnag.addOnError(new OnErrorCallback() {
             @Override
             public boolean onError(@NonNull Event event) {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledJavaSmokeScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledJavaSmokeScenario.java
@@ -39,6 +39,7 @@ public class HandledJavaSmokeScenario extends Scenario {
                 return true;
             }
         });
+        Bugsnag.addMetadata("TestData", "password", "NotTellingYou");
         Bugsnag.addMetadata("TestData", "ClientMetadata", true);
         Bugsnag.addOnError(new OnErrorCallback() {
             @Override

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJavaLoadedConfigScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJavaLoadedConfigScenario.java
@@ -26,6 +26,7 @@ public class UnhandledJavaLoadedConfigScenario extends Scenario {
         testConfig.setAutoTrackSessions(false);
         testConfig.setContext("FooContext");
         Bugsnag.start(this.getContext(), testConfig);
+        Bugsnag.addMetadata("TestData", "password", "NotTellingYou");
         throw new RuntimeException("UnhandledJavaLoadedConfigScenario");
     }
 

--- a/features/full_tests/batch_2/native_metadata.feature
+++ b/features/full_tests/batch_2/native_metadata.feature
@@ -48,4 +48,5 @@ Feature: Native Metadata API
         And the event "metaData.data.userId" equals "passUserId"
         And the event "metaData.data.metadata" equals "passMetaData"
         And the event "metaData.data.device" is not null
-        And the event "metaData.data.password" equals "[REDACTED]"
+        # TODO: Skipped pending PLAT-6176
+        # And the event "metaData.data.password" equals "[REDACTED]"

--- a/features/full_tests/batch_2/native_metadata.feature
+++ b/features/full_tests/batch_2/native_metadata.feature
@@ -48,3 +48,4 @@ Feature: Native Metadata API
         And the event "metaData.data.userId" equals "passUserId"
         And the event "metaData.data.metadata" equals "passMetaData"
         And the event "metaData.data.device" is not null
+        And the event "metaData.data.password" equals "[REDACTED]"

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -20,7 +20,7 @@ Scenario: Notify caught Java exception with default configuration
     And the event "exceptions.0.stacktrace.0.method" ends with "HandledJavaSmokeScenario.startScenario"
     And the exception "stacktrace.0.file" equals "HandledJavaSmokeScenario.java"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 7
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 8
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     And the thread with name "main" contains the error reporting flag
@@ -85,6 +85,7 @@ Scenario: Notify caught Java exception with default configuration
     # MetaData
     And the event "metaData.TestData.ClientMetadata" is true
     And the event "metaData.TestData.CallbackMetadata" is true
+    And the event "metaData.TestData.password" equals "[REDACTED]"
 
     # Runtime versions
     And the error payload field "events.0.device.runtimeVersions.androidApiLevel" is not null
@@ -215,6 +216,7 @@ Scenario: Handled C functionality
     # MetaData
     And the event "metaData.TestData.Source" equals "ClientCallback"
     And the event "metaData.TestData.JVM" equals "pre notify()"
+    And the event "metaData.TestData.password" equals "[REDACTED]"
 
     # Threads validation
     And the error payload field "events.0.threads" is a non-empty array

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -21,7 +21,7 @@ Scenario: Unhandled Java Exception with loaded configuration
     And the event "exceptions.0.stacktrace.0.method" ends with "UnhandledJavaLoadedConfigScenario.startScenario"
     And the exception "stacktrace.0.file" equals "UnhandledJavaLoadedConfigScenario.java"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 6
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 7
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     And the thread with name "main" contains the error reporting flag
@@ -39,8 +39,11 @@ Scenario: Unhandled Java Exception with loaded configuration
     And the error payload field "events.0.app.durationInForeground" is an integer
     And the event "app.inForeground" is true
     And the error payload field "events.0.metaData.app.memoryUsage" is greater than 0
+
+    # Metadata
     And the event "metaData.app.name" equals "MazeRunner"
     And the event "metaData.app.lowMemory" is false
+    And the event "metaData.TestData.password" equals "[REDACTED]"
 
     # Device data
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
@@ -221,6 +224,8 @@ Scenario: C++ exception thrown with overwritten config
     And the error payload field "events.0.device.totalMemory" is greater than 0
     And the event "device.orientation" equals "portrait"
     And the event "device.time" is a timestamp
+
+    # Metadata
     And the event "metaData.device.locationStatus" is not null
     And the event "metaData.device.emulator" is false
     And the event "metaData.device.networkAccess" is not null


### PR DESCRIPTION
## Goal

Adds more checks that `password` fields in metadata are redacted by default.  

## Testing

This seems to have found a bug in the NDK layer, as the value was coming through in plain text.  The corresponding step has been commented out internal ticket raised.