### PR TITLE
Relax checking of releaseStage

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -140,7 +140,7 @@ steps:
     concurrency_group: 'browserstack-app'
 
   #
-  # Flaky scenarios.  Theis should be skipped if there are no scenarios annotated with the @Flaky tag (as we should
+  # Flaky scenarios.  These should be skipped if there are no scenarios annotated with the @Flaky tag (as we should
   # always be aiming for) to avoid unnecessary CI wait times and potential flakes from resource unavailability.
   #
   - label: ':hankey: Flaky Android 9 NDK r21 end-to-end tests'

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
@@ -155,7 +156,32 @@ internal class ImmutableConfigTest {
     }
 
     @Test
-    fun configSanitisation() {
+    fun configSanitisationDevelopment() {
+        `when`(context.packageName).thenReturn("com.example.foo")
+        val appInfo = ApplicationInfo()
+        appInfo.flags = ApplicationInfo.FLAG_DEBUGGABLE
+        `when`(packageManager.getApplicationInfo("com.example.foo", PackageManager.GET_META_DATA)).thenReturn(appInfo)
+        `when`(context.packageManager).thenReturn(packageManager)
+        val cacheDir = Files.createTempDirectory("foo").toFile()
+        `when`(context.cacheDir).thenReturn(cacheDir)
+        val packageInfo = PackageInfo()
+        @Suppress("DEPRECATION")
+        packageInfo.versionCode = 55
+        `when`(packageManager.getPackageInfo("com.example.foo", 0)).thenReturn(packageInfo)
+
+        val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        seed.logger = NoopLogger
+        val config = sanitiseConfiguration(context, seed, connectivity)
+        assertEquals(NoopLogger, config.logger)
+        assertEquals(setOf("com.example.foo"), config.projectPackages)
+        assertEquals("development", config.releaseStage)
+        assertEquals(55, config.versionCode)
+        assertNotNull(config.delivery)
+        assertEquals(cacheDir, config.persistenceDirectory)
+    }
+
+    @Test
+    fun configSanitisationProduction() {
         `when`(context.packageName).thenReturn("com.example.foo")
         `when`(context.packageManager).thenReturn(packageManager)
         val cacheDir = Files.createTempDirectory("foo").toFile()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
@@ -21,6 +21,7 @@ fun prepareConfig(
 
     // disable auto session tracking by default to avoid unnecessary requests in scenarios
     config.autoTrackSessions = false
+    config.releaseStage = "mazerunner"
 
     with(config.enabledErrorTypes) {
         ndkCrashes = true

--- a/features/full_tests/batch_1/internal_error_reports.feature
+++ b/features/full_tests/batch_1/internal_error_reports.feature
@@ -33,7 +33,7 @@ Scenario: If an exception is thrown when sending errors/sessions then internal e
     # App data
     And the event "app.buildUUID" is not null
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" matches "(production|development)"
+    And the event "app.releaseStage" equals "mazerunner"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34

--- a/features/full_tests/batch_1/internal_error_reports.feature
+++ b/features/full_tests/batch_1/internal_error_reports.feature
@@ -33,7 +33,7 @@ Scenario: If an exception is thrown when sending errors/sessions then internal e
     # App data
     And the event "app.buildUUID" is not null
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" equals "production"
+    And the event "app.releaseStage" matches "(production|development)"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34

--- a/features/full_tests/batch_1/load_configuration.feature
+++ b/features/full_tests/batch_1/load_configuration.feature
@@ -35,7 +35,7 @@ Scenario: Load configuration initialised with nulls
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier with the apiKey "12312312312312312312312312312312"
     And the exception "message" equals "LoadConfigurationNullsScenario"
-    And the event "app.releaseStage" matches "(production|development)"
+    And the event "app.releaseStage" is not null
     And the event "metaData.test.foo" equals "bar"
     And the event "metaData.test.filter_me" equals "foobar"
     And the event "app.versionCode" equals 34

--- a/features/full_tests/batch_1/load_configuration.feature
+++ b/features/full_tests/batch_1/load_configuration.feature
@@ -35,7 +35,7 @@ Scenario: Load configuration initialised with nulls
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier with the apiKey "12312312312312312312312312312312"
     And the exception "message" equals "LoadConfigurationNullsScenario"
-    And the event "app.releaseStage" equals "production"
+    And the event "app.releaseStage" matches "(production|development)"
     And the event "metaData.test.foo" equals "bar"
     And the event "metaData.test.filter_me" equals "foobar"
     And the event "app.versionCode" equals 34

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -30,7 +30,7 @@ Scenario: Notify caught Java exception with default configuration
     # App data
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" equals "production"
+    And the event "app.releaseStage" matches "(production|development)"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34
@@ -175,7 +175,7 @@ Scenario: Handled C functionality
     # App data
     And the event "app.buildUUID" is not null
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" equals "production"
+    And the event "app.releaseStage" matches "(production|development)"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -30,7 +30,7 @@ Scenario: Notify caught Java exception with default configuration
     # App data
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" matches "(production|development)"
+    And the event "app.releaseStage" equals "mazerunner"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34
@@ -175,7 +175,7 @@ Scenario: Handled C functionality
     # App data
     And the event "app.buildUUID" is not null
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" matches "(production|development)"
+    And the event "app.releaseStage" equals "mazerunner"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -17,7 +17,7 @@ Scenario: Automated sessions send
     # App data
     And the session payload field "app.buildUUID" equals "test-7.5.3"
     And the session payload field "app.id" equals "com.bugsnag.android.mazerunner"
-    And the session payload field "app.releaseStage" matches the regex "(production|development)"
+    And the session payload field "app.releaseStage" equals "mazerunner"
     And the session payload field "app.type" equals "android"
     And the session payload field "app.version" equals "1.1.14"
     And the session payload field "app.versionCode" equals 34

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -17,7 +17,7 @@ Scenario: Automated sessions send
     # App data
     And the session payload field "app.buildUUID" equals "test-7.5.3"
     And the session payload field "app.id" equals "com.bugsnag.android.mazerunner"
-    And the session payload field "app.releaseStage" equals "production"
+    And the session payload field "app.releaseStage" matches the regex "(production|development)"
     And the session payload field "app.type" equals "android"
     And the session payload field "app.version" equals "1.1.14"
     And the session payload field "app.versionCode" equals 34

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -31,7 +31,7 @@ Scenario: Unhandled Java Exception with loaded configuration
     # App data
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" equals "production"
+    And the event "app.releaseStage" matches "(production|development)"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34
@@ -277,7 +277,7 @@ Scenario: ANR detection
     # App data
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" equals "production"
+    And the event "app.releaseStage" matches "(production|development)"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -31,7 +31,7 @@ Scenario: Unhandled Java Exception with loaded configuration
     # App data
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" matches "(production|development)"
+    And the event "app.releaseStage" equals "mazerunner"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34
@@ -277,7 +277,7 @@ Scenario: ANR detection
     # App data
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
-    And the event "app.releaseStage" matches "(production|development)"
+    And the event "app.releaseStage" equals "mazerunner"
     And the event "app.type" equals "android"
     And the event "app.version" equals "1.1.14"
     And the event "app.versionCode" equals 34


### PR DESCRIPTION
## Goal

Cater for device farms that instrument APKs updated for end-to-end tests.

## Design

Sauce Labs behaves differently than BrowserStack in that it instruments the APKs we upload for e2e tests, making them "debuggable" and causing our notifier to report the `releaseStage` as `development` rather than `production`.

## Changeset

This change relaxes the e2e test expectations to accept either `releaseStage` reported by the notifier, whilst also adding a unit test to ensure the notifier logic is properly tested.

## Testing

Covered by CI and the new unit test.