### PR TITLE
fix(ndk): clearly marked read-only `char*` arguments as `const`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Including bugsnag.h in C++ code will no longer cause writable-strings warnings
+  [1260](https://github.com/bugsnag/bugsnag-android/pull/1260)
+
 ## 5.9.3 (2021-05-18)
 
 * Avoid unnecessary collection of Thread stacktraces

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/bugsnag.h
@@ -16,29 +16,38 @@ typedef bool (*bsg_on_error)(void *);
  * @param env  The JNI environment to use when using convenience methods
  */
 void bugsnag_start(JNIEnv *env);
+
 /**
  * Sends an error report to Bugsnag
  * @param name     The name of the error
  * @param message  The error message
  * @param severity The severity of the error
  */
-void bugsnag_notify(char *name, char *message, bugsnag_severity severity);
-void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
+void bugsnag_notify(const char *name, const char *message,
+                    bugsnag_severity severity);
+
+void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
                         bugsnag_severity severity);
+
 /**
  * Set the current user
  * @param id    The identifier of the user
  * @param email The user's email
  * @param name  The user's name
  */
-void bugsnag_set_user(char *id, char *email, char *name);
-void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name);
+void bugsnag_set_user(const char *id, const char *email, const char *name);
+
+void bugsnag_set_user_env(JNIEnv *env, const char *id, const char *email,
+                          const char *name);
+
 /**
  * Leave a breadcrumb, indicating an event of significance which will be logged
  * in subsequent error reports
  */
-void bugsnag_leave_breadcrumb(char *message, bugsnag_breadcrumb_type type);
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
+void bugsnag_leave_breadcrumb(const char *message,
+                              bugsnag_breadcrumb_type type);
+
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, const char *message,
                                   bugsnag_breadcrumb_type type);
 
 /**

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -91,7 +91,7 @@ char *bugsnag_event_get_api_key(void *event_ptr);
  * @param event_ptr a pointer to the event supplied in an on_error callback
  * @param value the new event api key value, which cannot be NULL
  */
-void bugsnag_event_set_api_key(void *event_ptr, char *value);
+void bugsnag_event_set_api_key(void *event_ptr, const char *value);
 
 /* Accessors for event.context */
 
@@ -107,7 +107,7 @@ char *bugsnag_event_get_context(void *event_ptr);
  * @param event_ptr a pointer to the event supplied in an on_error callback
  * @param value the new event context value, which can be NULL
  */
-void bugsnag_event_set_context(void *event_ptr, char *value);
+void bugsnag_event_set_context(void *event_ptr, const char *value);
 
 /* Accessors for event.app */
 
@@ -135,10 +135,11 @@ char *bugsnag_app_get_binary_arch(void *event_ptr);
  * @param event_ptr - a pointer to the bugsnag event
  * @param value - the new value for the binary_arch field (nullable)
  */
-void bugsnag_app_set_binary_arch(void *event_ptr, char *value);
+void bugsnag_app_set_binary_arch(void *event_ptr, const char *value);
 
 char *bugsnag_app_get_build_uuid(void *event_ptr);
-void bugsnag_app_set_build_uuid(void *event_ptr, char *value);
+
+void bugsnag_app_set_build_uuid(void *event_ptr, const char *value);
 
 time_t bugsnag_app_get_duration(void *event_ptr);
 void bugsnag_app_set_duration(void *event_ptr, time_t value);
@@ -147,7 +148,8 @@ time_t bugsnag_app_get_duration_in_foreground(void *event_ptr);
 void bugsnag_app_set_duration_in_foreground(void *event_ptr, time_t value);
 
 char *bugsnag_app_get_id(void *event_ptr);
-void bugsnag_app_set_id(void *event_ptr, char *value);
+
+void bugsnag_app_set_id(void *event_ptr, const char *value);
 
 bool bugsnag_app_get_in_foreground(void *event_ptr);
 void bugsnag_app_set_in_foreground(void *event_ptr, bool value);
@@ -156,13 +158,16 @@ bool bugsnag_app_get_is_launching(void *event_ptr);
 void bugsnag_app_set_is_launching(void *event_ptr, bool value);
 
 char *bugsnag_app_get_release_stage(void *event_ptr);
-void bugsnag_app_set_release_stage(void *event_ptr, char *value);
+
+void bugsnag_app_set_release_stage(void *event_ptr, const char *value);
 
 char *bugsnag_app_get_type(void *event_ptr);
-void bugsnag_app_set_type(void *event_ptr, char *value);
+
+void bugsnag_app_set_type(void *event_ptr, const char *value);
 
 char *bugsnag_app_get_version(void *event_ptr);
-void bugsnag_app_set_version(void *event_ptr, char *value);
+
+void bugsnag_app_set_version(void *event_ptr, const char *value);
 
 int bugsnag_app_get_version_code(void *event_ptr);
 void bugsnag_app_set_version_code(void *event_ptr, int value);
@@ -173,42 +178,52 @@ bool bugsnag_device_get_jailbroken(void *event_ptr);
 void bugsnag_device_set_jailbroken(void *event_ptr, bool value);
 
 char *bugsnag_device_get_id(void *event_ptr);
-void bugsnag_device_set_id(void *event_ptr, char *value);
+
+void bugsnag_device_set_id(void *event_ptr, const char *value);
 
 char *bugsnag_device_get_locale(void *event_ptr);
-void bugsnag_device_set_locale(void *event_ptr, char *value);
+
+void bugsnag_device_set_locale(void *event_ptr, const char *value);
 
 char *bugsnag_device_get_manufacturer(void *event_ptr);
-void bugsnag_device_set_manufacturer(void *event_ptr, char *value);
+
+void bugsnag_device_set_manufacturer(void *event_ptr, const char *value);
 
 char *bugsnag_device_get_model(void *event_ptr);
-void bugsnag_device_set_model(void *event_ptr, char *value);
+
+void bugsnag_device_set_model(void *event_ptr, const char *value);
 
 char *bugsnag_device_get_os_version(void *event_ptr);
-void bugsnag_device_set_os_version(void *event_ptr, char *value);
+
+void bugsnag_device_set_os_version(void *event_ptr, const char *value);
 
 long bugsnag_device_get_total_memory(void *event_ptr);
 void bugsnag_device_set_total_memory(void *event_ptr, long value);
 
 char *bugsnag_device_get_orientation(void *event_ptr);
-void bugsnag_device_set_orientation(void *event_ptr, char *value);
+
+void bugsnag_device_set_orientation(void *event_ptr, const char *value);
 
 time_t bugsnag_device_get_time(void *event_ptr);
 void bugsnag_device_set_time(void *event_ptr, time_t value);
 
 char *bugsnag_device_get_os_name(void *event_ptr);
-void bugsnag_device_set_os_name(void *event_ptr, char *value);
+
+void bugsnag_device_set_os_name(void *event_ptr, const char *value);
 
 /* Accessors for event.error */
 
 char *bugsnag_error_get_error_class(void *event_ptr);
-void bugsnag_error_set_error_class(void *event_ptr, char *value);
+
+void bugsnag_error_set_error_class(void *event_ptr, const char *value);
 
 char *bugsnag_error_get_error_message(void *event_ptr);
-void bugsnag_error_set_error_message(void *event_ptr, char *value);
+
+void bugsnag_error_set_error_message(void *event_ptr, const char *value);
 
 char *bugsnag_error_get_error_type(void *event_ptr);
-void bugsnag_error_set_error_type(void *event_ptr, char *value);
+
+void bugsnag_error_set_error_type(void *event_ptr, const char *value);
 
 /* Accessors for event.user */
 
@@ -225,7 +240,9 @@ void bugsnag_error_set_error_type(void *event_ptr, char *value);
  * @return the user in the event, represented as a struct
  */
 bugsnag_user bugsnag_event_get_user(void *event_ptr);
-void bugsnag_event_set_user(void *event_ptr, char *id, char *email, char *name);
+
+void bugsnag_event_set_user(void *event_ptr, const char *id, const char *email,
+                            const char *name);
 
 /* Accessors for event.severity */
 
@@ -263,19 +280,24 @@ void bugsnag_event_set_unhandled(void *event_ptr, bool value);
 /* Accessors for event.groupingHash */
 
 char *bugsnag_event_get_grouping_hash(void *event_ptr);
-void bugsnag_event_set_grouping_hash(void *event_ptr, char *value);
+
+void bugsnag_event_set_grouping_hash(void *event_ptr, const char *value);
 
 /* Accessors for event.metadata */
 
-void bugsnag_event_add_metadata_double(void *event_ptr, char *section,
-                                       char *name, double value);
-void bugsnag_event_add_metadata_string(void *event_ptr, char *section,
-                                       char *name, char *value);
-void bugsnag_event_add_metadata_bool(void *event_ptr, char *section, char *name,
-                                     bool value);
+void bugsnag_event_add_metadata_double(void *event_ptr, const char *section,
+                                       const char *name, double value);
 
-void bugsnag_event_clear_metadata_section(void *event_ptr, char *section);
-void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name);
+void bugsnag_event_add_metadata_string(void *event_ptr, const char *section,
+                                       const char *name, const char *value);
+
+void bugsnag_event_add_metadata_bool(void *event_ptr, const char *section,
+                                     const char *name, bool value);
+
+void bugsnag_event_clear_metadata_section(void *event_ptr, const char *section);
+
+void bugsnag_event_clear_metadata(void *event_ptr, const char *section,
+                                  const char *name);
 
 /**
  * Retrieves the metadata type for a given section and key in this event.
@@ -299,8 +321,9 @@ void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name);
  * @return the type of the metadata, or BSG_METADATA_NONE_VALUE if no value
  * exists
  */
-bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr, char *section,
-                                                 char *name);
+bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr,
+                                                 const char *section,
+                                                 const char *name);
 
 /**
  * Retrieves the metadata value for a given section and key in this event.
@@ -319,16 +342,19 @@ bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr, char *section,
  * @param name - the metadata section name
  * @param value - the value to set on the given key/name
  */
-double bugsnag_event_get_metadata_double(void *event_ptr, char *section,
-                                         char *name);
-char *bugsnag_event_get_metadata_string(void *event_ptr, char *section,
-                                        char *name);
-bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section,
-                                     char *name);
+double bugsnag_event_get_metadata_double(void *event_ptr, const char *section,
+                                         const char *name);
+
+char *bugsnag_event_get_metadata_string(void *event_ptr, const char *section,
+                                        const char *name);
+
+bool bugsnag_event_get_metadata_bool(void *event_ptr, const char *section,
+                                     const char *name);
 
 /* Accessors for event.error.stacktrace */
 
 int bugsnag_event_get_stacktrace_size(void *event_ptr);
+
 bugsnag_stackframe *bugsnag_event_get_stackframe(void *event_ptr, int index);
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -18,13 +18,17 @@ void bugsnag_set_binary_arch(JNIEnv *env);
 
 void bugsnag_start(JNIEnv *env) { bsg_global_jni_env = env; }
 
-void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
+void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
                         bugsnag_severity severity);
-void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name);
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
+
+void bugsnag_set_user_env(JNIEnv *env, const char *id, const char *email,
+                          const char *name);
+
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, const char *message,
                                   bugsnag_breadcrumb_type type);
 
-void bugsnag_notify(char *name, char *message, bugsnag_severity severity) {
+void bugsnag_notify(const char *name, const char *message,
+                    bugsnag_severity severity) {
   if (bsg_global_jni_env != NULL) {
     bugsnag_notify_env(bsg_global_jni_env, name, message, severity);
   } else {
@@ -32,7 +36,7 @@ void bugsnag_notify(char *name, char *message, bugsnag_severity severity) {
   }
 }
 
-void bugsnag_set_user(char *id, char *email, char *name) {
+void bugsnag_set_user(const char *id, const char *email, const char *name) {
   if (bsg_global_jni_env != NULL) {
     bugsnag_set_user_env(bsg_global_jni_env, id, email, name);
   } else {
@@ -41,7 +45,8 @@ void bugsnag_set_user(char *id, char *email, char *name) {
   }
 }
 
-void bugsnag_leave_breadcrumb(char *message, bugsnag_breadcrumb_type type) {
+void bugsnag_leave_breadcrumb(const char *message,
+                              bugsnag_breadcrumb_type type) {
   if (bsg_global_jni_env != NULL) {
     bugsnag_leave_breadcrumb_env(bsg_global_jni_env, message, type);
   } else {
@@ -106,7 +111,7 @@ void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
   }
 }
 
-void bugsnag_notify_env(JNIEnv *env, char *name, char *message,
+void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
                         bugsnag_severity severity) {
   jclass interface_class = NULL;
   jmethodID notify_method = NULL;
@@ -241,7 +246,8 @@ exit:
   bsg_safe_delete_local_ref(env, interface_class);
 }
 
-void bugsnag_set_user_env(JNIEnv *env, char *id, char *email, char *name) {
+void bugsnag_set_user_env(JNIEnv *env, const char *id, const char *email,
+                          const char *name) {
   // lookup com/bugsnag/android/NativeInterface
   jclass interface_class = NULL;
   jmethodID set_user_method = NULL;
@@ -303,7 +309,7 @@ jfieldID bsg_parse_jcrumb_type(JNIEnv *env, bugsnag_breadcrumb_type type,
   }
 }
 
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, char *message,
+void bugsnag_leave_breadcrumb_env(JNIEnv *env, const char *message,
                                   bugsnag_breadcrumb_type type) {
   jclass interface_class = NULL;
   jmethodID leave_breadcrumb_method = NULL;

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -61,25 +61,26 @@ void bsg_add_metadata_value_bool(bugsnag_metadata *metadata,
   }
 }
 
-void bugsnag_event_add_metadata_double(void *event_ptr, char *section,
-                                       char *name, double value) {
+void bugsnag_event_add_metadata_double(void *event_ptr, const char *section,
+                                       const char *name, double value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_add_metadata_value_double(&event->metadata, section, name, value);
 }
 
-void bugsnag_event_add_metadata_string(void *event_ptr, char *section,
-                                       char *name, char *value) {
+void bugsnag_event_add_metadata_string(void *event_ptr, const char *section,
+                                       const char *name, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_add_metadata_value_str(&event->metadata, section, name, value);
 }
 
-void bugsnag_event_add_metadata_bool(void *event_ptr, char *section, char *name,
-                                     bool value) {
+void bugsnag_event_add_metadata_bool(void *event_ptr, const char *section,
+                                     const char *name, bool value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_add_metadata_value_bool(&event->metadata, section, name, value);
 }
 
-void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name) {
+void bugsnag_event_clear_metadata(void *event_ptr, const char *section,
+                                  const char *name) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   for (int i = 0; i < event->metadata.value_count; ++i) {
     if (strcmp(event->metadata.values[i].section, section) == 0 &&
@@ -95,7 +96,8 @@ void bugsnag_event_clear_metadata(void *event_ptr, char *section, char *name) {
   }
 }
 
-void bugsnag_event_clear_metadata_section(void *event_ptr, char *section) {
+void bugsnag_event_clear_metadata_section(void *event_ptr,
+                                          const char *section) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   for (int i = 0; i < event->metadata.value_count; ++i) {
     if (strcmp(event->metadata.values[i].section, section) == 0) {
@@ -104,8 +106,9 @@ void bugsnag_event_clear_metadata_section(void *event_ptr, char *section) {
   }
 }
 
-bsg_metadata_value bugsnag_get_metadata_value(void *event_ptr, char *section,
-                                              char *name) {
+bsg_metadata_value bugsnag_get_metadata_value(void *event_ptr,
+                                              const char *section,
+                                              const char *name) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
 
   for (int k = 0; k < event->metadata.value_count; ++k) {
@@ -119,13 +122,14 @@ bsg_metadata_value bugsnag_get_metadata_value(void *event_ptr, char *section,
   return data;
 }
 
-bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr, char *section,
-                                                 char *name) {
+bugsnag_metadata_type bugsnag_event_has_metadata(void *event_ptr,
+                                                 const char *section,
+                                                 const char *name) {
   return bugsnag_get_metadata_value(event_ptr, section, name).type;
 }
 
-double bugsnag_event_get_metadata_double(void *event_ptr, char *section,
-                                         char *name) {
+double bugsnag_event_get_metadata_double(void *event_ptr, const char *section,
+                                         const char *name) {
   bsg_metadata_value value =
       bugsnag_get_metadata_value(event_ptr, section, name);
 
@@ -135,8 +139,8 @@ double bugsnag_event_get_metadata_double(void *event_ptr, char *section,
   return 0.0;
 }
 
-char *bugsnag_event_get_metadata_string(void *event_ptr, char *section,
-                                        char *name) {
+char *bugsnag_event_get_metadata_string(void *event_ptr, const char *section,
+                                        const char *name) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
 
   for (int k = 0; k < event->metadata.value_count; ++k) {
@@ -148,8 +152,8 @@ char *bugsnag_event_get_metadata_string(void *event_ptr, char *section,
   return NULL;
 }
 
-bool bugsnag_event_get_metadata_bool(void *event_ptr, char *section,
-                                     char *name) {
+bool bugsnag_event_get_metadata_bool(void *event_ptr, const char *section,
+                                     const char *name) {
   bsg_metadata_value value =
       bugsnag_get_metadata_value(event_ptr, section, name);
 
@@ -174,7 +178,7 @@ char *bugsnag_event_get_api_key(void *event_ptr) {
   return event->api_key;
 }
 
-void bugsnag_event_set_api_key(void *event_ptr, char *value) {
+void bugsnag_event_set_api_key(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->api_key, value, sizeof(event->api_key));
 }
@@ -184,13 +188,13 @@ char *bugsnag_event_get_context(void *event_ptr) {
   return event->context;
 }
 
-void bugsnag_event_set_context(void *event_ptr, char *value) {
+void bugsnag_event_set_context(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->context, value, sizeof(event->context));
 }
 
-void bugsnag_event_set_user(void *event_ptr, char *id, char *email,
-                            char *name) {
+void bugsnag_event_set_user(void *event_ptr, const char *id, const char *email,
+                            const char *name) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->user.id, id, sizeof(event->user.id));
   bsg_strncpy_safe(event->user.email, email, sizeof(event->user.email));
@@ -227,7 +231,7 @@ char *bugsnag_app_get_binary_arch(void *event_ptr) {
   return event->app.binary_arch;
 }
 
-void bugsnag_app_set_binary_arch(void *event_ptr, char *value) {
+void bugsnag_app_set_binary_arch(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.binary_arch, value,
                    sizeof(event->app.binary_arch));
@@ -238,7 +242,7 @@ char *bugsnag_app_get_build_uuid(void *event_ptr) {
   return event->app.build_uuid;
 }
 
-void bugsnag_app_set_build_uuid(void *event_ptr, char *value) {
+void bugsnag_app_set_build_uuid(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.build_uuid, value, sizeof(event->app.build_uuid));
 }
@@ -248,7 +252,7 @@ char *bugsnag_app_get_id(void *event_ptr) {
   return event->app.id;
 }
 
-void bugsnag_app_set_id(void *event_ptr, char *value) {
+void bugsnag_app_set_id(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.id, value, sizeof(event->app.id));
 }
@@ -258,7 +262,7 @@ char *bugsnag_app_get_release_stage(void *event_ptr) {
   return event->app.release_stage;
 }
 
-void bugsnag_app_set_release_stage(void *event_ptr, char *value) {
+void bugsnag_app_set_release_stage(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.release_stage, value,
                    sizeof(event->app.release_stage));
@@ -269,7 +273,7 @@ char *bugsnag_app_get_type(void *event_ptr) {
   return event->app.type;
 }
 
-void bugsnag_app_set_type(void *event_ptr, char *value) {
+void bugsnag_app_set_type(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.type, value, sizeof(event->app.type));
 }
@@ -279,7 +283,7 @@ char *bugsnag_app_get_version(void *event_ptr) {
   return event->app.version;
 }
 
-void bugsnag_app_set_version(void *event_ptr, char *value) {
+void bugsnag_app_set_version(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->app.version, value, sizeof(event->app.version));
 }
@@ -351,7 +355,7 @@ char *bugsnag_device_get_id(void *event_ptr) {
   return event->device.id;
 }
 
-void bugsnag_device_set_id(void *event_ptr, char *value) {
+void bugsnag_device_set_id(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.id, value, sizeof(event->device.id));
 }
@@ -361,7 +365,7 @@ char *bugsnag_device_get_locale(void *event_ptr) {
   return event->device.locale;
 }
 
-void bugsnag_device_set_locale(void *event_ptr, char *value) {
+void bugsnag_device_set_locale(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.locale, value, sizeof(event->device.locale));
 }
@@ -371,7 +375,7 @@ char *bugsnag_device_get_manufacturer(void *event_ptr) {
   return event->device.manufacturer;
 }
 
-void bugsnag_device_set_manufacturer(void *event_ptr, char *value) {
+void bugsnag_device_set_manufacturer(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.manufacturer, value,
                    sizeof(event->device.manufacturer));
@@ -382,7 +386,7 @@ char *bugsnag_device_get_model(void *event_ptr) {
   return event->device.model;
 }
 
-void bugsnag_device_set_model(void *event_ptr, char *value) {
+void bugsnag_device_set_model(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.model, value, sizeof(event->device.model));
 }
@@ -392,7 +396,7 @@ char *bugsnag_device_get_os_version(void *event_ptr) {
   return event->device.os_version;
 }
 
-void bugsnag_device_set_os_version(void *event_ptr, char *value) {
+void bugsnag_device_set_os_version(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.os_version, value,
                    sizeof(event->device.os_version));
@@ -413,7 +417,7 @@ char *bugsnag_device_get_orientation(void *event_ptr) {
   return event->device.orientation;
 }
 
-void bugsnag_device_set_orientation(void *event_ptr, char *value) {
+void bugsnag_device_set_orientation(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.orientation, value,
                    sizeof(event->device.orientation));
@@ -434,7 +438,7 @@ char *bugsnag_device_get_os_name(void *event_ptr) {
   return event->device.os_name;
 }
 
-void bugsnag_device_set_os_name(void *event_ptr, char *value) {
+void bugsnag_device_set_os_name(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->device.os_name, value, sizeof(event->device.os_name));
 }
@@ -444,7 +448,7 @@ char *bugsnag_error_get_error_class(void *event_ptr) {
   return event->error.errorClass;
 }
 
-void bugsnag_error_set_error_class(void *event_ptr, char *value) {
+void bugsnag_error_set_error_class(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->error.errorClass, value,
                    sizeof(event->error.errorClass));
@@ -455,7 +459,7 @@ char *bugsnag_error_get_error_message(void *event_ptr) {
   return event->error.errorMessage;
 }
 
-void bugsnag_error_set_error_message(void *event_ptr, char *value) {
+void bugsnag_error_set_error_message(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->error.errorMessage, value,
                    sizeof(event->error.errorMessage));
@@ -466,7 +470,7 @@ char *bugsnag_error_get_error_type(void *event_ptr) {
   return event->error.type;
 }
 
-void bugsnag_error_set_error_type(void *event_ptr, char *value) {
+void bugsnag_error_set_error_type(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->error.type, value, sizeof(event->error.type));
 }
@@ -501,7 +505,7 @@ char *bugsnag_event_get_grouping_hash(void *event_ptr) {
   return event->grouping_hash;
 }
 
-void bugsnag_event_set_grouping_hash(void *event_ptr, char *value) {
+void bugsnag_event_set_grouping_hash(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
   bsg_strncpy_safe(event->grouping_hash, value, sizeof(event->grouping_hash));
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -3,9 +3,9 @@
 #include <stdbool.h>
 #include <string.h>
 
-void bsg_strcpy(char *dst, char *src) { bsg_strncpy(dst, src, INT_MAX); }
+void bsg_strcpy(char *dst, const char *src) { bsg_strncpy(dst, src, INT_MAX); }
 
-void bsg_strncpy(char *dst, char *src, size_t len) {
+void bsg_strncpy(char *dst, const char *src, size_t len) {
   int i = 0;
   while (i <= len) {
     char current = src[i];

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -11,7 +11,7 @@ extern "C" {
 /**
  * Copy the contents of src to dst where src is null-terminated
  */
-void bsg_strcpy(char *dst, char *src) __asyncsafe;
+void bsg_strcpy(char *dst, const char *src) __asyncsafe;
 
 /**
  * Return the length of a string
@@ -21,7 +21,7 @@ size_t bsg_strlen(const char *str) __asyncsafe;
 /**
  * Copy a maximum number of bytes from src to dst
  */
-void bsg_strncpy(char *dst, char *src, size_t len) __asyncsafe;
+void bsg_strncpy(char *dst, const char *src, size_t len) __asyncsafe;
 
 /**
  * Copy a string from src to dst, null padding the rest


### PR DESCRIPTION
## Goal
Fix the warnings emitted from the C++ compiler related to writable strings:
```
ISO C++11 does not allow conversion from string literal to 'char *'
```

## Testing
Relied on existing testing