### PR TITLE
Soft fail Android 5 smoke tests

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -18,6 +18,8 @@ steps:
           - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':android: Android 6 NDK r16 smoke tests'
     key: 'android-6-smoke'


### PR DESCRIPTION
## Goal

Soft fail the Android 5 smoke tests while we continue to investigate Appium stability issues.