### PR TITLE
Handle edge case where an exception's stack trace is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+ * Guard against exceptions with null stack traces
+   [1239](https://github.com/bugsnag/bugsnag-android/pull/1239)
+
  * Fix bug that terminated the app when multiple ANRs occur
    [#1235](https://github.com/bugsnag/bugsnag-android/pull/1235)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
@@ -15,7 +15,9 @@ internal class ErrorInternal @JvmOverloads internal constructor(
 
             var currentEx: Throwable? = exc
             while (currentEx != null) {
-                val trace = Stacktrace.stacktraceFromJavaTrace(currentEx.stackTrace, projectPackages, logger)
+                // Somehow it's possible for stackTrace to be null in rare cases
+                val stacktrace = currentEx.stackTrace ?: arrayOf<StackTraceElement>()
+                val trace = Stacktrace.stacktraceFromJavaTrace(stacktrace, projectPackages, logger)
                 errors.add(ErrorInternal(currentEx.javaClass.name, currentEx.localizedMessage, trace))
                 currentEx = currentEx.cause
             }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/NullStackTraceScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/NullStackTraceScenario.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.annotation.SuppressLint
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+@SuppressLint("NewApi")
+class MyThrowable(message: String?) : Throwable(message, null, false, false) {
+    override fun getStackTrace() = null
+}
+
+/**
+ * Sends an unhandled exception to Bugsnag.
+ */
+internal class NullStackTraceScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+
+    override fun startScenario() {
+        super.startScenario()
+        Bugsnag.notify(MyThrowable("NullStackTraceScenario"))
+    }
+}

--- a/features/full_tests/batch_1/null_stacktrace.feature
+++ b/features/full_tests/batch_1/null_stacktrace.feature
@@ -1,0 +1,10 @@
+Feature: Null Stacktrace reported
+
+Scenario: Exceptions with null stacktraces are sent
+    When I run "NullStackTraceScenario"
+    Then I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "notifier.name" equals "Android Bugsnag Notifier"
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "com.bugsnag.android.mazerunner.scenarios.MyThrowable"
+    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements


### PR DESCRIPTION
## Goal

There are rare cases where a throwable has a null `stackTrace`.

## Design

Check for null before attempting to iterate the stack trace.

## Testing

I wasn't able to build a repro case since there's no valid way to set a Throwable's `stackTrace` to null. Attempting to manually set it to null generates a NPE.

Re-ran e2e tests.
