### PR TITLE
refactoring(json): added support for Date directly to ObjectJsonStreamer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Prevent errors in rare cases where either ConnectivityManager or StorageManager is not available
   [1251](https://github.com/bugsnag/bugsnag-android/pull/1251)
 
+* Added Date support to ObjectJsonStreamer
+  [1256](https://github.com/bugsnag/bugsnag-android/pull/1256)
+
 ## 5.9.2 (2021-05-12)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbInternal.kt
@@ -25,7 +25,7 @@ internal class BreadcrumbInternal internal constructor(
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {
         writer.beginObject()
-        writer.name("timestamp").value(DateUtils.toIso8601(timestamp))
+        writer.name("timestamp").value(timestamp)
         writer.name("name").value(message)
         writer.name("type").value(type.toString())
         writer.name("metaData")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceWithState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceWithState.kt
@@ -42,7 +42,7 @@ class DeviceWithState internal constructor(
         writer.name("orientation").value(orientation)
 
         if (time != null) {
-            writer.name("time").value(DateUtils.toIso8601(time!!))
+            writer.name("time").value(time)
         }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -109,7 +109,7 @@ internal class EventInternal @JvmOverloads internal constructor(
             val copy = Session.copySession(session)
             writer.name("session").beginObject()
             writer.name("id").value(copy.id)
-            writer.name("startedAt").value(DateUtils.toIso8601(copy.startedAt))
+            writer.name("startedAt").value(copy.startedAt)
             writer.name("events").beginObject()
             writer.name("handled").value(copy.handledCount.toLong())
             writer.name("unhandled").value(copy.unhandledCount.toLong())

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import java.io.IOException
 import java.lang.reflect.Array
+import java.util.Date
 
 internal class ObjectJsonStreamer {
 
@@ -21,6 +22,7 @@ internal class ObjectJsonStreamer {
             obj is Number -> writer.value(obj)
             obj is Boolean -> writer.value(obj)
             obj is JsonStream.Streamable -> obj.toStream(writer)
+            obj is Date -> writer.value(DateUtils.toIso8601(obj))
             obj is Map<*, *> -> mapToStream(writer, obj, shouldRedactKeys)
             obj is Collection<*> -> collectionToStream(writer, obj)
             obj.javaClass.isArray -> arrayToStream(writer, obj)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
@@ -232,7 +232,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
     void serializeSessionInfo(@NonNull JsonStream writer) throws IOException {
         writer.beginObject();
         writer.name("id").value(id);
-        writer.name("startedAt").value(DateUtils.toIso8601(startedAt));
+        writer.name("startedAt").value(startedAt);
         writer.name("user").value(user);
         writer.endObject();
     }


### PR DESCRIPTION
## Goal
Add Date support to our JSON serialization layer to avoid making encoding mistakes when writing serialization code

## Testing
Relied on existing tests to ensure that the format has not changed