### PR TITLE
Use MazeRunner v5

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -101,7 +101,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -126,7 +125,6 @@ steps:
           - "--fail-fast"
           - "--tags"
           - "not @Flaky"
-          - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:
@@ -403,7 +401,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_5_0"
           - "--tags=@Flaky"
-          - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
 

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -15,7 +15,6 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_5_0"
           - "--fail-fast"
-          - "--appium-version=1.8.0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
     soft_fail:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.12.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.0.1'
+
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b590f1c94366349729f1b4413a9e6c050730a9fb
-  tag: v4.12.0
+  revision: 9aaf72b51c4f340f9d4901497752af70f526543f
+  tag: v5.0.1
   specs:
-    bugsnag-maze-runner (4.12.0)
+    bugsnag-maze-runner (5.0.1)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -24,10 +24,10 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.4.1)
+    appium_lib_core (4.5.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
-    backports (3.20.2)
+    backports (3.21.0)
     boring (0.1.0)
     builder (3.2.4)
     childprocess (3.0.0)
@@ -58,7 +58,7 @@ GEM
     minitest (5.14.4)
     multi_json (1.15.0)
     multi_test (0.1.2)
-    nokogiri (1.11.1)
+    nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     optimist (3.0.1)

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ test:
 	./gradlew connectedCheck
 
 remote-test:
-ifeq ($(MAZE_DEVICE_FARM_USERNAME),)
-	@$(error MAZE_DEVICE_FARM_USERNAME is not defined)
+ifeq ($(BROWSER_STACK_USERNAME),)
+	@$(error BROWSER_STACK_USERNAME is not defined)
 endif
-ifeq ($(MAZE_DEVICE_FARM_ACCESS_KEY),)
-	@$(error MAZE_DEVICE_FARM_ACCESS_KEY is not defined)
+ifeq ($(BROWSER_STACK_ACCESS_KEY),)
+	@$(error BROWSER_STACK_ACCESS_KEY is not defined)
 endif
 	@APP_LOCATION=/app/bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk \
 	 INSTRUMENTATION_DEVICES='["Google Nexus 5-4.4", "Google Pixel-7.1", "Google Pixel 3-9.0"]' \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v4-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
     environment:
       DEBUG:
       BUILDKITE:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v5-cli
     environment:
       DEBUG:
       BUILDKITE:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,10 @@ services:
       context: .
       dockerfile: dockerfiles/Dockerfile.android-ci-base
     environment:
-      MAZE_DEVICE_FARM_USERNAME:
-      MAZE_DEVICE_FARM_ACCESS_KEY:
+      BROWSER_STACK_USERNAME:
+      BROWSER_STACK_ACCESS_KEY:
+      SAUCE_LABS_USERNAME:
+      SAUCE_LABS_ACCESS_KEY:
       INSTRUMENTATION_DEVICES:
 
   android-builder:
@@ -58,8 +60,10 @@ services:
       DEBUG:
       BUILDKITE:
       BUILDKITE_PIPELINE_NAME:
-      MAZE_DEVICE_FARM_USERNAME:
-      MAZE_DEVICE_FARM_ACCESS_KEY:
+      BROWSER_STACK_USERNAME:
+      BROWSER_STACK_ACCESS_KEY:
+      SAUCE_LABS_USERNAME:
+      SAUCE_LABS_ACCESS_KEY:
     volumes:
       - ./build:/app/build
       - ./maze-output:/app/maze-output

--- a/docs/MAZERUNNER.md
+++ b/docs/MAZERUNNER.md
@@ -10,8 +10,8 @@ __Note: only Bugsnag employees can run the end-to-end tests.__ We have dedicated
 
 Remote tests can be run against real devices provided by BrowserStack. In order to run these tests, you need to set the following environment variables:
 
-- A BrowserStack App Automate Username: `MAZE_DEVICE_FARM_USERNAME`
-- A BrowserStack App Automate Access Key: `MAZE_DEVICE_FARM_ACCESS_KEY`
+- A BrowserStack App Automate Username: `BROWSER_STACK_USERNAME`
+- A BrowserStack App Automate Access Key: `BROWSER_STACK_ACCESS_KEY`
 - A path to a [BrowserStack local testing binary](https://www.browserstack.com/local-testing/app-automate): `MAZE_BS_LOCAL`
 
 ### Running an end-to-end test

--- a/features/full_tests/batch_1/in_foreground.feature
+++ b/features/full_tests/batch_1/in_foreground.feature
@@ -8,3 +8,6 @@ Scenario: Test handled exception in background
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the event "app.inForeground" is false
+    # Appium 1.9.1 - 1.20.2 changes the orientation to landscape when foregrounding.
+    # Return it to portrait to avoid impacting other scenarios.
+    And I set the screen orientation to portrait

--- a/features/full_tests/batch_1/internal_error_reports.feature
+++ b/features/full_tests/batch_1/internal_error_reports.feature
@@ -1,7 +1,8 @@
 Feature: Cached Error Reports
 
 Scenario: If an exception is thrown when sending errors/sessions then internal error reports should be sent
-    When I run "InternalErrorScenario"
+    When I set the screen orientation to portrait
+    And I run "InternalErrorScenario"
     And I wait to receive 1 errors
 
     # Validate internal error report for error serialization

--- a/features/full_tests/batch_1/internal_error_reports.feature
+++ b/features/full_tests/batch_1/internal_error_reports.feature
@@ -1,8 +1,7 @@
 Feature: Cached Error Reports
 
 Scenario: If an exception is thrown when sending errors/sessions then internal error reports should be sent
-    When I set the screen orientation to portrait
-    And I run "InternalErrorScenario"
+    When I run "InternalErrorScenario"
     And I wait to receive 1 errors
 
     # Validate internal error report for error serialization

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -54,6 +54,10 @@ When("I close and relaunch the app") do
   Maze.driver.launch_app
 end
 
+When('I set the screen orientation to portrait') do
+  Maze.driver.set_rotation(:portrait)
+end
+
 When("I relaunch the app after a crash") do
   # This step should only be used when the app has crashed, but the notifier needs a little
   # time to write the crash report before being forced to reopen.  From trials, 2s was not enough.

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -63,9 +63,13 @@ end
 
 When("I tap the screen {int} times") do |count|
   (1..count).each { |i|
-    touch_action = Appium::TouchAction.new
-    touch_action.tap({:x => 500, :y => 300})
-    touch_action.perform
+    begin
+      touch_action = Appium::TouchAction.new
+      touch_action.tap({:x => 500, :y => 300})
+      touch_action.perform
+    rescue Selenium::WebDriver::Error::ElementNotInteractableError
+      # Ignore it§
+    end
     sleep(1)
   }
 end

--- a/scripts/run-instrumentation-test.sh
+++ b/scripts/run-instrumentation-test.sh
@@ -10,7 +10,7 @@ export TEST_LOCATION=bugsnag-android-core/build/outputs/apk/androidTest/debug/bu
 # First app.  This is not actually used, but must be present and different to the test app.
 echo "Android Tests [$(timestamp)]: Starting instrumentation test run against devices: $INSTRUMENTATION_DEVICES"
 echo "Android Tests [$(timestamp)]: Uploading first test app from $APP_LOCATION to BrowserStack"
-app_response=$(curl -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@$APP_LOCATION")
+app_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/upload" -F "file=@$APP_LOCATION")
 app_url=$(echo "$app_response" | jq -r ".app_url")
 
 if [ -z "$app_url" ]; then
@@ -23,7 +23,7 @@ echo "Android Tests [$(timestamp)]: First app upload successful, url: $app_url"
 
 # Second app - the tests.
 echo "Android Tests [$(timestamp)]: Uploading second test app from $TEST_LOCATION to BrowserStack"
-test_response=$(curl -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/espresso/test-suite" -F "file=@$TEST_LOCATION")
+test_response=$(curl -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X POST "https://api-cloud.browserstack.com/app-automate/espresso/test-suite" -F "file=@$TEST_LOCATION")
 test_url=$(echo "$test_response" | jq -r ".test_url")
 
 if [ -z "$test_url" ]; then
@@ -35,7 +35,7 @@ fi
 echo "Android Tests [$(timestamp)]: Second app upload successful, url: $test_url"
 
 echo "Android Tests [$(timestamp)]: Starting test run"
-build_response=$(curl -X POST "https://api-cloud.browserstack.com/app-automate/espresso/build" -d \ "{\"devices\": $INSTRUMENTATION_DEVICES, \"app\": \"$app_url\", \"deviceLogs\" : true, \"testSuite\": \"$test_url\"}" -H "Content-Type: application/json" -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY")
+build_response=$(curl -X POST "https://api-cloud.browserstack.com/app-automate/espresso/build" -d \ "{\"devices\": $INSTRUMENTATION_DEVICES, \"app\": \"$app_url\", \"deviceLogs\" : true, \"testSuite\": \"$test_url\"}" -H "Content-Type: application/json" -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY")
 
 build_id=$(echo "$build_response" | jq -r ".build_id")
 
@@ -50,7 +50,7 @@ echo "Android Tests [$(timestamp)]: Test run creation successful, id: $build_id"
 echo "Android Tests [$(timestamp)]: Waiting for test run to begin"
 sleep 10 # Allow the tests to kick off
 
-status_response=$(curl -s -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+status_response=$(curl -s -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
 status=$(echo "$status_response" | jq -r ".status")
 
 WAIT_COUNT=0
@@ -58,7 +58,7 @@ until [ "$status" == "\"done\"" ] || [ "$status" == "\"error\"" ] || [ "$status"
     echo "Android Tests [$(timestamp)]: Current test status: $status, Time waited: $((WAIT_COUNT * 15))"
     ((WAIT_COUNT++))
     sleep 15
-    status_response=$(curl -s -u "$MAZE_DEVICE_FARM_USERNAME:$MAZE_DEVICE_FARM_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
+    status_response=$(curl -s -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY" -X GET https://api-cloud.browserstack.com/app-automate/espresso/builds/"$build_id")
     status=$(echo "$status_response" | jq ".status")
 done
 


### PR DESCRIPTION
## Goal

Use the Maze Runner v5, which provides the benefit of running the latest version of Appium available on each Android version (1.20.2 apart from on Android 4.4 which is limited to 1.9.1 on BrowserStack).

## Changeset

A couple of changes were needed in response to differences in Appium behavior:
- Catching and ignoring exceptions raised when attempting to push buttons during an ANR
- Ensuring the orientation is portrait for the scenario that asserts on it (the previous scenario can leave it landscape for some reason).

## Testing

Covered by a `[full ci]` run.