### PR TITLE
Allow publishing from master branch

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -526,11 +526,11 @@ steps:
 
   - block: 'Trigger package publish'
     key: trigger_publish
-    if: build.tag != null
+    if: build.branch == "master"
     blocked_state: passed
 
   - label: 'Publish :rocket:'
-    if: build.tag != null
+    if: build.branch == "master"
     depends_on:
       - 'trigger_publish'
     env:


### PR DESCRIPTION
## Goal

Allows publishing from the master branch rather than requiring a tag as this fits into our existing publishing process.

Tested by verifying that setting the `build.branch` to `PLAT-6241/publish-on-master` caused the publish step to appear - it's assumed that the publish step itself works as expected.