### PR TITLE
Detect non-sdk usages in E2E tests

### DIFF
--- a/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:label="MazeRunner"
         android:networkSecurityConfig="@xml/network_security_config"
         android:gwpAsanMode="always"
+        android:name=".MazerunnerApp"
         >
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
@@ -1,0 +1,30 @@
+package com.bugsnag.android.mazerunner
+
+import android.app.Application
+import android.os.Build
+import android.os.StrictMode
+
+class MazerunnerApp : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        setupNonSdkUsageStrictMode()
+    }
+
+    /**
+     * Configures the mazerunner app so that it will terminate with an exception if [StrictMode]
+     * detects that non-public Android APIs have been used. This is intended to provide an
+     * early warning system if Bugsnag is using these features internally.
+     *
+     * https://developer.android.com/about/versions/11/behavior-changes-all#non-sdk-restrictions
+     */
+    private fun setupNonSdkUsageStrictMode() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val policy = StrictMode.VmPolicy.Builder()
+                .detectNonSdkApiUsage()
+                .penaltyDeath()
+                .build()
+            StrictMode.setVmPolicy(policy)
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Android 9 and onwards [added restrictions](https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces) on the use of hidden Android APIs, which can trigger warnings/crashes if they are used within an app. This changeset alters the test fixture so that it will throw an exception if any non-sdk API is used by Bugsnag.

## Changeset

Setup `StrictMode` to throw an exception if any non-SDK API is used in the E2E tests.

It's worth noting that I also investigated [veridex](https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces#test-veridex-tool) for setting up on CI. I don't think it's necessary as `StrictMode` should cover this functionality (I also encountered a segfault when trying to use the latest version of the tool).

## Testing

Relied on existing test coverage.