### PR TITLE
Fix deletion of JvmCrashLoopScenario

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
@@ -303,10 +303,4 @@ Java_com_bugsnag_android_mazerunner_scenarios_MultiProcessUnhandledCXXErrorScena
   abort();
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_mazerunner_scenarios_CXXCrashLoopScenario_crash(JNIEnv *env,
-                                                                                             jobject instance) {
-  abort();
-}
-
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmCrashLoopScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmCrashLoopScenario.kt
@@ -8,7 +8,7 @@ import com.bugsnag.android.OnErrorCallback
 /**
  * Triggers a crash loop which Bugsnag allows recovery from.
  */
-internal class CXXCrashLoopScenario(
+internal class JvmCrashLoopScenario(
     config: Configuration,
     context: Context,
     eventMetadata: String?
@@ -16,8 +16,6 @@ internal class CXXCrashLoopScenario(
 
     init {
         config.autoTrackSessions = false
-        System.loadLibrary("bugsnag-ndk")
-        System.loadLibrary("cxx-scenarios-bugsnag")
         config.addOnError(
             OnErrorCallback { event ->
                 Bugsnag.getLastRunInfo()?.let {
@@ -34,8 +32,6 @@ internal class CXXCrashLoopScenario(
         )
     }
 
-    external fun crash()
-
     override fun startScenario() {
         super.startScenario()
         val lastRunInfo = Bugsnag.getLastRunInfo()
@@ -45,7 +41,7 @@ internal class CXXCrashLoopScenario(
         if (lastRunInfo?.crashedDuringLaunch == true) {
             Bugsnag.notify(IllegalArgumentException("Safe mode enabled"))
         } else {
-            crash()
+            throw IllegalStateException("First crash")
         }
     }
 }


### PR DESCRIPTION
## Goal

Removes the unused `CXXCrashLoopScenario` and replaced it with `JvmCrashLoopScenario`, which was removed from version control due to a bad merge.