### PR TITLE
fix(ndk): link directly to liblog without find_library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 * NDK: lowMemory attribute is now reported as expected
   [1262](https://github.com/bugsnag/bugsnag-android/pull/1262)
+  
+* Don't include loglog.so in ndk plugin builds performed on Linux
+  [1263](https://github.com/bugsnag/bugsnag-android/pull/1263)
 
 ## 5.9.3 (2021-05-18)
 

--- a/bugsnag-plugin-android-anr/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-anr/src/main/CMakeLists.txt
@@ -12,17 +12,10 @@ add_library( # Specifies the name of the library.
 
 include_directories(jni)
 
-find_library( # Defines the name of the path variable that stores the
-              # location of the NDK library.
-              log-lib
-              # Specifies the name of the NDK library that
-              # CMake needs to locate.
-              log )
-
 target_link_libraries( # Specifies the target library.
                      bugsnag-plugin-android-anr
                      # Links the log library to the target library.
-                     ${log-lib})
+                     log)
 
 set_target_properties(bugsnag-plugin-android-anr
                       PROPERTIES

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -33,19 +33,10 @@ include_directories(
 
 target_include_directories(bugsnag-ndk PRIVATE ${BUGSNAG_DIR}/assets/include)
 
-find_library( # Defines the name of the path variable that stores the
-              # location of the NDK library.
-              log-lib
-
-              # Specifies the name of the NDK library that
-              # CMake needs to locate.
-              log )
-
 target_link_libraries( # Specifies the target library.
                      bugsnag-ndk
-
                      # Links the log library to the target library.
-                     ${log-lib})
+                     log)
 
 set_target_properties(bugsnag-ndk
                       PROPERTIES


### PR DESCRIPTION
## Goal
Stop including the `liblog.so` file in the `aar` files during a build on Linux.

## Testing
Affects the build process and has been checked on MacOS and Linux