### PR TITLE
fix: avoid capturing thread stacktraces when not required to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Avoid unnecessary collection of Thread stacktraces
+  [1249](https://github.com/bugsnag/bugsnag-android/pull/1249)
+
 ## 5.9.2 (2021-05-12)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
@@ -23,8 +23,7 @@ class ThreadStateTest {
         ThreadSendPolicy.ALWAYS,
         Collections.emptyList(),
         NoopLogger,
-        Thread.currentThread(),
-        Thread.getAllStackTraces()
+        Thread.currentThread()
     )
     private val json = streamableToJsonArray(threadState)
 
@@ -133,7 +132,6 @@ class ThreadStateTest {
     @Test
     fun testUnhandledStacktrace() {
         val currentThread = Thread.currentThread()
-        val allStackTraces = Thread.getAllStackTraces()
         val exc: Throwable = RuntimeException("Whoops")
         val expectedTrace = exc.stackTrace
 
@@ -143,8 +141,7 @@ class ThreadStateTest {
             ThreadSendPolicy.ALWAYS,
             Collections.emptyList(),
             NoopLogger,
-            currentThread,
-            allStackTraces
+            currentThread
         )
         val json = streamableToJsonArray(state)
 
@@ -163,6 +160,30 @@ class ThreadStateTest {
                 assertEquals(element.lineNumber, jsonObject.getInt("lineNumber"))
             }
         }
+
+        assertTrue(json.length() > 1)
+    }
+
+    /**
+     * Test that using [ThreadSendPolicy.NEVER] ignores any stack-traces and reports an empty
+     * array of Threads
+     */
+    @Test
+    fun testNeverPolicyNeverSendsThreads() {
+        val currentThread = Thread.currentThread()
+        val allStackTraces = Thread.getAllStackTraces()
+        val state = ThreadState(
+            trace,
+            true,
+            ThreadSendPolicy.NEVER,
+            Collections.emptyList(),
+            NoopLogger,
+            currentThread,
+            allStackTraces
+        )
+        val json = streamableToJsonArray(state)
+
+        assertEquals(0, json.length())
     }
 
     private fun verifyCurrentThreadStructure(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -1,18 +1,20 @@
 package com.bugsnag.android
 
+import android.annotation.SuppressLint
+
 import java.io.IOException
 
 /**
  * Capture and serialize the state of all threads at the time of an exception.
  */
-internal class ThreadState @JvmOverloads constructor(
+internal class ThreadState @Suppress("LongParameterList") @JvmOverloads constructor(
     exc: Throwable?,
     isUnhandled: Boolean,
     sendThreads: ThreadSendPolicy,
     projectPackages: Collection<String>,
     logger: Logger,
     currentThread: java.lang.Thread = java.lang.Thread.currentThread(),
-    stackTraces: MutableMap<java.lang.Thread, Array<StackTraceElement>> = java.lang.Thread.getAllStackTraces()
+    stackTraces: MutableMap<java.lang.Thread, Array<StackTraceElement>>? = null
 ) : JsonStream.Streamable {
 
     internal constructor(
@@ -29,7 +31,7 @@ internal class ThreadState @JvmOverloads constructor(
 
         threads = when {
             recordThreads -> captureThreadTrace(
-                stackTraces,
+                stackTraces ?: java.lang.Thread.getAllStackTraces(),
                 currentThread,
                 exc,
                 isUnhandled,


### PR DESCRIPTION
## Goal
Avoid capturing all of the thread stacktraces when they won't be reported.

## Changeset

Instead of capturing stacktraces as a default in the constructor, the argument is now nullable and lazy-captured in the `init` block if required.

## Testing

Existing tests were altered to use the default null value, and a new test was added to ensure that the  `ThreadSendPolicy.NEVER` causes any stacktraces passed to `ThreadState` are discarded.