### PR TITLE
PLAT-6620: Do not shut down ANR thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Unity: Properly handle ANRs after multiple calls to autoNotify and autoDetectAnrs
+  [#1265](https://github.com/bugsnag/bugsnag-android/pull/1265)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/features/full_tests/batch_1/auto_notify.feature
+++ b/features/full_tests/batch_1/auto_notify.feature
@@ -48,20 +48,20 @@ Scenario: NDK signal captured with autoNotify reenabled
     And the event "severityReason.unhandledOverridden" is false
 
 # PLAT-6620
-# @skip_android_8_1
-# Scenario: ANR captured with autoDetectAnrs reenabled
-#     When I run "AutoDetectAnrsTrueScenario"
-#     And I wait for 2 seconds
-#     And I tap the screen 3 times
-#     And I wait for 4 seconds
-#     And I clear any error dialogue
-#     And I wait to receive an error
-#     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-#     And the error payload field "events" is an array with 1 elements
-#     And the exception "errorClass" equals "ANR"
-#     And the exception "message" starts with " Input dispatching timed out"
-#     And the exception "type" equals "android"
-#     And the event "unhandled" is true
-#     And the event "severity" equals "error"
-#     And the event "severityReason.type" equals "anrError"
-#     And the event "severityReason.unhandledOverridden" is false
+@skip_android_8_1
+Scenario: ANR captured with autoDetectAnrs reenabled
+    When I run "AutoDetectAnrsTrueScenario"
+    And I wait for 2 seconds
+    And I tap the screen 3 times
+    And I wait for 4 seconds
+    And I clear any error dialogue
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "ANR"
+    And the exception "message" starts with " Input dispatching timed out"
+    And the exception "type" equals "android"
+    And the event "unhandled" is true
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "anrError"
+    And the event "severityReason.unhandledOverridden" is false


### PR DESCRIPTION
## Goal

https://github.com/bugsnag/bugsnag-android/commit/54130ee7739498ce54d85cd095826c098d20ba51 was incomplete because some old trigger code was left in `bsg_handler_uninstall_anr()`, which could trigger a double-report if called in quick succession (as happened in the e2e tests). Also, Google ANR reporting was incorrectly gated on the `enabled` flag.

## Design

In the revised ANR system:

- Installing the ANR handler starts a monitoring thread that waits on a semaphore, triggers the Google ANR handler thread, triggers Bugsnag ANR handling (if enabled), and then resets everything to run again. This thread remains until app termination (so that we can detect multiple ANRs).
- Enabling/disabling ANR handling only changes the `enabled` flag. `SIGQUIT` processing still happens in the Bugsnag handler and gets forwarded to the Google ANR handler regardless, but the Bugsnag ANR processing only happens if `enabled` is true.

## Testing

Re-enabled the ANR enable/disable e2e test. Re-ran e2e tests multiple times locally to ensure passing wasn't a fluke.
