### PR TITLE
Fix flaky test by verifying scheduled executor is called

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LaunchCrashTracker.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LaunchCrashTracker.kt
@@ -10,10 +10,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  * configuration.launchDurationMillis, after which which the launch period is considered
  * complete. If this value is zero, then the user must manually call markLaunchCompleted().
  */
-internal class LaunchCrashTracker(config: ImmutableConfig) : BaseObservable() {
+internal class LaunchCrashTracker @JvmOverloads constructor(
+    config: ImmutableConfig,
+    private val executor: ScheduledThreadPoolExecutor = ScheduledThreadPoolExecutor(1)
+) : BaseObservable() {
 
     private val launching = AtomicBoolean(true)
-    private val executor = ScheduledThreadPoolExecutor(1)
     private val logger = config.logger
 
     init {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashTrackerTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashTrackerTest.kt
@@ -6,7 +6,17 @@ import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
+@RunWith(MockitoJUnitRunner::class)
 class LaunchCrashTrackerTest {
 
     @Test
@@ -36,16 +46,19 @@ class LaunchCrashTrackerTest {
 
     @Test
     fun smallLaunchPeriodAutomatic() {
-        val tracker = LaunchCrashTracker(
+        val executor = mock(ScheduledThreadPoolExecutor::class.java)
+        LaunchCrashTracker(
             convert(
                 generateConfiguration().apply {
                     launchDurationMillis = 1
                 }
-            )
+            ),
+            executor
         )
-        assertTrue(tracker.isLaunching())
-
-        java.lang.Thread.sleep(20)
-        assertFalse(tracker.isLaunching())
+        verify(executor, times(1)).schedule(
+            any(Runnable::class.java),
+            eq(1L),
+            eq(TimeUnit.MILLISECONDS)
+        )
     }
 }


### PR DESCRIPTION
## Goal

Alters the `LaunchCrashTrackerTest` as the `isLaunching` state might not be updated in the timeout required, as a `Runnable` is submitted to an `Executor`. Therefore the unit test just asserts that the necessary method on the mock is called.