### PR TITLE
Refactor test to avoid request flakes

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXMarkLaunchCompletedScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXMarkLaunchCompletedScenario.kt
@@ -3,6 +3,9 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.createDefaultDelivery
+import com.bugsnag.android.mazerunner.InterceptingDelivery
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Sends an NDK error to Bugsnag after markLaunchCompleted() is invoked.
@@ -13,18 +16,26 @@ internal class CXXMarkLaunchCompletedScenario(
     eventMetadata: String?
 ) : Scenario(config, context, eventMetadata) {
 
+    private val deliveryCount = AtomicInteger(0)
+
     external fun crash()
 
     init {
         config.autoTrackSessions = false
         config.launchDurationMillis = 0
         System.loadLibrary("cxx-scenarios")
+
+        // wait for Bugsnag.notify() to complete before triggering NDK crash
+        config.delivery = InterceptingDelivery(createDefaultDelivery()) {
+            if (deliveryCount.incrementAndGet() == 1) {
+                crash()
+            }
+        }
     }
 
     override fun startScenario() {
         super.startScenario()
         Bugsnag.notify(RuntimeException("first error"))
         Bugsnag.markLaunchCompleted()
-        crash()
     }
 }


### PR DESCRIPTION
## Goal

The `CxxMarkLaunchCompletedScenario` triggers an NDK crash immediately after calling `Bugsnag.notify()`. This triggers a race where the NDK crash can terminate the process before the JVM error has a chance to make a request.

This fixes the scenario to only trigger the NDK crash after the first request has been delivered.