### PR TITLE
Fix deserialization bug in persisted NDK errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fix deserialization bug in persisted NDK errors
+  [#1220](https://github.com/bugsnag/bugsnag-android/pull/1220)
+
 ## 5.9.0 (2021-03-30)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,7 +7,7 @@ import java.io.IOException
  */
 class Notifier @JvmOverloads constructor(
     var name: String = "Android Bugsnag Notifier",
-    var version: String = "5.9.0",
+    var version: String = "5.9.1",
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -100,7 +100,6 @@ typedef struct {
   time_t duration_ms_offset;
   time_t duration_in_foreground_ms_offset;
   bool in_foreground;
-  bool is_launching;
   char binary_arch[32];
 } bsg_app_info_v2;
 

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -515,6 +515,44 @@ TEST test_breadcrumbs_to_json(void) {
   PASS();
 }
 
+void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event);
+
+TEST test_migrate_app_v2(void) {
+  bugsnag_report_v4 *report_v4 = malloc(sizeof(bugsnag_report_v4));
+  bugsnag_event *event = malloc(sizeof(bugsnag_event));
+  bsg_app_info_v2 *seed = &report_v4->app;
+  bsg_app_info *app = &event->app;
+
+  strcpy(seed->id, "id");
+  strcpy(seed->release_stage, "beta");
+  strcpy(seed->type, "c");
+  strcpy(seed->version, "1.5.2");
+  strcpy(seed->active_screen, "ExampleActivity");
+  strcpy(seed->build_uuid, "10f9");
+  strcpy(seed->binary_arch, "x86");
+  seed->version_code = 5;
+  seed->duration = 52;
+  seed->duration_in_foreground = 25;
+  seed->duration_ms_offset = 3;
+  seed->duration_in_foreground_ms_offset = 11;
+
+  // migrate pre-populated data
+  migrate_app_v2(report_v4, event);
+
+  ASSERT_STR_EQ("id", app->id);
+  ASSERT_STR_EQ("beta", app->release_stage);
+  ASSERT_STR_EQ("c", app->type);
+  ASSERT_STR_EQ("1.5.2", app->version);
+  ASSERT_STR_EQ("ExampleActivity", app->active_screen);
+  ASSERT_STR_EQ("10f9", app->build_uuid);
+  ASSERT_STR_EQ("x86", app->binary_arch);
+  ASSERT_FALSE(app->is_launching);
+
+  free(report_v4);
+  free(event);
+  PASS();
+}
+
 SUITE(serialize_utils) {
   RUN_TEST(test_report_to_file);
   RUN_TEST(test_last_run_info_serialization);
@@ -532,4 +570,5 @@ SUITE(serialize_utils) {
   RUN_TEST(test_custom_info_to_json);
   RUN_TEST(test_exception_to_json);
   RUN_TEST(test_breadcrumbs_to_json);
+  RUN_TEST(test_migrate_app_v2);
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx4096m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
-VERSION_NAME=5.9.0
+VERSION_NAME=5.9.1
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git


### PR DESCRIPTION
## Goal

The memory offset for `bsg_app_info_v2` is wrong by one due to the unintentional inclusion of `is_launching`. This means that the first byte of `binary_arch` for persisted v4 structs is loaded into `is_launching`, causing the `binary_arch` to be incorrectly trimmed to '86' or 'rm64'.

## Changeset

Removed `is_launching` from `bsg_app_info_v2` as it was not originally present.

## Testing

Added additional unit test coverage of the migration function. Manually tested by triggering a fatal crash in v5.7.0, then updating to v5.9.0 to reproduce the behaviour. Confirmed that a local artefact with these changes fixed the issue.