### PR TITLE
fix: relay onLowMemory events to client Observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Small performance improvements to device and app state collection
   [1258](https://github.com/bugsnag/bugsnag-android/pull/1258)
 
+* NDK: lowMemory attribute is now reported as expected
+  [1262](https://github.com/bugsnag/bugsnag-android/pull/1262)
+
 ## 5.9.3 (2021-05-18)
 
 * Avoid unnecessary collection of Thread stacktraces

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/MemoryTrimTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/MemoryTrimTest.java
@@ -1,0 +1,62 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bugsnag.android.ObserverInterfaceTest.BugsnagTestObserver;
+
+import android.content.ComponentCallbacks;
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Heavily mocked test to ensure that onLowMemory events are distributed to Client Observers
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MemoryTrimTest {
+
+    @Spy
+    Context context = ApplicationProvider.getApplicationContext();
+
+    @Captor
+    ArgumentCaptor<ComponentCallbacks> componentCallbacksCaptor;
+
+    @Test
+    public void onLowMemoryEvent() {
+        when(context.getApplicationContext()).thenReturn(context);
+        Client client = new Client(context, BugsnagTestUtils.generateConfiguration());
+
+        // capture the registered ComponentCallbacks
+        verify(context, times(1)).registerComponentCallbacks(componentCallbacksCaptor.capture());
+
+        BugsnagTestObserver observer = new BugsnagTestObserver();
+        client.registerObserver(observer);
+
+        ComponentCallbacks callbacks = componentCallbacksCaptor.getValue();
+        callbacks.onLowMemory();
+
+        assertEquals(1, observer.observed.size());
+        Object observedEvent = observer.observed.get(0);
+
+        assertTrue(
+                "observed event should be UpdateMemoryTrimEvent",
+                observedEvent instanceof StateEvent.UpdateMemoryTrimEvent
+        );
+
+        assertTrue(
+                "observed event should be marked isLowMemory",
+                ((StateEvent.UpdateMemoryTrimEvent) observedEvent).isLowMemory()
+        );
+    }
+
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -207,7 +207,7 @@ public class ObserverInterfaceTest {
     }
 
     static class BugsnagTestObserver implements Observer {
-        private final ArrayList<Object> observed;
+        final ArrayList<Object> observed;
 
         BugsnagTestObserver() {
             observed = new ArrayList<>(4);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -19,6 +19,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import kotlin.Unit;
+import kotlin.jvm.functions.Function1;
 import kotlin.jvm.functions.Function2;
 
 import java.util.ArrayList;
@@ -224,6 +225,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         systemBroadcastReceiver = SystemBroadcastReceiver.register(this, logger, bgTaskService);
 
         registerOrientationChangeListener();
+        registerMemoryTrimListener();
 
         // load last run info
         lastRunInfoStore = new LastRunInfoStore(immutableConfig);
@@ -355,6 +357,18 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 }
         );
         ContextExtensionsKt.registerReceiverSafe(appContext, receiver, configFilter, logger);
+    }
+
+    private void registerMemoryTrimListener() {
+        appContext.registerComponentCallbacks(new ClientComponentCallbacks(
+                new Function1<Boolean, Unit>() {
+                    @Override
+                    public Unit invoke(Boolean isLowMemory) {
+                        clientObservable.postMemoryTrimEvent(isLowMemory);
+                        return null;
+                    }
+                }
+        ));
     }
 
     void setupNdkPlugin() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientComponentCallbacks.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientComponentCallbacks.kt
@@ -1,0 +1,14 @@
+package com.bugsnag.android
+
+import android.content.ComponentCallbacks
+import android.content.res.Configuration
+
+internal class ClientComponentCallbacks(
+    val callback: (Boolean) -> Unit
+) : ComponentCallbacks {
+    override fun onConfigurationChanged(newConfig: Configuration) {}
+
+    override fun onLowMemory() {
+        callback(true)
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
@@ -6,6 +6,10 @@ internal class ClientObservable : BaseObservable() {
         notifyObservers(StateEvent.UpdateOrientation(orientation))
     }
 
+    fun postMemoryTrimEvent(isLowMemory: Boolean) {
+        notifyObservers(StateEvent.UpdateMemoryTrimEvent(isLowMemory))
+    }
+
     fun postNdkInstall(conf: ImmutableConfig, lastRunInfoPath: String, consecutiveLaunchCrashes: Int) {
         notifyObservers(
             StateEvent.Install(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
@@ -42,4 +42,6 @@ sealed class StateEvent {
     class UpdateOrientation(val orientation: String?) : StateEvent()
 
     class UpdateUser(val user: User) : StateEvent()
+
+    class UpdateMemoryTrimEvent(val isLowMemory: Boolean) : StateEvent()
 }

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -80,6 +80,7 @@ class NativeBridge : Observer {
     external fun updateUserEmail(newValue: String)
     external fun updateUserName(newValue: String)
     external fun getUnwindStackFunction(): Long
+    external fun updateLowMemory(newValue: Boolean)
 
     /**
      * Creates a new native bridge for interacting with native components.
@@ -134,6 +135,7 @@ class NativeBridge : Observer {
                 updateUserName(makeSafe(msg.user.name ?: ""))
                 updateUserEmail(makeSafe(msg.user.email ?: ""))
             }
+            is StateEvent.UpdateMemoryTrimEvent -> updateLowMemory(msg.isLowMemory)
         }
     }
 


### PR DESCRIPTION
## Goal
Relay onLowMemory events to the NDK layer through the client Observable so that it will be included in all NDK reports.

## Testing
Included a heavily mocked unit test to ensure that the events are relayed to the client Observables. This task also requires manual testing.