### PR TITLE
Prevent rare NPE when capturing thread traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
  * Fix bug that terminated the app when multiple ANRs occur
    [#1235](https://github.com/bugsnag/bugsnag-android/pull/1235)
 
+* Prevent rare NPE when capturing thread traces
+  [#1237](https://github.com/bugsnag/bugsnag-android/pull/1237)
+
 ## 5.9.1 (2021-04-22)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -60,10 +60,16 @@ internal class ThreadState @JvmOverloads constructor(
         val currentThreadId = currentThread.id
         return stackTraces.keys
             .sortedBy { it.id }
-            .map {
-                val stacktrace = Stacktrace.stacktraceFromJavaTrace(stackTraces[it]!!, projectPackages, logger)
-                val errorThread = it.id == currentThreadId
-                Thread(it.id, it.name, ThreadType.ANDROID, errorThread, stacktrace, logger)
+            .mapNotNull { thread ->
+                val trace = stackTraces[thread]
+
+                if (trace != null) {
+                    val stacktrace = Stacktrace.stacktraceFromJavaTrace(trace, projectPackages, logger)
+                    val errorThread = thread.id == currentThreadId
+                    Thread(thread.id, thread.name, ThreadType.ANDROID, errorThread, stacktrace, logger)
+                } else {
+                    null
+                }
             }.toMutableList()
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadStateMissingTraceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadStateMissingTraceTest.kt
@@ -1,0 +1,34 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.RuntimeException
+import java.lang.Thread
+import java.util.Collections
+
+class ThreadStateMissingTraceTest {
+
+    @Test
+    fun handleNullThreadTraces() {
+        val currentThread = Thread.currentThread()
+        val traces = Thread.getAllStackTraces()
+
+        // make all stacktraces null
+        traces.keys.forEach {
+            traces[it] = null
+        }
+
+        val state = ThreadState(
+            RuntimeException(),
+            false,
+            ThreadSendPolicy.ALWAYS,
+            Collections.emptyList(),
+            NoopLogger,
+            currentThread,
+            traces
+        )
+        assertNotNull(state)
+        assertTrue(state.threads.isEmpty())
+    }
+}


### PR DESCRIPTION
## Goal

Prevents a rare NPE when capturing thread traces where the stacktrace element is returned as null. If this occurs then the thread trace is simply skipped as there's no way of recording the information.

## Testing

Added a unit test to verify that the behaviour is fixed.