### PR TITLE
fix: avoid recursive Throwable cause chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Prevent errors in rare cases where either ConnectivityManager or StorageManager is not available
   [1251](https://github.com/bugsnag/bugsnag-android/pull/1251)
 
+* Prevent resource exhaustion when Throwable cause chains are recursive
+  [1255](https://github.com/bugsnag/bugsnag-android/pull/1255)
+
 ## 5.9.2 (2021-05-12)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StrictModeHandler.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StrictModeHandler.java
@@ -89,7 +89,7 @@ class StrictModeHandler {
      * @return the root cause of the throwable
      */
     private Throwable getRootCause(Throwable throwable) {
-        List<Throwable> causes = ThrowableExtensionsKt.safeUnrollCauses(throwable);
+        List<Throwable> causes = ThrowableUtils.safeUnrollCauses(throwable);
         return causes.get(causes.size() - 1);
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StrictModeHandler.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StrictModeHandler.java
@@ -2,9 +2,11 @@ package com.bugsnag.android;
 
 import android.annotation.SuppressLint;
 import android.text.TextUtils;
+
 import androidx.annotation.Nullable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -87,12 +89,7 @@ class StrictModeHandler {
      * @return the root cause of the throwable
      */
     private Throwable getRootCause(Throwable throwable) {
-        Throwable cause = throwable.getCause();
-
-        if (cause == null) {
-            return throwable;
-        } else {
-            return getRootCause(cause);
-        }
+        List<Throwable> causes = ThrowableExtensionsKt.safeUnrollCauses(throwable);
+        return causes.get(causes.size() - 1);
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThrowableExtensions.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThrowableExtensions.kt
@@ -1,0 +1,18 @@
+package com.bugsnag.android
+
+/**
+ * Unroll the list of causes for this Throwable, handling any recursion that may appear within
+ * the chain. The first element returned will be this Throwable, and the last will be the root
+ * cause or last non-recursive Throwable.
+ */
+internal fun Throwable.safeUnrollCauses(): List<Throwable> {
+    val causes = LinkedHashSet<Throwable>()
+    var currentEx: Throwable? = this
+
+    // Set.add will return false if we have already "seen" currentEx
+    while (currentEx != null && causes.add(currentEx)) {
+        currentEx = currentEx.cause
+    }
+
+    return causes.toList()
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThrowableExtensions.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThrowableExtensions.kt
@@ -1,3 +1,4 @@
+@file:JvmName("ThrowableUtils")
 package com.bugsnag.android
 
 /**

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/RecursiveThrowableCauseTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/RecursiveThrowableCauseTest.kt
@@ -1,0 +1,33 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Test that delivering errors with a self-referencing cause chain does not break the reporter.
+ */
+class RecursiveThrowableCauseTest {
+    @Test(timeout = 100L)
+    fun testStrictModeHandler() {
+        val handler = StrictModeHandler()
+        val throwableChain = createRecursiveThrowableChain()
+        assertFalse(handler.isStrictModeThrowable(throwableChain))
+    }
+
+    @Test(timeout = 100L)
+    fun testCreateEvent() {
+        Error.createError(createRecursiveThrowableChain(), emptyList(), NoopLogger)
+    }
+
+    private fun createRecursiveThrowableChain(): Throwable {
+        val t1 = Throwable()
+        val t2 = Throwable()
+        val t3 = Throwable()
+
+        t1.initCause(t2)
+        t2.initCause(t3)
+        t3.initCause(t1)
+
+        return t1
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/UnrollThrowableCausesTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/UnrollThrowableCausesTest.kt
@@ -1,0 +1,50 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import java.io.IOException
+import java.lang.RuntimeException
+import java.util.concurrent.ExecutionException
+
+class UnrollThrowableCausesTest {
+    @Test
+    fun unrollSingle() {
+        val root = RuntimeException()
+        val chain = root.safeUnrollCauses()
+
+        assertEquals(1, chain.size)
+        assertSame(root, chain[0])
+    }
+
+    @Test
+    fun unrollSimple() {
+        val root = IOException()
+        val wrapper1 = RuntimeException(root)
+        val wrapper2 = ExecutionException(wrapper1)
+
+        val chain = wrapper2.safeUnrollCauses()
+        assertEquals(3, chain.size)
+        assertSame(wrapper2, chain[0])
+        assertSame(wrapper1, chain[1])
+        assertSame(root, chain[2])
+    }
+
+    @Test
+    fun unrollRecursive() {
+        val fakeRoot = IOException()
+        val wrapper1 = RuntimeException(fakeRoot)
+        val wrapper2 = ExecutionException(wrapper1)
+        val wrapper3 = ExecutionException(wrapper2)
+
+        // make it recursive
+        fakeRoot.initCause(wrapper2)
+
+        val chain = wrapper3.safeUnrollCauses()
+        assertEquals(4, chain.size)
+        assertSame(wrapper3, chain[0])
+        assertSame(wrapper2, chain[1])
+        assertSame(wrapper1, chain[2])
+        assertSame(fakeRoot, chain[3])
+    }
+}


### PR DESCRIPTION
## Goal
Avoid errors caused by Throwable.cause chains that are recursive (self-referencing).

## Design
Added a method to unroll the cause-chain into a flat List and handle any recursion. 

## Testing
Added RecursiveThrowableCauseTest to test code that previously had recursion problems, and UnrollThrowableCausesTest to test the contract of the new unroll method.