### PR TITLE
Setup native library for root detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   [#1195](https://github.com/bugsnag/bugsnag-android/pull/1195)
   [#1198](https://github.com/bugsnag/bugsnag-android/pull/1198)
   [#1200](https://github.com/bugsnag/bugsnag-android/pull/1200)
+  [#1201](https://github.com/bugsnag/bugsnag-android/pull/1201)
 
 * Add public API for crash-on-launch detection
   [#1157](https://github.com/bugsnag/bugsnag-android/pull/1157)

--- a/bugsnag-android-core/CMakeLists.txt
+++ b/bugsnag-android-core/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 3.4.1)
+add_subdirectory(src/main)

--- a/bugsnag-android-core/build.gradle
+++ b/bugsnag-android-core/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id("bugsnag-build-plugin")
 }
 
+bugsnagBuildOptions {
+    usesNdk = true
+}
+
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.dokka"
 

--- a/bugsnag-android-core/src/main/CMakeLists.txt
+++ b/bugsnag-android-core/src/main/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(BUGSNAG_VERSION 1.0.1)
+add_library( # Specifies the name of the library.
+             bugsnag-root-detection
+             # Sets the library as a shared library.
+             SHARED
+             # Provides a relative path to your source file(s).
+    jni/root_detection.c
+    )
+
+include_directories(jni)
+
+set_target_properties(bugsnag-root-detection
+                      PROPERTIES
+                      COMPILE_OPTIONS
+                      -Werror -Wall -pedantic)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -172,7 +172,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         Resources resources = appContext.getResources();
         deviceDataCollector = new DeviceDataCollector(connectivity, appContext,
                 resources, deviceId, info, Environment.getDataDirectory(),
-                new RootDetector(), bgTaskService, logger);
+                new RootDetector(logger), bgTaskService, logger);
 
         if (appContext instanceof Application) {
             Application application = (Application) appContext;

--- a/bugsnag-android-core/src/main/jni/root_detection.c
+++ b/bugsnag-android-core/src/main/jni/root_detection.c
@@ -1,0 +1,16 @@
+#include <jni.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT jboolean JNICALL
+Java_com_bugsnag_android_RootDetector_performNativeRootChecks(JNIEnv *env, jobject thiz) {
+// TODO: implement performNativeRootChecks()
+  return false;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/RootDetectorTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/RootDetectorTest.kt
@@ -18,7 +18,7 @@ import java.nio.file.Files
 @RunWith(MockitoJUnitRunner::class)
 class RootDetectorTest {
 
-    private val rootDetector = RootDetector()
+    private val rootDetector = RootDetector(logger = NoopLogger)
 
     @Mock
     lateinit var processBuilder: ProcessBuilder
@@ -68,7 +68,7 @@ class RootDetectorTest {
     @Test
     fun checkBuildTagsRooted() {
         val info = DeviceBuildInfo(null, null, null, null, null, null, "test-keys", null, null)
-        assertTrue(RootDetector(info).checkBuildTags())
+        assertTrue(RootDetector(info, logger = NoopLogger).checkBuildTags())
     }
 
     /**
@@ -77,7 +77,7 @@ class RootDetectorTest {
     @Test
     fun checkBuildTagsNotRooted() {
         val info = DeviceBuildInfo(null, null, null, null, null, null, "release-keys", null, null)
-        assertFalse(RootDetector(info).checkBuildTags())
+        assertFalse(RootDetector(info, logger = NoopLogger).checkBuildTags())
     }
 
     /**
@@ -85,7 +85,12 @@ class RootDetectorTest {
      */
     @Test
     fun checkRootBinaryRooted() {
-        assertFalse(RootDetector(rootBinaryLocations = listOf("/foo")).checkRootBinaries())
+        assertFalse(
+            RootDetector(
+                rootBinaryLocations = listOf("/foo"),
+                logger = NoopLogger
+            ).checkRootBinaries()
+        )
     }
 
     /**
@@ -95,7 +100,12 @@ class RootDetectorTest {
     fun checkRootBinaryNotRooted() {
         val tmpFile = Files.createTempFile("evilrootbinary", ".apk")
         val path = tmpFile.toFile().absolutePath
-        assertTrue(RootDetector(rootBinaryLocations = listOf(path)).checkRootBinaries())
+        assertTrue(
+            RootDetector(
+                rootBinaryLocations = listOf(path),
+                logger = NoopLogger
+            ).checkRootBinaries()
+        )
     }
 
     /**
@@ -104,7 +114,7 @@ class RootDetectorTest {
     @Test
     fun checkBuildPropsIOException() {
         val tmpFile = File("/foo")
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -113,7 +123,7 @@ class RootDetectorTest {
     @Test
     fun checkBuildPropsEmptyFile() {
         val tmpFile = Files.createTempFile("empty", ".prop").toFile()
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -123,7 +133,7 @@ class RootDetectorTest {
     fun checkBuildPropsNonRooted() {
         val tmpFile = Files.createTempFile("regular", ".prop").toFile()
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -135,7 +145,7 @@ class RootDetectorTest {
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
         tmpFile.appendText("ro.secure=[1]")
         tmpFile.appendText("ro.debuggable=[0]")
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -147,7 +157,7 @@ class RootDetectorTest {
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
         tmpFile.appendText("#ro.secure=[1]")
         tmpFile.appendText("#  ro.debuggable=[0]")
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -158,7 +168,7 @@ class RootDetectorTest {
         val tmpFile = Files.createTempFile("rooted", ".prop").toFile()
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
         tmpFile.appendText("\nro.debuggable=[1]\n")
-        assertTrue(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertTrue(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -169,7 +179,7 @@ class RootDetectorTest {
         val tmpFile = Files.createTempFile("rooted", ".prop").toFile()
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
         tmpFile.appendText("\nro.secure=[0]\n")
-        assertTrue(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertTrue(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     companion object {


### PR DESCRIPTION
## Goal

Creates a native library loaded by the `bugsnag-android-core` module that is responsible for detecting rooted devices. This is independent from the ANR/NDK native libraries and its sole purpose is to detect rooted devices.

## Changeset

- Created a new native library named `bugsnag-core`
- Loaded `bugsnag-core` library within the `RootDetector` class
- Perform a JNI call as part of the root detection. Currently this is unimplemented but a future PR will perform various root detection measures
- If the library cannot be loaded, default to false. This could either be due to root detection countermeasures blocking the library from loading, or genuine bugs with how the Android OS loads libraries.
- Added some additional logging

## Testing

- Confirmed that the native library loads through manual testing
- Confirmed that the `libbugsnag-core.so` file is extracted to `/build/intermediates/bugsnag-libs` by the bugsnag gradle plugin.