### PR TITLE
Add projectPackages field to error payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Add projectPackages field to error payloads
+  [#1226](https://github.com/bugsnag/bugsnag-android/pull/1226)
+
 * Fix deserialization bug in persisted NDK errors
   [#1220](https://github.com/bugsnag/bugsnag-android/pull/1220)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -11,6 +11,7 @@ internal class EventInternal @JvmOverloads internal constructor(
 
     val metadata: Metadata = data.copy()
     private val discardClasses: Set<String> = config.discardClasses.toSet()
+    private val projectPackages = config.projectPackages
 
     @JvmField
     internal var session: Session? = null
@@ -82,6 +83,12 @@ internal class EventInternal @JvmOverloads internal constructor(
         writer.name("exceptions")
         writer.beginArray()
         errors.forEach { writer.value(it) }
+        writer.endArray()
+
+        // Write project packages
+        writer.name("projectPackages")
+        writer.beginArray()
+        projectPackages.forEach { writer.value(it) }
         writer.endArray()
 
         // Write user info

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -21,6 +22,7 @@ final class BugsnagTestUtils {
         Configuration configuration = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
         configuration.setDelivery(generateDelivery());
         configuration.setLogger(NoopLogger.INSTANCE);
+        configuration.setProjectPackages(Collections.singleton("com.example.foo"));
         try {
             File dir = Files.createTempDirectory("test").toFile();
             configuration.setPersistenceDirectory(dir);

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -59,7 +59,7 @@ internal class ImmutableConfigTest {
             // release stages
             assertTrue(discardClasses.isEmpty())
             assertNull(enabledReleaseStages)
-            assertTrue(projectPackages.isEmpty())
+            assertEquals(setOf("com.example.foo"), projectPackages)
             assertEquals(seed.releaseStage, releaseStage)
 
             // identifiers

--- a/bugsnag-android-core/src/test/resources/event_redaction.json
+++ b/bugsnag-android-core/src/test/resources/event_redaction.json
@@ -17,6 +17,9 @@
   },
   "unhandled": false,
   "exceptions": [],
+  "projectPackages":[
+    "com.example.foo"
+  ],
   "user": {},
   "app": {
     "type": "android",

--- a/bugsnag-android-core/src/test/resources/event_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_0.json
@@ -7,6 +7,9 @@
   },
   "unhandled": false,
   "exceptions": [],
+  "projectPackages":[
+    "com.example.foo"
+  ],
   "user": {},
   "app": {
     "type": "android",

--- a/bugsnag-android-core/src/test/resources/event_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_1.json
@@ -8,6 +8,9 @@
   },
   "unhandled": false,
   "exceptions": [],
+  "projectPackages":[
+    "com.example.foo"
+  ],
   "user": {},
   "app": {
     "type": "android",

--- a/bugsnag-android-core/src/test/resources/event_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_2.json
@@ -7,6 +7,9 @@
   },
   "unhandled": false,
   "exceptions": [],
+  "projectPackages":[
+    "com.example.foo"
+  ],
   "user": {},
   "app": {
     "type": "android",

--- a/bugsnag-android-core/src/test/resources/event_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_3.json
@@ -7,6 +7,9 @@
   },
   "unhandled": false,
   "exceptions": [],
+  "projectPackages":[
+    "com.example.foo"
+  ],
   "user": {},
   "app": {
     "type": "android",

--- a/bugsnag-android-core/src/test/resources/event_serialization_4.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_4.json
@@ -7,6 +7,9 @@
   },
   "unhandled": false,
   "exceptions": [],
+  "projectPackages":[
+    "com.example.foo"
+  ],
   "user": {},
   "app": {
     "type": "android",

--- a/bugsnag-android-core/src/test/resources/event_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_5.json
@@ -7,6 +7,9 @@
   },
   "unhandled": false,
   "exceptions": [],
+  "projectPackages":[
+    "com.example.foo"
+  ],
   "user": {},
   "app": {
     "type": "android",

--- a/bugsnag-android-core/src/test/resources/event_serialization_6.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_6.json
@@ -24,6 +24,9 @@
       "stacktrace": []
     }
   ],
+  "projectPackages":[
+    "com.example.foo"
+  ],
   "user": {
     "name": "Jamie"
   },

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -22,6 +22,8 @@ Scenario: Notify caught Java exception with default configuration
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
     And the event "exceptions.0.stacktrace.0.lineNumber" equals 8
     And the event "exceptions.0.stacktrace.0.inProject" is true
+    And the error payload field "events.0.projectPackages" is a non-empty array
+    And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"
 
     And the thread with name "main" contains the error reporting flag
     And the "method" of stack frame 0 equals "com.bugsnag.android.mazerunner.scenarios.HandledJavaSmokeScenario.startScenario"
@@ -116,6 +118,8 @@ Scenario: Notify Kotlin exception with overwritten configuration
     And the event "severity" equals "error"
     And the event "severityReason.type" equals "userCallbackSetSeverity"
     And the event "severityReason.unhandledOverridden" is false
+    And the error payload field "events.0.projectPackages" is a non-empty array
+    And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"
 
     # Stacktrace validation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
@@ -171,6 +175,8 @@ Scenario: Handled C functionality
     And the event "severity" equals "error"
     And the event "severityReason.type" equals "userCallbackSetSeverity"
     And the event "severityReason.unhandledOverridden" is false
+    And the error payload field "events.0.projectPackages" is a non-empty array
+    And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"
 
     # App data
     And the event "app.buildUUID" is not null

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -15,6 +15,8 @@ Scenario: Unhandled Java Exception with loaded configuration
     And the event "severity" equals "error"
     And the event "severityReason.type" equals "unhandledException"
     And the event "severityReason.unhandledOverridden" is false
+    And the error payload field "events.0.projectPackages" is a non-empty array
+    And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"
 
     # Stacktrace validation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array


### PR DESCRIPTION
## Goal

Adds `projectPackages` to the event payload. This is used to improve deobfuscation when a class in the `projectPackages` package has been minified with ProGuard - `inProject` calculations do not work well here as the class name will be mangled.

## Testing

- Added unit tests to ensure `projectPackages` is serialized
- Updated smoke tests to add E2E assertions
- Tested errors sent in obfuscated example app