### PR TITLE
Basic journal functionality

### DIFF
--- a/bugsnag-android-core/build.gradle
+++ b/bugsnag-android-core/build.gradle
@@ -11,6 +11,10 @@ bugsnagBuildOptions {
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.dokka"
 
+dependencies {
+    implementation 'com.dslplatform:dsl-json:1.9.8'
+}
+
 dokka {
     outputFormat = "html"
     outputDirectory = "$buildDir/dokka"

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -14,8 +14,12 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 final class BugsnagTestUtils {
 
@@ -131,5 +135,84 @@ final class BugsnagTestUtils {
 
     public static App generateApp() {
         return new App(generateImmutableConfig(), null, null, null, null, null);
+    }
+
+    /**
+     * "Normalize" a map by changing all numeric types to their largest forms.
+     * This is necessary for comparing the results of serialization/deserialization
+     * operations because we have no control over what types the codec will choose,
+     * and equals() takes into account the underlying type.
+     *
+     * @param map The map to normalize
+     * @param <K> The key type
+     * @param <V> The value type
+     * @return The normalized map
+     */
+    @SuppressWarnings("unchecked")
+    public static <K, V> Map<K, V> normalizedMap(Map<K, V> map) {
+        Map<K, V> newMap = new HashMap<>(map.size());
+        Set<Map.Entry<K, V>> set = map.entrySet();
+        for (Map.Entry<K, V> entry: set) {
+            K key = entry.getKey();
+            K normalizedKey = (K)normalized(key);
+            if (!key.equals(normalizedKey)) {
+                key = normalizedKey;
+            }
+            newMap.put(key, (V)normalized(entry.getValue()));
+        }
+        return newMap;
+    }
+
+    /**
+     * "Normalize" a list by changing all numeric types to their largest forms.
+     * This is necessary for comparing the results of serialization/deserialization
+     * operations because we have no control over what types the codec will choose,
+     * and equals() takes into account the underlying type.
+     *
+     * @param list The list to normalize
+     * @param <T> The element type
+     * @return The normalized list
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> List<T> normalizedList(List<T> list) {
+        List<T> newList = new ArrayList<>(list.size());
+        for (T entry: list) {
+            newList.add((T)normalized(entry));
+        }
+        return newList;
+    }
+
+    /**
+     * "Normalize" an unknown value by changing all numeric types to their largest forms.
+     * This is necessary for comparing the results of serialization/deserialization
+     * operations because we have no control over what types the codec will choose,
+     * and equals() takes into account the underlying type.
+     *
+     * This function normalizes integers, floats, lists, and maps and their subobjects.
+     *
+     * @param obj The object to normalize.
+     * @return The normalized object (may be the same object passed in)
+     */
+    @SuppressWarnings("unchecked")
+    public static Object normalized(Object obj) {
+        if (obj instanceof Byte) {
+            return ((Byte)obj).longValue();
+        }
+        if (obj instanceof Short) {
+            return ((Short)obj).longValue();
+        }
+        if (obj instanceof Integer) {
+            return ((Integer)obj).longValue();
+        }
+        if (obj instanceof Float) {
+            return ((Float)obj).doubleValue();
+        }
+        if (obj instanceof Map) {
+            return normalizedMap((Map<Object, Object>)obj);
+        }
+        if (obj instanceof List) {
+            return normalizedList((List<Object>)obj);
+        }
+        return obj;
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/InterceptingLogger.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/InterceptingLogger.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android
+
+class InterceptingLogger : Logger {
+
+    var msg: String? = null
+
+    override fun w(msg: String) {
+        this.msg = msg
+    }
+
+    override fun w(msg: String, throwable: Throwable) {
+        this.msg = msg
+    }
+
+    override fun e(msg: String) {
+        this.msg = msg
+    }
+
+    override fun e(msg: String, throwable: Throwable) {
+        this.msg = msg
+    }
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/JournalCommandTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/JournalCommandTest.kt
@@ -1,0 +1,60 @@
+package com.bugsnag.android
+
+import com.dslplatform.json.DslJson
+import org.junit.Assert
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+
+class JournalCommandTest {
+    @Test
+    fun testSerializeBasic() {
+        assertSerializeDeserialize(
+            "{\"a\":1}",
+            Journal.Command("a", 1)
+        )
+        assertSerializeDeserialize(
+            "{\"a\":1.5}",
+            Journal.Command("a", 1.5)
+        )
+        assertSerializeDeserialize(
+            "{\"a\":\"x\"}",
+            Journal.Command("a", "x")
+        )
+        assertSerializeDeserialize(
+            "{\"a\":true}",
+            Journal.Command("a", true)
+        )
+        assertSerializeDeserialize(
+            "{\"a\":null}",
+            Journal.Command("a", null)
+        )
+    }
+
+    private fun serializeJournalEntry(entry: Journal.Command): String {
+        val os = ByteArrayOutputStream()
+        entry.serialize(os)
+        return os.toString(Charsets.UTF_8.name())
+    }
+
+    private fun deserializeJournalEntry(json: String): Journal.Command {
+        val dslJson = DslJson<Any>()
+        val document = json.toByteArray(Charsets.UTF_8)
+        return Journal.deserializeCommand(dslJson, document)
+    }
+
+    private fun assertSerializeDeserialize(json: String, entry: Journal.Command) {
+        val expectedJson = json
+        val actualJson = serializeJournalEntry(entry)
+        Assert.assertEquals(expectedJson, actualJson)
+
+        val expectedEntry = entry
+        val actualEntry = deserializeJournalEntry(json)
+        assertEquivalent(expectedEntry, actualEntry)
+    }
+
+    private fun assertEquivalent(expected: Journal.Command, actual: Journal.Command) {
+        val strExpected = serializeJournalEntry(expected)
+        val strActual = serializeJournalEntry(actual)
+        Assert.assertEquals(strExpected, strActual)
+    }
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/JournalTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/JournalTest.kt
@@ -1,0 +1,123 @@
+package com.bugsnag.android
+
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import org.junit.Assert
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+
+class JournalTest {
+    @Test
+    fun testEmptyEverything() {
+        val expected = mutableMapOf<String, Any>()
+        val journal = Journal()
+        val document = mutableMapOf<String, Any>()
+        val actual = journal.applyTo(document)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testBasicMap() {
+        val expected = mutableMapOf<String, Any>("a" to 1)
+        val journal = Journal()
+        journal.add(Journal.Command("a", 1))
+        val document = mutableMapOf<String, Any>()
+        val actual = journal.applyTo(document)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun test1EntryJournal() {
+        assertSerializeDeserialize(
+            "{\"a\":1}\u0000".toByteArray(Charsets.UTF_8),
+            Journal.Command("a", 1)
+        )
+    }
+
+    @Test
+    fun test2EntryJournal() {
+        assertSerializeDeserialize(
+            "{\"a\":1}\u0000{\"b\":\"x\"}\u0000".toByteArray(Charsets.UTF_8),
+            Journal.Command("a", 1),
+            Journal.Command("b", "x")
+        )
+    }
+
+    @Test
+    fun testRunSerializedJournal() {
+        assertRunSerializedJournal(
+            mutableMapOf("q" to 100),
+            "{\"a\":1}\u0000{\"b\":\"x\"}\u0000".toByteArray(Charsets.UTF_8),
+            mutableMapOf("q" to 100, "a" to 1, "b" to "x")
+        )
+    }
+
+    @Test
+    fun testRunSerializedJournalDeep() {
+        assertRunSerializedJournal(
+            mutableMapOf("q" to 100),
+            "{\"a.b.-1\":1}\u0000{\"b.-1.\":\"x\"}\u0000".toByteArray(Charsets.UTF_8),
+            mutableMapOf(
+                "q" to 100,
+                "a" to mapOf<String, Any>("b" to listOf<Any>(1.toLong())),
+                "b" to listOf<Any>(listOf<Any>("x"))
+            )
+        )
+    }
+
+    @Test
+    fun testDeserializeFail() {
+        assertDeserializeFails(
+            "{\"a.\":10false}\u0000".toByteArray(Charsets.UTF_8)
+        )
+    }
+
+    private fun assertDeserializeFails(serialized: ByteArray) {
+        val logger = InterceptingLogger()
+        assertNull(logger.msg)
+        deserialize(serialized, logger)
+        assertNotNull(logger.msg)
+    }
+
+    private fun assertSerializeDeserialize(serialized: ByteArray, vararg entries: Journal.Command) {
+        val journal = Journal()
+        for (entry in entries) {
+            journal.add(entry)
+        }
+        val expectedBytes = serialized
+        val actualBytes = serialize(journal)
+        Assert.assertArrayEquals(expectedBytes, actualBytes)
+
+        val expectedEntry = journal
+        val actualEntry = deserialize(serialized, NoopLogger)
+        assertEquivalent(expectedEntry, actualEntry)
+    }
+
+    private fun assertEquivalent(expected: Journal, actual: Journal) {
+        val bytesExpected = serialize(expected)
+        val bytesActual = serialize(actual)
+        Assert.assertArrayEquals(bytesExpected, bytesActual)
+    }
+
+    fun serialize(journal: Journal): ByteArray {
+        val outs = ByteArrayOutputStream()
+        journal.serialize(outs)
+        return outs.toByteArray()
+    }
+
+    fun deserialize(bytes: ByteArray, logger: Logger): Journal {
+        return Journal.deserialize(bytes, logger)
+    }
+
+    private fun assertRunSerializedJournal(
+        document: MutableMap<String, Any>,
+        bytes: ByteArray,
+        expectedDocument: Any
+    ) {
+        val journal = deserialize(bytes, NoopLogger)
+        val actualDocument = journal.applyTo(document)
+        val expectedMap = BugsnagTestUtils.normalized(expectedDocument)
+        val actualMap = BugsnagTestUtils.normalized(actualDocument)
+        Assert.assertEquals(expectedMap, actualMap)
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/IOUtils.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/IOUtils.java
@@ -6,6 +6,8 @@ import androidx.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.HttpURLConnection;
@@ -34,6 +36,23 @@ class IOUtils {
         while (EOF != (read = input.read(buffer))) {
             output.write(buffer, 0, read);
             count += read;
+        }
+
+        if (count > Integer.MAX_VALUE) {
+            return -1;
+        }
+
+        return (int) count;
+    }
+
+    public static int copy(final InputStream inputStream, final OutputStream outputStream)
+            throws IOException {
+        byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
+        long count = 0;
+        int bytesRead;
+        while (EOF != (bytesRead = inputStream.read(buffer))) {
+            outputStream.write(buffer, 0, bytesRead);
+            count += bytesRead;
         }
 
         if (count > Integer.MAX_VALUE) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPath.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPath.kt
@@ -1,0 +1,209 @@
+package com.bugsnag.android
+
+/**
+ * DocumentPath records a path into a hierarchical acyclic document, and can be used to modify
+ * documents by navigating down the DAG and then applying a modification at that level.
+ *
+ * Paths are explained as follows in PLAT-6353:
+ *
+ * Paths follow a dotted notation similar to internet hostnames, such that each path component
+ * is separated by a dot '.' If a literal dot is required, the path supports an escaping
+ * mechanism using the backslash character:
+ *
+ * \. = literal dot
+ * \\ = literal backslash
+ *
+ * Path components are either integers or non-integers. Integers refer to the previous path
+ * component as a list, providing the index to look up. Non-integers refer to the previous path
+ * component as a map, providing the key to look up (for example, in the path "a.b.3", "a" is
+ * treated as a map and "b" is treated as a list, so the path refers to document root with map
+ * key "a", which is then indexed with map key "b", which is then indexed with list index 3).
+ *
+ * Any nonexistent parts of the document are created on-demand as they are encountered while
+ * resolving paths (either as a list in the case of integer path components, or as a map for
+ * non-integers). In the case of lists, only index 0 of a nonexistent list is valid (in which
+ * case the list will be created, and the value stored at index 0).
+ *
+ * As well, the following special rules apply:
+ *
+ * - An empty path component refers to the document root, and causes the value to replace
+ * the entire document.
+ * - The integer path component -1 refers to the last index in the array, or index 0 if the
+ * array is empty or nonexistent.
+ * - If a path ends in a dot (e.g. events.exceptions.stacktrace.), It means that the last
+ * path entry (e.g. stacktrace) is to be treated as a list, and the value is to be appended
+ * to that list.
+ *
+ * The document to be modified must be serializable into JSON. The following types are supported:
+ * - null
+ * - boolean
+ * - integer (max 15 digits)
+ * - float
+ * - string
+ * - List(Object)
+ * - Map(String, Object)
+ */
+class DocumentPath(path: String) {
+    val directives: List<DocumentPathDirective> = toPathDirectives(path)
+
+    /**
+     * Modify a document, setting this path in the document to the specified value.
+     *
+     * @param document The document to modify.
+     * @param value    The value to modify with.
+     * @return The modified document (may not be the same document that was passed in).
+     */
+    fun modifyDocument(document: MutableMap<String, Any>, value: Any?): MutableMap<String, Any> {
+        if (directives.isEmpty()) {
+            requireNotNull(value) { "Cannot replace entire document with null" }
+            require(value is MutableMap<*, *>) { "Value replacing document must be a mutable map" }
+            @Suppress("UNCHECKED_CAST")
+            return value as MutableMap<String, Any>
+        }
+        val updatedDocument = fillInMissingContainers(document, 0)!!
+        applyValueToContainer(value, updatedDocument)
+        @Suppress("UNCHECKED_CAST")
+        return updatedDocument as MutableMap<String, Any>
+    }
+
+    // Fill in the document parts that will be navigated, but don't exist yet.
+    private fun fillInMissingContainers(parent: Any?, index: Int): Any? {
+        var updatedParent = parent
+        if (index >= directives.size) {
+            return null
+        }
+        val directive = directives[index]
+        if (updatedParent == null) {
+            updatedParent = directive.newContainer()
+        }
+        val result = fillInMissingContainers(directive.getFromContainer(updatedParent), index + 1)
+        if (result != null) {
+            directive.setInContainer(updatedParent, result)
+        }
+        return updatedParent
+    }
+
+    // Navigate down into a container, then set the specified value.
+    private fun applyValueToContainer(value: Any?, container: Any) {
+        // These directives navigate to where we want to edit the document.
+        var updatedContainer = container
+        for (i in 0 until directives.size - 1) {
+            val directive = directives[i]
+            updatedContainer = directive.getFromContainer(updatedContainer)!!
+        }
+
+        // The last directive does the actual setting.
+        val directive = directives[directives.size - 1]
+        directive.setInContainer(updatedContainer, value)
+    }
+
+    companion object {
+        fun toPathDirectives(path: String): List<DocumentPathDirective> {
+            val directives: MutableList<DocumentPathDirective> = ArrayList(0)
+            if (path.isEmpty()) {
+                return directives
+            }
+            var requiresEscaping = false
+            var strBegin = 0
+            var i = 0
+            while (i < path.length) {
+                when (path[i]) {
+                    '\\' -> {
+                        requiresEscaping = true
+                        i++
+                    }
+                    '.' -> {
+                        val pathComponent: String = if (requiresEscaping) {
+                            unescape(path, strBegin, i)
+                        } else {
+                            path.substring(strBegin, i)
+                        }
+                        directives.add(makeDirectiveFromPathComponent(pathComponent))
+                        strBegin = i + 1
+                        requiresEscaping = false
+                    }
+                    else -> {
+                    }
+                }
+                i++
+            }
+            if (strBegin < path.length) {
+                val pathComponent: String = if (requiresEscaping) {
+                    unescape(path, strBegin, path.length)
+                } else {
+                    path.substring(strBegin)
+                }
+                directives.add(makeDirectiveFromPathComponent(pathComponent))
+            }
+            if (isDotLast(path)) {
+                directives.add(DocumentPathDirective.ListInsertDirective())
+            }
+            return directives
+        }
+
+        private fun unescape(str: String, startOffset: Int, endOffset: Int): String {
+            val buff = StringBuilder(endOffset - startOffset)
+            var i = startOffset
+            while (i < endOffset) {
+                val ch = str[i]
+                if (ch == '\\') {
+                    i++
+                    require(i < endOffset) { "Path cannot end on an escape char '\\'" }
+                    buff.append(str[i])
+                } else {
+                    buff.append(ch)
+                }
+                i++
+            }
+            return buff.toString()
+        }
+
+        private fun isDotLast(path: String): Boolean {
+            if (path[path.length - 1] != '.') {
+                return false
+            }
+            if (path.length == 1) {
+                return true
+            }
+            var isUnescapedDot = true
+            for (i in path.length - 2 downTo 0) {
+                val ch = path[i]
+                isUnescapedDot = if (ch == '\\') {
+                    !isUnescapedDot
+                } else {
+                    break
+                }
+            }
+            return isUnescapedDot
+        }
+
+        private fun makeDirectiveFromPathComponent(pathComponent: String?): DocumentPathDirective {
+            if (isInteger(pathComponent)) {
+                val index = pathComponent!!.toInt()
+                return if (index == -1) {
+                    DocumentPathDirective.ListLastIndexDirective()
+                } else {
+                    DocumentPathDirective.ListIndexDirective(index)
+                }
+            }
+            return DocumentPathDirective.MapKeyDirective(pathComponent!!)
+        }
+
+        private fun isInteger(str: String?): Boolean {
+            if (str!!.isEmpty()) {
+                return false
+            }
+            var startIndex = 0
+            if (str[0] == '-') {
+                startIndex = 1
+            }
+            for (i in startIndex until str.length) {
+                val ch = str[i].toInt()
+                if (ch < '0'.toInt() || ch > '9'.toInt()) {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPathDirective.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPathDirective.kt
@@ -1,0 +1,123 @@
+package com.bugsnag.android
+
+/**
+ * A directive determines how document path commands are interpreted. Making a container,
+ * getting from a container, or setting to a container will require different operations to
+ * complete, depending on the context.
+ */
+interface DocumentPathDirective {
+    /**
+     * Make a new container at the current level.
+     *
+     * @return The new container.
+     */
+    fun newContainer(): Any
+
+    /**
+     * Get an object from the container at the current level.
+     *
+     * @param container The container to get the object from.
+     * @return The resulting object, or null if not found.
+     */
+    fun getFromContainer(container: Any): Any?
+
+    /**
+     * Set an object in a container at the current level.
+     *
+     * @param container The container to set a value in.
+     * @param value The value to set (can be null, which usually means "remove")
+     */
+    fun setInContainer(container: Any, value: Any?)
+
+    /**
+     * Modifies a particular key in a map, or creates a new (String, Object) map.
+     * Setting null removes the value.
+     */
+    class MapKeyDirective(private val key: String) : DocumentPathDirective {
+        override fun newContainer(): Any {
+            return mutableMapOf<String, Any>()
+        }
+
+        override fun getFromContainer(container: Any): Any? {
+            return (container as Map<*, *>)[key]
+        }
+
+        override fun setInContainer(container: Any, value: Any?) {
+            @Suppress("UNCHECKED_CAST")
+            val asMap = container as MutableMap<String, Any>
+            if (value == null) {
+                asMap.remove(
+                    key
+                )
+            } else {
+                asMap[key] = value
+            }
+        }
+    }
+
+    /**
+     * Modifies a list at the current level, or creates a new list.
+     * Setting null removes the item at the specified index.
+     */
+    open class ListIndexDirective(private val index: Int) : DocumentPathDirective {
+        override fun newContainer(): Any {
+            return mutableListOf<Any>()
+        }
+
+        override fun getFromContainer(container: Any): Any? {
+            return (container as List<Any?>)[index]
+        }
+
+        override fun setInContainer(container: Any, value: Any?) {
+            @Suppress("UNCHECKED_CAST")
+            val asList = container as MutableList<Any>
+            asList.removeAt(index)
+            if (value != null) {
+                asList.add(index, value)
+            }
+        }
+    }
+
+    /**
+     * Special list directive for the last index in a list (-1).
+     * This directive inserts a new entry if one isn't present already when setting.
+     * Setting null deletes the last index (if present).
+     */
+    class ListLastIndexDirective : ListIndexDirective(0) {
+        override fun getFromContainer(container: Any): Any? {
+            val containerImpl = container as List<*>
+            return if (containerImpl.isEmpty()) {
+                null
+            } else containerImpl[containerImpl.size - 1]
+        }
+
+        override fun setInContainer(container: Any, value: Any?) {
+            @Suppress("UNCHECKED_CAST")
+            val asList = container as MutableList<Any>
+            if (asList.isNotEmpty()) {
+                asList.removeAt(asList.size - 1)
+            }
+            if (value != null) {
+                asList.add(value)
+            }
+        }
+    }
+
+    /**
+     * Special list directive for insert (path ends in .)
+     * This one always inserts a new entry on set, and always returns null on get.
+     * Setting null is an error.
+     */
+    class ListInsertDirective : ListIndexDirective(0) {
+        override fun getFromContainer(container: Any): Any? {
+            return null
+        }
+
+        override fun setInContainer(container: Any, value: Any?) {
+            @Suppress("UNCHECKED_CAST")
+            val asList = container as MutableList<Any>
+            requireNotNull(value) { "Cannot use null for last path insert value" }
+            asList.add(value)
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/Journal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/Journal.kt
@@ -1,0 +1,146 @@
+package com.bugsnag.android
+
+import com.dslplatform.json.DslJson
+import java.io.IOException
+import java.io.OutputStream
+
+/**
+ * A journal represents a series of commands that will manipulate a document.
+ * Sometimes it's more efficient to store a base document and a list of modifications
+ * to be made to it rather than re-serialize the entire document after every modification.
+ */
+class Journal {
+    val commands: MutableList<Command> = mutableListOf()
+
+    /**
+     * Apply this journal to a document.
+     *
+     * This method goes through the journal entries one-by-one, applying their modification
+     * commands to the document. This is a destructive operation that will modify the document.
+     *
+     * Note: If a journal command replaces the root object, the resulting document will be a
+     * different object from the one passed in.
+     *
+     * @param document The document to apply to.
+     * @return The finished document (may be a different object from the one passed in).
+     */
+    fun applyTo(document: MutableMap<String, Any>): Any {
+        var updatedDocument = document
+        for (command in commands) {
+            updatedDocument = command.apply(updatedDocument)
+        }
+        return updatedDocument
+    }
+
+    /**
+     * Add a journal command to this journal
+     *
+     * @param command The journal command
+     */
+    fun add(command: Command) {
+        commands.add(command)
+    }
+
+    /**
+     * Clear the journal, removing all journal entries.
+     */
+    fun clear() {
+        commands.clear()
+    }
+
+    /**
+     * Serialize the journal to a stream.
+     *
+     * @param out The stream to serialize to.
+     * @throws IOException if an IO exception occurs.
+     */
+    @Throws(IOException::class)
+    fun serialize(out: OutputStream) {
+        for (command in commands) {
+            command.serialize(out)
+            out.write(0)
+            out.flush()
+        }
+    }
+
+    /**
+     * Represents a single journal command, consisting of a document path,
+     * and a value to be applied at that path level.
+     */
+    class Command(private val pathAsString: String, val value: Any?) {
+        private val path: DocumentPath = DocumentPath(pathAsString)
+
+        /**
+         * Apply this journal command to a document.
+         *
+         * @param document The document to modify.
+         * @return The resulting document (may not be the same as the one passed in).
+         */
+        fun apply(document: MutableMap<String, Any>): MutableMap<String, Any> {
+            return path.modifyDocument(document, value)
+        }
+
+        /**
+         * Serialize to an OutputStream
+         *
+         * @param out The stream
+         * @throws IOException If an IO exception occurs
+         */
+        @Throws(IOException::class)
+        fun serialize(out: OutputStream) {
+            val command: MutableMap<String, Any?> = HashMap()
+            command[pathAsString] = value
+            dslJson.serialize(command, out)
+        }
+    }
+
+    companion object {
+        val dslJson = DslJson<Any>()
+
+        /**
+         * Deserialize from a byte array.
+         *
+         * @param bytes The bytes to deserialize from
+         * @return The journal
+         */
+        fun deserialize(bytes: ByteArray, logger: Logger): Journal {
+            val journal = Journal()
+            var currentStart = 0
+            for (i in bytes.indices) {
+                if (bytes[i] == 0.toByte()) {
+                    try {
+                        val document = bytes.copyOfRange(currentStart, i)
+                        journal.add(deserializeCommand(dslJson, document))
+                        currentStart = i + 1
+                    } catch (exception: Exception) {
+                        logger.e(
+                            "Could not deserialize journal entry" + bytes.contentToString(),
+                            exception
+                        )
+                    }
+                }
+            }
+            return journal
+        }
+
+        /**
+         * Deserialize a command from a byte buffer.
+         *
+         * @param document The document to deserialize from
+         * @return The journal command
+         * @throws IOException If an IO exception occurs
+         */
+        @Throws(IOException::class)
+        fun deserializeCommand(dslJson: DslJson<Any>, document: ByteArray): Command {
+            @Suppress("UNCHECKED_CAST")
+            val map: Map<String, Any>? = dslJson.deserialize(
+                MutableMap::class.java,
+                document,
+                document.size
+            ) as Map<String, Any>?
+            require(!(map == null || map.isEmpty())) { "Document is invalid" }
+            val mapEntry = map.entries.iterator().next()
+            return Command(mapEntry.key, mapEntry.value)
+        }
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
@@ -1,0 +1,191 @@
+package com.bugsnag.android
+
+import org.junit.Assert
+import org.junit.Test
+import java.util.LinkedList
+import kotlin.collections.HashMap
+
+class DocumentPathTest {
+    @Test
+    fun testReplaceDocument() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("")
+        val value = mapOf<String, Any>("a" to 1)
+        val expected = mapOf<String, Any>("a" to 1)
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testMapPut() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a")
+        val value = 1
+        val expected = mapOf<String, Any>("a" to 1)
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testMapModify() {
+        val document = HashMap<String, Any>(mapOf("a" to 1))
+        val docpath = DocumentPath("a")
+        val value = 2
+        val expected = mapOf<String, Any>("a" to 2)
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testMapDelete() {
+        val document = HashMap<String, Any>(mapOf("a" to 1))
+        val docpath = DocumentPath("a")
+        val value = null
+        val expected = mapOf<String, Any>()
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testMapLevel2Put() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a.b")
+        val value = 1
+        val expected = mapOf("a" to mapOf("b" to 1))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testMapLevel2PutEscapes() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a\\.x.b\\.y")
+        val value = 1
+        val expected = mapOf("a.x" to mapOf("b.y" to 1))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testBadEscape() {
+        DocumentPath("a\\.x.b\\.y\\")
+    }
+
+    @Test
+    fun testListAppendEmpty() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a.-1")
+        val value = 1
+        val expected = mapOf<String, Any>("a" to listOf<Any>(1))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testListDeleteLast() {
+        val document = HashMap<String, Any>(
+            mapOf(
+                "a" to LinkedList<Any>(listOf<Any>(1, 2, 3))
+            )
+        )
+        val docpath = DocumentPath("a.-1")
+        val value = null
+        val expected = mapOf<String, Any>("a" to listOf<Any>(1, 2))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testListAppendEmptyNull() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a.-1")
+        val value = null
+        val expected = mapOf<String, Any>("a" to listOf<Any>())
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testListReplace() {
+        val document = HashMap<String, Any>(mapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(1, 2, 3))))
+        val docpath = DocumentPath("a.0")
+        val value = 9
+        val expected = mapOf<String, Any>("a" to listOf<Any>(9, 2, 3))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testListDelete() {
+        val document = HashMap<String, Any>(mapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(1, 2, 3))))
+        val docpath = DocumentPath("a.0")
+        val value = null
+        val expected = mapOf<String, Any>("a" to listOf<Any>(2, 3))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testListReplaceLast() {
+        val document = HashMap<String, Any>(mapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(5, 4, 3, 2, 1))))
+        val docpath = DocumentPath("a.-1")
+        val value = 9
+        val expected = mapOf<String, Any>("a" to listOf<Any>(5, 4, 3, 2, 9))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testListCreateAndAppend() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a.")
+        val value = 1
+        val expected = mapOf<String, Any>("a" to listOf<Any>(1))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testListCreateAndAppendEscape() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a\\..")
+        val value = 1
+        val expected = mapOf<String, Any>("a." to listOf<Any>(1))
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testEscapeLastDot() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a\\.")
+        val value = 1
+        val expected = mapOf<String, Any>("a." to 1)
+
+        val actual = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testLastDotNull() {
+        val document = HashMap<String, Any>()
+        val docpath = DocumentPath("a.")
+        val value = null
+
+        docpath.modifyDocument(document, value)
+    }
+}

--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/JournalBenchmarkTest.kt
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/JournalBenchmarkTest.kt
@@ -1,0 +1,50 @@
+package com.bugsnag.android.benchmark
+
+import android.app.Application
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bugsnag.android.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class JournalBenchmarkTest {
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    lateinit var client: Client
+    lateinit var ctx: Context
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext<Application>()
+        client = generateClient(ctx)
+    }
+
+    @Test
+    fun serializeEventPayload() {
+        val journal = Journal()
+        val entries = listOf<Journal.Command>(
+            Journal.Command("a", "b")
+        )
+
+        benchmarkRule.measureRepeated {
+            journal.clear()
+            val stream = benchmarkRule.scope.runWithTimingDisabled {
+                ByteArrayOutputStream()
+            }
+            stream.use {
+                for(entry in entries) {
+                    journal.add(entry)
+                }
+                journal.serialize(stream)
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/BugsnagBuildPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/BugsnagBuildPlugin.kt
@@ -115,6 +115,7 @@ class BugsnagBuildPlugin : Plugin<Project> {
             isCheckAllWarnings = true
             baseline(File(project.projectDir, "lint-baseline.xml"))
             disable("GradleDependency", "NewerVersionAvailable")
+            ignore("InvalidPackage")
         }
     }
 


### PR DESCRIPTION
## Goal

This is the high-level journal functionality based on PLAT-6353 that supports:
- Journal serialization to a stream
- Journal deserialization from a byte buffer
- Executing a journal's commands to modify a document

Future PRs will handle:
- Journal metadata entry
- Low level operations and shared memory
- File management
- Async-safe journal management
- Crash-time journal additions
- Integration into Bugsnag's event system

## Design

See PLAT-6353

## Testing

Each of the new components has unit tests. There is also a very basic performance test to make sure the JSON codec performance isn't terrible.
