### PR TITLE
Plat 6481/fix internal error header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 * Prevent errors in rare cases where either ConnectivityManager or StorageManager is not available
   [1251](https://github.com/bugsnag/bugsnag-android/pull/1251)
+  
+* Change the Bugsnag-Internal-Error header to "bugsnag-android"
+  [1252](https://github.com/bugsnag/bugsnag-android/pull/1252)
 
 ## 5.9.2 (2021-05-12)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -116,7 +116,7 @@ class InternalReportDelegate implements EventStore.Delegate {
                         // can only modify headers if DefaultDelivery is in use
                         if (delivery instanceof DefaultDelivery) {
                             Map<String, String> headers = params.getHeaders();
-                            headers.put(HEADER_INTERNAL_ERROR, "true");
+                            headers.put(HEADER_INTERNAL_ERROR, "bugsnag-android");
                             headers.remove(DeliveryHeadersKt.HEADER_API_KEY);
                             DefaultDelivery defaultDelivery = (DefaultDelivery) delivery;
                             defaultDelivery.deliver(params.getEndpoint(), payload, headers);

--- a/features/full_tests/batch_1/internal_error_reports.feature
+++ b/features/full_tests/batch_1/internal_error_reports.feature
@@ -5,7 +5,7 @@ Scenario: If an exception is thrown when sending errors/sessions then internal e
     And I wait to receive 1 errors
 
     # Validate internal error report for error serialization
-    Then the error "Bugsnag-Internal-Error" header equals "true"
+    Then the error "Bugsnag-Internal-Error" header equals "bugsnag-android"
 
     # Exception details
     And the error payload field "events" is an array with 1 elements


### PR DESCRIPTION
## Goal
Change the Bugnag-Internal-Error header to "bugsnag-android"

## Testing
Modified the `internal_error_reports` feature to expect the new header value instead of "true"