### PR TITLE
docs(mazerunner): updated the local setup for GPG changes

### DIFF
--- a/docs/MAZERUNNER.md
+++ b/docs/MAZERUNNER.md
@@ -14,9 +14,13 @@ Remote tests can be run against real devices provided by BrowserStack. In order 
 - A BrowserStack App Automate Access Key: `BROWSER_STACK_ACCESS_KEY`
 - A path to a [BrowserStack local testing binary](https://www.browserstack.com/local-testing/app-automate): `MAZE_BS_LOCAL`
 
+### Setting up local end-to-end testing
+
+1. Run `bundle install`
+1. Create and export a GPG key (follow the instructions in [RELEASING](RELEASING.md))
+
 ### Running an end-to-end test
 
-1. Run `bundle install` if you haven't run end-to-end tests before
 1. Check the contents of `Gemfile` to select the version of `maze-runner` to use
 1. To run a single feature:
     ```shell script

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -71,7 +71,7 @@ Manual publishing is discouraged, but is possible in exceptional circumstances b
 
 ### Creating a GPG key
 
--   Create a GPG key if you haven't got one already (`gpg --gen-key`). The build system requires a GPG key ring set up using GPG 1.x, but many systems now ship with GPG 2.x. As a workaround, after creating your key you can manually create the `secring.gpg` file by running `gpg --export-secret-keys >~/.gnupg/secring.gpg`
+-   Create a GPG key if you haven't got one already (`gpg --full-gen-key` and select RSA/4096bit). The build system requires a GPG key ring set up using GPG 1.x, but many systems now ship with GPG 2.x. As a workaround, after creating your key you can manually create the `secring.gpg` file by running `gpg --export-secret-keys >~/.gnupg/secring.gpg`
 -   Create a [Sonatype JIRA](https://issues.sonatype.org) account
 -   Ask in the [Bugsnag Sonatype JIRA ticket](https://issues.sonatype.org/browse/OSSRH-5533) to become a contributor
 -   Ask an existing contributor (likely Simon) to confirm in the ticket


### PR DESCRIPTION
## Goal
The latest GPG default algorithm (ed25519) is not supported by the Gradle signing plugin we are using, as such we need to generate RSA/4096 keys manually.

Also reference the RELEASING.md documentation from MAZERUNNER.md when referring to the need for a GPG key.