### PR TITLE
Optimize execution of callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Cache value of app.backgroundWorkRestricted
   [#1275](https://github.com/bugsnag/bugsnag-android/pull/1275)
 
+* Optimize execution of callbacks
+  [#1276](https://github.com/bugsnag/bugsnag-android/pull/1276)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/CallbackState.kt
@@ -33,6 +33,10 @@ internal data class CallbackState(
     }
 
     fun runOnErrorTasks(event: Event, logger: Logger): Boolean {
+        // optimization to avoid construction of iterator when no callbacks set
+        if (onErrorTasks.isEmpty()) {
+            return true
+        }
         onErrorTasks.forEach {
             try {
                 if (!it.onError(event)) {
@@ -46,6 +50,10 @@ internal data class CallbackState(
     }
 
     fun runOnBreadcrumbTasks(breadcrumb: Breadcrumb, logger: Logger): Boolean {
+        // optimization to avoid construction of iterator when no callbacks set
+        if (onBreadcrumbTasks.isEmpty()) {
+            return true
+        }
         onBreadcrumbTasks.forEach {
             try {
                 if (!it.onBreadcrumb(breadcrumb)) {
@@ -59,6 +67,10 @@ internal data class CallbackState(
     }
 
     fun runOnSessionTasks(session: Session, logger: Logger): Boolean {
+        // optimization to avoid construction of iterator when no callbacks set
+        if (onSessionTasks.isEmpty()) {
+            return true
+        }
         onSessionTasks.forEach {
             try {
                 if (!it.onSession(session)) {


### PR DESCRIPTION
## Goal

Bugsnag supplies the ability to set callbacks for when breadcrumbs are added, and when an error or session are captured. Breadcrumbs/errors in particular can be captured many times per second.

By default no callbacks are set. This changeset optimizes the default behaviour by performing an `isEmpty()` check before running the callbacks, which avoids construction of an iterator each time. For the addition of ~1000 breadcrumbs this saves ~3ms in the default case and has negligible impact when callbacks are set.

## Testing

Verified by profiling the changes in an example app with no callbacks set and observing `runOnBreadcrumbTasks()`:

<img width="1034" alt="baseline-no-cb" src="https://user-images.githubusercontent.com/11800640/122387702-0a84f980-cf67-11eb-9f28-66a190e59293.png">

<img width="968" alt="changes-no-cb" src="https://user-images.githubusercontent.com/11800640/122387707-0ce75380-cf67-11eb-911d-74ed8c2a288e.png">
