### PR TITLE
Fix NegativeArraySizeException during crash report deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Catch exceptions thrown by Context.registerReceiver to prevent rare crashes
   [#1240](https://github.com/bugsnag/bugsnag-android/pull/1240)
 
+* Fix possible NegativeArraySizeException in crash report deserialization
+  [#1245](https://github.com/bugsnag/bugsnag-android/pull/1245)
+
 ## 5.9.1 (2021-04-22)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventFilenameInfo.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventFilenameInfo.kt
@@ -86,7 +86,7 @@ internal data class EventFilenameInfo(
          * is not encoded for the given event
          */
         private fun findApiKeyInFilename(file: File, config: ImmutableConfig): String {
-            val name = file.name.replace("_$STARTUP_CRASH.json".toRegex(), "")
+            val name = file.name.removeSuffix("_$STARTUP_CRASH.json")
             val start = name.indexOf("_") + 1
             val end = name.indexOf("_", start)
             val apiKey = if (start == 0 || end == -1 || end <= start) {


### PR DESCRIPTION
### Goal
Prevent a possible NegativeArraySizeException which could occur when Matcher.groupSize returned a negative value.

### Testing
Relied on existing test coverage.