### PR TITLE
Set sensible default for autoTrackSessions in E2E tests

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAutoContextScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAutoContextScenario.java
@@ -22,7 +22,6 @@ public class CXXAutoContextScenario extends Scenario {
                                   @NonNull Context context,
                                   @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXBackgroundNotifyScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXBackgroundNotifyScenario.kt
@@ -13,7 +13,6 @@ internal class CXXBackgroundNotifyScenario(
     init {
         System.loadLibrary("bugsnag-ndk")
         System.loadLibrary("cxx-scenarios-bugsnag")
-        config.autoTrackSessions = false
     }
 
     external fun activate()

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCrashLoopScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCrashLoopScenario.kt
@@ -15,7 +15,6 @@ internal class CXXCrashLoopScenario(
 
     init {
         System.loadLibrary("cxx-scenarios-bugsnag")
-        config.autoTrackSessions = false
     }
 
     external fun crash()

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorFalseScenario.kt
@@ -11,7 +11,6 @@ class CXXExceptionOnErrorFalseScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         System.loadLibrary("bugsnag-ndk")
         System.loadLibrary("cxx-scenarios-bugsnag")
     }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorTrueScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionOnErrorTrueScenario.kt
@@ -12,7 +12,6 @@ class CXXExceptionOnErrorTrueScenario(
     init {
         System.loadLibrary("bugsnag-ndk")
         System.loadLibrary("cxx-scenarios-bugsnag")
-        config.autoTrackSessions = false
     }
 
     external fun crash()

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionSmokeScenario.kt
@@ -28,7 +28,6 @@ class CXXExceptionSmokeScenario(
 
     init {
         System.loadLibrary("cxx-scenarios-bugsnag")
-        config.autoTrackSessions = false
         config.appType = "Overwritten"
         config.appVersion = "9.9.9"
         config.versionCode = 999

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXGetJavaDataScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXGetJavaDataScenario.java
@@ -23,7 +23,6 @@ public class CXXGetJavaDataScenario extends Scenario {
                                   @NonNull Context context,
                                   @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
         config.addMetadata("notData", "vals", "passMetaData");
         config.setAppVersion("passAppVersion");
         config.setContext("passContext");

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXHandledOverrideScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXHandledOverrideScenario.kt
@@ -12,7 +12,6 @@ internal class CXXHandledOverrideScenario(
 
     init {
         System.loadLibrary("cxx-scenarios-bugsnag")
-        config.autoTrackSessions = false
         disableSessionDelivery(config)
     }
 

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaBreadcrumbNativeBreadcrumbScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaBreadcrumbNativeBreadcrumbScenario.java
@@ -4,7 +4,6 @@ import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
 
 import android.content.Context;
-import android.os.Handler;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -17,8 +16,6 @@ public class CXXJavaBreadcrumbNativeBreadcrumbScenario extends Scenario {
     }
 
     public native void activate();
-
-    private Handler handler = new Handler();
 
     public CXXJavaBreadcrumbNativeBreadcrumbScenario(@NonNull Configuration config,
                                                      @NonNull Context context,

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNativeUserInfoJavaCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNativeUserInfoJavaCrashScenario.java
@@ -20,7 +20,6 @@ public class CXXNativeUserInfoJavaCrashScenario extends Scenario {
                                               @NonNull Context context,
                                               @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNaughtyStringsScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNaughtyStringsScenario.kt
@@ -12,7 +12,6 @@ internal class CXXNaughtyStringsScenario(
 
     init {
         System.loadLibrary("cxx-scenarios")
-        config.autoTrackSessions = false
     }
 
     external fun crash()

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNotifySmokeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNotifySmokeScenario.java
@@ -26,7 +26,6 @@ public class CXXNotifySmokeScenario extends Scenario {
                                   @NonNull Context context,
                                   @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
         config.setContext("FooContext");
     }
 

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXRemoveDataScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXRemoveDataScenario.java
@@ -23,7 +23,6 @@ public class CXXRemoveDataScenario extends Scenario {
                                  @NonNull Context context,
                                  @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXRemoveOnErrorScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXRemoveOnErrorScenario.kt
@@ -12,7 +12,6 @@ class CXXRemoveOnErrorScenario(
     init {
         System.loadLibrary("bugsnag-ndk")
         System.loadLibrary("cxx-scenarios-bugsnag")
-        config.autoTrackSessions = false
         config.context = "CXXRemoveOnErrorScenario"
     }
 

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorFalseScenario.kt
@@ -11,7 +11,6 @@ class CXXSignalOnErrorFalseScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         System.loadLibrary("bugsnag-ndk")
         System.loadLibrary("cxx-scenarios-bugsnag")
     }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalSmokeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalSmokeScenario.java
@@ -34,7 +34,6 @@ public class CXXSignalSmokeScenario extends Scenario {
                                   @NonNull Context context,
                                   @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
         config.setAppType("Overwritten");
         config.setAppVersion("9.9.9");
         config.setVersionCode(999);

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartScenario.java
@@ -20,7 +20,6 @@ public class CXXStartScenario extends Scenario {
                             @NonNull Context context,
                             @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessHandledCXXErrorScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessHandledCXXErrorScenario.kt
@@ -14,7 +14,6 @@ internal class MultiProcessHandledCXXErrorScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.persistUser = true
         System.loadLibrary("bugsnag-ndk")
         System.loadLibrary("cxx-scenarios-bugsnag")

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessUnhandledCXXErrorScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessUnhandledCXXErrorScenario.kt
@@ -14,7 +14,6 @@ internal class MultiProcessUnhandledCXXErrorScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         System.loadLibrary("bugsnag-ndk")
         System.loadLibrary("cxx-scenarios-bugsnag")
     }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkDisabledScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkDisabledScenario.java
@@ -21,7 +21,6 @@ public class AutoDetectNdkDisabledScenario extends Scenario {
                                          @NonNull Context context,
                                          @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
         config.getEnabledErrorTypes().setNdkCrashes(false);
     }
 

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAbortScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAbortScenario.java
@@ -19,7 +19,6 @@ public class CXXAbortScenario extends Scenario {
                             @NonNull Context context,
                             @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAnrNdkDisabledScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAnrNdkDisabledScenario.kt
@@ -19,7 +19,6 @@ internal class CXXAnrNdkDisabledScenario(
     }
 
     init {
-        config.autoTrackSessions = false
         config.enabledErrorTypes.anrs = true
         config.enabledErrorTypes.ndkCrashes = false
     }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAnrScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAnrScenario.java
@@ -19,7 +19,6 @@ public class CXXAnrScenario extends Scenario {
                           @NonNull Context context,
                           @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXConfigurationMetadataNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXConfigurationMetadataNativeCrashScenario.java
@@ -21,7 +21,6 @@ public class CXXConfigurationMetadataNativeCrashScenario extends Scenario {
                                                        @NonNull Context context,
                                                        @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
         String metadata = getEventMetadata();
         if (metadata == null || !metadata.equals("no-metadata")) {
             config.addMetadata("fruit", "apple", "gala");

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.java
@@ -25,7 +25,6 @@ public class CXXDelayedCrashScenario extends Scenario {
                                    @NonNull Context context,
                                    @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedErrorScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedErrorScenario.kt
@@ -22,7 +22,6 @@ internal class CXXDelayedErrorScenario(
     external fun crash()
 
     init {
-        config.autoTrackSessions = false
         config.launchDurationMillis = CRASH_DELAY_MS
         System.loadLibrary("cxx-scenarios")
     }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDoubleFreeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDoubleFreeScenario.java
@@ -19,7 +19,6 @@ public class CXXDoubleFreeScenario extends Scenario {
                                  @NonNull Context context,
                                  @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionScenario.java
@@ -19,7 +19,6 @@ public class CXXExceptionScenario extends Scenario {
                                 @NonNull Context context,
                                 @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExternalStackElementScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExternalStackElementScenario.java
@@ -20,7 +20,6 @@ public class CXXExternalStackElementScenario extends Scenario {
                                            @NonNull Context context,
                                            @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExtraordinaryLongStringScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExtraordinaryLongStringScenario.java
@@ -21,7 +21,6 @@ public class CXXExtraordinaryLongStringScenario extends Scenario {
                                               @NonNull Context context,
                                               @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
         config.setAppVersion("22.312.749.78.300.810.24.167.321.505.337.177.970.655.513.768.209"
                 + ".616.429.5.654.552.117.275.422.698.110.941.6.611.737.439.489.121.879.119.207"
                 + ".999.721.827.22.312.749.78.300.810.24.167.321.505.337.177.970.655.513.768.209"

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXImproperTypecastScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXImproperTypecastScenario.java
@@ -19,7 +19,6 @@ public class CXXImproperTypecastScenario extends Scenario {
                                        @NonNull Context context,
                                        @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaBreadcrumbNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaBreadcrumbNativeCrashScenario.java
@@ -20,7 +20,6 @@ public class CXXJavaBreadcrumbNativeCrashScenario extends Scenario {
                                                 @NonNull Context context,
                                                 @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaUserInfoNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXJavaUserInfoNativeCrashScenario.java
@@ -20,7 +20,6 @@ public class CXXJavaUserInfoNativeCrashScenario extends Scenario {
                                               @NonNull Context context,
                                               @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXMarkLaunchCompletedScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXMarkLaunchCompletedScenario.kt
@@ -21,7 +21,6 @@ internal class CXXMarkLaunchCompletedScenario(
     external fun crash()
 
     init {
-        config.autoTrackSessions = false
         config.launchDurationMillis = 0
         System.loadLibrary("cxx-scenarios")
 

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNullPointerScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXNullPointerScenario.java
@@ -19,7 +19,6 @@ public class CXXNullPointerScenario extends Scenario {
                                   @NonNull Context context,
                                   @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXPausedSessionScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXPausedSessionScenario.kt
@@ -14,7 +14,6 @@ class CXXPausedSessionScenario(
 
     init {
         System.loadLibrary("cxx-scenarios")
-        config.autoTrackSessions = false
 
         config.delivery = InterceptingDelivery(createDefaultDelivery()) {
             crash(0)

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSessionInfoCrashScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSessionInfoCrashScenario.kt
@@ -17,7 +17,6 @@ class CXXSessionInfoCrashScenario(
 
     init {
         System.loadLibrary("cxx-scenarios")
-        config.autoTrackSessions = false
 
         config.delivery = InterceptingDelivery(createDefaultDelivery()) {
             when (deliveryCount.incrementAndGet()) {

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigabrtScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigabrtScenario.java
@@ -19,7 +19,6 @@ public class CXXSigabrtScenario extends Scenario {
                               @NonNull Context context,
                               @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigbusScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigbusScenario.java
@@ -19,7 +19,6 @@ public class CXXSigbusScenario extends Scenario {
                              @NonNull Context context,
                              @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigfpeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigfpeScenario.java
@@ -19,7 +19,6 @@ public class CXXSigfpeScenario extends Scenario {
                              @NonNull Context context,
                              @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigillScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigillScenario.java
@@ -19,7 +19,6 @@ public class CXXSigillScenario extends Scenario {
                              @NonNull Context context,
                              @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigsegvScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigsegvScenario.java
@@ -19,7 +19,6 @@ public class CXXSigsegvScenario extends Scenario {
                               @NonNull Context context,
                               @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigtrapScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSigtrapScenario.java
@@ -19,7 +19,6 @@ public class CXXSigtrapScenario extends Scenario {
                               @NonNull Context context,
                               @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStackoverflowScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStackoverflowScenario.java
@@ -19,7 +19,6 @@ public class CXXStackoverflowScenario extends Scenario {
                                     @NonNull Context context,
                                     @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXStartSessionScenario.kt
@@ -14,7 +14,6 @@ class CXXStartSessionScenario(
 
     init {
         System.loadLibrary("cxx-scenarios")
-        config.autoTrackSessions = false
 
         config.delivery = InterceptingDelivery(createDefaultDelivery()) {
             crash(0)

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingOutsideReleaseStagesScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingOutsideReleaseStagesScenario.kt
@@ -14,7 +14,6 @@ class CXXThrowSomethingOutsideReleaseStagesScenario(
      * Sets custom enabled release stages.
      */
     init {
-        config.autoTrackSessions = false
         config.enabledReleaseStages = setOf("fee-fi-fo-fum")
         System.loadLibrary("cxx-scenarios")
     }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXThrowSomethingScenario.java
@@ -19,7 +19,6 @@ public class CXXThrowSomethingScenario extends Scenario {
                                      @NonNull Context context,
                                      @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapOutsideReleaseStagesScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapOutsideReleaseStagesScenario.kt
@@ -11,7 +11,6 @@ class CXXTrapOutsideReleaseStagesScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.enabledReleaseStages = setOf("fee-fi-fo-fum")
         System.loadLibrary("cxx-scenarios")
     }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXTrapScenario.java
@@ -19,7 +19,6 @@ public class CXXTrapScenario extends Scenario {
                            @NonNull Context context,
                            @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXUpdateContextCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXUpdateContextCrashScenario.java
@@ -21,13 +21,11 @@ public class CXXUpdateContextCrashScenario extends Scenario {
                                          @NonNull Context context,
                                          @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override
     public void startScenario() {
         super.startScenario();
-        String metadata = getEventMetadata();
         Context context = getContext();
         Bugsnag.setContext("Everest");
 

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXWriteReadOnlyMemoryScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXWriteReadOnlyMemoryScenario.java
@@ -19,7 +19,6 @@ public class CXXWriteReadOnlyMemoryScenario extends Scenario {
                                           @NonNull Context context,
                                           @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
@@ -19,6 +19,9 @@ fun prepareConfig(
         config.endpoints = EndpointConfiguration(notify, sessions)
     }
 
+    // disable auto session tracking by default to avoid unnecessary requests in scenarios
+    config.autoTrackSessions = false
+
     with(config.enabledErrorTypes) {
         ndkCrashes = true
         anrs = true

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ArrayEnabledReleaseStageScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ArrayEnabledReleaseStageScenario.kt
@@ -14,7 +14,6 @@ internal class ArrayEnabledReleaseStageScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.releaseStage = "prod"
         config.enabledReleaseStages = setOf("dev", "prod")
     }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorConnectivityScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorConnectivityScenario.kt
@@ -22,7 +22,6 @@ internal class AsyncErrorConnectivityScenario(
     init {
         val delivery = createSlowDelivery()
         config.delivery = delivery
-        config.autoTrackSessions = false
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorDoubleFlushScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorDoubleFlushScenario.kt
@@ -20,7 +20,6 @@ internal class AsyncErrorDoubleFlushScenario(
 
     init {
         config.delivery = createSlowDelivery()
-        config.autoTrackSessions = false
     }
     override fun startScenario() {
         super.startScenario()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorLaunchScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AsyncErrorLaunchScenario.kt
@@ -21,7 +21,6 @@ internal class AsyncErrorLaunchScenario(
 
     init {
         config.delivery = createSlowDelivery()
-        config.autoTrackSessions = false
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoContextScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoContextScenario.kt
@@ -15,10 +15,6 @@ internal class AutoContextScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         registerActivityLifecycleCallbacks()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoRedactKeysScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoRedactKeysScenario.kt
@@ -13,10 +13,6 @@ internal class AutoRedactKeysScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.addMetadata("user", "password", "hunter2")

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionSmokeScenario.kt
@@ -19,6 +19,7 @@ internal class AutoSessionSmokeScenario(
     init {
         val baseDelivery = createDefaultDelivery()
         var intercept = true
+        config.autoTrackSessions = true
         config.delivery = InterceptingDelivery(baseDelivery) {
             if (intercept) {
                 intercept = false

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbAutoScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbAutoScenario.kt
@@ -15,7 +15,6 @@ internal class BreadcrumbAutoScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.enabledBreadcrumbTypes = setOf(BreadcrumbType.STATE)
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbDisabledScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbDisabledScenario.kt
@@ -14,7 +14,6 @@ internal class BreadcrumbDisabledScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.enabledBreadcrumbTypes = emptySet()
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BreadcrumbScenario.kt
@@ -16,7 +16,6 @@ internal class BreadcrumbScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.enabledBreadcrumbTypes = setOf(BreadcrumbType.MANUAL, BreadcrumbType.USER)
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BugsnagInitScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BugsnagInitScenario.kt
@@ -18,10 +18,6 @@ internal class BugsnagInitScenario(
         private const val POOL_SIZE = 8
     }
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         val threadPool = Executors.newFixedThreadPool(POOL_SIZE)
         val callables = mutableListOf<Callable<Client?>>()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
@@ -12,10 +12,6 @@ internal class CrashHandlerScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         val previousHandler = Thread.getDefaultUncaughtExceptionHandler()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomHttpClientFlushScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomHttpClientFlushScenario.kt
@@ -16,8 +16,6 @@ internal class CustomHttpClientFlushScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     override fun startBugsnag(startBugsnagOnly: Boolean) {
-        config.autoTrackSessions = false
-
         if (startBugsnagOnly) {
             config.delivery = createCustomHeaderDelivery()
         } else {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomHttpClientScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomHttpClientScenario.kt
@@ -17,7 +17,6 @@ internal class CustomHttpClientScenario(
 
     init {
         config.delivery = createCustomHeaderDelivery()
-        config.autoTrackSessions = false
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomPluginNotifierDescriptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomPluginNotifierDescriptionScenario.kt
@@ -11,7 +11,6 @@ internal class CustomPluginNotifierDescriptionScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.addPlugin(CustomPluginExample())
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DisableAutoDetectErrorsScenario.kt
@@ -15,7 +15,6 @@ internal class DisableAutoDetectErrorsScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.enabledErrorTypes.unhandledExceptions = false
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyEnabledReleaseStageScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyEnabledReleaseStageScenario.kt
@@ -14,7 +14,6 @@ internal class EmptyEnabledReleaseStageScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.releaseStage = "prod"
         config.enabledReleaseStages = emptySet()
     }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyStacktraceScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyStacktraceScenario.kt
@@ -14,10 +14,6 @@ internal class EmptyStacktraceScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.notify(EmptyException("EmptyStacktraceScenario"))

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionApiKeyChangeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionApiKeyChangeScenario.kt
@@ -13,10 +13,6 @@ internal class HandledExceptionApiKeyChangeScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.notify(generateException()) { event ->

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionScenario.kt
@@ -13,10 +13,6 @@ internal class HandledExceptionScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.notify(generateException())

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionWithoutMessageScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledExceptionWithoutMessageScenario.kt
@@ -14,10 +14,6 @@ internal class HandledExceptionWithoutMessageScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.notify(SomeException())

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledJavaSmokeScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledJavaSmokeScenario.java
@@ -23,7 +23,6 @@ public class HandledJavaSmokeScenario extends Scenario {
                                     @NonNull Context context,
                                     @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledKotlinSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledKotlinSmokeScenario.kt
@@ -15,8 +15,8 @@ internal class HandledKotlinSmokeScenario(
     context: Context,
     eventMetadata: String?
 ) : Scenario(config, context, eventMetadata) {
+
     init {
-        config.autoTrackSessions = false
         config.appType = "Overwritten"
         config.appVersion = "9.9.9"
         config.versionCode = 999

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/IgnoredExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/IgnoredExceptionScenario.kt
@@ -15,7 +15,6 @@ internal class IgnoredExceptionScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.discardClasses = setOf("java.lang.RuntimeException")
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InForegroundScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InForegroundScenario.kt
@@ -15,10 +15,6 @@ internal class InForegroundScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         registerActivityLifecycleCallbacks()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalErrorScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InternalErrorScenario.kt
@@ -11,10 +11,6 @@ internal class InternalErrorScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         triggerInternalBugsnagForError(Bugsnag.getClient())

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrDisabledScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrDisabledScenario.kt
@@ -13,8 +13,8 @@ internal class JvmAnrDisabledScenario(
     context: Context,
     eventMetadata: String?
 ) : Scenario(config, context, eventMetadata) {
+
     init {
-        config.autoTrackSessions = false
         config.enabledErrorTypes.anrs = false
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrLoopScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrLoopScenario.kt
@@ -15,7 +15,6 @@ internal class JvmAnrLoopScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.enabledErrorTypes.anrs = true
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrMinimalFixtureScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrMinimalFixtureScenario.kt
@@ -15,7 +15,6 @@ internal class JvmAnrMinimalFixtureScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.enabledErrorTypes.anrs = false
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
@@ -20,7 +20,6 @@ public class JvmAnrOutsideReleaseStagesScenario extends Scenario {
                                               @NonNull Context context,
                                               @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
         config.setEnabledReleaseStages(Collections.singleton("fee-fi-fo-fum"));
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrSleepScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrSleepScenario.kt
@@ -16,7 +16,6 @@ internal class JvmAnrSleepScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.enabledErrorTypes.anrs = true
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmCrashLoopScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmCrashLoopScenario.kt
@@ -15,7 +15,6 @@ internal class JvmCrashLoopScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.addOnError(
             OnErrorCallback { event ->
                 Bugsnag.getLastRunInfo()?.let {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmDelayedErrorScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmDelayedErrorScenario.kt
@@ -20,7 +20,6 @@ internal class JvmDelayedErrorScenario(
     }
 
     init {
-        config.autoTrackSessions = false
         config.launchDurationMillis = CRASH_DELAY_MS
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmMarkLaunchCompletedScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmMarkLaunchCompletedScenario.kt
@@ -14,7 +14,6 @@ internal class JvmMarkLaunchCompletedScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.launchDurationMillis = 0
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualRedactKeysScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualRedactKeysScenario.kt
@@ -14,7 +14,6 @@ internal class ManualRedactKeysScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.redactedKeys = setOf("foo")
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ManualSessionSmokeScenario.kt
@@ -14,7 +14,6 @@ internal class ManualSessionSmokeScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     override fun startBugsnag(startBugsnagOnly: Boolean) {
-        config.autoTrackSessions = false
         super.startBugsnag(startBugsnagOnly)
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MetadataNestedNullScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MetadataNestedNullScenario.kt
@@ -14,10 +14,6 @@ internal class MetadataNestedNullScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MetadataScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MetadataScenario.kt
@@ -13,10 +13,6 @@ internal class MetadataScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.notify(RuntimeException("MetadataScenario")) {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessHandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessHandledExceptionScenario.kt
@@ -14,10 +14,6 @@ internal class MultiProcessHandledExceptionScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         if (!isRunningFromBackgroundService()) {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessUnhandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiProcessUnhandledExceptionScenario.kt
@@ -13,10 +13,6 @@ internal class MultiProcessUnhandledExceptionScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/NaughtyStringScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/NaughtyStringScenario.kt
@@ -14,9 +14,6 @@ internal class NaughtyStringScenario(
     context: Context,
     eventMetadata: String?
 ) : Scenario(config, context, eventMetadata) {
-    init {
-        config.autoTrackSessions = false
-    }
 
     override fun startScenario() {
         super.startScenario()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/NullReleaseStageScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/NullReleaseStageScenario.kt
@@ -14,7 +14,6 @@ internal class NullReleaseStageScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.releaseStage = null
         config.enabledReleaseStages = setOf("prod")
     }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OomScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OomScenario.kt
@@ -13,10 +13,6 @@ internal class OomScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     private val queue = LinkedList<Array<String>>()
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OutsideReleaseStageScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OutsideReleaseStageScenario.kt
@@ -15,7 +15,6 @@ internal class OutsideReleaseStageScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.releaseStage = "prod"
         config.enabledReleaseStages = setOf("dev")
     }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToHandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToHandledExceptionScenario.kt
@@ -14,8 +14,8 @@ internal class OverrideToHandledExceptionScenario(
     context: Context,
     eventMetadata: String?
 ) : Scenario(config, context, eventMetadata) {
+
     init {
-        config.autoTrackSessions = true
         config.addOnError(
             OnErrorCallback {
                 it.isUnhandled = false

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToUnhandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToUnhandledExceptionScenario.kt
@@ -15,7 +15,6 @@ internal class OverrideToUnhandledExceptionScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.addOnSession(OnSessionCallback { false })
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ReportCacheScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ReportCacheScenario.kt
@@ -13,7 +13,6 @@ internal class ReportCacheScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         if (eventMetadata != "online") {
             disableAllDelivery(config)
         }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionCacheScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionCacheScenario.kt
@@ -14,7 +14,6 @@ internal class SessionCacheScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         if (eventMetadata == "offline") {
             disableAllDelivery(config)
         }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionPersistUserDisabledScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionPersistUserDisabledScenario.kt
@@ -14,7 +14,6 @@ internal class SessionPersistUserDisabledScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.persistUser = false
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionPersistUserScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionPersistUserScenario.kt
@@ -14,7 +14,6 @@ internal class SessionPersistUserScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.persistUser = true
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionStoppingScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionStoppingScenario.kt
@@ -20,7 +20,6 @@ internal class SessionStoppingScenario(
     private var stateMachine: ScenarioState = ScenarioState.FIRST_SESSION
 
     init {
-        config.autoTrackSessions = false
         config.delivery = InterceptingDelivery(createDefaultDelivery()) { status ->
             check(status == DeliveryStatus.DELIVERED) {
                 "Request failed, aborting scenario. status=$status"

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SharedPrefMigrationScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SharedPrefMigrationScenario.kt
@@ -16,7 +16,6 @@ internal class SharedPrefMigrationScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.persistUser = true
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StackOverflowScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StackOverflowScenario.kt
@@ -12,10 +12,6 @@ internal class StackOverflowScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         calculateValue(0)

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StartupCrashFlushScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StartupCrashFlushScenario.kt
@@ -25,7 +25,6 @@ internal class StartupCrashFlushScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         if ("CrashOfflineWithDelay" == eventMetadata || "CrashOfflineAtStartup" == eventMetadata) {
             // Part 2 - Persist a startup crash to disk
             disableAllDelivery(config)

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
@@ -14,10 +14,6 @@ internal class StrictModeDiscScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         StrictMode.setThreadPolicy(

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
@@ -15,10 +15,6 @@ internal class StrictModeNetworkScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         StrictMode.setThreadPolicy(

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TrimmedStacktraceScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/TrimmedStacktraceScenario.kt
@@ -14,10 +14,6 @@ internal class TrimmedStacktraceScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         val stacktrace = mutableListOf<StackTraceElement>()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledExceptionApiKeyChangeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledExceptionApiKeyChangeScenario.kt
@@ -14,7 +14,6 @@ internal class UnhandledExceptionApiKeyChangeScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
-        config.autoTrackSessions = false
         config.addOnError(
             OnErrorCallback { event ->
                 event.apiKey = "0000111122223333aaaabbbbcccc9999"

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledExceptionScenario.kt
@@ -12,10 +12,6 @@ internal class UnhandledExceptionScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         throw generateException()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnsatisfiedLinkErrorScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnsatisfiedLinkErrorScenario.java
@@ -15,7 +15,6 @@ public class UnsatisfiedLinkErrorScenario extends Scenario {
                                         @NonNull Context context,
                                         @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
-        config.setAutoTrackSessions(false);
     }
 
     @Override

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UserCallbackScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UserCallbackScenario.kt
@@ -13,10 +13,6 @@ internal class UserCallbackScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.setUser("abc", "user@example.com", "Jake")

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UserDisabledScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UserDisabledScenario.kt
@@ -13,10 +13,6 @@ internal class UserDisabledScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.setUser(null, null, null)

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UserIdScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UserIdScenario.kt
@@ -13,10 +13,6 @@ internal class UserIdScenario(
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
 
-    init {
-        config.autoTrackSessions = false
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.setUser("abc", null, null)


### PR DESCRIPTION
## Goal

Sets a sensible default for our E2E tests by ensuring autoTrackSessions is false by default, since most of the time we only assert on error requests. This reduces some duplication in the test code.