### PR TITLE
Optimize implementation of internal state change observers

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -84,21 +84,6 @@ steps:
     concurrency: 9
     concurrency_group: 'browserstack-app'
 
-  - label: ':android: Performance benchmarks'
-    key: 'perf-benchmarks'
-    depends_on:
-      - "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.7.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-      TEST_APK_LOCATION: 'bugsnag-benchmarks/build/outputs/apk/androidTest/release/bugsnag-benchmarks-release-androidTest.apk'
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-
   - label: ':android: Android 5 NDK r16 end-to-end tests - batch 1'
     depends_on:
       - "fixture-r16"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Optimize execution of callbacks
   [#1276](https://github.com/bugsnag/bugsnag-android/pull/1276)
 
+* Optimize implementation of internal state change observers
+  [#1274](https://github.com/bugsnag/bugsnag-android/pull/1274)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/MemoryTrimTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/MemoryTrimTest.java
@@ -40,7 +40,7 @@ public class MemoryTrimTest {
         verify(context, times(1)).registerComponentCallbacks(componentCallbacksCaptor.capture());
 
         BugsnagTestObserver observer = new BugsnagTestObserver();
-        client.registerObserver(observer);
+        client.addObserver(observer);
 
         ComponentCallbacks callbacks = componentCallbacksCaptor.getValue();
         callbacks.onLowMemory();

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -8,10 +8,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.bugsnag.android.internal.StateObserver;
+
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SmallTest;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,8 +22,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Observable;
-import java.util.Observer;
 import java.util.Set;
 
 @SmallTest
@@ -47,7 +48,7 @@ public class ObserverInterfaceTest {
         config.addMetadata("foo", "bar", true);
         client = new Client(ApplicationProvider.getApplicationContext(), config);
         observer = new BugsnagTestObserver();
-        client.registerObserver(observer);
+        client.addObserver(observer);
     }
 
     @After
@@ -206,7 +207,7 @@ public class ObserverInterfaceTest {
         throw new RuntimeException("Failed to find StateEvent message " + argClass.getSimpleName());
     }
 
-    static class BugsnagTestObserver implements Observer {
+    static class BugsnagTestObserver implements StateObserver {
         final ArrayList<Object> observed;
 
         BugsnagTestObserver() {
@@ -214,8 +215,8 @@ public class ObserverInterfaceTest {
         }
 
         @Override
-        public void update(Observable observable, Object arg) {
-            observed.add(arg);
+        public void onStateChange(@NotNull StateEvent event) {
+            observed.add(event);
         }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BaseObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BaseObservable.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 
 internal open class BaseObservable {
 
-    private val observers = CopyOnWriteArrayList<StateObserver>()
+    internal val observers = CopyOnWriteArrayList<StateObserver>()
 
     /**
      * Adds an observer that can react to [StateEvent] messages.
@@ -26,7 +26,7 @@ internal open class BaseObservable {
      * has been set, it will be notified of the [StateEvent] message so that it can react
      * appropriately. If no observer has been set then this method will no-op.
      */
-    fun updateState(provider: () -> StateEvent) {
+    internal inline fun updateState(provider: () -> StateEvent) {
         // optimization to avoid unnecessary iterator and StateEvent construction
         if (observers.isEmpty()) {
             return
@@ -36,4 +36,11 @@ internal open class BaseObservable {
         val event = provider()
         observers.forEach { it.onStateChange(event) }
     }
+
+    /**
+     * An eager version of [updateState], which is intended primarily for use in Java code.
+     * If the event will occur very frequently, you should consider calling the lazy method
+     * instead.
+     */
+    fun updateState(event: StateEvent) = updateState { event }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BaseObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BaseObservable.kt
@@ -1,10 +1,39 @@
 package com.bugsnag.android
 
-import java.util.Observable
+import com.bugsnag.android.internal.StateObserver
+import java.util.concurrent.CopyOnWriteArrayList
 
-internal open class BaseObservable : Observable() {
-    fun notifyObservers(event: StateEvent) {
-        setChanged()
-        super.notifyObservers(event)
+internal open class BaseObservable {
+
+    private val observers = CopyOnWriteArrayList<StateObserver>()
+
+    /**
+     * Adds an observer that can react to [StateEvent] messages.
+     */
+    fun addObserver(observer: StateObserver) {
+        observers.addIfAbsent(observer)
+    }
+
+    /**
+     * Removes a previously added observer that reacts to [StateEvent] messages.
+     */
+    fun removeObserver(observer: StateObserver) {
+        observers.remove(observer)
+    }
+
+    /**
+     * This method should be invoked when the notifier's state has changed. If an observer
+     * has been set, it will be notified of the [StateEvent] message so that it can react
+     * appropriately. If no observer has been set then this method will no-op.
+     */
+    fun updateState(provider: () -> StateEvent) {
+        // optimization to avoid unnecessary iterator and StateEvent construction
+        if (observers.isEmpty()) {
+            return
+        }
+
+        // construct the StateEvent object and notify observers
+        val event = provider()
+        observers.forEach { it.onStateChange(event) }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -36,14 +36,15 @@ internal class BreadcrumbState(
 
         store.add(breadcrumb)
         pruneBreadcrumbs()
-        notifyObservers(
+
+        updateState {
             StateEvent.AddBreadcrumb(
                 breadcrumb.message,
                 breadcrumb.type,
                 DateUtils.toIso8601(breadcrumb.timestamp),
                 breadcrumb.metadata ?: mutableMapOf()
             )
-        )
+        }
     }
 
     private fun pruneBreadcrumbs() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -5,6 +5,8 @@ import static com.bugsnag.android.ContextExtensionsKt.getStorageManagerFrom;
 import static com.bugsnag.android.ImmutableConfigKt.sanitiseConfiguration;
 import static com.bugsnag.android.SeverityReason.REASON_HANDLED_EXCEPTION;
 
+import com.bugsnag.android.internal.StateObserver;
+
 import android.app.ActivityManager;
 import android.app.Application;
 import android.content.Context;
@@ -28,7 +30,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Observer;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -379,7 +380,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         clientObservable.postNdkDeliverPending();
     }
 
-    void registerObserver(Observer observer) {
+    void addObserver(StateObserver observer) {
         metadataState.addObserver(observer);
         breadcrumbState.addObserver(observer);
         sessionTracker.addObserver(observer);
@@ -390,15 +391,15 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         launchCrashTracker.addObserver(observer);
     }
 
-    void unregisterObserver(Observer observer) {
-        metadataState.deleteObserver(observer);
-        breadcrumbState.deleteObserver(observer);
-        sessionTracker.deleteObserver(observer);
-        clientObservable.deleteObserver(observer);
-        userState.deleteObserver(observer);
-        contextState.deleteObserver(observer);
-        deliveryDelegate.deleteObserver(observer);
-        launchCrashTracker.deleteObserver(observer);
+    void removeObserver(StateObserver observer) {
+        metadataState.removeObserver(observer);
+        breadcrumbState.removeObserver(observer);
+        sessionTracker.removeObserver(observer);
+        clientObservable.removeObserver(observer);
+        userState.removeObserver(observer);
+        contextState.removeObserver(observer);
+        deliveryDelegate.removeObserver(observer);
+        launchCrashTracker.removeObserver(observer);
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
@@ -3,15 +3,19 @@ package com.bugsnag.android
 internal class ClientObservable : BaseObservable() {
 
     fun postOrientationChange(orientation: String?) {
-        notifyObservers(StateEvent.UpdateOrientation(orientation))
+        updateState { StateEvent.UpdateOrientation(orientation) }
     }
 
     fun postMemoryTrimEvent(isLowMemory: Boolean) {
-        notifyObservers(StateEvent.UpdateMemoryTrimEvent(isLowMemory))
+        updateState { StateEvent.UpdateMemoryTrimEvent(isLowMemory) }
     }
 
-    fun postNdkInstall(conf: ImmutableConfig, lastRunInfoPath: String, consecutiveLaunchCrashes: Int) {
-        notifyObservers(
+    fun postNdkInstall(
+        conf: ImmutableConfig,
+        lastRunInfoPath: String,
+        consecutiveLaunchCrashes: Int
+    ) {
+        updateState {
             StateEvent.Install(
                 conf.apiKey,
                 conf.enabledErrorTypes.ndkCrashes,
@@ -21,10 +25,10 @@ internal class ClientObservable : BaseObservable() {
                 lastRunInfoPath,
                 consecutiveLaunchCrashes
             )
-        )
+        }
     }
 
     fun postNdkDeliverPending() {
-        notifyObservers(StateEvent.DeliverPending)
+        updateState { StateEvent.DeliverPending }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ContextState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ContextState.kt
@@ -7,7 +7,7 @@ internal class ContextState(context: String? = null) : BaseObservable() {
             emitObservableEvent()
         }
 
-    fun emitObservableEvent() = notifyObservers(StateEvent.UpdateContext(context))
+    fun emitObservableEvent() = updateState { StateEvent.UpdateContext(context) }
 
     fun copy() = ContextState(context)
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -46,20 +46,10 @@ class DeliveryDelegate extends BaseObservable {
         if (session != null) {
             if (event.isUnhandled()) {
                 event.setSession(session.incrementUnhandledAndCopy());
-                updateState(new Function0<StateEvent>() {
-                    @Override
-                    public StateEvent invoke() {
-                        return StateEvent.NotifyUnhandled.INSTANCE;
-                    }
-                });
+                updateState(StateEvent.NotifyUnhandled.INSTANCE);
             } else {
                 event.setSession(session.incrementHandledAndCopy());
-                updateState(new Function0<StateEvent>() {
-                    @Override
-                    public StateEvent invoke() {
-                        return StateEvent.NotifyHandled.INSTANCE;
-                    }
-                });
+                updateState(StateEvent.NotifyHandled.INSTANCE);
             }
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -5,6 +5,8 @@ import static com.bugsnag.android.SeverityReason.REASON_PROMISE_REJECTION;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
+import kotlin.jvm.functions.Function0;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -44,10 +46,20 @@ class DeliveryDelegate extends BaseObservable {
         if (session != null) {
             if (event.isUnhandled()) {
                 event.setSession(session.incrementUnhandledAndCopy());
-                notifyObservers(StateEvent.NotifyUnhandled.INSTANCE);
+                updateState(new Function0<StateEvent>() {
+                    @Override
+                    public StateEvent invoke() {
+                        return StateEvent.NotifyUnhandled.INSTANCE;
+                    }
+                });
             } else {
                 event.setSession(session.incrementHandledAndCopy());
-                notifyObservers(StateEvent.NotifyHandled.INSTANCE);
+                updateState(new Function0<StateEvent>() {
+                    @Override
+                    public StateEvent invoke() {
+                        return StateEvent.NotifyHandled.INSTANCE;
+                    }
+                });
             }
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LaunchCrashTracker.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LaunchCrashTracker.kt
@@ -34,7 +34,7 @@ internal class LaunchCrashTracker @JvmOverloads constructor(
     fun markLaunchCompleted() {
         executor.shutdown()
         launching.set(false)
-        notifyObservers(StateEvent.UpdateIsLaunching(false))
+        updateState { StateEvent.UpdateIsLaunching(false) }
         logger.d("App launch period marked as complete")
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -28,8 +28,8 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) :
 
     private fun notifyClear(section: String, key: String?) {
         when (key) {
-            null -> notifyObservers(StateEvent.ClearMetadataSection(section))
-            else -> notifyObservers(StateEvent.ClearMetadataValue(section, key))
+            null -> updateState { StateEvent.ClearMetadataSection(section) }
+            else -> updateState { StateEvent.ClearMetadataValue(section, key) }
         }
     }
 
@@ -55,13 +55,13 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) :
     private fun notifyMetadataAdded(section: String, key: String, value: Any?) {
         when (value) {
             null -> notifyClear(section, key)
-            else -> notifyObservers(AddMetadata(section, key, metadata.getMetadata(section, key)))
+            else -> updateState { AddMetadata(section, key, metadata.getMetadata(section, key)) }
         }
     }
 
     private fun notifyMetadataAdded(section: String, value: Map<String, Any?>) {
         value.entries.forEach {
-            notifyObservers(AddMetadata(section, it.key, metadata.getMetadata(it.key)))
+            updateState { AddMetadata(section, it.key, metadata.getMetadata(it.key)) }
         }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -97,12 +97,7 @@ class SessionTracker extends BaseObservable {
 
         if (session != null) {
             session.isPaused.set(true);
-            updateState(new Function0<StateEvent>() {
-                @Override
-                public StateEvent invoke() {
-                    return StateEvent.PauseSession.INSTANCE;
-                }
-            });
+            updateState(StateEvent.PauseSession.INSTANCE);
         }
     }
 
@@ -125,13 +120,8 @@ class SessionTracker extends BaseObservable {
 
     private void notifySessionStartObserver(final Session session) {
         final String startedAt = DateUtils.toIso8601(session.getStartedAt());
-        updateState(new Function0<StateEvent>() {
-            @Override
-            public StateEvent invoke() {
-                return new StateEvent.StartSession(session.getId(), startedAt,
-                        session.getHandledCount(), session.getUnhandledCount());
-            }
-        });
+        updateState(new StateEvent.StartSession(session.getId(), startedAt,
+                        session.getHandledCount(), session.getUnhandledCount()));
     }
 
     /**
@@ -155,12 +145,7 @@ class SessionTracker extends BaseObservable {
                     client.getNotifier(), logger);
             notifySessionStartObserver(session);
         } else {
-            updateState(new Function0<StateEvent>() {
-                @Override
-                public StateEvent invoke() {
-                    return StateEvent.PauseSession.INSTANCE;
-                }
-            });
+            updateState(StateEvent.PauseSession.INSTANCE);
         }
         currentSession.set(session);
         return session;
@@ -378,12 +363,7 @@ class SessionTracker extends BaseObservable {
     private void notifyNdkInForeground() {
         Boolean inForeground = isInForeground();
         final boolean foreground = inForeground != null ? inForeground : false;
-        updateState(new Function0<StateEvent>() {
-            @Override
-            public StateEvent invoke() {
-                return new StateEvent.UpdateInForeground(foreground, getContextActivity());
-            }
-        });
+        updateState(new StateEvent.UpdateInForeground(foreground, getContextActivity()));
     }
 
     @Nullable

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -4,6 +4,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import kotlin.jvm.functions.Function0;
+
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
@@ -95,7 +97,12 @@ class SessionTracker extends BaseObservable {
 
         if (session != null) {
             session.isPaused.set(true);
-            notifyObservers(StateEvent.PauseSession.INSTANCE);
+            updateState(new Function0<StateEvent>() {
+                @Override
+                public StateEvent invoke() {
+                    return StateEvent.PauseSession.INSTANCE;
+                }
+            });
         }
     }
 
@@ -116,10 +123,15 @@ class SessionTracker extends BaseObservable {
         return resumed;
     }
 
-    private void notifySessionStartObserver(Session session) {
-        String startedAt = DateUtils.toIso8601(session.getStartedAt());
-        notifyObservers(new StateEvent.StartSession(session.getId(), startedAt,
-                session.getHandledCount(), session.getUnhandledCount()));
+    private void notifySessionStartObserver(final Session session) {
+        final String startedAt = DateUtils.toIso8601(session.getStartedAt());
+        updateState(new Function0<StateEvent>() {
+            @Override
+            public StateEvent invoke() {
+                return new StateEvent.StartSession(session.getId(), startedAt,
+                        session.getHandledCount(), session.getUnhandledCount());
+            }
+        });
     }
 
     /**
@@ -143,7 +155,12 @@ class SessionTracker extends BaseObservable {
                     client.getNotifier(), logger);
             notifySessionStartObserver(session);
         } else {
-            notifyObservers(StateEvent.PauseSession.INSTANCE);
+            updateState(new Function0<StateEvent>() {
+                @Override
+                public StateEvent invoke() {
+                    return StateEvent.PauseSession.INSTANCE;
+                }
+            });
         }
         currentSession.set(session);
         return session;
@@ -360,8 +377,13 @@ class SessionTracker extends BaseObservable {
 
     private void notifyNdkInForeground() {
         Boolean inForeground = isInForeground();
-        boolean foreground = inForeground != null ? inForeground : false;
-        notifyObservers(new StateEvent.UpdateInForeground(foreground, getContextActivity()));
+        final boolean foreground = inForeground != null ? inForeground : false;
+        updateState(new Function0<StateEvent>() {
+            @Override
+            public StateEvent invoke() {
+                return new StateEvent.UpdateInForeground(foreground, getContextActivity());
+            }
+        });
     }
 
     @Nullable

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserState.kt
@@ -7,5 +7,5 @@ internal class UserState(user: User) : BaseObservable() {
             emitObservableEvent()
         }
 
-    fun emitObservableEvent() = notifyObservers(StateEvent.UpdateUser(user))
+    fun emitObservableEvent() = updateState { StateEvent.UpdateUser(user) }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserStore.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.StateObserver
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicReference
@@ -55,11 +56,13 @@ internal class UserStore @JvmOverloads constructor(
             else -> UserState(User(deviceId, null, null))
         }
 
-        userState.addObserver { _, arg ->
-            if (arg is StateEvent.UpdateUser) {
-                save(arg.user)
+        userState.addObserver(
+            StateObserver { event ->
+                if (event is StateEvent.UpdateUser) {
+                    save(event.user)
+                }
             }
-        }
+        )
         return userState
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/StateObserver.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/StateObserver.java
@@ -1,0 +1,14 @@
+package com.bugsnag.android.internal;
+
+import com.bugsnag.android.StateEvent;
+
+import androidx.annotation.NonNull;
+
+public interface StateObserver {
+
+    /**
+     * This is called whenever the notifier's state is altered, so that observers can react
+     * appropriately. This is intended for internal use only.
+     */
+    void onStateChange(@NonNull StateEvent event);
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -7,11 +7,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.bugsnag.android.internal.StateObserver;
+
 import android.content.Context;
 import android.os.storage.StorageManager;
 
 import androidx.annotation.NonNull;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,8 +25,6 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Observable;
-import java.util.Observer;
 
 @SuppressWarnings("ConstantConditions")
 @RunWith(MockitoJUnitRunner.class)
@@ -492,12 +493,12 @@ public class ClientFacadeTest {
 
     @Test
     public void registerObserver() {
-        Observer observer = new Observer() {
+        StateObserver observer = new StateObserver() {
             @Override
-            public void update(Observable observable, Object arg) {
+            public void onStateChange(@NotNull StateEvent event) {
             }
         };
-        client.registerObserver(observer);
+        client.addObserver(observer);
 
         verify(metadataState, times(1)).addObserver(observer);
         verify(breadcrumbState, times(1)).addObserver(observer);
@@ -511,21 +512,21 @@ public class ClientFacadeTest {
 
     @Test
     public void unregisterObserver() {
-        Observer observer = new Observer() {
+        StateObserver observer = new StateObserver() {
             @Override
-            public void update(Observable observable, Object arg) {
+            public void onStateChange(@NotNull StateEvent event) {
             }
         };
-        client.unregisterObserver(observer);
+        client.removeObserver(observer);
 
-        verify(metadataState, times(1)).deleteObserver(observer);
-        verify(breadcrumbState, times(1)).deleteObserver(observer);
-        verify(sessionTracker, times(1)).deleteObserver(observer);
-        verify(clientObservable, times(1)).deleteObserver(observer);
-        verify(userState, times(1)).deleteObserver(observer);
-        verify(contextState, times(1)).deleteObserver(observer);
-        verify(deliveryDelegate, times(1)).deleteObserver(observer);
-        verify(launchCrashTracker, times(1)).deleteObserver(observer);
+        verify(metadataState, times(1)).removeObserver(observer);
+        verify(breadcrumbState, times(1)).removeObserver(observer);
+        verify(sessionTracker, times(1)).removeObserver(observer);
+        verify(clientObservable, times(1)).removeObserver(observer);
+        verify(userState, times(1)).removeObserver(observer);
+        verify(contextState, times(1)).removeObserver(observer);
+        verify(deliveryDelegate, times(1)).removeObserver(observer);
+        verify(launchCrashTracker, times(1)).removeObserver(observer);
     }
 
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientObservableTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientObservableTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.StateObserver
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -10,26 +11,32 @@ class ClientObservableTest {
 
     @Test
     fun postOrientationChange() {
-        clientObservable.addObserver { _, arg ->
-            val msg = arg as StateEvent.UpdateOrientation
-            assertEquals("landscape", msg.orientation)
-        }
+        clientObservable.addObserver(
+            StateObserver {
+                val msg = it as StateEvent.UpdateOrientation
+                assertEquals("landscape", msg.orientation)
+            }
+        )
         clientObservable.postOrientationChange("landscape")
     }
 
     @Test
     fun postNdkInstall() {
         clientObservable.postNdkInstall(BugsnagTestUtils.generateImmutableConfig(), "/foo", 0)
-        clientObservable.addObserver { _, arg ->
-            assertTrue(arg is StateEvent.Install)
-        }
+        clientObservable.addObserver(
+            StateObserver {
+                assertTrue(it is StateEvent.Install)
+            }
+        )
     }
 
     @Test
     fun postNdkDeliverPending() {
         clientObservable.postNdkDeliverPending()
-        clientObservable.addObserver { _, arg ->
-            assertTrue(arg is StateEvent.DeliverPending)
-        }
+        clientObservable.addObserver(
+            StateObserver {
+                assertTrue(it is StateEvent.DeliverPending)
+            }
+        )
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import com.bugsnag.android.internal.StateObserver
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -44,9 +45,11 @@ internal class DeliveryDelegateTest {
     @Test
     fun generateUnhandledReport() {
         var msg: StateEvent.NotifyUnhandled? = null
-        deliveryDelegate.addObserver { _, arg ->
-            msg = arg as StateEvent.NotifyUnhandled
-        }
+        deliveryDelegate.addObserver(
+            StateObserver {
+                msg = it as StateEvent.NotifyUnhandled
+            }
+        )
         deliveryDelegate.deliver(event)
 
         // verify message sent
@@ -66,9 +69,11 @@ internal class DeliveryDelegateTest {
         event.session = Session("123", Date(), User(null, null, null), false, notifier, NoopLogger)
 
         var msg: StateEvent.NotifyHandled? = null
-        deliveryDelegate.addObserver { _, arg ->
-            msg = arg as StateEvent.NotifyHandled
-        }
+        deliveryDelegate.addObserver(
+            StateObserver {
+                msg = it as StateEvent.NotifyHandled
+            }
+        )
         deliveryDelegate.deliver(event)
 
         // verify message sent
@@ -88,9 +93,11 @@ internal class DeliveryDelegateTest {
         event.errors.clear()
 
         var msg: StateEvent.NotifyHandled? = null
-        deliveryDelegate.addObserver { _, arg ->
-            msg = arg as StateEvent.NotifyHandled
-        }
+        deliveryDelegate.addObserver(
+            StateObserver {
+                msg = it as StateEvent.NotifyHandled
+            }
+        )
         deliveryDelegate.deliver(event)
 
         // verify no payload was sent for an Event with no errors

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.StateObserver
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Before
@@ -50,10 +51,12 @@ internal class MetadataStateTest {
         state.addMetadata("bar", "another", true)
 
         val data = mutableSetOf<String>()
-        state.addObserver { _, arg ->
-            val msg = arg as StateEvent.AddMetadata
-            data.add(msg.section)
-        }
+        state.addObserver(
+            StateObserver {
+                val msg = it as StateEvent.AddMetadata
+                data.add(msg.section)
+            }
+        )
 
         state.emitObservableEvent()
         assertEquals(setOf("foo", "bar"), data)
@@ -72,11 +75,13 @@ internal class MetadataStateTest {
 
         val sections = mutableSetOf<String>()
         val keys = mutableSetOf<String?>()
-        state.addObserver { _, arg ->
-            val msg = arg as StateEvent.AddMetadata
-            sections.add(msg.section)
-            keys.add(msg.key)
-        }
+        state.addObserver(
+            StateObserver {
+                val msg = it as StateEvent.AddMetadata
+                sections.add(msg.section)
+                keys.add(msg.key)
+            }
+        )
 
         state.emitObservableEvent()
         assertEquals(setOf("foo"), sections)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/UserStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/UserStateTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.StateObserver
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -23,9 +24,11 @@ internal class UserStateTest {
     @Test
     fun setUser() {
         val msgs = mutableListOf<StateEvent>()
-        state.addObserver { _, arg ->
-            msgs.add(arg as StateEvent)
-        }
+        state.addObserver(
+            StateObserver {
+                msgs.add(it)
+            }
+        )
 
         state.user = User("99", "tc@example.com", "Tobias")
 

--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -2,9 +2,9 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
-    <ID>ComplexMethod:NativeBridge.kt$NativeBridge$override fun update(observable: Observable, arg: Any?)</ID>
+    <ID>ComplexMethod:NativeBridge.kt$NativeBridge$override fun onStateChange(event: StateEvent)</ID>
     <ID>LongParameterList:NativeBridge.kt$NativeBridge$( apiKey: String, reportingDirectory: String, lastRunInfoPath: String, consecutiveLaunchCrashes: Int, autoDetectNdkCrashes: Boolean, apiLevel: Int, is32bit: Boolean, appVersion: String, buildUuid: String, releaseStage: String )</ID>
     <ID>NestedBlockDepth:NativeBridge.kt$NativeBridge$private fun deliverPendingReports()</ID>
-    <ID>TooManyFunctions:NativeBridge.kt$NativeBridge : Observer</ID>
+    <ID>TooManyFunctions:NativeBridge.kt$NativeBridge : StateObserver</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -21,7 +21,7 @@ internal class NdkPlugin : Plugin {
 
     private fun initNativeBridge(client: Client): NativeBridge {
         val nativeBridge = NativeBridge()
-        client.registerObserver(nativeBridge)
+        client.addObserver(nativeBridge)
         client.setupNdkPlugin()
         return nativeBridge
     }
@@ -56,7 +56,7 @@ internal class NdkPlugin : Plugin {
         if (libraryLoader.isLoaded) {
             disableCrashReporting()
             nativeBridge?.let { bridge ->
-                client?.unregisterObserver(bridge)
+                client?.removeObserver(bridge)
             }
         }
     }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -35,7 +35,7 @@ class BugsnagReactNativePlugin : Plugin {
         observerBridge = BugsnagReactNativeBridge(client) {
             jsCallback?.invoke(it)
         }
-        client.registerObserver(observerBridge)
+        client.addObserver(observerBridge)
         client.logger.i("Initialized React Native Plugin")
     }
 

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativeBridgeTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativeBridgeTest.java
@@ -41,7 +41,7 @@ public class BugsnagReactNativeBridgeTest {
         BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
 
         User user = new User("123", "joe@example.com", "Joe Bloggs");
-        bridge.update(new Observable(), new StateEvent.UpdateUser(user));
+        bridge.onStateChange(new StateEvent.UpdateUser(user));
         assertNotNull(cb.event);
         assertEquals("UserUpdate", cb.event.getType());
 
@@ -57,7 +57,7 @@ public class BugsnagReactNativeBridgeTest {
         MessageEventCb cb = new MessageEventCb();
         BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
 
-        bridge.update(new Observable(), new StateEvent.UpdateContext("Foo"));
+        bridge.onStateChange(new StateEvent.UpdateContext("Foo"));
         assertNotNull(cb.event);
         assertEquals("ContextUpdate", cb.event.getType());
         assertEquals("Foo", cb.event.getData());
@@ -69,7 +69,7 @@ public class BugsnagReactNativeBridgeTest {
         BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
 
         StateEvent.AddMetadata arg = new StateEvent.AddMetadata("foo", "bar", true);
-        bridge.update(new Observable(), arg);
+        bridge.onStateChange(arg);
         assertNotNull(cb.event);
         assertEquals("MetadataUpdate", cb.event.getType());
         assertEquals(metadata, cb.event.getData());
@@ -81,7 +81,7 @@ public class BugsnagReactNativeBridgeTest {
         BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
 
         StateEvent.ClearMetadataSection arg = new StateEvent.ClearMetadataSection("baz");
-        bridge.update(new Observable(), arg);
+        bridge.onStateChange(arg);
         assertNotNull(cb.event);
         assertEquals("MetadataUpdate", cb.event.getType());
         assertEquals(metadata, cb.event.getData());
@@ -93,7 +93,7 @@ public class BugsnagReactNativeBridgeTest {
         BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
 
         StateEvent.ClearMetadataValue arg = new StateEvent.ClearMetadataValue("baz", "wham");
-        bridge.update(new Observable(), arg);
+        bridge.onStateChange(arg);
         assertNotNull(cb.event);
         assertEquals("MetadataUpdate", cb.event.getType());
         assertEquals(metadata, cb.event.getData());


### PR DESCRIPTION
## Goal

Optimizes the implementation of the internal system used for notifying observers of state changes.

## Changeset

This new solution avoids the performance disadvantages of the previous solution:

- The `StateEvent` message is lazily created which avoids object instantiation if no observers are registered
- `BaseObservable` avoids creating a `Vector` by replacing `update()` with `onStateChange()` (this also grants additional type safety)
- `BaseObservable` uses `CopyOnWriteArrayList` which avoids the need for synchronization when adding/removing observers. This was seen as acceptable as observers will be added/removed very rarely, whereas the collection will be iterated over many times

The remaining changes entail updating the rest of the code and the tests to use the new method signatures.

## Testing

Updated existing unit test coverage and relied on existing tests.

## Performance

Profiled app to confirm there was no performance regression, and also checked CI stats.

<img width="780" alt="changes_flame" src="https://user-images.githubusercontent.com/11800640/122371624-ea9a0980-cf57-11eb-9d19-fb2aed381561.png">

<img width="920" alt="baseline_flame" src="https://user-images.githubusercontent.com/11800640/122371614-e8d04600-cf57-11eb-9049-3409a06aba07.png">
