### PR TITLE
[PLAT-5874] Add assertions for secondary error handlers using logs

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
-import android.util.Log
 import com.bugsnag.android.Configuration
 
 /**

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
@@ -13,8 +13,6 @@ internal class CrashHandlerScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    private var loggedMessages: MutableList<String> = mutableListOf()
-
     init {
         config.autoTrackSessions = false
     }
@@ -23,14 +21,13 @@ internal class CrashHandlerScenario(
         super.startScenario()
         val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
 
-        Thread.setDefaultUncaughtExceptionHandler({ t, e ->
-            Log.d("Bugsnag", "CrashHandlerScenario: Intercepted uncaught exception")
-            loggedMessages.add("CrashHandlerScenario: Intercepted uncaught exception")
+        Thread.setDefaultUncaughtExceptionHandler { t, e ->
+            config.logger.d("Bugsnag", "CrashHandlerScenario: Intercepted uncaught exception")
             previousHandler.uncaughtException(t, e)
-        })
+        }
         throw RuntimeException("CrashHandlerScenario")
     }
 
     override fun getInterceptedLogMessages() =
-        loggedMessages
+        listOf("CrashHandlerScenario: Intercepted uncaught exception")
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
@@ -22,7 +22,7 @@ internal class CrashHandlerScenario(
         val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
 
         Thread.setDefaultUncaughtExceptionHandler { t, e ->
-            config.logger.d("Bugsnag", "CrashHandlerScenario: Intercepted uncaught exception")
+            config.logger?.d("CrashHandlerScenario: Intercepted uncaught exception")
             previousHandler.uncaughtException(t, e)
         }
         throw RuntimeException("CrashHandlerScenario")

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
@@ -13,7 +13,7 @@ internal class CrashHandlerScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    protected var loggedMessages: MutableList<String> = mutableListOf()
+    private var loggedMessages: MutableList<String> = mutableListOf()
 
     init {
         config.autoTrackSessions = false

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
@@ -13,6 +13,8 @@ internal class CrashHandlerScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
+    protected var loggedMessages: MutableList<String> = mutableListOf()
+
     init {
         config.autoTrackSessions = false
     }
@@ -22,9 +24,13 @@ internal class CrashHandlerScenario(
         val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
 
         Thread.setDefaultUncaughtExceptionHandler({ t, e ->
-            Log.d("Bugsnag", "Intercepted uncaught exception")
+            Log.d("Bugsnag", "CrashHandlerScenario: Intercepted uncaught exception")
+            loggedMessages.add("CrashHandlerScenario: Intercepted uncaught exception")
             previousHandler.uncaughtException(t, e)
         })
         throw RuntimeException("CrashHandlerScenario")
     }
+
+    override fun getInterceptedLogMessages() =
+        loggedMessages
 }

--- a/features/full_tests/batch_1/crash_handler.feature
+++ b/features/full_tests/batch_1/crash_handler.feature
@@ -4,7 +4,9 @@ Scenario: Other uncaught exception handler installed
     When I run "CrashHandlerScenario" and relaunch the app
     And I configure Bugsnag for "CrashHandlerScenario"
     And I wait to receive an error
+    And I wait to receive a log
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "CrashHandlerScenario"
+    Then the "debug" level log message equals "CrashHandlerScenario: Intercepted uncaught exception"


### PR DESCRIPTION
## Goal

Adds an assertion that a secondary error handler will be called correctly, using the log assertions added recently