### PR TITLE
Cache value of app.backgroundWorkRestricted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Unity: Properly handle ANRs after multiple calls to autoNotify and autoDetectAnrs
   [#1265](https://github.com/bugsnag/bugsnag-android/pull/1265)
 
+* Cache value of app.backgroundWorkRestricted
+  [#1275](https://github.com/bugsnag/bugsnag-android/pull/1275)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -24,6 +24,7 @@ internal class AppDataCollector(
     private val packageName: String = appContext.packageName
     private var packageInfo = packageManager?.getPackageInfo(packageName, 0)
     private var appInfo: ApplicationInfo? = packageManager?.getApplicationInfo(packageName, 0)
+    private val bgWorkRestricted = isBackgroundWorkRestricted()
 
     private var binaryArch: String? = null
     private val appName = getAppName()
@@ -51,8 +52,8 @@ internal class AppDataCollector(
         map["memoryUsage"] = getMemoryUsage()
         map["lowMemory"] = isLowMemory()
 
-        isBackgroundWorkRestricted()?.let {
-            map["backgroundWorkRestricted"] = it
+        bgWorkRestricted?.let {
+            map["backgroundWorkRestricted"] = bgWorkRestricted
         }
         return map
     }


### PR DESCRIPTION
## Goal

Caches the value of `app.backgroundWorkRestricted` as it is unlikely to change over a session. This should improve the performance of subsequent `Bugsnag.notify()` calls as the API call took ~3ms on a OnePlus 7.

## Testing

Ran the example app with the artefact and confirmed the field is reported correctly.