### PR TITLE
Unity: add methods for setting autoNotify and autoDetectAnrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Unity: add methods for setting autoNotify and autoDetectAnrs
+  [#1233](https://github.com/bugsnag/bugsnag-android/pull/1233)
+
 ## 5.9.1 (2021-04-22)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -88,7 +88,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     final LastRunInfoStore lastRunInfoStore;
     final LaunchCrashTracker launchCrashTracker;
     final BackgroundTaskService bgTaskService = new BackgroundTaskService();
-    private ExceptionHandler exceptionHandler;
+    private final ExceptionHandler exceptionHandler;
 
     /**
      * Initialize a Bugsnag client
@@ -264,7 +264,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             Logger logger,
             DeliveryDelegate deliveryDelegate,
             LastRunInfoStore lastRunInfoStore,
-            LaunchCrashTracker launchCrashTracker
+            LaunchCrashTracker launchCrashTracker,
+            ExceptionHandler exceptionHandler
     ) {
         this.immutableConfig = immutableConfig;
         this.metadataState = metadataState;
@@ -289,6 +290,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         this.lastRunInfoStore = lastRunInfoStore;
         this.launchCrashTracker = launchCrashTracker;
         this.lastRunInfo = null;
+        this.exceptionHandler = exceptionHandler;
     }
 
     private LastRunInfo loadLastRunInfo() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ExceptionHandler.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ExceptionHandler.java
@@ -23,7 +23,14 @@ class ExceptionHandler implements UncaughtExceptionHandler {
         this.client = client;
         this.logger = logger;
         this.originalHandler = Thread.getDefaultUncaughtExceptionHandler();
+    }
+
+    void install() {
         Thread.setDefaultUncaughtExceptionHandler(this);
+    }
+
+    void uninstall() {
+        Thread.setDefaultUncaughtExceptionHandler(originalHandler);
     }
 
     @Override

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
@@ -4,7 +4,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 class LibraryLoader {
 
-    private AtomicBoolean attemptedLoad = new AtomicBoolean();
+    private final AtomicBoolean attemptedLoad = new AtomicBoolean();
+    private boolean loaded = false;
 
     /**
      * Attempts to load a native library, returning false if the load was unsuccessful.
@@ -21,11 +22,16 @@ class LibraryLoader {
         if (!attemptedLoad.getAndSet(true)) {
             try {
                 System.loadLibrary(name);
+                loaded = true;
                 return true;
             } catch (UnsatisfiedLinkError error) {
                 client.notify(error, callback);
             }
         }
         return false;
+    }
+
+    boolean isLoaded() {
+        return loaded;
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -405,11 +405,23 @@ public class NativeInterface {
         return getClient().getConfig().getLogger();
     }
 
+    /**
+     * Switches automatic error detection on/off after Bugsnag has initialized.
+     * This is required to support legacy functionality in Unity.
+     *
+     * @param autoNotify whether errors should be automatically detected.
+     */
     public static void setAutoNotify(boolean autoNotify) {
-        // TODO implement me
+        getClient().setAutoNotify(autoNotify);
     }
 
+    /**
+     * Switches automatic ANR detection on/off after Bugsnag has initialized.
+     * This is required to support legacy functionality in Unity.
+     *
+     * @param autoDetectAnrs whether ANRs should be automatically detected.
+     */
     public static void setAutoDetectAnrs(boolean autoDetectAnrs) {
-        // TODO implement me
+        getClient().setAutoDetectAnrs(autoDetectAnrs);
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbFacadeTest.java
@@ -75,4 +75,9 @@ public class BreadcrumbFacadeTest {
     public void dateValid() {
         assertEquals(new Date(0).getTime(), crumb.getTimestamp().getTime());
     }
+
+    @Test
+    public void stringDateValid() {
+        assertEquals("1970-01-01T00:00:00.000Z", crumb.getStringTimestamp());
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.storage.StorageManager;
 
 import androidx.annotation.NonNull;
@@ -23,6 +22,8 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
 
 @SuppressWarnings("ConstantConditions")
 @RunWith(MockitoJUnitRunner.class)
@@ -42,6 +43,9 @@ public class ClientFacadeTest {
 
     @Mock
     UserState userState;
+
+    @Mock
+    ClientObservable clientObservable;
 
     @Mock
     Context appContext;
@@ -72,9 +76,6 @@ public class ClientFacadeTest {
 
     @Mock
     SessionLifecycleCallback sessionLifecycleCallback;
-
-    @Mock
-    SharedPreferences sharedPrefs;
 
     @Mock
     Connectivity connectivity;
@@ -112,6 +113,7 @@ public class ClientFacadeTest {
                 contextState,
                 callbackState,
                 userState,
+                clientObservable,
                 appContext,
                 deviceDataCollector,
                 appDataCollector,
@@ -482,4 +484,44 @@ public class ClientFacadeTest {
         client.markLaunchCompleted();
         verify(launchCrashTracker, times(1)).markLaunchCompleted();
     }
+
+
+    @Test
+    public void registerObserver() {
+        Observer observer = new Observer() {
+            @Override
+            public void update(Observable observable, Object arg) {
+            }
+        };
+        client.registerObserver(observer);
+
+        verify(metadataState, times(1)).addObserver(observer);
+        verify(breadcrumbState, times(1)).addObserver(observer);
+        verify(sessionTracker, times(1)).addObserver(observer);
+        verify(clientObservable, times(1)).addObserver(observer);
+        verify(userState, times(1)).addObserver(observer);
+        verify(contextState, times(1)).addObserver(observer);
+        verify(deliveryDelegate, times(1)).addObserver(observer);
+        verify(launchCrashTracker, times(1)).addObserver(observer);
+    }
+
+    @Test
+    public void unregisterObserver() {
+        Observer observer = new Observer() {
+            @Override
+            public void update(Observable observable, Object arg) {
+            }
+        };
+        client.unregisterObserver(observer);
+
+        verify(metadataState, times(1)).deleteObserver(observer);
+        verify(breadcrumbState, times(1)).deleteObserver(observer);
+        verify(sessionTracker, times(1)).deleteObserver(observer);
+        verify(clientObservable, times(1)).deleteObserver(observer);
+        verify(userState, times(1)).deleteObserver(observer);
+        verify(contextState, times(1)).deleteObserver(observer);
+        verify(deliveryDelegate, times(1)).deleteObserver(observer);
+        verify(launchCrashTracker, times(1)).deleteObserver(observer);
+    }
+
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -98,6 +98,9 @@ public class ClientFacadeTest {
     @Mock
     LaunchCrashTracker launchCrashTracker;
 
+    @Mock
+    ExceptionHandler exceptionHandler;
+
     private Client client;
     private InterceptingLogger logger;
 
@@ -129,7 +132,8 @@ public class ClientFacadeTest {
                 logger,
                 deliveryDelegate,
                 lastRunInfoStore,
-                launchCrashTracker
+                launchCrashTracker,
+                exceptionHandler
         );
 
         // required fields for generating an event

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
@@ -35,7 +35,13 @@ internal class ExceptionHandlerTest {
     @Test
     fun handlerInstalled() {
         val exceptionHandler = ExceptionHandler(client, NoopLogger)
+        assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+
+        exceptionHandler.install()
         assertSame(exceptionHandler, Thread.getDefaultUncaughtExceptionHandler())
+
+        exceptionHandler.uninstall()
+        assertSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/LibraryLoaderTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/LibraryLoaderTest.kt
@@ -20,6 +20,7 @@ class LibraryLoaderTest {
         val libraryLoader = LibraryLoader()
         val loaded = libraryLoader.loadLibrary("foo", client) { true }
         assertFalse(loaded)
+        assertFalse(libraryLoader.isLoaded)
         verify(client, times(1)).notify(any(), any())
     }
 
@@ -28,10 +29,12 @@ class LibraryLoaderTest {
         val libraryLoader = LibraryLoader()
         var loaded = libraryLoader.loadLibrary("foo", client) { true }
         assertFalse(loaded)
+        assertFalse(libraryLoader.isLoaded)
 
         // duplicate calls only invoke System.loadLibrary once
         loaded = libraryLoader.loadLibrary("foo", client) { true }
         assertFalse(loaded)
+        assertFalse(libraryLoader.isLoaded)
         verify(client, times(1)).notify(any(), any())
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -223,4 +223,16 @@ internal class NativeInterfaceApiTest {
         NativeInterface.notify("SIGPIPE", "SIGSEGV 11", Severity.ERROR, arrayOf())
         verify(client, times(1)).notify(any(), any())
     }
+
+    @Test
+    fun autoDetectAnrs() {
+        NativeInterface.setAutoDetectAnrs(true)
+        verify(client, times(1)).setAutoDetectAnrs(true)
+    }
+
+    @Test
+    fun autoNotify() {
+        NativeInterface.setAutoNotify(true)
+        verify(client, times(1)).setAutoNotify(true)
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/PluginClientTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/PluginClientTest.kt
@@ -1,5 +1,7 @@
 package com.bugsnag.android
 
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -23,5 +25,12 @@ class PluginClientTest {
         val pluginClient = PluginClient(setOf(plugin), config, NoopLogger)
         pluginClient.loadPlugins(client)
         Mockito.verify(plugin, times(1)).load(client)
+    }
+
+    @Test
+    fun findPlugin() {
+        val pluginClient = PluginClient(setOf(plugin), config, NoopLogger)
+        assertNull(pluginClient.findPlugin(String::class.java))
+        assertEquals(plugin, pluginClient.findPlugin(plugin::class.java))
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/cxx-scenarios.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/cxx-scenarios.cpp
@@ -353,4 +353,14 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXMarkLaunchCompletedScenario_cra
                                                                                    jobject thiz) {
   abort();
 }
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_UnhandledNdkAutoNotifyTrueScenario_crash(JNIEnv *env) {
+  abort();
+}
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_UnhandledNdkAutoNotifyFalseScenario_crash(JNIEnv *env) {
+  abort();
+}
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledNdkAutoNotifyFalseScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledNdkAutoNotifyFalseScenario.kt
@@ -1,0 +1,30 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
+import com.bugsnag.android.setAutoNotify
+
+class UnhandledNdkAutoNotifyFalseScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        System.loadLibrary("cxx-scenarios")
+    }
+
+    external fun crash()
+
+    override fun startScenario() {
+        super.startScenario()
+        setAutoNotify(Bugsnag.getClient(), false)
+        crash()
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
+    }
+}

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledNdkAutoNotifyTrueScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledNdkAutoNotifyTrueScenario.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.setAutoNotify
+
+class UnhandledNdkAutoNotifyTrueScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        System.loadLibrary("cxx-scenarios")
+    }
+
+    external fun crash()
+
+    override fun startScenario() {
+        super.startScenario()
+        setAutoNotify(Bugsnag.getClient(), false)
+        setAutoNotify(Bugsnag.getClient(), true)
+        crash()
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -4,6 +4,8 @@
   <CurrentIssues>
     <ID>MagicNumber:AnrHelper.kt$1000</ID>
     <ID>MagicNumber:AnrHelper.kt$&lt;no name provided&gt;$60000</ID>
+    <ID>MagicNumber:AutoDetectAnrsFalseScenario.kt$AutoDetectAnrsFalseScenario$100000</ID>
+    <ID>MagicNumber:AutoDetectAnrsTrueScenario.kt$AutoDetectAnrsTrueScenario$100000</ID>
     <ID>MagicNumber:BugsnagInitScenario.kt$BugsnagInitScenario$25</ID>
     <ID>MagicNumber:HandledKotlinSmokeScenario.kt$HandledKotlinSmokeScenario$999</ID>
     <ID>MagicNumber:JvmAnrSleepScenario.kt$JvmAnrSleepScenario$100000</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
@@ -88,3 +88,11 @@ fun generateEvent(client: Client): Event {
     event.device = generateDeviceWithState()
     return event
 }
+
+fun setAutoNotify(client: Client, enabled: Boolean) {
+    client.setAutoNotify(enabled)
+}
+
+fun setAutoDetectAnrs(client: Client, enabled: Boolean) {
+    client.setAutoDetectAnrs(enabled)
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectAnrsFalseScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectAnrsFalseScenario.kt
@@ -1,0 +1,37 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
+import com.bugsnag.android.setAutoDetectAnrs
+
+internal class AutoDetectAnrsFalseScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.enabledErrorTypes.anrs = true
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+        setAutoDetectAnrs(Bugsnag.getClient(), false)
+
+        val main = Handler(Looper.getMainLooper())
+        main.postDelayed(
+            Runnable {
+                Thread.sleep(100000)
+            },
+            1
+        ) // A moment of delay so there is something to 'tap' onscreen
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectAnrsTrueScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectAnrsTrueScenario.kt
@@ -1,0 +1,33 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.setAutoDetectAnrs
+
+internal class AutoDetectAnrsTrueScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.enabledErrorTypes.anrs = true
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+        setAutoDetectAnrs(Bugsnag.getClient(), false)
+        setAutoDetectAnrs(Bugsnag.getClient(), true)
+
+        val main = Handler(Looper.getMainLooper())
+        main.postDelayed(
+            Runnable {
+                Thread.sleep(100000)
+            },
+            1
+        ) // A moment of delay so there is something to 'tap' onscreen
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledJvmAutoNotifyFalseScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/HandledJvmAutoNotifyFalseScenario.kt
@@ -1,0 +1,19 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.setAutoNotify
+
+class HandledJvmAutoNotifyFalseScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    override fun startScenario() {
+        super.startScenario()
+        setAutoNotify(Bugsnag.getClient(), false)
+        Bugsnag.notify(generateException())
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJvmAutoNotifyFalseScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJvmAutoNotifyFalseScenario.kt
@@ -1,0 +1,24 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
+import com.bugsnag.android.setAutoNotify
+
+class UnhandledJvmAutoNotifyFalseScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    override fun startScenario() {
+        super.startScenario()
+        setAutoNotify(Bugsnag.getClient(), false)
+        throw generateException()
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJvmAutoNotifyTrueScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJvmAutoNotifyTrueScenario.kt
@@ -1,0 +1,20 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.setAutoNotify
+
+class UnhandledJvmAutoNotifyTrueScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    override fun startScenario() {
+        super.startScenario()
+        setAutoNotify(Bugsnag.getClient(), false)
+        setAutoNotify(Bugsnag.getClient(), true)
+        throw generateException()
+    }
+}

--- a/features/full_tests/batch_1/auto_notify.feature
+++ b/features/full_tests/batch_1/auto_notify.feature
@@ -1,0 +1,66 @@
+Feature: Switching automatic error detection on/off for Unity
+
+Scenario: Handled JVM exceptions are captured with autoNotify=false
+    When I run "HandledJvmAutoNotifyFalseScenario"
+    Then I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "HandledJvmAutoNotifyFalseScenario"
+
+Scenario: JVM exception not captured with autoNotify=false
+    When I run "UnhandledJvmAutoNotifyFalseScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledJvmAutoNotifyFalseScenario"
+    Then Bugsnag confirms it has no errors to send
+
+Scenario: NDK signal not captured with autoNotify=false
+    When I run "UnhandledNdkAutoNotifyFalseScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledNdkAutoNotifyFalseScenario"
+    Then Bugsnag confirms it has no errors to send
+
+@skip_android_8_1
+Scenario: ANR not captured with autoDetectAnrs=false
+    When I run "AutoDetectAnrsFalseScenario" and relaunch the app
+    And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
+    Then Bugsnag confirms it has no errors to send
+
+Scenario: JVM exception captured with autoNotify reenabled
+    When I run "UnhandledJvmAutoNotifyTrueScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledJvmAutoNotifyTrueScenario"
+    Then I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the exception "message" equals "UnhandledJvmAutoNotifyTrueScenario"
+    And the exception "type" equals "android"
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+
+Scenario: NDK signal captured with autoNotify reenabled
+    When I run "UnhandledNdkAutoNotifyTrueScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledNdkAutoNotifyTrueScenario"
+    Then I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "events" is an array with 1 elements
+    And the exception "message" equals "Abort program"
+    And the exception "type" equals "c"
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.unhandledOverridden" is false
+
+@skip_android_8_1
+Scenario: ANR captured with autoDetectAnrs reenabled
+    When I run "AutoDetectAnrsTrueScenario"
+    And I wait for 2 seconds
+    And I tap the screen 3 times
+    And I wait for 4 seconds
+    And I clear any error dialogue
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "ANR"
+    And the exception "message" starts with " Input dispatching timed out"
+    And the exception "type" equals "android"
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "anrError"
+    And the event "severityReason.unhandledOverridden" is false


### PR DESCRIPTION
## Goal

Adds non-public methods to support the autoNotify and autoDetectAnrs APIs on Unity, which allow automatic error detection to be switched off after Bugsnag has been initilized: https://docs.bugsnag.com/platforms/unity/configuration-options/#autodetectanrs

## Changeset

- Added `NativeInterface.setAutoDetectAnrs` and `NativeInterface.setAutoNotify`, which will be invoked from Unity
- Refactored `AnrPlugin` and `NdkPlugin` to allow for signal handlers etc to be unregistered in a call to `Plugin#unload()`
- Refactored `ExceptionHandler` to allow uninstalling
- Altered `Client` and `PluginClient` to ensure that any change in `autoNotify/autoDetectAnrs` is propagated to all automatic error detection sources

## Testing

Added unit tests throughout, and added E2E tests which verify that ANRs/JVM/NDK errors are recorded appropriately when automatic capture is enabled/disabled.
