### PR TITLE
Add BackgroundTaskService to replace Async.java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   [#1159](https://github.com/bugsnag/bugsnag-android/pull/1159)
   [#1165](https://github.com/bugsnag/bugsnag-android/pull/1165)
   [#1164](https://github.com/bugsnag/bugsnag-android/pull/1164)
+  [#1182](https://github.com/bugsnag/bugsnag-android/pull/1182)
 
 ## 5.7.0 (2021-02-18)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BackgroundTaskService.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BackgroundTaskService.kt
@@ -1,0 +1,174 @@
+package com.bugsnag.android
+
+import androidx.annotation.VisibleForTesting
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+/**
+ * The type of task which is being submitted. This determines which execution queue
+ * the task will be added to.
+ */
+internal enum class TaskType {
+
+    /**
+     * A task that sends an error request. Any filesystem operations
+     * that persist/delete errors must be submitted using this type.
+     */
+    ERROR_REQUEST,
+
+    /**
+     * A task that sends a session request. Any filesystem operations
+     * that persist/delete sessions must be submitted using this type.
+     */
+    SESSION_REQUEST,
+
+    /**
+     * A task that performs I/O, such as reading a file on disk. This should NOT include operations
+     * related to error/session storage - use [ERROR_REQUEST] or [SESSION_REQUEST] instead.
+     */
+    IO,
+
+    /**
+     * A task that sends an internal error report to Bugsnag.
+     */
+    INTERNAL_REPORT,
+
+    /**
+     * Any other task that needs to run in the background. These will typically be
+     * short-lived operations that take <100ms, such as registering a
+     * [android.content.BroadcastReceiver].
+     */
+    DEFAULT
+}
+
+private const val SHUTDOWN_WAIT_MS = 1500L
+
+// these values have been loosely adapted from android.os.AsyncTask over the years.
+private const val THREAD_POOL_SIZE = 1
+private const val KEEP_ALIVE_SECS = 30L
+private const val TASK_QUEUE_SIZE = 128
+
+internal fun createExecutor(name: String, keepAlive: Boolean): ThreadPoolExecutor {
+    val queue: BlockingQueue<Runnable> = LinkedBlockingQueue(TASK_QUEUE_SIZE)
+    val threadFactory = ThreadFactory { Thread(it, name) }
+
+    // certain executors (error/session/io) should always keep their threads alive, but others
+    // are less important so are allowed a pool size of 0 that expands on demand.
+    val coreSize = when {
+        keepAlive -> THREAD_POOL_SIZE
+        else -> 0
+    }
+    return ThreadPoolExecutor(
+        coreSize,
+        THREAD_POOL_SIZE,
+        KEEP_ALIVE_SECS,
+        TimeUnit.SECONDS,
+        queue,
+        threadFactory
+    )
+}
+
+/**
+ * Provides a service for submitting lengthy tasks to run on background threads.
+ *
+ * A [TaskType] must be submitted with each task, which routes it to the appropriate executor.
+ * Setting the correct [TaskType] is critical as it can be used to enforce thread confinement.
+ * It also avoids short-running operations being held up by long-running operations submitted
+ * to the same executor.
+ */
+internal class BackgroundTaskService(
+    // these executors must remain single-threaded - the SDK makes assumptions
+    // about synchronization based on this.
+    @VisibleForTesting
+    internal val errorExecutor: ThreadPoolExecutor = createExecutor(
+        "Bugsnag Error thread",
+        true
+    ),
+
+    @VisibleForTesting
+    internal val sessionExecutor: ThreadPoolExecutor = createExecutor(
+        "Bugsnag Session thread",
+        true
+    ),
+
+    @VisibleForTesting
+    internal val ioExecutor: ThreadPoolExecutor = createExecutor(
+        "Bugsnag IO thread",
+        true
+    ),
+
+    @VisibleForTesting
+    internal val internalReportExecutor: ThreadPoolExecutor = createExecutor(
+        "Bugsnag Internal Report thread",
+        false
+    ),
+
+    @VisibleForTesting
+    internal val defaultExecutor: ThreadPoolExecutor = createExecutor(
+        "Bugsnag Default thread",
+        false
+    )
+) {
+
+    /**
+     * Submits a task for execution on a single-threaded executor. It is guaranteed that tasks
+     * with the same [TaskType] are executed in the order of submission.
+     *
+     * The caller is responsible for catching and handling
+     * [java.util.concurrent.RejectedExecutionException] if the executor is saturated.
+     *
+     * On process termination the service will attempt to wait for previously submitted jobs
+     * with the task type [TaskType.ERROR_REQUEST], [TaskType.SESSION_REQUEST] and [TaskType.IO].
+     * This is a best-effort attempt - no guarantee can be made that the operations will complete.
+     */
+    @Throws(RejectedExecutionException::class)
+    fun submitTask(taskType: TaskType, runnable: Runnable): Future<*> {
+        return submitTask(taskType, Executors.callable(runnable))
+    }
+
+    /**
+     * @see [submitTask]
+     */
+    @Throws(RejectedExecutionException::class)
+    fun <T> submitTask(taskType: TaskType, callable: Callable<T>): Future<T> {
+        return when (taskType) {
+            TaskType.ERROR_REQUEST -> errorExecutor.submit(callable)
+            TaskType.SESSION_REQUEST -> sessionExecutor.submit(callable)
+            TaskType.IO -> ioExecutor.submit(callable)
+            TaskType.INTERNAL_REPORT -> internalReportExecutor.submit(callable)
+            TaskType.DEFAULT -> defaultExecutor.submit(callable)
+        }
+    }
+
+    /**
+     * Notifies the background service that the process is about to terminate. This causes it to
+     * shutdown submission of tasks to executors, while allowing for in-flight tasks
+     * to be completed within a reasonable grace period.
+     */
+    fun shutdown() {
+        // don't wait for existing tasks to complete for these executors, as they are
+        // less essential
+        internalReportExecutor.shutdownNow()
+        defaultExecutor.shutdownNow()
+
+        // shutdown the error/session executors first, waiting for existing tasks to complete.
+        // If a request fails it may perform IO to persist the payload for delivery next launch,
+        // which would submit tasks to the IO executor - therefore it's critical to
+        // shutdown the IO executor last.
+        errorExecutor.shutdown()
+        sessionExecutor.shutdown()
+        errorExecutor.awaitTermination(SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)
+        sessionExecutor.awaitTermination(SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)
+
+        // shutdown the IO executor last, waiting for any existing tasks to complete
+        ioExecutor.shutdown()
+        ioExecutor.awaitTermination(SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BackgroundTaskServiceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BackgroundTaskServiceTest.kt
@@ -1,0 +1,165 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.lang.Thread
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+
+private const val WAIT_TIME_MS = 200L
+private const val CONFINEMENT_TEST_ATTEMPTS = 20
+
+internal class BackgroundTaskServiceTest {
+
+    /**
+     * Verifies that the task type submits a Runnable to the correct executor.
+     */
+    @Test
+    fun testSubmitRunnable() {
+        val service = BackgroundTaskService()
+        runSubmitRunnableTest(service, TaskType.ERROR_REQUEST, "Bugsnag Error thread")
+        runSubmitRunnableTest(service, TaskType.SESSION_REQUEST, "Bugsnag Session thread")
+        runSubmitRunnableTest(service, TaskType.IO, "Bugsnag IO thread")
+        runSubmitRunnableTest(service, TaskType.INTERNAL_REPORT, "Bugsnag Internal Report thread")
+        runSubmitRunnableTest(service, TaskType.DEFAULT, "Bugsnag Default thread")
+    }
+
+    private fun runSubmitRunnableTest(
+        service: BackgroundTaskService,
+        taskType: TaskType,
+        expectedName: String
+    ) {
+        val runnable = Runnable {
+            val name = Thread.currentThread().name
+            assertEquals(expectedName, name)
+        }
+        val future = service.submitTask(taskType, runnable)
+        assertNull(future.get(WAIT_TIME_MS, TimeUnit.MILLISECONDS))
+    }
+
+    /**
+     * Verifies that the task type submits a Callable to the correct executor.
+     */
+    @Test
+    fun testSubmitCallable() {
+        val service = BackgroundTaskService()
+        runSubmitCallableTest(service, TaskType.ERROR_REQUEST, 1, "Bugsnag Error thread")
+        runSubmitCallableTest(service, TaskType.SESSION_REQUEST, 2, "Bugsnag Session thread")
+        runSubmitCallableTest(service, TaskType.IO, 3, "Bugsnag IO thread")
+        runSubmitCallableTest(
+            service,
+            TaskType.INTERNAL_REPORT,
+            4,
+            "Bugsnag Internal Report thread"
+        )
+        runSubmitCallableTest(service, TaskType.DEFAULT, 5, "Bugsnag Default thread")
+    }
+
+    private fun runSubmitCallableTest(
+        service: BackgroundTaskService,
+        taskType: TaskType,
+        result: Int,
+        expectedName: String
+    ) {
+        val callable = Callable {
+            val name = Thread.currentThread().name
+            assertEquals(expectedName, name)
+            result
+        }
+        val future = service.submitTask(taskType, callable)
+        assertEquals(result, future.get(WAIT_TIME_MS, TimeUnit.MILLISECONDS))
+    }
+
+    /**
+     * Validates that each executor only uses a single thread by submitting tasks ~20 times
+     * by verifying the thread ID is always the same.
+     */
+    @Test
+    fun testThreadConfinement() {
+        val service = BackgroundTaskService()
+        TaskType.values().forEach { taskType ->
+            runThreadConfinementTest(service, taskType)
+        }
+    }
+
+    private fun runThreadConfinementTest(
+        service: BackgroundTaskService,
+        taskType: TaskType
+    ) {
+        val threadIds = mutableSetOf<Long>()
+        repeat(CONFINEMENT_TEST_ATTEMPTS) {
+            val future = service.submitTask(
+                taskType,
+                Runnable {
+                    threadIds.add(Thread.currentThread().id)
+                }
+            )
+            future.get()
+        }
+        assertEquals(1, threadIds.size)
+    }
+
+    /**
+     * Verifies that executors are shutdown and allow tasks to gracefully complete execution.
+     */
+    @Test
+    fun testShutdown() {
+        val service = BackgroundTaskService()
+        val latch = CountDownLatch(1)
+
+        // 0. Track which tasks complete via mutable sets
+        val completedFirstTasks = mutableSetOf<TaskType>()
+        val completedSecondTasks = mutableSetOf<TaskType>()
+
+        // 1. Make all the executors do work by submitting a Runnable that blocks with a CountdownLatch.
+        TaskType.values().forEach { taskType ->
+            submitBlockingJob(service, latch, completedFirstTasks, taskType)
+        }
+
+        // 2. submit additional tasks which wait in the work queue
+        TaskType.values().forEach { taskType ->
+            submitBlockingJob(service, latch, completedSecondTasks, taskType)
+        }
+
+        // 3. Shutdown the service and release latch, allowing jobs to execute
+        latch.countDown()
+        service.shutdown()
+
+        // 4. verify that all executors now reject submission of new tasks
+        assertRejectedExecution(service, TaskType.ERROR_REQUEST)
+        assertRejectedExecution(service, TaskType.SESSION_REQUEST)
+        assertRejectedExecution(service, TaskType.INTERNAL_REPORT)
+        assertRejectedExecution(service, TaskType.DEFAULT)
+        assertRejectedExecution(service, TaskType.IO)
+    }
+
+    private fun submitBlockingJob(
+        service: BackgroundTaskService,
+        latch: CountDownLatch,
+        completedTasks: MutableSet<TaskType>,
+        taskType: TaskType
+    ) {
+        service.submitTask(
+            taskType,
+            Runnable {
+                latch.await()
+                Thread.sleep(10)
+                completedTasks.add(taskType)
+            }
+        )
+    }
+
+    private fun assertRejectedExecution(
+        service: BackgroundTaskService,
+        taskType: TaskType
+    ) {
+        try {
+            service.submitTask(taskType, Runnable { })
+            throw IllegalStateException()
+        } catch (ignored: RejectedExecutionException) {
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Adds `BackgroundTaskService` with the intent of replacing the `Async` class. For general motivations of why this is necessary, please read [the following](https://github.com/bugsnag/bugsnag-android/pull/1172#issue-584912344).

## Changeset

- Added `BackgroundTaskService` class which will have the responsibility of controlling how all lengthy tasks are run in the background
- Created `submitTask` method to which callers can submit a `Runnable` or `Callable` and receive a `Future` in return
- Created a `TaskType` enumeration that determines what single-threaded executor the task is executed on
- Added a more nuanced shutdown strategy that only waits for IO/Error/Session requests to complete on process termination
- Diverged from the `Async` implementation by ensuring that each executor is single-threaded (this gives a deterministic request order) and only executes a specific task type (short-running operations aren't blocked by long running ones)
- Created a single-threaded executor with a max queue size of 128. These are essentially the same defaults as were used in `Async`.

## Testing

Added unit tests to verify that the service behaves as expected. Additionally the service will have general E2E/integration test coverage when the `Client` is converted to use the service in future PRs.

Manual/stress testing of the delivery mechanism will be performed before UAT which should additionally cover some of this functionality.