### PR TITLE
Root files detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   [#1194](https://github.com/bugsnag/bugsnag-android/pull/1194)
   [#1195](https://github.com/bugsnag/bugsnag-android/pull/1195)
   [#1198](https://github.com/bugsnag/bugsnag-android/pull/1198)
+  [#1201](https://github.com/bugsnag/bugsnag-android/pull/1201)
 
 * Add public API for crash-on-launch detection
   [#1157](https://github.com/bugsnag/bugsnag-android/pull/1157)

--- a/bugsnag-android-core/CMakeLists.txt
+++ b/bugsnag-android-core/CMakeLists.txt
@@ -1,0 +1,2 @@
+cmake_minimum_required(VERSION 3.4.1)
+add_subdirectory(src/main)

--- a/bugsnag-android-core/build.gradle
+++ b/bugsnag-android-core/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id("bugsnag-build-plugin")
 }
 
+bugsnagBuildOptions {
+    usesNdk = true
+}
+
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.dokka"
 

--- a/bugsnag-android-core/src/main/CMakeLists.txt
+++ b/bugsnag-android-core/src/main/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(BUGSNAG_VERSION 1.0.1)
+add_library( # Specifies the name of the library.
+             bugsnag-core
+             # Sets the library as a shared library.
+             SHARED
+             # Provides a relative path to your source file(s).
+    jni/root_detection.c
+    )
+
+include_directories(jni)
+
+set_target_properties(bugsnag-core
+                      PROPERTIES
+                      COMPILE_OPTIONS
+                      -Werror -Wall -pedantic)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -172,7 +172,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         Resources resources = appContext.getResources();
         deviceDataCollector = new DeviceDataCollector(connectivity, appContext,
                 resources, deviceId, info, Environment.getDataDirectory(),
-                new RootDetector(), logger);
+                new RootDetector(logger), logger);
 
         if (appContext instanceof Application) {
             Application application = (Application) appContext;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/RootDetector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/RootDetector.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import java.io.BufferedReader
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Attempts to detect whether the device is rooted. Root detection errs on the side of false
@@ -13,10 +14,11 @@ import java.io.IOException
  * possible to manipulate Java return values & native library loading, it will always be possible
  * for a determined application to defeat these root checks.
  */
-internal class RootDetector(
+internal class RootDetector @JvmOverloads constructor(
     private val deviceBuildInfo: DeviceBuildInfo = DeviceBuildInfo.defaultInfo(),
     private val rootBinaryLocations: List<String> = ROOT_INDICATORS,
-    private val buildProps: File = BUILD_PROP_FILE
+    private val buildProps: File = BUILD_PROP_FILE,
+    private val logger: Logger
 ) {
 
     companion object {
@@ -39,13 +41,27 @@ internal class RootDetector(
         )
     }
 
+    private val libraryLoaded = AtomicBoolean(false)
+
+    init {
+        try {
+            System.loadLibrary("bugsnag-core")
+            libraryLoaded.set(true)
+        } catch (ignored: UnsatisfiedLinkError) {
+            // library couldn't load. This could be due to root detection countermeasures,
+            // or down to genuine OS level bugs with library loading - in either case
+            // Bugsnag will default to skipping the checks.
+        }
+    }
+
     /**
      * Determines whether the device is rooted or not.
      */
     fun isRooted(): Boolean {
         return try {
-            checkBuildTags() || checkSuExists() || checkBuildProps() || checkRootBinaries()
+            checkBuildTags() || checkSuExists() || checkBuildProps() || checkRootBinaries() || nativeCheckRoot()
         } catch (exc: Throwable) {
+            logger.w("Root detection failed", exc)
             false
         }
     }
@@ -55,19 +71,19 @@ internal class RootDetector(
      * indicates that the binary is present, which is a good indicator that the device
      * may have been rooted.
      */
-    fun checkSuExists(): Boolean = checkSuExists(ProcessBuilder())
+    private fun checkSuExists(): Boolean = checkSuExists(ProcessBuilder())
 
     /**
      * Checks whether the build tags contain 'test-keys', which indicates that the OS was signed
      * with non-standard keys.
      */
-    fun checkBuildTags(): Boolean = deviceBuildInfo.tags?.contains("test-keys") == true
+    internal fun checkBuildTags(): Boolean = deviceBuildInfo.tags?.contains("test-keys") == true
 
     /**
      * Checks whether common root binaries exist on disk, which are a good indicator of whether
      * the device is rooted.
      */
-    fun checkRootBinaries(): Boolean {
+    internal fun checkRootBinaries(): Boolean {
         runCatching {
             for (candidate in rootBinaryLocations) {
                 if (File(candidate).exists()) {
@@ -83,7 +99,7 @@ internal class RootDetector(
      * These properties give a good indication that a phone might be using a custom
      * ROM and is therefore rooted.
      */
-    fun checkBuildProps(): Boolean {
+    internal fun checkBuildProps(): Boolean {
         runCatching {
             return buildProps.bufferedReader().useLines { lines ->
                 lines
@@ -111,5 +127,15 @@ internal class RootDetector(
         } finally {
             process?.destroy()
         }
+    }
+
+    private external fun performNativeRootChecks(): Boolean
+
+    /**
+     * Performs root checks which require native code.
+     */
+    private fun nativeCheckRoot(): Boolean = when {
+        libraryLoaded.get() -> performNativeRootChecks()
+        else -> false
     }
 }

--- a/bugsnag-android-core/src/main/jni/root_detection.c
+++ b/bugsnag-android-core/src/main/jni/root_detection.c
@@ -1,0 +1,16 @@
+#include <jni.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT jboolean JNICALL
+Java_com_bugsnag_android_RootDetector_performNativeRootChecks(JNIEnv *env, jobject thiz) {
+// TODO: implement performNativeRootChecks()
+  return false;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/bugsnag-android-core/src/main/jni/root_detection.c
+++ b/bugsnag-android-core/src/main/jni/root_detection.c
@@ -5,10 +5,88 @@
 extern "C" {
 #endif
 
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static const char *su_paths[] = {
+        // Common binaries
+        "/system/xbin/su",
+        "/system/bin/su",
+        // < Android 5.0
+        "/system/app/Superuser.apk",
+        "/system/app/SuperSU.apk",
+        // >= Android 5.0
+        "/system/app/Superuser",
+        "/system/app/SuperSU",
+        // Fallback
+        "/system/xbin/daemonsu",
+        // Systemless root
+        "/su/bin"
+};
+static const int su_paths_count = sizeof(su_paths) / sizeof(*su_paths);
+
+static const char *should_not_be_writable[] = {
+        "/system",
+        "/system/bin",
+        "/vendor/bin",
+        "/sbin",
+        "/etc",
+};
+static const int should_not_be_writable_count = sizeof(should_not_be_writable) / sizeof(*should_not_be_writable);
+
+static inline int get_mode(const char* path) {
+  struct stat st;
+  if (lstat(path, &st) < 0) {
+    return -1;
+  }
+  return st.st_mode;
+}
+
+static inline bool does_path_exist(const char* path) {
+  return get_mode(path) >= 0;
+}
+
+static inline bool is_path_writable(const char* path) {
+  int mode = get_mode(path);
+  if (mode < 0) {
+    return false;
+  }
+  return (mode & 2) != 0;
+}
+
+static bool assert_no_su_paths() {
+  for (int i = 0; i < su_paths_count; i++) {
+    if (does_path_exist(su_paths[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool assert_no_writable_paths() {
+  for (int i = 0; i < should_not_be_writable_count; i++) {
+    if (is_path_writable(should_not_be_writable[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool is_rooted() {
+  if (!assert_no_su_paths()) {
+    return true;
+  }
+  if (!assert_no_writable_paths()) {
+    return true;
+  }
+  return false;
+}
+
+#include <stdio.h>
 JNIEXPORT jboolean JNICALL
 Java_com_bugsnag_android_RootDetector_performNativeRootChecks(JNIEnv *env, jobject thiz) {
-// TODO: implement performNativeRootChecks()
-  return false;
+  return is_rooted();
 }
 
 #ifdef __cplusplus

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/RootDetectorTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/RootDetectorTest.kt
@@ -18,7 +18,7 @@ import java.nio.file.Files
 @RunWith(MockitoJUnitRunner::class)
 class RootDetectorTest {
 
-    private val rootDetector = RootDetector()
+    private val rootDetector = RootDetector(logger = NoopLogger)
 
     @Mock
     lateinit var processBuilder: ProcessBuilder
@@ -68,7 +68,7 @@ class RootDetectorTest {
     @Test
     fun checkBuildTagsRooted() {
         val info = DeviceBuildInfo(null, null, null, null, null, null, "test-keys", null, null)
-        assertTrue(RootDetector(info).checkBuildTags())
+        assertTrue(RootDetector(info, logger = NoopLogger).checkBuildTags())
     }
 
     /**
@@ -77,7 +77,7 @@ class RootDetectorTest {
     @Test
     fun checkBuildTagsNotRooted() {
         val info = DeviceBuildInfo(null, null, null, null, null, null, "release-keys", null, null)
-        assertFalse(RootDetector(info).checkBuildTags())
+        assertFalse(RootDetector(info, logger = NoopLogger).checkBuildTags())
     }
 
     /**
@@ -85,7 +85,12 @@ class RootDetectorTest {
      */
     @Test
     fun checkRootBinaryRooted() {
-        assertFalse(RootDetector(rootBinaryLocations = listOf("/foo")).checkRootBinaries())
+        assertFalse(
+            RootDetector(
+                rootBinaryLocations = listOf("/foo"),
+                logger = NoopLogger
+            ).checkRootBinaries()
+        )
     }
 
     /**
@@ -95,7 +100,12 @@ class RootDetectorTest {
     fun checkRootBinaryNotRooted() {
         val tmpFile = Files.createTempFile("evilrootbinary", ".apk")
         val path = tmpFile.toFile().absolutePath
-        assertTrue(RootDetector(rootBinaryLocations = listOf(path)).checkRootBinaries())
+        assertTrue(
+            RootDetector(
+                rootBinaryLocations = listOf(path),
+                logger = NoopLogger
+            ).checkRootBinaries()
+        )
     }
 
     /**
@@ -104,7 +114,7 @@ class RootDetectorTest {
     @Test
     fun checkBuildPropsIOException() {
         val tmpFile = File("/foo")
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -113,7 +123,7 @@ class RootDetectorTest {
     @Test
     fun checkBuildPropsEmptyFile() {
         val tmpFile = Files.createTempFile("empty", ".prop").toFile()
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -123,7 +133,7 @@ class RootDetectorTest {
     fun checkBuildPropsNonRooted() {
         val tmpFile = Files.createTempFile("regular", ".prop").toFile()
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -135,7 +145,7 @@ class RootDetectorTest {
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
         tmpFile.appendText("ro.secure=[1]")
         tmpFile.appendText("ro.debuggable=[0]")
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -147,7 +157,7 @@ class RootDetectorTest {
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
         tmpFile.appendText("#ro.secure=[1]")
         tmpFile.appendText("#  ro.debuggable=[0]")
-        assertFalse(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertFalse(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -158,7 +168,7 @@ class RootDetectorTest {
         val tmpFile = Files.createTempFile("rooted", ".prop").toFile()
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
         tmpFile.appendText("\nro.debuggable=[1]\n")
-        assertTrue(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertTrue(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     /**
@@ -169,7 +179,7 @@ class RootDetectorTest {
         val tmpFile = Files.createTempFile("rooted", ".prop").toFile()
         tmpFile.writeText(SAMPLE_BUILD_PROPS)
         tmpFile.appendText("\nro.secure=[0]\n")
-        assertTrue(RootDetector(buildProps = tmpFile).checkBuildProps())
+        assertTrue(RootDetector(buildProps = tmpFile, logger = NoopLogger).checkBuildProps())
     }
 
     companion object {


### PR DESCRIPTION
## Goal

https://bugsnag.atlassian.net/browse/PLAT-6106

## Design

Use `lstat` to check for file existence and mode. We can't safely use syscalls since later versions of Android lock down certain functions, and some syscalls aren't directly accessible without guessing their numbers (which could break if they ever change).

## Changeset

Check for existence of a number of files, and writability of other files, per https://github.com/scottyab/rootbeer

## Testing

Ran on jailbroken and non-jailbroken devices (emulated and real)
