### PR TITLE
Bump compileSdkVersion to apiLevel 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Enhancements
 
+* Bump compileSdkVersion to apiLevel 30
+  [#1202](https://github.com/bugsnag/bugsnag-android/pull/1202)
+
 * Add public API for crash-on-launch detection
   [#1157](https://github.com/bugsnag/bugsnag-android/pull/1157)
   [#1159](https://github.com/bugsnag/bugsnag-android/pull/1159)

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/FileStoreTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/FileStoreTest.kt
@@ -20,7 +20,8 @@ class FileStoreTest {
         assertEquals("Crash report serialization", delegate.context)
         assertEquals(File(dir, "foo.json"), delegate.errorFile)
         assertEquals(exc, delegate.exception)
-        assertEquals(0, dir.listFiles().size)
+        val files = requireNotNull(dir.listFiles())
+        assertEquals(0, files.size)
     }
 }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -93,9 +93,11 @@ internal class AppDataCollector(
      * AndroidManifest.xml
      */
     private fun getAppName(): String? {
-        val hasInfo = packageManager != null && appInfo != null
+        val copy = appInfo
         return when {
-            hasInfo -> packageManager?.getApplicationLabel(appInfo).toString()
+            packageManager != null && copy != null -> {
+                packageManager.getApplicationLabel(copy).toString()
+            }
             else -> null
         }
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
@@ -119,7 +119,7 @@ internal class ConnectivityApi24(
             cb?.invoke(false, retrieveNetworkAccessState())
         }
 
-        override fun onAvailable(network: Network?) {
+        override fun onAvailable(network: Network) {
             super.onAvailable(network)
             cb?.invoke(true, retrieveNetworkAccessState())
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
@@ -50,7 +50,7 @@ internal class ObjectJsonStreamer {
         writer.endArray()
     }
 
-    private fun arrayToStream(writer: JsonStream, obj: Any?) {
+    private fun arrayToStream(writer: JsonStream, obj: Any) {
         // Primitive array objects
         writer.beginArray()
         val length = Array.getLength(obj)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -84,7 +84,8 @@ class BreadcrumbStateTest {
     @Test
     fun testDefaultBreadcrumbType() {
         breadcrumbState.add(Breadcrumb("1", NoopLogger))
-        assertEquals(MANUAL, breadcrumbState.store.peek().type)
+        val crumb = requireNotNull(breadcrumbState.store.peek())
+        assertEquals(MANUAL, crumb.type)
     }
 
     /**

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.bugsnag.android
 
 import android.content.Context
@@ -14,7 +16,6 @@ import org.mockito.Mockito
 import org.mockito.Mockito.times
 import org.mockito.junit.MockitoJUnitRunner
 
-@Suppress("DEPRECATION")
 @RunWith(MockitoJUnitRunner::class)
 class ConnectivityLegacyTest {
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -104,7 +104,7 @@ internal class DeliveryDelegateTest {
         assertEquals(DeliveryStatus.DELIVERED, status)
         assertEquals("Sent 1 new event to Bugsnag", logger.msg)
 
-        val breadcrumb = breadcrumbState.store.peek()
+        val breadcrumb = requireNotNull(breadcrumbState.store.peek())
         assertEquals(BreadcrumbType.ERROR, breadcrumb.type)
         assertEquals("java.lang.RuntimeException", breadcrumb.message)
         assertEquals("java.lang.RuntimeException", breadcrumb.metadata!!["errorClass"])

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
@@ -40,7 +40,7 @@ class EventStoreMaxLimitTest {
         repeat(40) {
             eventStore.write(event)
         }
-        val files = errorDir.list()
+        val files = requireNotNull(errorDir.list())
         assertEquals(32, files.size)
     }
 
@@ -56,7 +56,7 @@ class EventStoreMaxLimitTest {
         repeat(7) {
             eventStore.write(event)
         }
-        val files = errorDir.list()
+        val files = requireNotNull(errorDir.list())
         assertEquals(5, files.size)
     }
 
@@ -70,7 +70,7 @@ class EventStoreMaxLimitTest {
 
         val event = generateEvent()
         eventStore.write(event)
-        val files = errorDir.list()
+        val files = requireNotNull(errorDir.list())
         assertEquals(0, files.size)
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionStoreMaxLimitTest.kt
@@ -40,7 +40,7 @@ class SessionStoreMaxLimitTest {
         repeat(140) {
             sessionStore.write(session)
         }
-        val files = sessionDir.list()
+        val files = requireNotNull(sessionDir.list())
         assertEquals(128, files.size)
     }
 
@@ -56,7 +56,7 @@ class SessionStoreMaxLimitTest {
         repeat(7) {
             sessionStore.write(session)
         }
-        val files = sessionDir.list()
+        val files = requireNotNull(sessionDir.list())
         assertEquals(5, files.size)
     }
 
@@ -70,7 +70,7 @@ class SessionStoreMaxLimitTest {
 
         val session = generateSession()
         sessionStore.write(session)
-        val files = sessionDir.list()
+        val files = requireNotNull(sessionDir.list())
         assertEquals(0, files.size)
     }
 

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/BugsnagBuildPluginExtension.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/BugsnagBuildPluginExtension.kt
@@ -7,7 +7,7 @@ import org.gradle.api.model.ObjectFactory
  * allows for unwanted behaviour to be switched off - e.g., modules which don't use the NDK
  * can disable it.
  */
-open class BugsnagBuildPluginExtension(objects: ObjectFactory) {
+open class BugsnagBuildPluginExtension(@Suppress("UNUSED_PARAMETER") objects: ObjectFactory) {
 
     /**
      * Whether this project compiles code or not. If this is set to false then unnecessary

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/Versions.kt
@@ -8,7 +8,7 @@ import org.gradle.api.JavaVersion
 object Versions {
     // Note minSdkVersion must be >=21 for 64 bit architectures
     val minSdkVersion = 14
-    val compileSdkVersion = 28
+    val compileSdkVersion = 30
     val ndk = "16.1.4479499"
     val java = JavaVersion.VERSION_1_7
     val kotlin = "1.3.72"

--- a/dockerfiles/Dockerfile.android-common
+++ b/dockerfiles/Dockerfile.android-common
@@ -27,7 +27,6 @@ RUN rm $CMDLINE_TOOLS_NAME
 
 # Install Android tools using sdkmanager
 RUN yes | sdkmanager "platform-tools" > /dev/null
-RUN yes | sdkmanager "platforms;android-28" > /dev/null
 RUN yes | sdkmanager "platforms;android-30" > /dev/null
 RUN yes | sdkmanager "ndk;16.1.4479499" > /dev/null
 RUN yes | sdkmanager "cmake;3.6.4111459" > /dev/null


### PR DESCRIPTION
## Goal

Bumps the [compileSdkVersion](https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd) to apiLevel 30 from 28. This ensures that our SDK is compiled against the latest version of Android while retaining compatibility for previously supported versions.

## Changeset

- Bumped compileSdkVersion to 30
- Removed unused API 28 system image from CI, reducing docker image size
- Suppressed new deprecations where necessary
- Altered internal code and tests where nullability annotations have been changed between 28/30, e.g. `fun onAvailable(network: Network?)` was altered to `fun onAvailable(network: Network)`. This should have no effect on our public API or customer behaviour.

## Testing

Relied on existing test coverage. Additionally read the [Android 10](https://developer.android.com/about/versions/10/behavior-changes-all#non-sdk-restrictions) and [Android 11](https://developer.android.com/about/versions/11/behavior-changes-all#non-sdk-restrictions) behaviour change list for any differences that might affect us.