### PR TITLE
Deliver events using BackgroundTaskService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   [#1164](https://github.com/bugsnag/bugsnag-android/pull/1164)
   [#1182](https://github.com/bugsnag/bugsnag-android/pull/1182)
   [#1184](https://github.com/bugsnag/bugsnag-android/pull/1184)
+  [#1185](https://github.com/bugsnag/bugsnag-android/pull/1185)
 
 ## 5.7.0 (2021-02-18)
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -57,6 +57,19 @@ final class BugsnagTestUtils {
                 new Notifier(), NoopLogger.INSTANCE);
     }
 
+    static Event generateEvent() {
+        Throwable exc = new RuntimeException();
+        Event event = new Event(
+                exc,
+                BugsnagTestUtils.generateImmutableConfig(),
+                SeverityReason.newInstance(SeverityReason.REASON_HANDLED_EXCEPTION),
+                NoopLogger.INSTANCE
+        );
+        event.setApp(generateAppWithState());
+        event.setDevice(generateDeviceWithState());
+        return event;
+    }
+
     static Configuration generateConfiguration() {
         Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventStoreConfinementTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventStoreConfinementTest.kt
@@ -1,0 +1,132 @@
+package com.bugsnag.android
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+private const val EVENT_CONFINEMENT_ATTEMPTS = 20
+
+/**
+ * Confirms that delivery of events is confined to a single thread, resulting in no
+ * duplicate requests.
+ */
+internal class EventStoreConfinementTest {
+
+    private lateinit var retainingDelivery: RetainingDelivery
+    lateinit var client: Client
+
+    @Before
+    fun setUp() {
+        // setup delivery for interception
+        retainingDelivery = RetainingDelivery()
+        val cfg = BugsnagTestUtils.generateConfiguration().apply {
+            autoTrackSessions = false
+            delivery = retainingDelivery
+        }
+        client = Client(ApplicationProvider.getApplicationContext(), cfg)
+    }
+
+    /**
+     * Calling notify() is confined to a single thread
+     */
+    @Test
+    fun notifyIsThreadConfined() {
+        // send 20 errors
+        repeat(EVENT_CONFINEMENT_ATTEMPTS) { count ->
+            client.notify(RuntimeException("$count"))
+        }
+        retainingDelivery.latch.await(1, TimeUnit.SECONDS)
+
+        // confirm that no dupe requests are sent and that the request order is deterministic
+        val payloads = retainingDelivery.payloads
+        assertEquals(EVENT_CONFINEMENT_ATTEMPTS, payloads.size)
+        assertEquals(EVENT_CONFINEMENT_ATTEMPTS, payloads.toSet().size)
+
+        payloads.forEachIndexed { index, event ->
+            val exc = requireNotNull(event.originalError)
+            assertEquals("$index", exc.message)
+        }
+    }
+
+    /**
+     * Calling flushAsync() is confined to a single thread
+     */
+    @Test
+    fun flushAsyncIsThreadConfined() {
+        val eventStore = client.eventStore
+
+        // send 20 errors
+        repeat(EVENT_CONFINEMENT_ATTEMPTS) { count ->
+            val event = BugsnagTestUtils.generateEvent().apply {
+                apiKey = "$count"
+            }
+            eventStore.write(event)
+            eventStore.flushAsync()
+        }
+        retainingDelivery.latch.await(5, TimeUnit.SECONDS)
+
+        // confirm that no dupe requests are sent
+        val filenames = retainingDelivery.files
+        assertEquals(EVENT_CONFINEMENT_ATTEMPTS, filenames.size)
+        assertEquals(EVENT_CONFINEMENT_ATTEMPTS, filenames.toSet().size)
+
+        retainingDelivery.files.forEachIndexed { index, file ->
+            val eventInfo = EventFilenameInfo.fromFile(file, client.immutableConfig)
+            assertEquals("$index", eventInfo.apiKey)
+        }
+    }
+
+    /**
+     * Calling flushOnLaunch() is confined to a single thread
+     */
+    @Test
+    fun flushOnLaunchIsThreadConfined() {
+        val eventStore = client.eventStore
+
+        // send 20 errors
+        repeat(EVENT_CONFINEMENT_ATTEMPTS) { count ->
+            val event = BugsnagTestUtils.generateEvent().apply {
+                apiKey = "$count"
+            }
+            eventStore.write(event)
+            eventStore.flushOnLaunch()
+        }
+        retainingDelivery.latch.await(5, TimeUnit.SECONDS)
+
+        // confirm that no dupe requests are sent
+        val filenames = retainingDelivery.files
+        assertEquals(EVENT_CONFINEMENT_ATTEMPTS, filenames.size)
+        assertEquals(EVENT_CONFINEMENT_ATTEMPTS, filenames.toSet().size)
+
+        retainingDelivery.files.forEachIndexed { index, file ->
+            val eventInfo = EventFilenameInfo.fromFile(file, client.immutableConfig)
+            assertEquals("$index", eventInfo.apiKey)
+        }
+    }
+
+    /**
+     * Retains all the sent error payloads
+     */
+    private class RetainingDelivery : Delivery {
+        val files = mutableListOf<File>()
+        val payloads = mutableListOf<Event>()
+        val latch = CountDownLatch(EVENT_CONFINEMENT_ATTEMPTS)
+
+        override fun deliver(payload: Session, deliveryParams: DeliveryParams) =
+            DeliveryStatus.DELIVERED
+
+        override fun deliver(
+            payload: EventPayload,
+            deliveryParams: DeliveryParams
+        ): DeliveryStatus {
+            payload.event?.let(payloads::add)
+            payload.eventFile?.let(files::add)
+            latch.countDown()
+            return DeliveryStatus.DELIVERED
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -7,7 +7,6 @@ import androidx.annotation.VisibleForTesting;
 
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
@@ -19,15 +18,20 @@ class DeliveryDelegate extends BaseObservable {
     private final ImmutableConfig immutableConfig;
     final BreadcrumbState breadcrumbState;
     private final Notifier notifier;
+    final BackgroundTaskService backgroundTaskService;
 
-    DeliveryDelegate(Logger logger, EventStore eventStore,
-                     ImmutableConfig immutableConfig, BreadcrumbState breadcrumbState,
-                     Notifier notifier) {
+    DeliveryDelegate(Logger logger,
+                     EventStore eventStore,
+                     ImmutableConfig immutableConfig,
+                     BreadcrumbState breadcrumbState,
+                     Notifier notifier,
+                     BackgroundTaskService backgroundTaskService) {
         this.logger = logger;
         this.eventStore = eventStore;
         this.immutableConfig = immutableConfig;
         this.breadcrumbState = breadcrumbState;
         this.notifier = notifier;
+        this.backgroundTaskService = backgroundTaskService;
     }
 
     void deliver(@NonNull Event event) {
@@ -64,7 +68,7 @@ class DeliveryDelegate extends BaseObservable {
 
         // Attempt to send the eventPayload in the background
         try {
-            Async.run(new Runnable() {
+            backgroundTaskService.submitTask(TaskType.ERROR_REQUEST, new Runnable() {
                 @Override
                 public void run() {
                     deliverPayloadInternal(finalEventPayload, finalEvent);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
@@ -12,7 +12,7 @@ import java.io.IOException
 class EventPayload @JvmOverloads internal constructor(
     var apiKey: String?,
     val event: Event? = null,
-    private val eventFile: File? = null,
+    internal val eventFile: File? = null,
     notifier: Notifier,
     private val config: ImmutableConfig
 ) : JsonStream.Streamable {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -30,7 +30,14 @@ internal class DeliveryDelegateTest {
     @Before
     fun setUp() {
         deliveryDelegate =
-            DeliveryDelegate(logger, eventStore, config, breadcrumbState, notifier)
+            DeliveryDelegate(
+                logger,
+                eventStore,
+                config,
+                breadcrumbState,
+                notifier,
+                BackgroundTaskService()
+            )
         event.session = Session("123", Date(), User(null, null, null), false, notifier, NoopLogger)
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
@@ -79,6 +79,7 @@ class EventStoreMaxLimitTest {
             config,
             NoopLogger,
             Notifier(),
+            BackgroundTaskService(),
             FileStore.Delegate { _, _, _ -> }
         )
     }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
@@ -3,8 +3,6 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.createDefaultDelivery
-import com.bugsnag.android.mazerunner.InterceptingDelivery
 
 /**
  * Sends an exception after pausing the session
@@ -17,31 +15,25 @@ internal class ManualSessionSmokeScenario(
 
     override fun startBugsnag(startBugsnagOnly: Boolean) {
         config.autoTrackSessions = false
-
-        if (!startBugsnagOnly) {
-            val baseDelivery = createDefaultDelivery()
-            var state = 0
-            config.delivery = InterceptingDelivery(baseDelivery) {
-                when (state) {
-                    0 -> Bugsnag.notify(generateException())
-                    1 -> {
-                        Bugsnag.pauseSession()
-                        Bugsnag.notify(generateException())
-                    }
-                    2 -> {
-                        Bugsnag.resumeSession()
-                        throw generateException()
-                    }
-                }
-                state++
-            }
-        }
         super.startBugsnag(startBugsnagOnly)
     }
 
     override fun startScenario() {
         super.startScenario()
         Bugsnag.setUser("123", "ABC.CBA.CA", "ManualSessionSmokeScenario")
+
+        // send session
         Bugsnag.startSession()
+
+        // send exception with session
+        Bugsnag.notify(generateException())
+
+        // send exception without session
+        Bugsnag.pauseSession()
+        Bugsnag.notify(generateException())
+
+        // throw exception with session
+        Bugsnag.resumeSession()
+        throw generateException()
     }
 }


### PR DESCRIPTION
## Goal

Updates the event delivery mechanism to use `BackgroundTaskService` rather than `Async`. This allows for better control over asynchronous operations and negates the need for a `Semaphore` which was a source of non-deterministic behaviour that could lead to some session requests not immediately being sent. This is based on changes made in #1182.

## Changeset

- Converted `DeliveryDelegate` and `EventStore` to use `BackgroundTaskService`
- Altered `ManualSessionSmokeTest` to account for deterministic behaviour, and avoid flaky delivery limitations.
- Called `bgTaskService.shutdown()` after a fatal JVM error, which avoids dropping in-flight requests

## Testing

Added a unit test to confirm that event requests are confined to a thread, otherwise relied on existing E2E test coverage.