### PR TITLE
Update synchronous crash reporting logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   [#1185](https://github.com/bugsnag/bugsnag-android/pull/1185)
   [#1186](https://github.com/bugsnag/bugsnag-android/pull/1186)
   [#1180](https://github.com/bugsnag/bugsnag-android/pull/1180)
+  [#1188](https://github.com/bugsnag/bugsnag-android/pull/1188)
 
 ## 5.7.1 (2021-03-03)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -234,6 +234,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
         // Flush any on-disk errors and sessions
         eventStore.flushOnLaunch();
+        eventStore.flushAsync();
         sessionTracker.flushAsync();
 
         lastRunInfoStore = new LastRunInfoStore(immutableConfig);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventFilenameInfo.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventFilenameInfo.kt
@@ -62,7 +62,7 @@ internal data class EventFilenameInfo(
                 sanitizedApiKey,
                 uuid,
                 timestamp,
-                findSuffixForEvent(obj, config),
+                findSuffixForEvent(obj),
                 findErrorTypesForEvent(obj)
             )
         }
@@ -140,24 +140,18 @@ internal data class EventFilenameInfo(
         /**
          * Calculates the suffix for the given event
          */
-        private fun findSuffixForEvent(obj: Any, config: ImmutableConfig): String {
+        private fun findSuffixForEvent(obj: Any): String {
             return when (obj) {
                 is Event -> {
-                    val duration = obj.app.duration
-                    if (duration != null && isStartupCrash(duration.toLong(), config)) {
-                        STARTUP_CRASH
-                    } else {
-                        ""
+                    when (obj.app.isLaunching) {
+                        true -> STARTUP_CRASH
+                        else -> ""
                     }
                 }
                 else -> {
                     NON_JVM_CRASH
                 }
             }
-        }
-
-        private fun isStartupCrash(durationMs: Long, config: ImmutableConfig): Boolean {
-            return durationMs < config.launchDurationMillis
         }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -1,16 +1,20 @@
 package com.bugsnag.android;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.File;
-import java.lang.Thread;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Store and flush Event reports which couldn't be sent immediately due to
@@ -19,13 +23,11 @@ import java.util.concurrent.RejectedExecutionException;
 class EventStore extends FileStore {
 
     private static final long LAUNCH_CRASH_TIMEOUT_MS = 2000;
-    private static final int LAUNCH_CRASH_POLL_MS = 50;
 
-    volatile boolean flushOnLaunchCompleted = false;
     private final ImmutableConfig config;
     private final Delegate delegate;
     private final Notifier notifier;
-    private final BackgroundTaskService backgroundTaskService;
+    private final BackgroundTaskService bgTaskSevice;
     final Logger logger;
 
     static final Comparator<File> EVENT_COMPARATOR = new Comparator<File>() {
@@ -47,7 +49,7 @@ class EventStore extends FileStore {
     EventStore(@NonNull ImmutableConfig config,
                @NonNull Logger logger,
                Notifier notifier,
-               BackgroundTaskService backgroundTaskService,
+               BackgroundTaskService bgTaskSevice,
                Delegate delegate) {
         super(new File(config.getPersistenceDirectory(), "bugsnag-errors"),
                 config.getMaxPersistedEvents(),
@@ -58,56 +60,70 @@ class EventStore extends FileStore {
         this.logger = logger;
         this.delegate = delegate;
         this.notifier = notifier;
-        this.backgroundTaskService = backgroundTaskService;
+        this.bgTaskSevice = bgTaskSevice;
     }
 
+    /**
+     * Flush startup crashes synchronously on the main thread
+     */
     void flushOnLaunch() {
-        if (config.getLaunchDurationMillis() != 0) {
-            List<File> storedFiles = findStoredFiles();
-            final List<File> crashReports = findLaunchCrashReports(storedFiles);
-
-            // cancel non-launch crash reports
-            storedFiles.removeAll(crashReports);
-            cancelQueuedFiles(storedFiles);
-
-            if (!crashReports.isEmpty()) {
-
-                // Block the main thread for a 2 second interval as the app may crash very soon.
-                // The request itself will run in a background thread and will continue after the 2
-                // second period until the request completes, or the app crashes.
-                flushOnLaunchCompleted = false;
-                logger.i("Attempting to send launch crash reports");
-
-                try {
-                    backgroundTaskService.submitTask(TaskType.ERROR_REQUEST, new Runnable() {
-                        @Override
-                        public void run() {
-                            flushReports(crashReports);
-                            flushOnLaunchCompleted = true;
-                        }
-                    });
-                } catch (RejectedExecutionException ex) {
-                    logger.w("Failed to flush launch crash reports", ex);
-                    flushOnLaunchCompleted = true;
+        if (!config.getSendLaunchCrashesSynchronously()) {
+            return;
+        }
+        Future<?> future = null;
+        try {
+            future = bgTaskSevice.submitTask(TaskType.ERROR_REQUEST, new Runnable() {
+                @Override
+                public void run() {
+                    flushLaunchCrashReport();
                 }
+            });
+        } catch (RejectedExecutionException exc) {
+            logger.d("Failed to flush launch crash reports, continuing.", exc);
+        }
 
-                long waitMs = 0;
+        try {
+            if (future != null) {
+                future.get(LAUNCH_CRASH_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException | ExecutionException | TimeoutException exc) {
+            logger.d("Failed to send launch crash reports within 2s timeout, continuing.", exc);
+        }
+    }
 
-                while (!flushOnLaunchCompleted && waitMs < LAUNCH_CRASH_TIMEOUT_MS) {
-                    try {
-                        Thread.sleep(LAUNCH_CRASH_POLL_MS);
-                        waitMs += LAUNCH_CRASH_POLL_MS;
-                    } catch (InterruptedException exception) {
-                        logger.w("Interrupted while waiting for launch crash report request");
-                    }
-                }
-                logger.i("Continuing with Bugsnag initialisation");
-            } else {
-                logger.d("No startupcrash events to flush to Bugsnag.");
+    void flushLaunchCrashReport() {
+        List<File> storedFiles = findStoredFiles();
+        File launchCrashReport = findLaunchCrashReport(storedFiles);
+
+        // cancel non-launch crash reports
+        if (launchCrashReport != null) {
+            storedFiles.remove(launchCrashReport);
+        }
+        cancelQueuedFiles(storedFiles);
+
+        if (launchCrashReport != null) {
+            logger.i("Attempting to send the most recent launch crash report");
+            flushReports(Collections.singletonList(launchCrashReport));
+            logger.i("Continuing with Bugsnag initialisation");
+        } else {
+            logger.d("No startupcrash events to flush to Bugsnag.");
+        }
+    }
+
+    @Nullable
+    File findLaunchCrashReport(Collection<File> storedFiles) {
+        List<File> launchCrashes = new ArrayList<>();
+
+        for (File file : storedFiles) {
+            EventFilenameInfo filenameInfo = EventFilenameInfo.Companion.fromFile(file, config);
+            if (filenameInfo.isLaunchCrashReport()) {
+                launchCrashes.add(file);
             }
         }
 
-        flushAsync(); // flush any remaining errors async that weren't delivered
+        // sort to get most recent timestamp
+        Collections.sort(launchCrashes, EVENT_COMPARATOR);
+        return launchCrashes.isEmpty() ? null : launchCrashes.get(launchCrashes.size() - 1);
     }
 
     /**
@@ -115,7 +131,7 @@ class EventStore extends FileStore {
      */
     void flushAsync() {
         try {
-            backgroundTaskService.submitTask(TaskType.ERROR_REQUEST, new Runnable() {
+            bgTaskSevice.submitTask(TaskType.ERROR_REQUEST, new Runnable() {
                 @Override
                 public void run() {
                     List<File> storedFiles = findStoredFiles();
@@ -133,7 +149,7 @@ class EventStore extends FileStore {
     void flushReports(Collection<File> storedReports) {
         if (!storedReports.isEmpty()) {
             logger.i(String.format(Locale.US,
-                "Sending %d saved error(s) to Bugsnag", storedReports.size()));
+                    "Sending %d saved error(s) to Bugsnag", storedReports.size()));
 
             for (File eventFile : storedReports) {
                 flushEventFile(eventFile);
@@ -147,7 +163,8 @@ class EventStore extends FileStore {
             String apiKey = eventInfo.getApiKey();
             EventPayload payload = new EventPayload(apiKey, null, eventFile, notifier, config);
             DeliveryParams deliveryParams = config.getErrorApiDeliveryParams(payload);
-            DeliveryStatus deliveryStatus = config.getDelivery().deliver(payload, deliveryParams);
+            Delivery delivery = config.getDelivery();
+            DeliveryStatus deliveryStatus = delivery.deliver(payload, deliveryParams);
 
             switch (deliveryStatus) {
                 case DELIVERED:
@@ -178,31 +195,19 @@ class EventStore extends FileStore {
         deleteStoredFiles(Collections.singleton(eventFile));
     }
 
-    private List<File> findLaunchCrashReports(Collection<File> storedFiles) {
-        List<File> launchCrashes = new ArrayList<>();
-
-        for (File file : storedFiles) {
-            EventFilenameInfo filenameInfo = EventFilenameInfo.Companion.fromFile(file, config);
-            if (filenameInfo.isLaunchCrashReport()) {
-                launchCrashes.add(file);
-            }
-        }
-        return launchCrashes;
-    }
-
     @NonNull
     @Override
     String getFilename(Object object) {
         EventFilenameInfo eventInfo
                 = EventFilenameInfo.Companion.fromEvent(object, null, config);
         String encodedInfo = eventInfo.encode();
-        return String.format(Locale.US, "%s.json", encodedInfo);
+        return String.format(Locale.US, "%s", encodedInfo);
     }
 
     String getNdkFilename(Object object, String apiKey) {
         EventFilenameInfo eventInfo
                 = EventFilenameInfo.Companion.fromEvent(object, apiKey, config);
         String encodedInfo = eventInfo.encode();
-        return String.format(Locale.US, "%s.json", encodedInfo);
+        return String.format(Locale.US, "%s", encodedInfo);
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashDeliveryTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashDeliveryTest.kt
@@ -1,0 +1,165 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
+import com.bugsnag.android.BugsnagTestUtils.generateEvent
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.lang.Thread
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Verifies that crashes on launch are sent synchronously and other crashes are not.
+ */
+class LaunchCrashDeliveryTest {
+
+    private lateinit var storageDir: File
+    private lateinit var errorDir: File
+
+    @Before
+    fun setUp() {
+        storageDir = Files.createTempDirectory("tmp").toFile()
+        errorDir = File(storageDir, "bugsnag-errors")
+    }
+
+    @After
+    fun tearDown() {
+        storageDir.deleteRecursively()
+    }
+
+    /**
+     * Verifies that flushOnLaunch() blocks the main thread by simulating a slow delivery.
+     */
+    @Test
+    fun flushOnLaunchBlocksMainThread() {
+        val delivery = SlowDelivery()
+        val backgroundTaskService = BackgroundTaskService()
+        val eventStore = createEventStore(delivery, backgroundTaskService)
+        val event = generateEvent()
+        event.app.isLaunching = true
+        eventStore.write(event)
+
+        // check time difference in ms is >1500, proving thread was blocked
+        val baseline = System.currentTimeMillis()
+        eventStore.flushOnLaunch()
+        val now = System.currentTimeMillis()
+        assertTrue(now - baseline > 1500)
+        backgroundTaskService.shutdown()
+        assertEquals(1, delivery.count.get())
+    }
+
+    /**
+     * Crashes on launch are delivered synchronously
+     */
+    @Test
+    fun flushOnLaunchSync() {
+        val delivery = TestDelivery()
+        val backgroundTaskService = BackgroundTaskService()
+        val eventStore = createEventStore(delivery, backgroundTaskService)
+
+        // launch crashes are delivered in flushOnLaunch()
+        val event = generateEvent()
+        event.app.isLaunching = true
+        eventStore.write(event)
+        eventStore.flushOnLaunch()
+        assertEquals(1, delivery.count.get())
+        assertEquals("Bugsnag Error thread", delivery.threadName)
+
+        // non-launch crashes are not delivered in flushOnLaunch()
+        event.app.isLaunching = false
+        eventStore.write(event)
+        eventStore.flushOnLaunch()
+        assertEquals(1, delivery.count.get())
+
+        // non-launch crashes are delivered in flushAsync() instead
+        eventStore.flushAsync()
+        backgroundTaskService.shutdown()
+        assertEquals(2, delivery.count.get())
+        assertEquals("Bugsnag Error thread", delivery.threadName)
+    }
+
+    /**
+     * Only the most recent crash report is sent by flushOnLaunch()
+     */
+    @Test
+    fun flushOnLaunchSendsMostRecent() {
+        val delivery = TestDelivery()
+        val backgroundTaskService = BackgroundTaskService()
+        val eventStore = createEventStore(delivery, backgroundTaskService)
+
+        // launch crashes are delivered in flushOnLaunch()
+        val event = generateEvent()
+        event.app.isLaunching = true
+        event.apiKey = "First"
+        eventStore.write(event)
+        event.apiKey = "Second"
+        eventStore.write(event)
+
+        // only the first event should be sent
+        eventStore.flushOnLaunch()
+        assertEquals(1, delivery.count.get())
+        val payload = requireNotNull(delivery.payload)
+        val filenameInfo = EventFilenameInfo.fromFile(
+            requireNotNull(payload.eventFile),
+            BugsnagTestUtils.generateImmutableConfig()
+        )
+        assertEquals("Second", filenameInfo.apiKey)
+    }
+
+    private class TestDelivery : Delivery {
+        var threadName: String? = null
+        val count = AtomicInteger(0)
+        var payload: EventPayload? = null
+
+        override fun deliver(payload: Session, deliveryParams: DeliveryParams) =
+            DeliveryStatus.DELIVERED
+
+        override fun deliver(
+            payload: EventPayload,
+            deliveryParams: DeliveryParams
+        ): DeliveryStatus {
+            // capture thread on which executor was running
+            threadName = Thread.currentThread().name
+            count.getAndIncrement()
+            this.payload = payload
+            return DeliveryStatus.DELIVERED
+        }
+    }
+
+    private class SlowDelivery : Delivery {
+        val count = AtomicInteger(0)
+
+        override fun deliver(payload: Session, deliveryParams: DeliveryParams) =
+            DeliveryStatus.DELIVERED
+
+        override fun deliver(
+            payload: EventPayload,
+            deliveryParams: DeliveryParams
+        ): DeliveryStatus {
+            Thread.sleep(3000)
+            count.getAndIncrement()
+            return DeliveryStatus.DELIVERED
+        }
+    }
+
+    private fun createEventStore(
+        testDelivery: Delivery,
+        backgroundTaskService: BackgroundTaskService
+    ): EventStore {
+        val config = generateConfiguration().apply {
+            persistenceDirectory = storageDir
+            this.delivery = testDelivery
+        }
+        return EventStore(
+            BugsnagTestUtils.convert(config),
+            NoopLogger,
+            Notifier(),
+            backgroundTaskService,
+            FileStore.Delegate { _, _, _ -> }
+        )
+    }
+}


### PR DESCRIPTION
## Goal

Updates the existing synchronous reporting of launch crashes so that they fit the behaviour of the new spec. Specifically, synchronous delivery should only be attempted for the most recent startup crash.

## Changeset

- "_startupcrash" is appended to the filename based on whether `app.isLaunching` is set to true, rather than the previous `app.duration` exceeding a threshold
- Refactored `flushOnLaunch()` so that it creates a `Future` and blocks for 2 seconds calling `get()`. This avoids a busy wait that the previous implementation used
- Altered `EventStore` so that it only looks for the most recent startupcrash, as determined by the timestamp and "_startupcrash_ suffix encoded in the filename
- Fixed a bug where .json was encoded in the filename twice (this does not affect any functionality)
- `flushOnLaunch()` no longer calls `flushAsync()` to improve testability

## Testing

- Updated existing test coverage where necessary
- Added new unit tests for logic around finding a launch crash
- Created tests that validate what thread event delivery occurs on, and confirms that `flushOnLaunch()` blocks the main thread for a short duration