### PR TITLE
Trigger RN tests when building next

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,4 +1,13 @@
 steps:
+  - label: 'Trigger RN tests'
+    trigger: 'bugsnag-js'
+    build:
+      branch: 'next'
+      message: 'Run RN tests with latest Android next branch'
+      env:
+        BUILD_RN_WITH_LATEST_NATIVES: "true"
+    async: true
+
   - label: ':android: Build minimal fixture APK'
     key: "fixture-minimal"
     depends_on: "android-ci"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,13 +1,4 @@
 steps:
-  - label: 'Trigger RN tests'
-    trigger: 'bugsnag-js'
-    build:
-      branch: 'next'
-      message: 'Run RN tests with latest Android next branch'
-      env:
-        BUILD_RN_WITH_LATEST_NATIVES: "true"
-    async: true
-
   - label: ':android: Build minimal fixture APK'
     key: "fixture-minimal"
     depends_on: "android-ci"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,15 +1,5 @@
 steps:
 
-  - label: 'Trigger RN tests for all builds of our next branch'
-    if: build.branch == "next"
-    trigger: 'bugsnag-js'
-    build:
-      branch: 'next'
-      message: 'Run RN tests with latest Android next branch'
-      env:
-        BUILD_RN_WITH_LATEST_NATIVES: "true"
-    async: true
-
   # downloads the Android toolchain
   - label: ':docker: Build Android base image'
     key: "android-common"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
 
   - label: 'Trigger RN tests if next has changed'
-    #if: build.branch == "next"
+    if: build.branch == "next"
     trigger: 'bugsnag-js'
     build:
       branch: 'next'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,15 @@
 steps:
 
+  - label: 'Trigger RN tests for all builds of our next branch'
+    if: build.branch == "next"
+    trigger: 'bugsnag-js'
+    build:
+      branch: 'next'
+      message: 'Run RN tests with latest Android next branch'
+      env:
+        BUILD_RN_WITH_LATEST_NATIVES: "true"
+    async: true
+
   # downloads the Android toolchain
   - label: ':docker: Build Android base image'
     key: "android-common"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,15 @@
 steps:
+
+  - label: 'Trigger RN tests if next has changed'
+    #if: build.branch == "next"
+    trigger: 'bugsnag-js'
+    build:
+      branch: 'next'
+      message: 'Run RN tests with latest Android next branch'
+      env:
+        BUILD_RN_WITH_LATEST_NATIVES: "true"
+    async: true
+
   # downloads the Android toolchain
   - label: ':docker: Build Android base image'
     key: "android-common"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,6 @@
 steps:
 
-  - label: 'Trigger RN tests if next has changed'
+  - label: 'Trigger RN tests for all builds of our next branch'
     if: build.branch == "next"
     trigger: 'bugsnag-js'
     build:


### PR DESCRIPTION
## Goal

Trigger the `bugsnag-js` pipeline when building the Android `next` branch, passing the `BUILD_RN_WITH_LATEST_NATIVES` variable set to "true".  This will cause the React Native e2e tests to be run with the latest version of the Android (and Cocoa) notifier from `next`.

The onus will be on the native notifier maintainers to check the RN test run before making a release.