### PR TITLE
Update SessionTracker to use BackgroundTaskService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   [#1165](https://github.com/bugsnag/bugsnag-android/pull/1165)
   [#1164](https://github.com/bugsnag/bugsnag-android/pull/1164)
   [#1182](https://github.com/bugsnag/bugsnag-android/pull/1182)
+  [#1184](https://github.com/bugsnag/bugsnag-android/pull/1184)
 
 ## 5.7.0 (2021-02-18)
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackerConfinementTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackerConfinementTest.kt
@@ -1,0 +1,58 @@
+package com.bugsnag.android
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Date
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+private const val SESSION_CONFINEMENT_ATTEMPTS = 20
+
+/**
+ * Confirms that delivery of sessions is confined to a single thread, resulting in no
+ * duplicate requests.
+ */
+internal class SessionTrackerConfinementTest {
+
+    @Test
+    fun trackingSessionsIsThreadConfined() {
+        // setup delivery for interception
+        val retainingDelivery = RetainingDelivery()
+        val config = BugsnagTestUtils.generateConfiguration().apply {
+            autoTrackSessions = false
+            delivery = retainingDelivery
+        }
+        val client = Client(ApplicationProvider.getApplicationContext(), config)
+
+        // send 20 sessions
+        repeat(SESSION_CONFINEMENT_ATTEMPTS) { count ->
+            client.sessionTracker.startNewSession(Date(0), User("$count"), false)
+        }
+        retainingDelivery.latch.await(1, TimeUnit.SECONDS)
+
+        // confirm that no dupe requests are sent and that the request order is deterministic
+        assertEquals(SESSION_CONFINEMENT_ATTEMPTS, retainingDelivery.payloads.size)
+
+        retainingDelivery.payloads.forEachIndexed { index, session ->
+            assertEquals("$index", session.getUser().id)
+        }
+    }
+
+    /**
+     * Retains all the sent session payloads
+     */
+    private class RetainingDelivery : Delivery {
+        val payloads = mutableListOf<Session>()
+        val latch = CountDownLatch(SESSION_CONFINEMENT_ATTEMPTS)
+
+        override fun deliver(payload: Session, deliveryParams: DeliveryParams): DeliveryStatus {
+            payloads.add(payload)
+            latch.countDown()
+            return DeliveryStatus.DELIVERED
+        }
+
+        override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams) =
+            DeliveryStatus.DELIVERED
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -85,6 +85,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     LastRunInfo lastRunInfo;
     final LastRunInfoStore lastRunInfoStore;
     final LaunchCrashTracker launchCrashTracker;
+    final BackgroundTaskService bgTaskService = new BackgroundTaskService();
 
     /**
      * Initialize a Bugsnag client
@@ -147,7 +148,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
         sessionStore = new SessionStore(immutableConfig, logger, null);
         sessionTracker = new SessionTracker(immutableConfig, callbackState, this,
-                sessionStore, logger);
+                sessionStore, logger, bgTaskService);
         metadataState = copyMetadataState(configuration);
 
         ActivityManager am =
@@ -963,8 +964,10 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         deviceDataCollector.addRuntimeVersionInfo(key, value);
     }
 
+    @VisibleForTesting
     void close() {
         connectivity.unregisterForNetworkChanges();
+        bgTaskService.shutdown();
     }
 
     Logger getLogger() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
@@ -60,7 +60,8 @@ internal class SessionTrackerPauseResumeTest {
             configuration.impl.callbackState,
             client,
             sessionStore,
-            NoopLogger
+            NoopLogger,
+            BackgroundTaskService()
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
@@ -28,6 +28,7 @@ public class SessionTrackerTest {
     private User user;
     private Configuration configuration;
     private ImmutableConfig immutableConfig;
+    private final BackgroundTaskService bgTaskService = new BackgroundTaskService();
 
     @Mock
     Client client;
@@ -67,7 +68,8 @@ public class SessionTrackerTest {
         configuration.setDelivery(BugsnagTestUtils.generateDelivery());
         immutableConfig = BugsnagTestUtils.generateImmutableConfig();
         sessionTracker = new SessionTracker(immutableConfig,
-                configuration.impl.callbackState, client, sessionStore, NoopLogger.INSTANCE);
+                configuration.impl.callbackState, client, sessionStore, NoopLogger.INSTANCE,
+                bgTaskService);
         configuration.setAutoTrackSessions(true);
         user = new User(null, null, null);
     }
@@ -156,7 +158,7 @@ public class SessionTrackerTest {
     public void testZeroSessionTimeout() {
         CallbackState callbackState = configuration.impl.callbackState;
         sessionTracker = new SessionTracker(immutableConfig, callbackState, client,
-            0, sessionStore, NoopLogger.INSTANCE);
+            0, sessionStore, NoopLogger.INSTANCE, bgTaskService);
 
         long now = System.currentTimeMillis();
         sessionTracker.updateForegroundTracker(ACTIVITY_NAME, true, now);
@@ -172,7 +174,7 @@ public class SessionTrackerTest {
     public void testSessionTimeout() {
         CallbackState callbackState = configuration.impl.callbackState;
         sessionTracker = new SessionTracker(immutableConfig, callbackState, client,
-            100, sessionStore, NoopLogger.INSTANCE);
+            100, sessionStore, NoopLogger.INSTANCE, bgTaskService);
 
         long now = System.currentTimeMillis();
         sessionTracker.updateForegroundTracker(ACTIVITY_NAME, true, now);


### PR DESCRIPTION
## Goal

Updates `SessionTracker` to use `BackgroundTaskService` rather than `Async`. This allows for better control over asynchronous operations and negates the need for a `Semaphore` which was a source of non-deterministic behaviour that could lead to some session requests not immediately being sent. This is based on changes made in #1182.

## Changeset

- Create a `BackgroundTaskService` in the `Client`
- Updated `SessionTracker` to require a `BackgroundTaskService` constructor param
- Refactored `SessionTracker` to submit two types of task to the session request executor: flushing stored sessions from disk, and flushing in-memory sessions

## Testing

Added a unit test to confirm that requests on the session tracker are confined to a thread, otherwise relied on existing E2E test coverage for sessions.