### PR TITLE
Fix flaky mazerunner tests

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -9,6 +9,7 @@
     <ID>MagicNumber:JvmAnrSleepScenario.kt$JvmAnrSleepScenario$100000</ID>
     <ID>MagicNumber:LoadConfigurationKotlinScenario.kt$LoadConfigurationKotlinScenario$10000</ID>
     <ID>MagicNumber:LoadConfigurationKotlinScenario.kt$LoadConfigurationKotlinScenario$98</ID>
+    <ID>MagicNumber:ManualSessionSmokeScenario.kt$ManualSessionSmokeScenario$3</ID>
     <ID>MagicNumber:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$6000</ID>
     <ID>MagicNumber:TestHarnessHooks.kt$&lt;no name provided&gt;$500</ID>
     <ID>MagicNumber:TrimmedStacktraceScenario.kt$TrimmedStacktraceScenario$100000</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
@@ -31,5 +31,4 @@ internal class CrashHandlerScenario(
         }
         throw RuntimeException("CrashHandlerScenario")
     }
-
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CrashHandlerScenario.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
+import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 
 /**
@@ -14,15 +15,21 @@ internal class CrashHandlerScenario(
 
     override fun startScenario() {
         super.startScenario()
-        val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
+        val previousHandler = requireNotNull(Thread.getDefaultUncaughtExceptionHandler())
+        var customHandlerInvoked = false
 
+        // detect whether custom handler was invoked or not & add this to error reports
+        Bugsnag.addOnError {
+            it.addMetadata("customHandler", "invoked", customHandlerInvoked)
+            true
+        }
+
+        // set a custom handler that calls into the default handler
         Thread.setDefaultUncaughtExceptionHandler { t, e ->
-            config.logger?.d("CrashHandlerScenario: Intercepted uncaught exception")
+            customHandlerInvoked = true
             previousHandler.uncaughtException(t, e)
         }
         throw RuntimeException("CrashHandlerScenario")
     }
 
-    override fun getInterceptedLogMessages() =
-        listOf("CrashHandlerScenario: Intercepted uncaught exception")
 }

--- a/features/full_tests/batch_1/crash_handler.feature
+++ b/features/full_tests/batch_1/crash_handler.feature
@@ -4,9 +4,8 @@ Scenario: Other uncaught exception handler installed
     When I run "CrashHandlerScenario" and relaunch the app
     And I configure Bugsnag for "CrashHandlerScenario"
     And I wait to receive an error
-    And I wait to receive a log
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "CrashHandlerScenario"
-    Then the "debug" level log message equals "CrashHandlerScenario: Intercepted uncaught exception"
+    And the event "metaData.customHandler.invoked" is true


### PR DESCRIPTION
## Goal

Fixes a couple of flaky mazerunner tests identified via scheduled builds.

## Changeset

`CrashHandlerScenario` was inherently racy as the log endpoint makes a network request which may or may not be successful before the uncaught exception terminates the process. It has been rewritten so the custom crash handler alters metadata, and the scenario verifies the handler was invoked.

`ManualSmokeSessionScenario` was flaky in very specific circumstances: if the last handled error + unhandled error are written to disk in the same millisecond, and the generated UUID meant the [request order](https://github.com/bugsnag/bugsnag-android/blob/next/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java#L124) was wrong. The scenario has been updated to ensure that the handled errors are always delivered first.