### PR TITLE
Collect whether the system has restricted background work for the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Bump compileSdkVersion to apiLevel 30
   [#1202](https://github.com/bugsnag/bugsnag-android/pull/1202)
 
+* Collect whether the system has restricted background work for the app
+  [#1211](https://github.com/bugsnag/bugsnag-android/pull/1211)
+
 * Add public API for crash-on-launch detection
   [#1157](https://github.com/bugsnag/bugsnag-android/pull/1157)
   [#1159](https://github.com/bugsnag/bugsnag-android/pull/1159)

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
@@ -1,0 +1,80 @@
+package com.bugsnag.android
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class AppDataCollectorTest {
+
+    lateinit var client: Client
+    lateinit var context: Context
+
+    @Mock
+    lateinit var am: ActivityManager
+
+    /**
+     * Generates a configuration and clears sharedPrefs values to begin the test with a clean slate
+     */
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext<Context>()
+        client = BugsnagTestUtils.generateClient()
+    }
+
+    /**
+     * The flag is not set in the app metadata if the user has not enabled background restrictions
+     */
+    @Test
+    fun testNoBackgroundRestrictions() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            `when`(am.isBackgroundRestricted).thenReturn(false)
+        }
+
+        val collector = AppDataCollector(
+            context,
+            context.packageManager,
+            client.immutableConfig,
+            client.sessionTracker,
+            am,
+            client.launchCrashTracker,
+            NoopLogger
+        )
+        val app = collector.getAppDataMetadata()
+        assertNull(app["backgroundWorkRestricted"])
+    }
+
+    /**
+     * The flag is set in the app metadata if the user has enabled background restrictions
+     */
+    @Test
+    fun testBackgroundRestrictionsEnabled() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            `when`(am.isBackgroundRestricted).thenReturn(true)
+        }
+        val collector = AppDataCollector(
+            context,
+            context.packageManager,
+            client.immutableConfig,
+            client.sessionTracker,
+            am,
+            client.launchCrashTracker,
+            NoopLogger
+        )
+        val app = collector.getAppDataMetadata()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            assertTrue(app["backgroundWorkRestricted"] as Boolean)
+        } else {
+            assertNull(app["backgroundWorkRestricted"])
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.SystemClock
 import java.util.HashMap
 
@@ -44,6 +45,10 @@ internal class AppDataCollector(
         map["activeScreen"] = getActiveScreenClass()
         map["memoryUsage"] = getMemoryUsage()
         map["lowMemory"] = isLowMemory()
+
+        isBackgroundWorkRestricted()?.let {
+            map["backgroundWorkRestricted"] = it
+        }
         return map
     }
 
@@ -56,6 +61,20 @@ internal class AppDataCollector(
     private fun getMemoryUsage(): Long {
         val runtime = Runtime.getRuntime()
         return runtime.totalMemory() - runtime.freeMemory()
+    }
+
+    /**
+     * Checks whether the user has restricted the amount of work this app can do in the background.
+     * https://developer.android.com/reference/android/app/ActivityManager#isBackgroundRestricted()
+     */
+    private fun isBackgroundWorkRestricted(): Boolean? {
+        return if (activityManager == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            null
+        } else if (activityManager.isBackgroundRestricted) {
+            true // only return non-null value if true to avoid noise in error reports
+        } else {
+            null
+        }
     }
 
     /**

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -458,6 +458,14 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   event->app.version_code =
       bsg_get_map_value_int(env, jni_cache, data, "versionCode");
 
+  bool restricted =
+      bsg_get_map_value_bool(env, jni_cache, data, "backgroundWorkRestricted");
+
+  if (restricted) {
+    bugsnag_event_add_metadata_bool(event, "app", "backgroundWorkRestricted",
+                                    restricted);
+  }
+
   bsg_safe_delete_local_ref(env, data);
 }
 


### PR DESCRIPTION
## Goal

Collects whether the system has restricted background work for the app, as reported by [`isBackgroundRestricted()`](https://developer.android.com/reference/android/app/ActivityManager#isBackgroundRestricted()), which is available on Android 9+.

This is useful information as some users do enable battery optimizations that throttle the amount of work an app can do in the background. For example, scheduled services and alarms may not execute. It seems probable that this could lead to bugs in some apps so this would be useful information to collect.

<img width="378" alt="Screenshot 2021-03-25 at 12 08 24" src="https://user-images.githubusercontent.com/11800640/112470994-3d9e5f00-8d63-11eb-8fc1-084ea736f475.png">

## Changeset

- Added `backgroundWorkRestricted` to the `app` metadata (only when restrictions are enabled, otherwise the field is not added)
- Added unit tests to confirm the functionality works as expected