### PR TITLE
Plat 6092/improve device data gathering performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Including bugsnag.h in C++ code will no longer cause writable-strings warnings
   [1260](https://github.com/bugsnag/bugsnag-android/pull/1260)
 
+* Small performance improvements to device and app state collection
+  [1258](https://github.com/bugsnag/bugsnag-android/pull/1258)
+
 ## 5.9.3 (2021-05-18)
 
 * Avoid unnecessary collection of Thread stacktraces

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -369,21 +369,8 @@ class SessionTracker extends BaseObservable {
         return foregroundDetector.isInForeground();
     }
 
-    //FUTURE:SM This shouldnt be here
-    @Nullable
-    Long getDurationInForegroundMs(long nowMs) {
-        long durationMs = 0;
-        long sessionStartTimeMs = lastEnteredForegroundMs.get();
-
-        Boolean inForeground = isInForeground();
-
-        if (inForeground == null) {
-            return null;
-        }
-        if (inForeground && sessionStartTimeMs != 0) {
-            durationMs = nowMs - sessionStartTimeMs;
-        }
-        return durationMs > 0 ? durationMs : 0;
+    long getLastEnteredForegroundMs() {
+        return lastEnteredForegroundMs.get();
     }
 
     @Nullable

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/AppDataCollectorForegroundTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/AppDataCollectorForegroundTest.kt
@@ -1,0 +1,92 @@
+package com.bugsnag.android
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * Test the contract for `AppWithState.inForeground` and `AppWithState.durationInForeground` as
+ * produced by `AppDataCollector.generateAppWithState`
+ */
+@RunWith(MockitoJUnitRunner::class)
+class AppDataCollectorForegroundTest {
+
+    @Mock
+    internal lateinit var appContext: Context
+
+    @Mock
+    internal lateinit var sessionTracker: SessionTracker
+
+    @Mock
+    internal lateinit var launchCrashTracker: LaunchCrashTracker
+
+    private lateinit var appDataCollector: AppDataCollector
+
+    @Before
+    fun setUp() {
+        `when`(appContext.packageName).thenReturn("test.package.name")
+
+        appDataCollector = AppDataCollector(
+            appContext,
+            null,
+            BugsnagTestUtils.generateImmutableConfig(),
+            sessionTracker,
+            null,
+            launchCrashTracker,
+            NoopLogger
+        )
+    }
+
+    /**
+     * When the app is detected "in the foreground" both properties should be populated as such
+     */
+    @Test
+    fun durationInForeground() {
+        val time = System.currentTimeMillis()
+        val lastForegroundTime = time - 1000L
+
+        `when`(sessionTracker.isInForeground).thenReturn(true)
+        `when`(sessionTracker.lastEnteredForegroundMs).thenReturn(lastForegroundTime)
+
+        val appWithState = appDataCollector.generateAppWithState()
+        assertEquals(true, appWithState.inForeground)
+        // allow for 20ms of error
+        assertTrue(
+            "Unexpected durationInForeground: ${appWithState.durationInForeground}",
+            appWithState.durationInForeground in 1000L..1020L
+        )
+
+        verify(sessionTracker, times(1)).isInForeground
+    }
+
+    /**
+     * When the app is detected "in the background", the durationInForeground should be zero (0)
+     */
+    @Test
+    fun inBackground() {
+        `when`(sessionTracker.isInForeground).thenReturn(false)
+        val appWithState = appDataCollector.generateAppWithState()
+        assertEquals(false, appWithState.inForeground)
+        assertEquals(0L, appWithState.durationInForeground)
+    }
+
+    /**
+     * When the foreground detection is not possible, both properties should be `null`
+     */
+    @Test
+    fun foregroundNotAvailable() {
+        `when`(sessionTracker.isInForeground).thenReturn(null)
+        val appWithState = appDataCollector.generateAppWithState()
+        assertNull(appWithState.inForeground)
+        assertNull(appWithState.durationInForeground)
+    }
+}


### PR DESCRIPTION
## Goal
Improve the performance of data gathering by only capturing the foreground and battery status once (where we were capturing it twice).

## Testing
Added a unit-test to cover the different possible outputs of `foregroundDuration`