### PR TITLE
Move migration code from serializer.c to its own file

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library( # Specifies the name of the library.
     jni/handlers/signal_handler.c
     jni/handlers/cpp_handler.cpp
     jni/utils/crash_info.c
+    jni/utils/migrate.c
     jni/utils/stack_unwinder.c
     jni/utils/stack_unwinder_libunwindstack.cpp
     jni/utils/stack_unwinder_libcorkscrew.c

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.c
@@ -1,0 +1,399 @@
+//
+// Created by Karl Stenerud on 23.04.21.
+//
+
+#include "string.h"
+
+#include "migrate.h"
+#include "migrate_internal.h"
+#include <event.h>
+#include <fcntl.h>
+#include <metadata.h>
+#include <parson/parson.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+// ==================================================================
+// Reading
+
+static bugsnag_report_v1 *report_v1_read(int fd) {
+  size_t event_size = sizeof(bugsnag_report_v1);
+  bugsnag_report_v1 *event = malloc(event_size);
+
+  ssize_t len = read(fd, event, event_size);
+  if (len != event_size) {
+    free(event);
+    return NULL;
+  }
+  return event;
+}
+
+static bugsnag_report_v2 *report_v2_read(int fd) {
+  size_t event_size = sizeof(bugsnag_report_v2);
+  bugsnag_report_v2 *event = malloc(event_size);
+
+  ssize_t len = read(fd, event, event_size);
+  if (len != event_size) {
+    free(event);
+    return NULL;
+  }
+  return event;
+}
+
+static bugsnag_report_v3 *report_v3_read(int fd) {
+  size_t event_size = sizeof(bugsnag_report_v3);
+  bugsnag_report_v3 *event = malloc(event_size);
+
+  ssize_t len = read(fd, event, event_size);
+  if (len != event_size) {
+    free(event);
+    return NULL;
+  }
+  return event;
+}
+
+static bugsnag_report_v4 *report_v4_read(int fd) {
+  size_t event_size = sizeof(bugsnag_report_v4);
+  bugsnag_report_v4 *event = malloc(event_size);
+
+  ssize_t len = read(fd, event, event_size);
+  if (len != event_size) {
+    free(event);
+    return NULL;
+  }
+  return event;
+}
+
+// ==================================================================
+// Migration
+
+int bsg_calculate_total_crumbs(int old_count) {
+  return old_count < BUGSNAG_CRUMBS_MAX ? old_count : BUGSNAG_CRUMBS_MAX;
+}
+
+int bsg_calculate_v1_start_index(int old_count) {
+  return old_count < BUGSNAG_CRUMBS_MAX ? 0 : old_count % BUGSNAG_CRUMBS_MAX;
+}
+
+int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index) {
+  return (crumb_pos + first_index) % V1_BUGSNAG_CRUMBS_MAX;
+}
+
+void bsg_migrate_app_v1(bugsnag_report_v2 *report_v2,
+                        bugsnag_report_v3 *event) {
+  bsg_strcpy(event->app.id, report_v2->app.id);
+  bsg_strcpy(event->app.release_stage, report_v2->app.release_stage);
+  bsg_strcpy(event->app.type, report_v2->app.type);
+  bsg_strcpy(event->app.version, report_v2->app.version);
+  bsg_strcpy(event->app.active_screen, report_v2->app.active_screen);
+  bsg_strcpy(event->app.build_uuid, report_v2->app.build_uuid);
+  bsg_strcpy(event->app.binary_arch, report_v2->app.binaryArch);
+  event->app.version_code = report_v2->app.version_code;
+  event->app.duration = report_v2->app.duration;
+  event->app.duration_in_foreground = report_v2->app.duration_in_foreground;
+  event->app.duration_ms_offset = report_v2->app.duration_ms_offset;
+  event->app.duration_in_foreground_ms_offset =
+      report_v2->app.duration_in_foreground_ms_offset;
+  event->app.in_foreground = report_v2->app.in_foreground;
+
+  // migrate legacy fields to metadata
+  bugsnag_event_add_metadata_string(event, "app", "packageName",
+                                    report_v2->app.package_name);
+  bugsnag_event_add_metadata_string(event, "app", "versionName",
+                                    report_v2->app.version_name);
+  bugsnag_event_add_metadata_string(event, "app", "name", report_v2->app.name);
+}
+
+void bsg_migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event) {
+  bsg_strncpy_safe(event->app.id, report_v4->app.id, sizeof(event->app.id));
+  bsg_strncpy_safe(event->app.release_stage, report_v4->app.release_stage,
+                   sizeof(event->app.release_stage));
+  bsg_strncpy_safe(event->app.type, report_v4->app.type,
+                   sizeof(event->app.type));
+  bsg_strncpy_safe(event->app.version, report_v4->app.version,
+                   sizeof(event->app.version));
+  bsg_strncpy_safe(event->app.active_screen, report_v4->app.active_screen,
+                   sizeof(event->app.active_screen));
+  bsg_strncpy_safe(event->app.build_uuid, report_v4->app.build_uuid,
+                   sizeof(event->app.build_uuid));
+  bsg_strncpy_safe(event->app.binary_arch, report_v4->app.binary_arch,
+                   sizeof(event->app.binary_arch));
+  event->app.version_code = report_v4->app.version_code;
+  event->app.duration = report_v4->app.duration;
+  event->app.duration_in_foreground = report_v4->app.duration_in_foreground;
+  event->app.duration_ms_offset = report_v4->app.duration_ms_offset;
+  event->app.duration_in_foreground_ms_offset =
+      report_v4->app.duration_in_foreground_ms_offset;
+  event->app.in_foreground = report_v4->app.in_foreground;
+
+  // no info available, set to sensible default
+  event->app.is_launching = false;
+}
+
+static void migrate_device_v1(bugsnag_report_v2 *report_v2,
+                              bugsnag_report_v3 *event) {
+  bsg_strcpy(event->device.os_name,
+             bsg_os_name()); // os_name was not a field in v2
+  event->device.api_level = report_v2->device.api_level;
+  event->device.cpu_abi_count = report_v2->device.cpu_abi_count;
+  event->device.time = report_v2->device.time;
+  event->device.jailbroken = report_v2->device.jailbroken;
+  event->device.total_memory = report_v2->device.total_memory;
+
+  for (int k = 0; k < report_v2->device.cpu_abi_count &&
+                  k < sizeof(report_v2->device.cpu_abi);
+       k++) {
+    bsg_strcpy(event->device.cpu_abi[k].value,
+               report_v2->device.cpu_abi[k].value);
+    event->device.cpu_abi_count++;
+  }
+
+  bsg_strcpy(event->device.orientation, report_v2->device.orientation);
+  bsg_strcpy(event->device.id, report_v2->device.id);
+  bsg_strcpy(event->device.locale, report_v2->device.locale);
+  bsg_strcpy(event->device.manufacturer, report_v2->device.manufacturer);
+  bsg_strcpy(event->device.model, report_v2->device.model);
+  bsg_strcpy(event->device.os_build, report_v2->device.os_build);
+  bsg_strcpy(event->device.os_version, report_v2->device.os_version);
+
+  // migrate legacy fields to metadata
+  bugsnag_event_add_metadata_bool(event, "device", "emulator",
+                                  report_v2->device.emulator);
+  bugsnag_event_add_metadata_double(event, "device", "dpi",
+                                    report_v2->device.dpi);
+  bugsnag_event_add_metadata_double(event, "device", "screenDensity",
+                                    report_v2->device.screen_density);
+  bugsnag_event_add_metadata_double(event, "device", "batteryLevel",
+                                    report_v2->device.battery_level);
+  bugsnag_event_add_metadata_string(event, "device", "locationStatus",
+                                    report_v2->device.location_status);
+  bugsnag_event_add_metadata_string(event, "device", "brand",
+                                    report_v2->device.brand);
+  bugsnag_event_add_metadata_string(event, "device", "networkAccess",
+                                    report_v2->device.network_access);
+  bugsnag_event_add_metadata_string(event, "device", "screenResolution",
+                                    report_v2->device.screen_resolution);
+}
+
+static bugsnag_event *map_v4_to_report(bugsnag_report_v4 *report_v4) {
+  if (report_v4 == NULL) {
+    return NULL;
+  }
+  bugsnag_event *event = malloc(sizeof(bugsnag_event));
+
+  if (event != NULL) {
+    event->notifier = report_v4->notifier;
+    event->device = report_v4->device;
+    event->user = report_v4->user;
+    event->error = report_v4->error;
+    event->metadata = report_v4->metadata;
+    event->crumb_count = report_v4->crumb_count;
+    event->crumb_first_index = report_v4->crumb_first_index;
+    memcpy(event->breadcrumbs, report_v4->breadcrumbs,
+           sizeof(event->breadcrumbs));
+    event->severity = report_v4->severity;
+    bsg_strncpy_safe(event->session_id, report_v4->session_id,
+                     sizeof(event->session_id));
+    bsg_strncpy_safe(event->session_start, report_v4->session_start,
+                     sizeof(event->session_id));
+    event->handled_events = report_v4->handled_events;
+    event->unhandled_events = report_v4->unhandled_events;
+    bsg_strncpy_safe(event->grouping_hash, report_v4->grouping_hash,
+                     sizeof(event->session_id));
+    event->unhandled = report_v4->unhandled;
+    bsg_strncpy_safe(event->api_key, report_v4->api_key,
+                     sizeof(event->api_key));
+    bsg_migrate_app_v2(report_v4, event);
+    free(report_v4);
+  }
+  return event;
+}
+
+static void report_v3_add_breadcrumb(bugsnag_report_v3 *event,
+                                     bugsnag_breadcrumb *crumb) {
+  int crumb_index;
+  if (event->crumb_count < BUGSNAG_CRUMBS_MAX) {
+    crumb_index = event->crumb_count;
+    event->crumb_count++;
+  } else {
+    crumb_index = event->crumb_first_index;
+    event->crumb_first_index =
+        (event->crumb_first_index + 1) % BUGSNAG_CRUMBS_MAX;
+  }
+  memcpy(&event->breadcrumbs[crumb_index], crumb, sizeof(bugsnag_breadcrumb));
+}
+
+static void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2,
+                                  bugsnag_report_v3 *event) {
+  event->crumb_count = 0;
+  event->crumb_first_index = 0;
+
+  // previously breadcrumbs had 30 elements, now they have 25.
+  // if more than 25 breadcrumbs were collected in the legacy report,
+  // offset them accordingly by moving the start position by count -
+  // BUGSNAG_CRUMBS_MAX.
+  int new_crumb_total = bsg_calculate_total_crumbs(report_v2->crumb_count);
+  int k = bsg_calculate_v1_start_index(report_v2->crumb_count);
+
+  for (; k < new_crumb_total; k++) {
+    int crumb_index =
+        bsg_calculate_v1_crumb_index(k, report_v2->crumb_first_index);
+    bugsnag_breadcrumb_v1 *old_crumb = &report_v2->breadcrumbs[crumb_index];
+    bugsnag_breadcrumb *new_crumb = malloc(sizeof(bugsnag_breadcrumb));
+
+    // copy old crumb fields to new
+    new_crumb->type = old_crumb->type;
+    bsg_strncpy_safe(new_crumb->name, old_crumb->name, sizeof(new_crumb->name));
+    bsg_strncpy_safe(new_crumb->timestamp, old_crumb->timestamp,
+                     sizeof(new_crumb->timestamp));
+
+    for (int j = 0; j < 8; j++) {
+      bsg_char_metadata_pair pair = old_crumb->metadata[j];
+
+      if (strlen(pair.value) > 0 && strlen(pair.key) > 0) {
+        bsg_add_metadata_value_str(&new_crumb->metadata, "metaData", pair.key,
+                                   pair.value);
+      }
+    }
+
+    // add crumb to event by copying memory
+    report_v3_add_breadcrumb(event, new_crumb);
+    free(new_crumb);
+  }
+}
+
+static bugsnag_event *map_v3_to_report(bugsnag_report_v3 *report_v3) {
+  if (report_v3 == NULL) {
+    return NULL;
+  }
+  bugsnag_report_v4 *event = malloc(sizeof(bugsnag_event));
+
+  if (event != NULL) {
+    event->notifier = report_v3->notifier;
+    event->app = report_v3->app;
+    event->device = report_v3->device;
+    event->user = report_v3->user;
+    event->error = report_v3->error;
+    event->metadata = report_v3->metadata;
+    event->crumb_count = report_v3->crumb_count;
+    event->crumb_first_index = report_v3->crumb_first_index;
+    memcpy(event->breadcrumbs, report_v3->breadcrumbs,
+           sizeof(event->breadcrumbs));
+    event->severity = report_v3->severity;
+    strcpy(event->session_id, report_v3->session_id);
+    strcpy(event->session_start, report_v3->session_start);
+    event->handled_events = report_v3->handled_events;
+    event->unhandled_events = report_v3->unhandled_events;
+    strcpy(event->grouping_hash, report_v3->grouping_hash);
+    event->unhandled = report_v3->unhandled;
+
+    // set a default value for the api key
+    strcpy(event->api_key, "");
+    free(report_v3);
+  }
+  return map_v4_to_report(event);
+}
+
+static bugsnag_event *map_v2_to_report(bugsnag_report_v2 *report_v2) {
+  if (report_v2 == NULL) {
+    return NULL;
+  }
+  bugsnag_report_v3 *event = malloc(sizeof(bugsnag_report_v3));
+
+  if (event != NULL) {
+    // assign metadata first as old app/device fields are migrated there
+    event->metadata = report_v2->metadata;
+    bsg_migrate_app_v1(report_v2, event);
+    migrate_device_v1(report_v2, event);
+    event->user = report_v2->user;
+    migrate_breadcrumb_v1(report_v2, event);
+
+    strcpy(event->context, report_v2->context);
+    event->severity = report_v2->severity;
+    strcpy(event->session_id, report_v2->session_id);
+    strcpy(event->session_start, report_v2->session_start);
+    event->handled_events = report_v2->handled_events;
+    event->unhandled_events = report_v2->unhandled_events;
+
+    // migrate changed notifier fields
+    strcpy(event->notifier.version, report_v2->notifier.version);
+    strcpy(event->notifier.name, report_v2->notifier.name);
+    strcpy(event->notifier.url, report_v2->notifier.url);
+
+    // migrate changed error fields
+    strcpy(event->error.errorClass, report_v2->exception.name);
+    strcpy(event->error.errorMessage, report_v2->exception.message);
+    strcpy(event->error.type, report_v2->exception.type);
+    event->error.frame_count = report_v2->exception.frame_count;
+    size_t error_size = sizeof(bugsnag_stackframe) * BUGSNAG_FRAMES_MAX;
+    memcpy(&event->error.stacktrace, report_v2->exception.stacktrace,
+           error_size);
+
+    // Fatal C errors are always true by default, previously this was hardcoded
+    // and not a field on the struct
+    event->unhandled = true;
+    free(report_v2);
+  }
+  return map_v3_to_report(event);
+}
+
+static bugsnag_event *map_v1_to_report(bugsnag_report_v1 *report_v1) {
+  if (report_v1 == NULL) {
+    return NULL;
+  }
+  size_t report_size = sizeof(bugsnag_report_v2);
+  bugsnag_report_v2 *event_v2 = malloc(report_size);
+
+  if (event_v2 != NULL) {
+    event_v2->notifier = report_v1->notifier;
+    event_v2->app = report_v1->app;
+    event_v2->device = report_v1->device;
+    event_v2->user = report_v1->user;
+    event_v2->exception = report_v1->exception;
+    event_v2->metadata = report_v1->metadata;
+    event_v2->crumb_count = report_v1->crumb_count;
+    event_v2->crumb_first_index = report_v1->crumb_first_index;
+
+    size_t breadcrumb_size =
+        sizeof(bugsnag_breadcrumb_v1) * V1_BUGSNAG_CRUMBS_MAX;
+    memcpy(&event_v2->breadcrumbs, report_v1->breadcrumbs, breadcrumb_size);
+
+    strcpy(event_v2->context, report_v1->context);
+    event_v2->severity = report_v1->severity;
+    strcpy(event_v2->session_id, report_v1->session_id);
+    strcpy(event_v2->session_start, report_v1->session_start);
+    event_v2->handled_events = report_v1->handled_events;
+    event_v2->unhandled_events = 1;
+
+    free(report_v1);
+  }
+  return map_v2_to_report(event_v2);
+}
+
+// ==================================================================
+// Public API
+
+bool bsg_event_requires_migration(int event_version) {
+  return event_version != 5;
+}
+
+bugsnag_event *bsg_event_read_and_migrate(int event_version, int fd) {
+  if (event_version == 1) { // 'event->unhandled_events' was added in v2
+    bugsnag_report_v1 *report_v1 = report_v1_read(fd);
+    return map_v1_to_report(report_v1);
+  } else if (event_version == 2) {
+    bugsnag_report_v2 *report_v2 = report_v2_read(fd);
+    return map_v2_to_report(report_v2);
+  } else if (event_version == 3) {
+    bugsnag_report_v3 *report_v3 = report_v3_read(fd);
+    return map_v3_to_report(report_v3);
+  } else if (event_version == 4) {
+    bugsnag_report_v4 *report_v4 = report_v4_read(fd);
+    return map_v4_to_report(report_v4);
+  } else {
+    return NULL;
+  }
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -15,7 +15,7 @@ extern "C" {
 bool bsg_event_requires_migration(int event_version);
 
 /**
- * Read an event of the specified version from an FD and migrate it to the
+ * Read an event of the specified version from a FD and migrate it to the
  * latest structure.
  * @param event_version The version decoded from the event file header
  * @param fd The file descriptor after reading the header.

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -3,225 +3,25 @@
 
 #include "event.h"
 
-#ifndef V1_BUGSNAG_CRUMBS_MAX
-#define V1_BUGSNAG_CRUMBS_MAX 30
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * migrate.h contains definitions of structs that were used in previous versions
- * of a notifier release.
- *
- * Because these structs are serialized to disk directly, we need to retain the
- * original structs whenever a field is added or changed.
- *
- * The bsg_report_header indicates what version was serialized to disk. Knowing
- * this information, it is possible to migrate old payloads by first serializing
- * them into an old struct, and then mapping them into the latest version of
- * bugsnag_event.
+ * Check if the specified event version requires migration
+ * @param event_version
+ * @return true if this version requires migration
  */
+bool bsg_event_requires_migration(int event_version);
 
-typedef struct {
-  char name[64];
-  char version[16];
-  char url[64];
-} bsg_library;
-
-/** a Bugsnag exception */
-typedef struct {
-  /** The exception name or stringified code */
-  char name[64];
-  /** A description of what went wrong */
-  char message[256];
-  /** The variety of exception which needs to be processed by the pipeline */
-  char type[32];
-
-  /**
-   * The number of frames used in the stacktrace. Must be less than
-   * BUGSNAG_FRAMES_MAX.
-   */
-  ssize_t frame_count;
-  /**
-   * An ordered list of stack frames from the oldest to the most recent
-   */
-  bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
-} bsg_exception;
-
-typedef struct {
-  char key[64];
-  char value[64];
-} bsg_char_metadata_pair;
-
-typedef struct {
-  char name[33];
-  char timestamp[37];
-  bugsnag_breadcrumb_type type;
-
-  /**
-   * Key/value pairs of related information for debugging
-   */
-  bsg_char_metadata_pair metadata[8];
-} bugsnag_breadcrumb_v1;
-
-typedef struct {
-  char name[64];
-  char id[64];
-  char package_name[64];
-  char release_stage[64];
-  char type[32];
-  char version[32];
-  char version_name[32];
-  char active_screen[64];
-  int version_code;
-  char build_uuid[64];
-  time_t duration;
-  time_t duration_in_foreground;
-  time_t duration_ms_offset;
-  time_t duration_in_foreground_ms_offset;
-  bool in_foreground;
-  bool low_memory;
-  size_t memory_usage;
-  char binaryArch[32];
-} bsg_app_info_v1;
-
-typedef struct {
-  char id[64];
-  char release_stage[64];
-  char type[32];
-  char version[32];
-  char active_screen[64];
-  int version_code;
-  char build_uuid[64];
-  time_t duration;
-  time_t duration_in_foreground;
-  time_t duration_ms_offset;
-  time_t duration_in_foreground_ms_offset;
-  bool in_foreground;
-  char binary_arch[32];
-} bsg_app_info_v2;
-
-typedef struct {
-  int api_level;
-  double battery_level;
-  char brand[64];
-  int cpu_abi_count;
-  bsg_cpu_abi cpu_abi[8];
-  int dpi;
-  bool emulator;
-  char orientation[32];
-  time_t time;
-  char id[64];
-  bool jailbroken;
-  char locale[32];
-  char location_status[32];
-  char manufacturer[64];
-  char model[64];
-  char network_access[64];
-  char os_build[64];
-  char os_version[64];
-  float screen_density;
-  char screen_resolution[32];
-  long total_memory;
-} bsg_device_info_v1;
-
-typedef struct {
-  bsg_library notifier;
-  bsg_app_info_v1 app;
-  bsg_device_info_v1 device;
-  bugsnag_user user;
-  bsg_exception exception;
-  bugsnag_metadata metadata;
-
-  int crumb_count;
-  // Breadcrumbs are a ring; the first index moves as the
-  // structure is filled and replaced.
-  int crumb_first_index;
-  bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
-
-  char context[64];
-  bugsnag_severity severity;
-
-  char session_id[33];
-  char session_start[33];
-  int handled_events;
-} bugsnag_report_v1;
-
-typedef struct {
-  bsg_library notifier;
-  bsg_app_info_v1 app;
-  bsg_device_info_v1 device;
-  bugsnag_user user;
-  bsg_exception exception;
-  bugsnag_metadata metadata;
-
-  int crumb_count;
-  // Breadcrumbs are a ring; the first index moves as the
-  // structure is filled and replaced.
-  int crumb_first_index;
-  bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
-
-  char context[64];
-  bugsnag_severity severity;
-
-  char session_id[33];
-  char session_start[33];
-  int handled_events;
-  int unhandled_events;
-} bugsnag_report_v2;
-
-typedef struct {
-  bsg_notifier notifier;
-  bsg_app_info_v2 app;
-  bsg_device_info device;
-  bugsnag_user user;
-  bsg_error error;
-  bugsnag_metadata metadata;
-
-  int crumb_count;
-  // Breadcrumbs are a ring; the first index moves as the
-  // structure is filled and replaced.
-  int crumb_first_index;
-  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
-
-  char context[64];
-  bugsnag_severity severity;
-
-  char session_id[33];
-  char session_start[33];
-  int handled_events;
-  int unhandled_events;
-  char grouping_hash[64];
-  bool unhandled;
-} bugsnag_report_v3;
-
-typedef struct {
-  bsg_notifier notifier;
-  bsg_app_info_v2 app;
-  bsg_device_info device;
-  bugsnag_user user;
-  bsg_error error;
-  bugsnag_metadata metadata;
-
-  int crumb_count;
-  // Breadcrumbs are a ring; the first index moves as the
-  // structure is filled and replaced.
-  int crumb_first_index;
-  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
-
-  char context[64];
-  bugsnag_severity severity;
-
-  char session_id[33];
-  char session_start[33];
-  int handled_events;
-  int unhandled_events;
-  char grouping_hash[64];
-  bool unhandled;
-  char api_key[64];
-} bugsnag_report_v4;
+/**
+ * Read an event of the specified version from an FD and migrate it to the
+ * latest structure.
+ * @param event_version The version decoded from the event file header
+ * @param fd The file descriptor after reading the header.
+ * @return The event or NULL if the version is not handled.
+ */
+bugsnag_event *bsg_event_read_and_migrate(int event_version, int fd);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate_internal.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate_internal.h
@@ -1,0 +1,241 @@
+//
+// Created by Karl Stenerud on 23.04.21.
+//
+
+#ifndef BUGSNAG_ANDROID_MIGRATE_INTERNAL_H
+#define BUGSNAG_ANDROID_MIGRATE_INTERNAL_H
+
+#include "string.h"
+
+#include "migrate.h"
+#include <event.h>
+#include <fcntl.h>
+#include <metadata.h>
+#include <parson/parson.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#define V1_BUGSNAG_CRUMBS_MAX 30
+
+/**
+ * Definitions of structs that were used in previous versions of a notifier
+ * release.
+ *
+ * Because these structs are serialized to disk directly, we need to retain the
+ * original structs whenever a field is added or changed.
+ *
+ * The bsg_report_header indicates what version was serialized to disk. Knowing
+ * this information, it is possible to migrate old payloads by first serializing
+ * them into an old struct, and then mapping them into the latest version of
+ * bugsnag_event.
+ */
+
+typedef struct {
+  char name[64];
+  char version[16];
+  char url[64];
+} bsg_library;
+
+/** a Bugsnag exception */
+typedef struct {
+  /** The exception name or stringified code */
+  char name[64];
+  /** A description of what went wrong */
+  char message[256];
+  /** The variety of exception which needs to be processed by the pipeline */
+  char type[32];
+
+  /**
+   * The number of frames used in the stacktrace. Must be less than
+   * BUGSNAG_FRAMES_MAX.
+   */
+  ssize_t frame_count;
+  /**
+   * An ordered list of stack frames from the oldest to the most recent
+   */
+  bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+} bsg_exception;
+
+typedef struct {
+  char key[64];
+  char value[64];
+} bsg_char_metadata_pair;
+
+typedef struct {
+  char name[33];
+  char timestamp[37];
+  bugsnag_breadcrumb_type type;
+
+  /**
+   * Key/value pairs of related information for debugging
+   */
+  bsg_char_metadata_pair metadata[8];
+} bugsnag_breadcrumb_v1;
+
+typedef struct {
+  char name[64];
+  char id[64];
+  char package_name[64];
+  char release_stage[64];
+  char type[32];
+  char version[32];
+  char version_name[32];
+  char active_screen[64];
+  int version_code;
+  char build_uuid[64];
+  time_t duration;
+  time_t duration_in_foreground;
+  time_t duration_ms_offset;
+  time_t duration_in_foreground_ms_offset;
+  bool in_foreground;
+  bool low_memory;
+  size_t memory_usage;
+  char binaryArch[32];
+} bsg_app_info_v1;
+
+typedef struct {
+  char id[64];
+  char release_stage[64];
+  char type[32];
+  char version[32];
+  char active_screen[64];
+  int version_code;
+  char build_uuid[64];
+  time_t duration;
+  time_t duration_in_foreground;
+  time_t duration_ms_offset;
+  time_t duration_in_foreground_ms_offset;
+  bool in_foreground;
+  char binary_arch[32];
+} bsg_app_info_v2;
+
+typedef struct {
+  int api_level;
+  double battery_level;
+  char brand[64];
+  int cpu_abi_count;
+  bsg_cpu_abi cpu_abi[8];
+  int dpi;
+  bool emulator;
+  char orientation[32];
+  time_t time;
+  char id[64];
+  bool jailbroken;
+  char locale[32];
+  char location_status[32];
+  char manufacturer[64];
+  char model[64];
+  char network_access[64];
+  char os_build[64];
+  char os_version[64];
+  float screen_density;
+  char screen_resolution[32];
+  long total_memory;
+} bsg_device_info_v1;
+
+typedef struct {
+  bsg_library notifier;
+  bsg_app_info_v1 app;
+  bsg_device_info_v1 device;
+  bugsnag_user user;
+  bsg_exception exception;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+} bugsnag_report_v1;
+
+typedef struct {
+  bsg_library notifier;
+  bsg_app_info_v1 app;
+  bsg_device_info_v1 device;
+  bugsnag_user user;
+  bsg_exception exception;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb_v1 breadcrumbs[V1_BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+} bugsnag_report_v2;
+
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info_v2 app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+} bugsnag_report_v3;
+
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info_v2 app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
+} bugsnag_report_v4;
+
+int bsg_calculate_total_crumbs(int old_count);
+int bsg_calculate_v1_start_index(int old_count);
+int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index);
+
+void bsg_migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event);
+
+#endif // BUGSNAG_ANDROID_MIGRATE_INTERNAL_H

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -12,27 +12,10 @@
 #include <unistd.h>
 #include <utils/migrate.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-bool bsg_event_write(bsg_report_header *header, bugsnag_event *event, int fd);
-
-bugsnag_event *bsg_event_read(int fd);
-bsg_report_header *bsg_report_header_read(int fd);
-bugsnag_event *bsg_map_v4_to_report(bugsnag_report_v4 *report_v4);
-bugsnag_event *bsg_map_v3_to_report(bugsnag_report_v3 *report_v3);
-bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2);
-bugsnag_event *bsg_map_v1_to_report(bugsnag_report_v1 *report_v1);
-
-void migrate_app_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event);
-void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event);
-void migrate_device_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event);
-void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2,
-                           bugsnag_report_v3 *event);
-
-#ifdef __cplusplus
-}
-#endif
+static bool event_write(bsg_report_header *header, bugsnag_event *event,
+                        int fd);
+static bugsnag_event *event_read(int fd);
+static bsg_report_header *report_header_read(int fd);
 
 /**
  * Serializes the LastRunInfo to the file. This persists information about
@@ -56,7 +39,7 @@ bool bsg_serialize_event_to_file(bsg_environment *env) {
     return false;
   }
 
-  return bsg_event_write(&env->report_header, &env->next_event, fd);
+  return event_write(&env->report_header, &env->next_event, fd);
 }
 
 bugsnag_event *bsg_deserialize_event_from_file(char *filepath) {
@@ -65,58 +48,10 @@ bugsnag_event *bsg_deserialize_event_from_file(char *filepath) {
     return NULL;
   }
 
-  return bsg_event_read(fd);
+  return event_read(fd);
 }
 
-bugsnag_report_v1 *bsg_report_v1_read(int fd) {
-  size_t event_size = sizeof(bugsnag_report_v1);
-  bugsnag_report_v1 *event = malloc(event_size);
-
-  ssize_t len = read(fd, event, event_size);
-  if (len != event_size) {
-    free(event);
-    return NULL;
-  }
-  return event;
-}
-
-bugsnag_report_v2 *bsg_report_v2_read(int fd) {
-  size_t event_size = sizeof(bugsnag_report_v2);
-  bugsnag_report_v2 *event = malloc(event_size);
-
-  ssize_t len = read(fd, event, event_size);
-  if (len != event_size) {
-    free(event);
-    return NULL;
-  }
-  return event;
-}
-
-bugsnag_report_v3 *bsg_report_v3_read(int fd) {
-  size_t event_size = sizeof(bugsnag_report_v3);
-  bugsnag_report_v3 *event = malloc(event_size);
-
-  ssize_t len = read(fd, event, event_size);
-  if (len != event_size) {
-    free(event);
-    return NULL;
-  }
-  return event;
-}
-
-bugsnag_report_v4 *bsg_report_v4_read(int fd) {
-  size_t event_size = sizeof(bugsnag_report_v4);
-  bugsnag_report_v4 *event = malloc(event_size);
-
-  ssize_t len = read(fd, event, event_size);
-  if (len != event_size) {
-    free(event);
-    return NULL;
-  }
-  return event;
-}
-
-bugsnag_event *bsg_report_v5_read(int fd) {
+static bugsnag_event *report_read(int fd) {
   size_t event_size = sizeof(bugsnag_event);
   bugsnag_event *event = malloc(event_size);
 
@@ -138,8 +73,8 @@ bugsnag_event *bsg_report_v5_read(int fd) {
  * - this is to conserve memory when migrating particularly old payload
  * versions.
  */
-bugsnag_event *bsg_event_read(int fd) {
-  bsg_report_header *header = bsg_report_header_read(fd);
+static bugsnag_event *event_read(int fd) {
+  bsg_report_header *header = report_header_read(fd);
   if (header == NULL) {
     return NULL;
   }
@@ -148,326 +83,14 @@ bugsnag_event *bsg_event_read(int fd) {
   free(header);
   bugsnag_event *event = NULL;
 
-  if (event_version == 1) { // 'event->unhandled_events' was added in v2
-    bugsnag_report_v1 *report_v1 = bsg_report_v1_read(fd);
-    event = bsg_map_v1_to_report(report_v1);
-  } else if (event_version == 2) {
-    bugsnag_report_v2 *report_v2 = bsg_report_v2_read(fd);
-    event = bsg_map_v2_to_report(report_v2);
-  } else if (event_version == 3) {
-    bugsnag_report_v3 *report_v3 = bsg_report_v3_read(fd);
-    event = bsg_map_v3_to_report(report_v3);
-  } else if (event_version == 4) {
-    bugsnag_report_v4 *report_v4 = bsg_report_v4_read(fd);
-    event = bsg_map_v4_to_report(report_v4);
-  } else if (event_version == 5) {
-    event = bsg_report_v5_read(fd);
-  }
-  return event;
-}
-
-bugsnag_event *bsg_map_v4_to_report(bugsnag_report_v4 *report_v4) {
-  if (report_v4 == NULL) {
-    return NULL;
-  }
-  bugsnag_event *event = malloc(sizeof(bugsnag_event));
-
-  if (event != NULL) {
-    event->notifier = report_v4->notifier;
-    event->device = report_v4->device;
-    event->user = report_v4->user;
-    event->error = report_v4->error;
-    event->metadata = report_v4->metadata;
-    event->crumb_count = report_v4->crumb_count;
-    event->crumb_first_index = report_v4->crumb_first_index;
-    memcpy(event->breadcrumbs, report_v4->breadcrumbs,
-           sizeof(event->breadcrumbs));
-    event->severity = report_v4->severity;
-    bsg_strncpy_safe(event->session_id, report_v4->session_id,
-                     sizeof(event->session_id));
-    bsg_strncpy_safe(event->session_start, report_v4->session_start,
-                     sizeof(event->session_id));
-    event->handled_events = report_v4->handled_events;
-    event->unhandled_events = report_v4->unhandled_events;
-    bsg_strncpy_safe(event->grouping_hash, report_v4->grouping_hash,
-                     sizeof(event->session_id));
-    event->unhandled = report_v4->unhandled;
-    bsg_strncpy_safe(event->api_key, report_v4->api_key,
-                     sizeof(event->api_key));
-    migrate_app_v2(report_v4, event);
-    free(report_v4);
-  }
-  return event;
-}
-
-bugsnag_event *bsg_map_v3_to_report(bugsnag_report_v3 *report_v3) {
-  if (report_v3 == NULL) {
-    return NULL;
-  }
-  bugsnag_report_v4 *event = malloc(sizeof(bugsnag_event));
-
-  if (event != NULL) {
-    event->notifier = report_v3->notifier;
-    event->app = report_v3->app;
-    event->device = report_v3->device;
-    event->user = report_v3->user;
-    event->error = report_v3->error;
-    event->metadata = report_v3->metadata;
-    event->crumb_count = report_v3->crumb_count;
-    event->crumb_first_index = report_v3->crumb_first_index;
-    memcpy(event->breadcrumbs, report_v3->breadcrumbs,
-           sizeof(event->breadcrumbs));
-    event->severity = report_v3->severity;
-    strcpy(event->session_id, report_v3->session_id);
-    strcpy(event->session_start, report_v3->session_start);
-    event->handled_events = report_v3->handled_events;
-    event->unhandled_events = report_v3->unhandled_events;
-    strcpy(event->grouping_hash, report_v3->grouping_hash);
-    event->unhandled = report_v3->unhandled;
-
-    // set a default value for the api key
-    strcpy(event->api_key, "");
-    free(report_v3);
-  }
-  return bsg_map_v4_to_report(event);
-}
-
-bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2) {
-  if (report_v2 == NULL) {
-    return NULL;
-  }
-  bugsnag_report_v3 *event = malloc(sizeof(bugsnag_report_v3));
-
-  if (event != NULL) {
-    // assign metadata first as old app/device fields are migrated there
-    event->metadata = report_v2->metadata;
-    migrate_app_v1(report_v2, event);
-    migrate_device_v1(report_v2, event);
-    event->user = report_v2->user;
-    migrate_breadcrumb_v1(report_v2, event);
-
-    strcpy(event->context, report_v2->context);
-    event->severity = report_v2->severity;
-    strcpy(event->session_id, report_v2->session_id);
-    strcpy(event->session_start, report_v2->session_start);
-    event->handled_events = report_v2->handled_events;
-    event->unhandled_events = report_v2->unhandled_events;
-
-    // migrate changed notifier fields
-    strcpy(event->notifier.version, report_v2->notifier.version);
-    strcpy(event->notifier.name, report_v2->notifier.name);
-    strcpy(event->notifier.url, report_v2->notifier.url);
-
-    // migrate changed error fields
-    strcpy(event->error.errorClass, report_v2->exception.name);
-    strcpy(event->error.errorMessage, report_v2->exception.message);
-    strcpy(event->error.type, report_v2->exception.type);
-    event->error.frame_count = report_v2->exception.frame_count;
-    size_t error_size = sizeof(bugsnag_stackframe) * BUGSNAG_FRAMES_MAX;
-    memcpy(&event->error.stacktrace, report_v2->exception.stacktrace,
-           error_size);
-
-    // Fatal C errors are always true by default, previously this was hardcoded
-    // and not a field on the struct
-    event->unhandled = true;
-    free(report_v2);
-  }
-  return bsg_map_v3_to_report(event);
-}
-
-int bsg_calculate_total_crumbs(int old_count) {
-  return old_count < BUGSNAG_CRUMBS_MAX ? old_count : BUGSNAG_CRUMBS_MAX;
-}
-
-int bsg_calculate_v1_start_index(int old_count) {
-  return old_count < BUGSNAG_CRUMBS_MAX ? 0 : old_count % BUGSNAG_CRUMBS_MAX;
-}
-
-int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index) {
-  return (crumb_pos + first_index) % V1_BUGSNAG_CRUMBS_MAX;
-}
-
-void bugsnag_report_v3_add_breadcrumb(bugsnag_report_v3 *event,
-                                      bugsnag_breadcrumb *crumb) {
-  int crumb_index;
-  if (event->crumb_count < BUGSNAG_CRUMBS_MAX) {
-    crumb_index = event->crumb_count;
-    event->crumb_count++;
+  if (bsg_event_requires_migration(event_version)) {
+    return bsg_event_read_and_migrate(event_version, fd);
   } else {
-    crumb_index = event->crumb_first_index;
-    event->crumb_first_index =
-        (event->crumb_first_index + 1) % BUGSNAG_CRUMBS_MAX;
-  }
-  memcpy(&event->breadcrumbs[crumb_index], crumb, sizeof(bugsnag_breadcrumb));
-}
-
-void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2,
-                           bugsnag_report_v3 *event) {
-  event->crumb_count = 0;
-  event->crumb_first_index = 0;
-
-  // previously breadcrumbs had 30 elements, now they have 25.
-  // if more than 25 breadcrumbs were collected in the legacy report,
-  // offset them accordingly by moving the start position by count -
-  // BUGSNAG_CRUMBS_MAX.
-  int new_crumb_total = bsg_calculate_total_crumbs(report_v2->crumb_count);
-  int k = bsg_calculate_v1_start_index(report_v2->crumb_count);
-
-  for (; k < new_crumb_total; k++) {
-    int crumb_index =
-        bsg_calculate_v1_crumb_index(k, report_v2->crumb_first_index);
-    bugsnag_breadcrumb_v1 *old_crumb = &report_v2->breadcrumbs[crumb_index];
-    bugsnag_breadcrumb *new_crumb = malloc(sizeof(bugsnag_breadcrumb));
-
-    // copy old crumb fields to new
-    new_crumb->type = old_crumb->type;
-    bsg_strncpy_safe(new_crumb->name, old_crumb->name, sizeof(new_crumb->name));
-    bsg_strncpy_safe(new_crumb->timestamp, old_crumb->timestamp,
-                     sizeof(new_crumb->timestamp));
-
-    for (int j = 0; j < 8; j++) {
-      bsg_char_metadata_pair pair = old_crumb->metadata[j];
-
-      if (strlen(pair.value) > 0 && strlen(pair.key) > 0) {
-        bsg_add_metadata_value_str(&new_crumb->metadata, "metaData", pair.key,
-                                   pair.value);
-      }
-    }
-
-    // add crumb to event by copying memory
-    bugsnag_report_v3_add_breadcrumb(event, new_crumb);
-    free(new_crumb);
+    return report_read(fd);
   }
 }
 
-void migrate_app_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event) {
-  bsg_strcpy(event->app.id, report_v2->app.id);
-  bsg_strcpy(event->app.release_stage, report_v2->app.release_stage);
-  bsg_strcpy(event->app.type, report_v2->app.type);
-  bsg_strcpy(event->app.version, report_v2->app.version);
-  bsg_strcpy(event->app.active_screen, report_v2->app.active_screen);
-  bsg_strcpy(event->app.build_uuid, report_v2->app.build_uuid);
-  bsg_strcpy(event->app.binary_arch, report_v2->app.binaryArch);
-  event->app.version_code = report_v2->app.version_code;
-  event->app.duration = report_v2->app.duration;
-  event->app.duration_in_foreground = report_v2->app.duration_in_foreground;
-  event->app.duration_ms_offset = report_v2->app.duration_ms_offset;
-  event->app.duration_in_foreground_ms_offset =
-      report_v2->app.duration_in_foreground_ms_offset;
-  event->app.in_foreground = report_v2->app.in_foreground;
-
-  // migrate legacy fields to metadata
-  bugsnag_event_add_metadata_string(event, "app", "packageName",
-                                    report_v2->app.package_name);
-  bugsnag_event_add_metadata_string(event, "app", "versionName",
-                                    report_v2->app.version_name);
-  bugsnag_event_add_metadata_string(event, "app", "name", report_v2->app.name);
-}
-
-void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event) {
-  bsg_strncpy_safe(event->app.id, report_v4->app.id, sizeof(event->app.id));
-  bsg_strncpy_safe(event->app.release_stage, report_v4->app.release_stage,
-                   sizeof(event->app.release_stage));
-  bsg_strncpy_safe(event->app.type, report_v4->app.type,
-                   sizeof(event->app.type));
-  bsg_strncpy_safe(event->app.version, report_v4->app.version,
-                   sizeof(event->app.version));
-  bsg_strncpy_safe(event->app.active_screen, report_v4->app.active_screen,
-                   sizeof(event->app.active_screen));
-  bsg_strncpy_safe(event->app.build_uuid, report_v4->app.build_uuid,
-                   sizeof(event->app.build_uuid));
-  bsg_strncpy_safe(event->app.binary_arch, report_v4->app.binary_arch,
-                   sizeof(event->app.binary_arch));
-  event->app.version_code = report_v4->app.version_code;
-  event->app.duration = report_v4->app.duration;
-  event->app.duration_in_foreground = report_v4->app.duration_in_foreground;
-  event->app.duration_ms_offset = report_v4->app.duration_ms_offset;
-  event->app.duration_in_foreground_ms_offset =
-      report_v4->app.duration_in_foreground_ms_offset;
-  event->app.in_foreground = report_v4->app.in_foreground;
-
-  // no info available, set to sensible default
-  event->app.is_launching = false;
-}
-
-void migrate_device_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event) {
-  bsg_strcpy(event->device.os_name,
-             bsg_os_name()); // os_name was not a field in v2
-  event->device.api_level = report_v2->device.api_level;
-  event->device.cpu_abi_count = report_v2->device.cpu_abi_count;
-  event->device.time = report_v2->device.time;
-  event->device.jailbroken = report_v2->device.jailbroken;
-  event->device.total_memory = report_v2->device.total_memory;
-
-  for (int k = 0; k < report_v2->device.cpu_abi_count &&
-                  k < sizeof(report_v2->device.cpu_abi);
-       k++) {
-    bsg_strcpy(event->device.cpu_abi[k].value,
-               report_v2->device.cpu_abi[k].value);
-    event->device.cpu_abi_count++;
-  }
-
-  bsg_strcpy(event->device.orientation, report_v2->device.orientation);
-  bsg_strcpy(event->device.id, report_v2->device.id);
-  bsg_strcpy(event->device.locale, report_v2->device.locale);
-  bsg_strcpy(event->device.manufacturer, report_v2->device.manufacturer);
-  bsg_strcpy(event->device.model, report_v2->device.model);
-  bsg_strcpy(event->device.os_build, report_v2->device.os_build);
-  bsg_strcpy(event->device.os_version, report_v2->device.os_version);
-
-  // migrate legacy fields to metadata
-  bugsnag_event_add_metadata_bool(event, "device", "emulator",
-                                  report_v2->device.emulator);
-  bugsnag_event_add_metadata_double(event, "device", "dpi",
-                                    report_v2->device.dpi);
-  bugsnag_event_add_metadata_double(event, "device", "screenDensity",
-                                    report_v2->device.screen_density);
-  bugsnag_event_add_metadata_double(event, "device", "batteryLevel",
-                                    report_v2->device.battery_level);
-  bugsnag_event_add_metadata_string(event, "device", "locationStatus",
-                                    report_v2->device.location_status);
-  bugsnag_event_add_metadata_string(event, "device", "brand",
-                                    report_v2->device.brand);
-  bugsnag_event_add_metadata_string(event, "device", "networkAccess",
-                                    report_v2->device.network_access);
-  bugsnag_event_add_metadata_string(event, "device", "screenResolution",
-                                    report_v2->device.screen_resolution);
-}
-
-bugsnag_event *bsg_map_v1_to_report(bugsnag_report_v1 *report_v1) {
-  if (report_v1 == NULL) {
-    return NULL;
-  }
-  size_t report_size = sizeof(bugsnag_report_v2);
-  bugsnag_report_v2 *event_v2 = malloc(report_size);
-
-  if (event_v2 != NULL) {
-    event_v2->notifier = report_v1->notifier;
-    event_v2->app = report_v1->app;
-    event_v2->device = report_v1->device;
-    event_v2->user = report_v1->user;
-    event_v2->exception = report_v1->exception;
-    event_v2->metadata = report_v1->metadata;
-    event_v2->crumb_count = report_v1->crumb_count;
-    event_v2->crumb_first_index = report_v1->crumb_first_index;
-
-    size_t breadcrumb_size =
-        sizeof(bugsnag_breadcrumb_v1) * V1_BUGSNAG_CRUMBS_MAX;
-    memcpy(&event_v2->breadcrumbs, report_v1->breadcrumbs, breadcrumb_size);
-
-    strcpy(event_v2->context, report_v1->context);
-    event_v2->severity = report_v1->severity;
-    strcpy(event_v2->session_id, report_v1->session_id);
-    strcpy(event_v2->session_start, report_v1->session_start);
-    event_v2->handled_events = report_v1->handled_events;
-    event_v2->unhandled_events = 1;
-
-    free(report_v1);
-  }
-  return bsg_map_v2_to_report(event_v2);
-}
-
-bsg_report_header *bsg_report_header_read(int fd) {
+static bsg_report_header *report_header_read(int fd) {
   bsg_report_header *header = malloc(sizeof(bsg_report_header));
   ssize_t len = read(fd, header, sizeof(bsg_report_header));
   if (len != sizeof(bsg_report_header)) {
@@ -484,7 +107,8 @@ bool bsg_report_header_write(bsg_report_header *header, int fd) {
   return len == sizeof(bsg_report_header);
 }
 
-bool bsg_event_write(bsg_report_header *header, bugsnag_event *event, int fd) {
+static bool event_write(bsg_report_header *header, bugsnag_event *event,
+                        int fd) {
   if (!bsg_report_header_write(header, fd)) {
     return false;
   }
@@ -493,7 +117,7 @@ bool bsg_event_write(bsg_report_header *header, bugsnag_event *event, int fd) {
   return len == sizeof(bugsnag_event);
 }
 
-const char *bsg_crumb_type_string(bugsnag_breadcrumb_type type) {
+static const char *crumb_type_string(bugsnag_breadcrumb_type type) {
   switch (type) {
   case BSG_CRUMB_ERROR:
     return "error";
@@ -514,7 +138,7 @@ const char *bsg_crumb_type_string(bugsnag_breadcrumb_type type) {
   }
 }
 
-const char *bsg_severity_string(bugsnag_severity type) {
+static const char *severity_string(bugsnag_severity type) {
   switch (type) {
   case BSG_SEVERITY_INFO:
     return "info";
@@ -533,8 +157,8 @@ void bsg_serialize_context(const bugsnag_event *event, JSON_Object *event_obj) {
   }
 }
 
-void bsg_serialize_grouping_hash(const bugsnag_event *event,
-                                 JSON_Object *event_obj) {
+static void serialize_grouping_hash(const bugsnag_event *event,
+                                    JSON_Object *event_obj) {
   if (strlen(event->grouping_hash) > 0) {
     json_object_set_string(event_obj, "groupingHash", event->grouping_hash);
   }
@@ -546,7 +170,7 @@ void bsg_serialize_severity_reason(const bugsnag_event *event,
   // over-optimized for signal handling. in the future we may want to handle
   // C++ exceptions, etc as well.
   json_object_set_string(event_obj, "severity",
-                         bsg_severity_string(event->severity));
+                         severity_string(event->severity));
   bool unhandled = event->unhandled;
   json_object_dotset_boolean(event_obj, "unhandled", unhandled);
 
@@ -693,17 +317,6 @@ void bsg_serialize_session(bugsnag_event *event, JSON_Object *event_obj) {
   }
 }
 
-void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
-                         JSON_Array *stacktrace) {
-  json_object_set_string(exception, "errorClass", exc.errorClass);
-  json_object_set_string(exception, "message", exc.errorMessage);
-  json_object_set_string(exception, "type", "c");
-  for (int findex = 0; findex < exc.frame_count; findex++) {
-    bugsnag_stackframe stackframe = exc.stacktrace[findex];
-    bsg_serialize_stackframe(&stackframe, stacktrace);
-  }
-}
-
 void bsg_serialize_stackframe(bugsnag_stackframe *stackframe,
                               JSON_Array *stacktrace) {
   JSON_Value *frame_val = json_value_init_object();
@@ -727,6 +340,17 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe,
   json_array_append_value(stacktrace, frame_val);
 }
 
+void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
+                         JSON_Array *stacktrace) {
+  json_object_set_string(exception, "errorClass", exc.errorClass);
+  json_object_set_string(exception, "message", exc.errorMessage);
+  json_object_set_string(exception, "type", "c");
+  for (int findex = 0; findex < exc.frame_count; findex++) {
+    bugsnag_stackframe stackframe = exc.stacktrace[findex];
+    bsg_serialize_stackframe(&stackframe, stacktrace);
+  }
+}
+
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs) {
   if (event->crumb_count > 0) {
     int current_index = event->crumb_first_index;
@@ -738,8 +362,7 @@ void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs) {
       bugsnag_breadcrumb breadcrumb = event->breadcrumbs[current_index];
       json_object_set_string(crumb, "name", breadcrumb.name);
       json_object_set_string(crumb, "timestamp", breadcrumb.timestamp);
-      json_object_set_string(crumb, "type",
-                             bsg_crumb_type_string(breadcrumb.type));
+      json_object_set_string(crumb, "type", crumb_type_string(breadcrumb.type));
       bsg_serialize_breadcrumb_metadata(breadcrumb.metadata, crumb);
       current_index++;
       if (current_index == BUGSNAG_CRUMBS_MAX) {
@@ -767,7 +390,7 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   char *serialized_string = NULL;
   {
     bsg_serialize_context(event, event_obj);
-    bsg_serialize_grouping_hash(event, event_obj);
+    serialize_grouping_hash(event, event_obj);
     bsg_serialize_severity_reason(event, event_obj);
     bsg_serialize_app(event->app, event_obj);
     bsg_serialize_app_metadata(event->app, event_obj);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -1,46 +1,16 @@
 #include "../bugsnag_ndk.h"
-#include "build.h"
-#include <fcntl.h>
-#include <parson/parson.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+bugsnag_event *bsg_deserialize_event_from_file(char *filepath);
 
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 
 bool bsg_serialize_event_to_file(bsg_environment *env) __asyncsafe;
 
 bool bsg_serialize_last_run_info_to_file(bsg_environment *env) __asyncsafe;
-
-bugsnag_event *bsg_deserialize_event_from_file(char *filepath);
-
-void bsg_serialize_context(const bugsnag_event *event, JSON_Object *event_obj);
-void bsg_serialize_severity_reason(const bugsnag_event *event,
-                                   JSON_Object *event_obj);
-void bsg_serialize_app(const bsg_app_info app, JSON_Object *event_obj);
-void bsg_serialize_app_metadata(const bsg_app_info app, JSON_Object *event_obj);
-void bsg_serialize_device(const bsg_device_info device, JSON_Object *event_obj);
-void bsg_serialize_device_metadata(const bsg_device_info device,
-                                   JSON_Object *event_obj);
-void bsg_serialize_custom_metadata(const bugsnag_metadata metadata,
-                                   JSON_Object *event_obj);
-void bsg_serialize_user(const bugsnag_user user, JSON_Object *event_obj);
-void bsg_serialize_session(bugsnag_event *event, JSON_Object *event_obj);
-void bsg_serialize_stackframe(bugsnag_stackframe *stackframe,
-                              JSON_Array *stacktrace);
-void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
-                         JSON_Array *stacktrace);
-void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
-char *bsg_serialize_event_to_json_string(bugsnag_event *event);
-
-int bsg_calculate_total_crumbs(int old_count);
-int bsg_calculate_v1_start_index(int old_count);
-int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(bugsnag-ndk-test SHARED
     cpp/main.c
     cpp/test_utils_string.c
     cpp/test_utils_serialize.c
+    cpp/test_migrate.c
     cpp/test_serializer.c
     cpp/test_breadcrumbs.c
     cpp/test_bsg_event.c

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_migrate.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_migrate.c
@@ -1,0 +1,370 @@
+#include <greatest/greatest.h>
+#include <utils/serializer.h>
+#include <stdlib.h>
+#include <utils/migrate.h>
+#include <utils/migrate_internal.h>
+
+#define SERIALIZE_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo.crash"
+
+bugsnag_breadcrumb *init_breadcrumb(const char *name, char *message, bugsnag_breadcrumb_type type);
+bool bsg_report_header_write(bsg_report_header *header, int fd);
+
+static bool bsg_report_v1_write(bsg_report_header *header, bugsnag_report_v1 *report,
+                         int fd) {
+  if (!bsg_report_header_write(header, fd)) {
+    return false;
+  }
+  ssize_t len = write(fd, report, sizeof(bugsnag_report_v1));
+  return len == sizeof(bugsnag_report_v1);
+}
+
+static bool bsg_report_v2_write(bsg_report_header *header, bugsnag_report_v2 *report,
+                         int fd) {
+  if (!bsg_report_header_write(header, fd)) {
+    return false;
+  }
+  ssize_t len = write(fd, report, sizeof(bugsnag_report_v2));
+  return len == sizeof(bugsnag_report_v2);
+}
+
+static bool bsg_report_v3_write(bsg_report_header *header, bugsnag_report_v3 *report,
+                         int fd) {
+    if (!bsg_report_header_write(header, fd)) {
+        return false;
+    }
+    ssize_t len = write(fd, report, sizeof(bugsnag_report_v3));
+    return len == sizeof(bugsnag_report_v3);
+}
+
+static bool bsg_report_v4_write(bsg_report_header *header, bugsnag_report_v4 *report,
+                         int fd) {
+  if (!bsg_report_header_write(header, fd)) {
+    return false;
+  }
+  ssize_t len = write(fd, report, sizeof(bugsnag_report_v4));
+  return len == sizeof(bugsnag_report_v4);
+}
+
+static bool bsg_serialize_report_v1_to_file(bsg_environment *env, bugsnag_report_v1 *report) {
+  int fd = open(env->next_event_path, O_WRONLY | O_CREAT, 0644);
+  if (fd == -1) {
+    return false;
+  }
+  return bsg_report_v1_write(&env->report_header, report, fd);
+}
+
+static bool bsg_serialize_report_v2_to_file(bsg_environment *env, bugsnag_report_v2 *report) {
+  int fd = open(env->next_event_path, O_WRONLY | O_CREAT, 0644);
+  if (fd == -1) {
+    return false;
+  }
+  return bsg_report_v2_write(&env->report_header, report, fd);
+}
+
+static bool bsg_serialize_report_v3_to_file(bsg_environment *env, bugsnag_report_v3 *report) {
+    int fd = open(env->next_event_path, O_WRONLY | O_CREAT, 0644);
+    if (fd == -1) {
+        return false;
+    }
+    return bsg_report_v3_write(&env->report_header, report, fd);
+}
+
+static bool bsg_serialize_report_v4_to_file(bsg_environment *env, bugsnag_report_v4 *report) {
+  int fd = open(env->next_event_path, O_WRONLY | O_CREAT, 0644);
+  if (fd == -1) {
+    return false;
+  }
+  return bsg_report_v4_write(&env->report_header, report, fd);
+}
+
+
+static void generate_basic_report(bugsnag_event *event) {
+  strcpy(event->grouping_hash, "foo-hash");
+  strcpy(event->api_key, "5d1e5fbd39a74caa1200142706a90b20");
+  strcpy(event->context, "SomeActivity");
+  strcpy(event->error.errorClass, "SIGBUS");
+  strcpy(event->error.errorMessage, "POSIX is serious about oncoming traffic");
+  event->error.stacktrace[0].frame_address = 454379;
+  event->error.stacktrace[1].frame_address = 342334;
+  event->error.frame_count = 2;
+  strcpy(event->error.type, "C");
+  strcpy(event->error.stacktrace[0].method, "makinBacon");
+  strcpy(event->app.id, "com.example.PhotoSnapPlus");
+  strcpy(event->app.release_stage, "リリース");
+  strcpy(event->app.version, "2.0.52");
+  event->app.version_code = 57;
+  strcpy(event->app.build_uuid, "1234-9876-adfe");
+  strcpy(event->device.manufacturer, "HI-TEC™");
+  strcpy(event->device.model, "Rasseur");
+  strcpy(event->device.locale, "en_AU#Melbun");
+  strcpy(event->device.os_name, "android");
+  strcpy(event->user.email, "fenton@io.example.com");
+  strcpy(event->user.id, "fex");
+  event->device.total_memory = 234678100;
+  event->app.duration = 6502;
+  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
+  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
+  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
+  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.8);
+
+  event->crumb_count = 0;
+  event->crumb_first_index = 0;
+  bugsnag_breadcrumb *crumb1 = init_breadcrumb("decrease torque", "Moving laterally 26º", BSG_CRUMB_STATE);
+  bugsnag_event_add_breadcrumb(event, crumb1);
+
+  bugsnag_breadcrumb *crumb2 = init_breadcrumb("enable blasters", "this is a drill.", BSG_CRUMB_USER);
+  bugsnag_event_add_breadcrumb(event, crumb2);
+
+  event->handled_events = 1;
+  event->unhandled_events = 1;
+  strcpy(event->session_id, "f1ab");
+  strcpy(event->session_start, "2019-03-19T12:58:19+00:00");
+
+  strcpy(event->notifier.version, "1.0");
+  strcpy(event->notifier.url, "bugsnag.com");
+  strcpy(event->notifier.name, "Test Notifier");
+}
+
+static bugsnag_report_v4 *bsg_generate_report_v4(void) {
+  bugsnag_report_v4 *report = calloc(1, sizeof(bugsnag_report_v4));
+  generate_basic_report((bugsnag_event *) report);
+  return report;
+}
+
+static bugsnag_report_v3 *bsg_generate_report_v3(void) {
+    bugsnag_report_v3 *report = calloc(1, sizeof(bugsnag_report_v3));
+    generate_basic_report((bugsnag_event *) report);
+    return report;
+}
+
+static bugsnag_report_v2 *bsg_generate_report_v2(void) {
+  bugsnag_report_v2 *report = calloc(1, sizeof(bugsnag_report_v2));
+  generate_basic_report((bugsnag_event *) report);
+
+  strcpy(report->exception.name, "SIGBUS");
+  strcpy(report->exception.message, "POSIX is serious about oncoming traffic");
+  report->exception.stacktrace[0].frame_address = 454379;
+  report->exception.frame_count = 1;
+  strcpy(report->exception.type, "C");
+  strcpy(report->exception.stacktrace[0].method, "makinBacon");
+
+  strcpy(report->app.package_name, "com.example.foo");
+  strcpy(report->app.version_name, "2.5");
+
+  bugsnag_breadcrumb_v1 *crumb1 = &report->breadcrumbs[0];
+  crumb1->type = BSG_CRUMB_STATE;
+  strcpy(crumb1->timestamp, "2018-08-29T21:41:39Z");
+  strcpy(crumb1->name, "decrease torque");
+  strcpy(crumb1->metadata[0].key, "message");
+  strcpy(crumb1->metadata[0].value, "Moving laterally 26º");
+
+  bugsnag_breadcrumb_v1 *crumb2 = &report->breadcrumbs[1];
+  crumb2->type = BSG_CRUMB_USER;
+  strcpy(crumb2->timestamp, "2018-08-29T21:41:39Z");
+  strcpy(crumb2->name, "enable blasters");
+  strcpy(crumb2->metadata[0].key, "message");
+  strcpy(crumb2->metadata[0].value, "this is a drill.");
+
+  report->crumb_first_index = 0;
+  report->crumb_count = 2;
+
+  return report;
+}
+
+static bugsnag_report_v1 *bsg_generate_report_v1(void) {
+  bugsnag_report_v1 *report = calloc(1, sizeof(bugsnag_report_v1));
+  strcpy(report->session_id, "f1ab");
+  strcpy(report->session_start, "2019-03-19T12:58:19+00:00");
+  report->handled_events = 1;
+  return report;
+}
+
+static bugsnag_event *bsg_generate_event(void) {
+  bugsnag_event *report = calloc(1, sizeof(bugsnag_event));
+  generate_basic_report(report);
+  report->unhandled_events = 2;
+  return report;
+}
+
+TEST test_report_v1_migration(void) {
+  bsg_environment *env = malloc(sizeof(bsg_environment));
+  env->report_header.version = 1;
+  env->report_header.big_endian = 1;
+  strcpy(env->report_header.os_build, "macOS Sierra");
+  bugsnag_report_v1 *generated_report = bsg_generate_report_v1();
+  memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v1));
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
+  bsg_serialize_report_v1_to_file(env, generated_report);
+
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
+  ASSERT(event != NULL);
+  ASSERT(strcmp("f1ab", event->session_id) == 0);
+  ASSERT(strcmp("2019-03-19T12:58:19+00:00", event->session_start) == 0);
+  ASSERT_EQ(1, event->handled_events);
+  ASSERT_EQ(1, event->unhandled_events);
+  ASSERT_FALSE(event->app.is_launching);
+
+  free(generated_report);
+  free(env);
+  free(event);
+  PASS();
+}
+
+TEST test_report_v2_migration(void) {
+  bsg_environment *env = malloc(sizeof(bsg_environment));
+
+  bugsnag_report_v2 *generated_report = bsg_generate_report_v2();
+  memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v2));
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
+
+  env->report_header.version = 2;
+  env->report_header.big_endian = 1;
+  strcpy(env->report_header.os_build, "macOS Sierra");
+  bsg_serialize_report_v2_to_file(env, generated_report);
+
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
+  ASSERT(event != NULL);
+
+  // bsg_library -> bsg_notifier
+  ASSERT_STR_EQ("Test Notifier", event->notifier.name);
+  ASSERT_STR_EQ("bugsnag.com", event->notifier.url);
+  ASSERT_STR_EQ("1.0", event->notifier.version);
+
+  // bsg_exception -> bsg_error
+  ASSERT_STR_EQ("SIGBUS", event->error.errorClass);
+  ASSERT_STR_EQ("POSIX is serious about oncoming traffic", event->error.errorMessage);
+  ASSERT_STR_EQ("C", event->error.type);
+  ASSERT_EQ(1, event->error.frame_count);
+  ASSERT_STR_EQ("makinBacon", event->error.stacktrace[0].method);
+
+  // event.device
+  ASSERT_STR_EQ("android", event->device.os_name);
+
+  // package_name/version_name are migrated to metadata
+  ASSERT_STR_EQ("com.example.foo", event->metadata.values[0].char_value);
+  ASSERT_STR_EQ("2.5", event->metadata.values[1].char_value);
+
+  // breadcrumbs are migrated correctly
+  ASSERT_EQ(2, event->crumb_count);
+  ASSERT_EQ(0, event->crumb_first_index);
+
+  bugsnag_breadcrumb_v1 *crumb = &generated_report->breadcrumbs[0];
+  bsg_char_metadata_pair *val = &crumb->metadata[0];
+
+  ASSERT_STR_EQ("decrease torque", crumb->name);
+  ASSERT_STR_EQ("2018-08-29T21:41:39Z", crumb->timestamp);
+  ASSERT_EQ(BSG_CRUMB_STATE, crumb->type);
+  ASSERT_STR_EQ("message", val->key);
+  ASSERT_STR_EQ("Moving laterally 26º", val->value);
+  ASSERT_FALSE(event->app.is_launching);
+
+  free(generated_report);
+  free(env);
+  free(event);
+  PASS();
+}
+
+TEST test_report_v3_migration(void) {
+  bsg_environment *env = malloc(sizeof(bsg_environment));
+  env->report_header.version = 3;
+  env->report_header.big_endian = 1;
+  strcpy(env->report_header.os_build, "macOS Sierra");
+
+  bugsnag_report_v3 *generated_report = bsg_generate_report_v3();
+  memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v3));
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
+  bsg_serialize_report_v3_to_file(env, generated_report);
+
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
+  ASSERT(event != NULL);
+
+  // api key is set to sensible default
+  ASSERT_STR_EQ("", event->api_key);
+
+  // other fields appear reasonable and are copied over
+  ASSERT_STR_EQ("Test Notifier", event->notifier.name);
+  ASSERT_STR_EQ("bugsnag.com", event->notifier.url);
+  ASSERT_STR_EQ("1.0", event->notifier.version);
+  ASSERT_STR_EQ("SIGBUS", event->error.errorClass);
+  ASSERT_STR_EQ("POSIX is serious about oncoming traffic", event->error.errorMessage);
+  ASSERT_STR_EQ("C", event->error.type);
+  ASSERT_FALSE(event->app.is_launching);
+
+  free(generated_report);
+  free(env);
+  free(event);
+  PASS();
+}
+
+TEST test_report_v4_migration(void) {
+  bsg_environment *env = malloc(sizeof(bsg_environment));
+  env->report_header.version = 4;
+  env->report_header.big_endian = 1;
+  strcpy(env->report_header.os_build, "macOS Sierra");
+
+  bugsnag_report_v4 *generated_report = bsg_generate_report_v4();
+  memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v4));
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
+  bsg_serialize_report_v4_to_file(env, generated_report);
+
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
+  ASSERT(event != NULL);
+
+  // values are migrated correctly
+  ASSERT_STR_EQ("com.example.PhotoSnapPlus", event->app.id);
+  ASSERT_STR_EQ("リリース", event->app.release_stage);
+  ASSERT_STR_EQ("2.0.52", event->app.version);
+  ASSERT_EQ(57, event->app.version_code);
+  ASSERT_STR_EQ("1234-9876-adfe", event->app.build_uuid);
+  ASSERT_FALSE(event->app.in_foreground);
+  ASSERT_FALSE(event->app.is_launching);
+
+  free(generated_report);
+  free(env);
+  free(event);
+  PASS();
+}
+
+TEST test_migrate_app_v2(void) {
+  bugsnag_report_v4 *report_v4 = malloc(sizeof(bugsnag_report_v4));
+  bugsnag_event *event = malloc(sizeof(bugsnag_event));
+  bsg_app_info_v2 *seed = &report_v4->app;
+  bsg_app_info *app = &event->app;
+
+  strcpy(seed->id, "id");
+  strcpy(seed->release_stage, "beta");
+  strcpy(seed->type, "c");
+  strcpy(seed->version, "1.5.2");
+  strcpy(seed->active_screen, "ExampleActivity");
+  strcpy(seed->build_uuid, "10f9");
+  strcpy(seed->binary_arch, "x86");
+  seed->version_code = 5;
+  seed->duration = 52;
+  seed->duration_in_foreground = 25;
+  seed->duration_ms_offset = 3;
+  seed->duration_in_foreground_ms_offset = 11;
+
+  // migrate pre-populated data
+  bsg_migrate_app_v2(report_v4, event);
+
+  ASSERT_STR_EQ("id", app->id);
+  ASSERT_STR_EQ("beta", app->release_stage);
+  ASSERT_STR_EQ("c", app->type);
+  ASSERT_STR_EQ("1.5.2", app->version);
+  ASSERT_STR_EQ("ExampleActivity", app->active_screen);
+  ASSERT_STR_EQ("10f9", app->build_uuid);
+  ASSERT_STR_EQ("x86", app->binary_arch);
+  ASSERT_FALSE(app->is_launching);
+
+  free(report_v4);
+  free(event);
+  PASS();
+}
+
+SUITE(serialize_migrate) {
+  RUN_TEST(test_report_v1_migration);
+  RUN_TEST(test_report_v2_migration);
+  RUN_TEST(test_report_v3_migration);
+  RUN_TEST(test_report_v4_migration);
+  RUN_TEST(test_migrate_app_v2);
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
@@ -4,6 +4,8 @@
 #include <utils/serializer.h>
 #include <stdlib.h>
 #include <utils/migrate.h>
+#include <parson/parson.h>
+#include "event.h"
 
 typedef struct {
     void *data_ptr;
@@ -23,3 +25,22 @@ bugsnag_event * loadSessionTestCase(jint num);
 bugsnag_event * loadBreadcrumbsTestCase(jint num);
 bugsnag_stackframe * loadStackframeTestCase(jint num);
 bsg_error * loadExceptionTestCase(jint num);
+
+// Exposed internals from serializer.c
+void bsg_serialize_context(const bugsnag_event *event, JSON_Object *event_obj);
+void bsg_serialize_severity_reason(const bugsnag_event *event,
+                                   JSON_Object *event_obj);
+void bsg_serialize_app(const bsg_app_info app, JSON_Object *event_obj);
+void bsg_serialize_app_metadata(const bsg_app_info app, JSON_Object *event_obj);
+void bsg_serialize_device(const bsg_device_info device, JSON_Object *event_obj);
+void bsg_serialize_device_metadata(const bsg_device_info device,
+                                   JSON_Object *event_obj);
+void bsg_serialize_custom_metadata(const bugsnag_metadata metadata,
+                                   JSON_Object *event_obj);
+void bsg_serialize_user(const bugsnag_user user, JSON_Object *event_obj);
+void bsg_serialize_session(bugsnag_event *event, JSON_Object *event_obj);
+void bsg_serialize_stackframe(bugsnag_stackframe *stackframe,
+                              JSON_Array *stacktrace);
+void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
+                         JSON_Array *stacktrace);
+void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -2,6 +2,7 @@
 #include <utils/serializer.h>
 #include <stdlib.h>
 #include <utils/migrate.h>
+#include <utils/migrate_internal.h>
 
 #define SERIALIZE_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo.crash"
 
@@ -197,7 +198,7 @@ char *test_read_last_run_info(const bsg_environment *env) {
   return buf;
 }
 
-test_last_run_info_serialization(void) {
+TEST test_last_run_info_serialization(void) {
   bsg_environment *env = malloc(sizeof(bsg_environment));
   strcpy(env->last_run_info_path, SERIALIZE_TEST_FILE);
   
@@ -515,8 +516,6 @@ TEST test_breadcrumbs_to_json(void) {
   PASS();
 }
 
-void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event);
-
 TEST test_migrate_app_v2(void) {
   bugsnag_report_v4 *report_v4 = malloc(sizeof(bugsnag_report_v4));
   bugsnag_event *event = malloc(sizeof(bugsnag_event));
@@ -537,7 +536,7 @@ TEST test_migrate_app_v2(void) {
   seed->duration_in_foreground_ms_offset = 11;
 
   // migrate pre-populated data
-  migrate_app_v2(report_v4, event);
+  bsg_migrate_app_v2(report_v4, event);
 
   ASSERT_STR_EQ("id", app->id);
   ASSERT_STR_EQ("beta", app->release_stage);


### PR DESCRIPTION
## Goal

serializer.c was getting too big. The migration code can be self-contained in a separate file.

## Testing

Re-ran unit tests and e2e tests.