### PR TITLE
Make sure enabled flag is set before installing the ANR handler

### DIFF
--- a/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_handler.c
@@ -337,12 +337,12 @@ static void install_signal_handler() {
 bool bsg_handler_install_anr(JNIEnv *env, jobject plugin) {
   pthread_mutex_lock(&bsg_anr_handler_config);
 
+  enabled = true;
   if (!installed && configure_anr_jni(env) && plugin != NULL) {
     obj_plugin = (*env)->NewGlobalRef(env, plugin);
     install_signal_handler();
     installed = true;
   }
-  enabled = true;
   pthread_mutex_unlock(&bsg_anr_handler_config);
   return true;
 }


### PR DESCRIPTION
## Goal

The previous ANR fix had the `enable` flag being set AFTER creating a new thread that depends upon it. This resulted in flakey behaviour.

## Testing

re-run e2e tests and verify that they don't flake anymore.
