### PR TITLE
Discard unwanted automatic data earlier where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 * Avoid using regex to validate api key
   [#1282](https://github.com/bugsnag/bugsnag-android/pull/1282)
 
+* Discard unwanted automatic data earlier where possible
+  [#1280](https://github.com/bugsnag/bugsnag-android/pull/1280)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -1,5 +1,8 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+import com.bugsnag.android.internal.ImmutableConfigKt;
+
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventPayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventPayloadTest.java
@@ -5,6 +5,8 @@ import static com.bugsnag.android.BugsnagTestUtils.generateDeviceWithState;
 import static com.bugsnag.android.BugsnagTestUtils.streamableToJson;
 import static org.junit.Assert.assertEquals;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import androidx.test.filters.SmallTest;
 
 import org.json.JSONArray;
@@ -22,7 +24,6 @@ public class EventPayloadTest {
 
     /**
      * Generates a eventPayload
-     *
      */
     @Before
     public void setUp() {

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/LastRunInfoStoreTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/LastRunInfoStoreTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
+import com.bugsnag.android.internal.convertToImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/UserStoreTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/UserStoreTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
+import com.bugsnag.android.internal.ImmutableConfig
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/App.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/App.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import java.io.IOException
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -6,6 +6,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.SystemClock
+import com.bugsnag.android.internal.ImmutableConfig
 
 /**
  * Collects various data on the application state

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppWithState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppWithState.kt
@@ -1,5 +1,7 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
+
 /**
  * Stateful information set by the notifier about your app can be found on this class. These values
  * can be accessed and amended if necessary.

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
@@ -1,5 +1,7 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
+
 internal class ClientObservable : BaseObservable() {
 
     fun postOrientationChange(orientation: String?) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -2,10 +2,10 @@ package com.bugsnag.android;
 
 import static com.bugsnag.android.SeverityReason.REASON_PROMISE_REJECTION;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
-
-import kotlin.jvm.functions.Function0;
 
 import java.util.Date;
 import java.util.HashMap;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventFilenameInfo.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventFilenameInfo.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import java.io.File
 import java.util.Locale
 import java.util.UUID

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import java.io.IOException
 
 internal class EventInternal @JvmOverloads internal constructor(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import java.io.File
 import java.io.IOException
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ExceptionHandler.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ExceptionHandler.java
@@ -35,6 +35,9 @@ class ExceptionHandler implements UncaughtExceptionHandler {
 
     @Override
     public void uncaughtException(@NonNull Thread thread, @NonNull Throwable throwable) {
+        if (client.getConfig().shouldDiscardError(throwable)) {
+            return;
+        }
         boolean strictModeThrowable = strictModeHandler.isStrictModeThrowable(throwable);
 
         // Notify any subscribed clients of the uncaught exception

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -3,6 +3,8 @@ package com.bugsnag.android;
 import static com.bugsnag.android.DeliveryHeadersKt.HEADER_INTERNAL_ERROR;
 import static com.bugsnag.android.SeverityReason.REASON_UNHANDLED_EXCEPTION;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Build;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LastRunInfoStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LastRunInfoStore.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import java.io.File
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.withLock

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LaunchCrashTracker.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LaunchCrashTracker.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -325,7 +327,7 @@ public class NativeInterface {
         ImmutableConfig config = client.getConfig();
         if (releaseStage == null
                 || releaseStage.length() == 0
-                || config.shouldNotifyForReleaseStage()) {
+                || !config.shouldDiscardByReleaseStage()) {
             EventStore eventStore = client.getEventStore();
 
             String filename = eventStore.getNdkFilename(payload, apiKey);
@@ -368,6 +370,9 @@ public class NativeInterface {
                               @NonNull final String message,
                               @NonNull final Severity severity,
                               @NonNull final StackTraceElement[] stacktrace) {
+        if (getClient().getConfig().shouldDiscardError(name)) {
+            return;
+        }
         Throwable exc = new RuntimeException();
         exc.setStackTrace(stacktrace);
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/PluginClient.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/PluginClient.kt
@@ -1,5 +1,7 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
+
 internal class PluginClient(
     userPlugins: Set<Plugin>,
     private val immutableConfig: ImmutableConfig,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
@@ -1,10 +1,13 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 
 import java.util.HashMap;
@@ -121,7 +124,9 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
     private Map<String, BreadcrumbType> buildActions() {
 
         Map<String, BreadcrumbType> actions = new HashMap<>();
-        if (client.getConfig().shouldRecordBreadcrumbType(BreadcrumbType.USER)) {
+        ImmutableConfig config = client.getConfig();
+
+        if (!config.shouldDiscardBreadcrumb(BreadcrumbType.USER)) {
             actions.put("android.appwidget.action.APPWIDGET_DELETED", BreadcrumbType.USER);
             actions.put("android.appwidget.action.APPWIDGET_DISABLED", BreadcrumbType.USER);
             actions.put("android.appwidget.action.APPWIDGET_ENABLED", BreadcrumbType.USER);
@@ -130,7 +135,7 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
             actions.put("android.intent.action.DOCK_EVENT", BreadcrumbType.USER);
         }
 
-        if (client.getConfig().shouldRecordBreadcrumbType(BreadcrumbType.STATE)) {
+        if (!config.shouldDiscardBreadcrumb(BreadcrumbType.STATE)) {
             actions.put("android.appwidget.action.APPWIDGET_HOST_RESTORED", BreadcrumbType.STATE);
             actions.put("android.appwidget.action.APPWIDGET_RESTORED", BreadcrumbType.STATE);
             actions.put("android.appwidget.action.APPWIDGET_UPDATE", BreadcrumbType.STATE);
@@ -158,7 +163,7 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
             actions.put("android.os.action.POWER_SAVE_MODE_CHANGED", BreadcrumbType.STATE);
         }
 
-        if (client.getConfig().shouldRecordBreadcrumbType(BreadcrumbType.NAVIGATION)) {
+        if (!config.shouldDiscardBreadcrumb(BreadcrumbType.NAVIGATION)) {
             actions.put("android.intent.action.DREAMING_STARTED", BreadcrumbType.NAVIGATION);
             actions.put("android.intent.action.DREAMING_STOPPED", BreadcrumbType.NAVIGATION);
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import java.io.IOException
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserStore.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import com.bugsnag.android.internal.StateObserver
 import java.io.File
 import java.io.IOException

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -1,5 +1,8 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+import com.bugsnag.android.internal.ImmutableConfigKt;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.bugsnag.android.internal.ImmutableConfig;
 import com.bugsnag.android.internal.StateObserver;
 
 import android.content.Context;
@@ -141,7 +142,6 @@ public class ClientFacadeTest {
         when(metadataState.getMetadata()).thenReturn(new Metadata());
         when(immutableConfig.getLogger()).thenReturn(logger);
         when(immutableConfig.getSendThreads()).thenReturn(ThreadSendPolicy.ALWAYS);
-        when(immutableConfig.shouldNotifyForReleaseStage()).thenReturn(true);
 
         when(deviceDataCollector.generateDeviceWithState(anyLong())).thenReturn(device);
         when(deviceDataCollector.getDeviceMetadata()).thenReturn(new HashMap<String, Object>());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,51 +41,26 @@ public class ConfigurationTest {
         ImmutableConfig immutableConfig;
         immutableConfig = createConfigWithReleaseStages(config,
                 null, "development");
-        assertTrue(immutableConfig.shouldNotifyForReleaseStage());
+        assertFalse(immutableConfig.shouldDiscardByReleaseStage());
 
         // Should not notify if enabledReleaseStages is null
         immutableConfig = createConfigWithReleaseStages(config,
                 Collections.<String>emptySet(), "development");
-        assertFalse(immutableConfig.shouldNotifyForReleaseStage());
+        assertTrue(immutableConfig.shouldDiscardByReleaseStage());
 
         // Shouldn't notify if enabledReleaseStages is set and releaseStage is null
         Set<String> example = Collections.singleton("example");
         immutableConfig = createConfigWithReleaseStages(config, example, null);
-        assertFalse(immutableConfig.shouldNotifyForReleaseStage());
+        assertTrue(immutableConfig.shouldDiscardByReleaseStage());
 
         // Shouldn't notify if releaseStage not in enabledReleaseStages
         Set<String> stages = Collections.singleton("production");
         immutableConfig = createConfigWithReleaseStages(config, stages, "not-production");
-        assertFalse(immutableConfig.shouldNotifyForReleaseStage());
+        assertTrue(immutableConfig.shouldDiscardByReleaseStage());
 
         // Should notify if releaseStage in enabledReleaseStages
         immutableConfig = createConfigWithReleaseStages(config, stages, "production");
-        assertTrue(immutableConfig.shouldNotifyForReleaseStage());
-    }
-
-    @Test
-    public void testShouldSendBreadcrumb() {
-        ImmutableConfig immutableConfig;
-
-        // Should notify if enabledBreadcrumbTypes is null
-        config.setEnabledBreadcrumbTypes(null);
-        immutableConfig = BugsnagTestUtils.convert(config);
-        assertTrue(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
-
-        // Should not notify if enabledBreadcrumbTypes is empty
-        config.setEnabledBreadcrumbTypes(Collections.<BreadcrumbType>emptySet());
-        immutableConfig = BugsnagTestUtils.convert(config);
-        assertFalse(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
-
-        // Should notify if present in enabled types
-        config.setEnabledBreadcrumbTypes(Collections.singleton(BreadcrumbType.MANUAL));
-        immutableConfig = BugsnagTestUtils.convert(config);
-        assertTrue(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
-
-        // Should not notify if not present in enabled types
-        config.setEnabledBreadcrumbTypes(Collections.singleton(BreadcrumbType.ERROR));
-        immutableConfig = BugsnagTestUtils.convert(config);
-        assertFalse(immutableConfig.shouldRecordBreadcrumbType(BreadcrumbType.MANUAL));
+        assertFalse(immutableConfig.shouldDiscardByReleaseStage());
     }
 
     private ImmutableConfig createConfigWithReleaseStages(Configuration config,

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryHeadersTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryHeadersTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateEventPayload
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import com.bugsnag.android.internal.convertToImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DiscardTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DiscardTest.kt
@@ -1,0 +1,135 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.lang.RuntimeException
+
+/**
+ * Verifies the logic for discarding automatically captured errors/sessions/breadcrumbs.
+ */
+class DiscardTest {
+
+    private lateinit var config: Configuration
+
+    @Before
+    fun setUp() {
+        config = BugsnagTestUtils.generateConfiguration()
+    }
+
+    @Test
+    fun testShouldDiscardErrorUsingThrowable() {
+        val exc = RuntimeException()
+
+        // Should not discard if enabledReleaseStages is null
+        config.enabledReleaseStages = null
+        var cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardError(exc))
+
+        // Should discard if outside enabledReleaseStages
+        config.enabledReleaseStages = setOf("prod")
+        config.releaseStage = "dev"
+        cfg = BugsnagTestUtils.convert(config)
+        assertTrue(cfg.shouldDiscardError(exc))
+
+        // Should not discard if inside enabledReleaseStages
+        config.enabledReleaseStages = setOf("prod")
+        config.releaseStage = "prod"
+        cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardError(exc))
+
+        // Should not discard if outside discard classes
+        config.discardClasses = setOf("UnwantedError")
+        cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardError(exc))
+
+        // Should discard if inside discard classes
+        config.discardClasses = setOf("java.lang.RuntimeException")
+        cfg = BugsnagTestUtils.convert(config)
+        assertTrue(cfg.shouldDiscardError(exc))
+    }
+
+    @Test
+    fun testShouldDiscardErrorUsingClz() {
+        // Should not discard if enabledReleaseStages is null
+        config.enabledReleaseStages = null
+        var cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardError("MyError"))
+
+        // Should discard if outside enabledReleaseStages
+        config.enabledReleaseStages = setOf("prod")
+        config.releaseStage = "dev"
+        cfg = BugsnagTestUtils.convert(config)
+        assertTrue(cfg.shouldDiscardError("MyError"))
+
+        // Should not discard if inside enabledReleaseStages
+        config.enabledReleaseStages = setOf("prod")
+        config.releaseStage = "prod"
+        cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardError("MyError"))
+
+        // Should not discard if outside discard classes
+        config.discardClasses = setOf("UnwantedError")
+        cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardError("MyError"))
+
+        // Should discard if inside discard classes
+        config.discardClasses = setOf("UnwantedError")
+        cfg = BugsnagTestUtils.convert(config)
+        assertTrue(cfg.shouldDiscardError("UnwantedError"))
+    }
+
+    @Test
+    fun testShouldDiscardSession() {
+        // Should not discard if enabledReleaseStages is null
+        config.enabledReleaseStages = null
+        var cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardSession(false))
+
+        // Should discard if outside enabledReleaseStages
+        config.enabledReleaseStages = setOf("prod")
+        config.releaseStage = "dev"
+        cfg = BugsnagTestUtils.convert(config)
+        assertTrue(cfg.shouldDiscardSession(false))
+
+        // Should not discard if inside enabledReleaseStages
+        config.enabledReleaseStages = setOf("prod")
+        config.releaseStage = "prod"
+        cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardSession(false))
+
+        // Should not discard if autoTrack disabled and autoCapture == false
+        config.autoTrackSessions = false
+        cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardSession(false))
+
+        // Should discard if autoTrack disabled and autoCapture == false
+        config.autoTrackSessions = false
+        cfg = BugsnagTestUtils.convert(config)
+        assertTrue(cfg.shouldDiscardSession(true))
+    }
+
+    @Test
+    fun testShouldDiscardBreadcrumb() {
+        // Should not discard if enabledBreadcrumbTypes is null
+        config.enabledBreadcrumbTypes = null
+        var cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardBreadcrumb(BreadcrumbType.MANUAL))
+
+        // Should discard if enabledBreadcrumbTypes is empty
+        config.enabledBreadcrumbTypes = emptySet<BreadcrumbType>()
+        cfg = BugsnagTestUtils.convert(config)
+        assertTrue(cfg.shouldDiscardBreadcrumb(BreadcrumbType.MANUAL))
+
+        // Should not discard if present in enabled types
+        config.enabledBreadcrumbTypes = setOf(BreadcrumbType.MANUAL)
+        cfg = BugsnagTestUtils.convert(config)
+        assertFalse(cfg.shouldDiscardBreadcrumb(BreadcrumbType.MANUAL))
+
+        // Should discard if not present in enabled types
+        config.enabledBreadcrumbTypes = setOf(BreadcrumbType.ERROR)
+        cfg = BugsnagTestUtils.convert(config)
+        assertTrue(cfg.shouldDiscardBreadcrumb(BreadcrumbType.MANUAL))
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EnabledErrorTypesTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
+import com.bugsnag.android.internal.convertToImmutableConfig
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventErrorTypeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventErrorTypeTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.convertToImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.File

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFacadeTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStateTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStateTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
@@ -2,6 +2,8 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateEvent
+import com.bugsnag.android.internal.ImmutableConfig
+import com.bugsnag.android.internal.convertToImmutableConfig
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
@@ -73,4 +73,19 @@ internal class ExceptionHandlerTest {
         exceptionHandler.uncaughtException(thread, RuntimeException("Whoops"))
         assertTrue(propagated)
     }
+
+    @Test
+    fun uncaughtExceptionOutsideReleaseStages() {
+        val exceptionHandler = ExceptionHandler(client, NoopLogger)
+        val thread = Thread.currentThread()
+        val exc = RuntimeException("Whoops")
+        `when`(cfg.shouldDiscardError(exc)).thenReturn(true)
+        exceptionHandler.uncaughtException(thread, exc)
+        verify(client, times(0)).notifyUnhandledException(
+            eq(exc),
+            any(),
+            eq(SeverityReason.REASON_UNHANDLED_EXCEPTION),
+            eq(null)
+        )
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.ImmutableConfig
 import org.junit.After
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -9,6 +10,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
+import org.mockito.Mockito.`when`
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
@@ -20,11 +22,15 @@ internal class ExceptionHandlerTest {
     @Mock
     lateinit var client: Client
 
+    @Mock
+    lateinit var cfg: ImmutableConfig
+
     var originalHandler: Thread.UncaughtExceptionHandler? = null
 
     @Before
     fun setUp() {
         originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+        `when`(client.config).thenReturn(cfg)
     }
 
     @After

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -5,6 +5,8 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
+import com.bugsnag.android.internal.convertToImmutableConfig
+import com.bugsnag.android.internal.sanitiseConfiguration
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NativeInterfaceApiTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import android.content.Context
 import com.bugsnag.android.BugsnagTestUtils.generateAppWithState
 import com.bugsnag.android.BugsnagTestUtils.generateDeviceWithState
+import com.bugsnag.android.internal.ImmutableConfig
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/NullMetadataTest.java
@@ -3,6 +3,8 @@ package com.bugsnag.android;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionStoreMaxLimitTest.kt
@@ -2,6 +2,8 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateSession
+import com.bugsnag.android.internal.ImmutableConfig
+import com.bugsnag.android.internal.convertToImmutableConfig
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.content.Context
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateDevice
+import com.bugsnag.android.internal.ImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -29,6 +30,9 @@ internal class SessionTrackerPauseResumeTest {
     lateinit var client: Client
 
     @Mock
+    lateinit var cfg: ImmutableConfig
+
+    @Mock
     lateinit var appDataCollector: AppDataCollector
 
     @Mock
@@ -51,6 +55,7 @@ internal class SessionTrackerPauseResumeTest {
         `when`(client.getNotifier()).thenReturn(Notifier())
         `when`(client.getAppContext()).thenReturn(context)
         `when`(client.getAppDataCollector()).thenReturn(appDataCollector)
+        `when`(client.config).thenReturn(cfg)
         `when`(appDataCollector.generateApp()).thenReturn(app)
         `when`(client.getDeviceDataCollector()).thenReturn(deviceDataCollector)
         `when`(deviceDataCollector.generateDevice()).thenReturn(generateDevice())

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import android.app.ActivityManager;
 import android.content.Context;
 
@@ -34,6 +36,9 @@ public class SessionTrackerTest {
     Client client;
 
     @Mock
+    ImmutableConfig cfg;
+
+    @Mock
     AppDataCollector appDataCollector;
 
     @Mock
@@ -59,6 +64,7 @@ public class SessionTrackerTest {
         when(client.getNotifier()).thenReturn(new Notifier());
         when(client.getAppContext()).thenReturn(context);
         when(client.getAppDataCollector()).thenReturn(appDataCollector);
+        when(client.getConfig()).thenReturn(cfg);
         when(appDataCollector.generateApp()).thenReturn(app);
         when(client.getDeviceDataCollector()).thenReturn(deviceDataCollector);
         when(deviceDataCollector.generateDevice()).thenReturn(generateDevice());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SystemBroadcastReceiverTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import com.bugsnag.android.SystemBroadcastReceiver.shortenActionNameIfNeeded
+import com.bugsnag.android.internal.ImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/EventHooks.java
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/EventHooks.java
@@ -2,6 +2,9 @@ package com.bugsnag.android;
 
 import static com.bugsnag.android.ClientHooksKt.generateConfig;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+import com.bugsnag.android.internal.ImmutableConfigKt;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Date;

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -7,8 +7,11 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal class AnrPlugin : Plugin {
 
     internal companion object {
+
         private const val LOAD_ERR_MSG = "Native library could not be linked. Bugsnag will " +
             "not report ANRs. See https://docs.bugsnag.com/platforms/android/anr-link-errors"
+        private const val ANR_ERROR_CLASS = "ANR"
+        private const val ANR_ERROR_MSG = "Application did not respond to UI input"
 
         internal fun doesJavaTraceLeadToNativeTrace(
             javaTrace: Array<StackTraceElement>
@@ -89,6 +92,9 @@ internal class AnrPlugin : Plugin {
      */
     private fun notifyAnrDetected(nativeTrace: List<NativeStackframe>) {
         try {
+            if (client.immutableConfig.shouldDiscardError(ANR_ERROR_CLASS)) {
+                return
+            }
             // generate a full report as soon as possible, then wait for extra process error info
             val stackTrace = Looper.getMainLooper().thread.stackTrace
             val hasNativeComponent = doesJavaTraceLeadToNativeTrace(stackTrace)
@@ -101,8 +107,8 @@ internal class AnrPlugin : Plugin {
                 SeverityReason.newInstance(SeverityReason.REASON_ANR)
             )
             val err = event.errors[0]
-            err.errorClass = "ANR"
-            err.errorMessage = "Application did not respond to UI input"
+            err.errorClass = ANR_ERROR_CLASS
+            err.errorMessage = ANR_ERROR_MSG
 
             // append native stackframes to error/thread stacktrace
             if (hasNativeComponent) {

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -1,5 +1,8 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+import com.bugsnag.android.internal.ImmutableConfigKt;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -77,7 +77,7 @@ class BugsnagReactNativePlugin : Plugin {
         if (!ignoreJsExceptionCallbackAdded) { ignoreJavaScriptExceptions() }
 
         val map = HashMap<String, Any?>()
-        configSerializer.serialize(map, internalHooks.config)
+        configSerializer.serialize(map, client.config)
         return map
     }
 
@@ -138,6 +138,14 @@ class BugsnagReactNativePlugin : Plugin {
         requireNotNull(payload)
         val projectPackages = internalHooks.getProjectPackages(client.config)
         val event = EventDeserializer(client, projectPackages).deserialize(payload)
+
+        if (event.errors.isEmpty()) {
+            return
+        }
+        val errorClass = event.errors[0].errorClass
+        if (client.immutableConfig.shouldDiscardError(errorClass)) {
+            return
+        }
         client.notifyInternal(event, null)
     }
 

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -11,10 +13,6 @@ class InternalHooks {
 
     public InternalHooks(Client client) {
         this.client = client;
-    }
-
-    public ImmutableConfig getConfig() {
-        return client.getConfig();
     }
 
     public AppWithState getAppWithState() {
@@ -34,7 +32,7 @@ class InternalHooks {
     }
 
     public List<Thread> getThreads(boolean unhandled) {
-        return new ThreadState(null, unhandled, getConfig()).getThreads();
+        return new ThreadState(null, unhandled, client.getConfig()).getThreads();
     }
 
     public Collection<String> getProjectPackages(ImmutableConfig config) {

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeStackDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeStackDeserializer.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
@@ -1,10 +1,9 @@
 package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.bugsnag.android.ImmutableConfig;
+import com.bugsnag.android.internal.ImmutableConfig;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.ImmutableConfig;
+
 import androidx.annotation.NonNull;
 
 import java.util.Collections;

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyEnabledReleaseStageScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/EmptyEnabledReleaseStageScenario.kt
@@ -23,6 +23,5 @@ internal class EmptyEnabledReleaseStageScenario(
         Bugsnag.notify(generateException())
     }
 
-    override fun getInterceptedLogMessages() =
-        listOf("Skipping notification - should not notify for this release stage")
+    override fun getInterceptedLogMessages() = listOf("Bugsnag loaded")
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/IgnoredExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/IgnoredExceptionScenario.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import java.lang.IllegalStateException
 
 /**
  * Attempts to send an ignored handled exception to Bugsnag, which should not result
@@ -21,8 +22,6 @@ internal class IgnoredExceptionScenario(
     override fun startScenario() {
         super.startScenario()
         Bugsnag.notify(RuntimeException("Should never appear"))
+        Bugsnag.notify(IllegalStateException("Is it me you're looking for?"))
     }
-
-    override fun getInterceptedLogMessages() =
-        listOf("Skipping notification - should not notify for this class")
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/NullReleaseStageScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/NullReleaseStageScenario.kt
@@ -23,6 +23,5 @@ internal class NullReleaseStageScenario(
         Bugsnag.notify(generateException())
     }
 
-    override fun getInterceptedLogMessages() =
-        listOf("Skipping notification - should not notify for this release stage")
+    override fun getInterceptedLogMessages() = listOf("Bugsnag loaded")
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OutsideReleaseStageScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OutsideReleaseStageScenario.kt
@@ -24,6 +24,5 @@ internal class OutsideReleaseStageScenario(
         Bugsnag.notify(RuntimeException("OutsideReleaseStageScenario"))
     }
 
-    override fun getInterceptedLogMessages() =
-        listOf("Skipping notification - should not notify for this release stage")
+    override fun getInterceptedLogMessages() = listOf("Bugsnag loaded")
 }

--- a/features/full_tests/batch_1/ignored_reports.feature
+++ b/features/full_tests/batch_1/ignored_reports.feature
@@ -2,8 +2,11 @@ Feature: Reports are ignored
 
 Scenario: Exception classname ignored
     When I run "IgnoredExceptionScenario"
-    And I wait to receive 1 logs
-    Then the "debug" level log message equals "Skipping notification - should not notify for this class"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "java.lang.IllegalStateException"
+    And the exception "message" equals "Is it me you're looking for?"
+    And the event "unhandled" is false
 
 Scenario: Disabled Exception Handler
     When I run "DisableAutoDetectErrorsScenario" and relaunch the app

--- a/features/full_tests/batch_2/release_stage.feature
+++ b/features/full_tests/batch_2/release_stage.feature
@@ -3,17 +3,17 @@ Feature: Reporting exceptions with release stages
 Scenario: Exception not reported when outside release stage
     When I run "OutsideReleaseStageScenario"
     And I wait to receive 1 logs
-    Then the "debug" level log message equals "Skipping notification - should not notify for this release stage"
+    Then the "debug" level log message equals "Bugsnag loaded"
 
 Scenario: Exception not reported when release stage null
     When I run "NullReleaseStageScenario"
     And I wait to receive 1 logs
-    Then the "debug" level log message equals "Skipping notification - should not notify for this release stage"
+    Then the "debug" level log message equals "Bugsnag loaded"
 
 Scenario: Exception reported when release stages empty
     When I run "EmptyEnabledReleaseStageScenario"
     And I wait to receive 1 logs
-    Then the "debug" level log message equals "Skipping notification - should not notify for this release stage"
+    Then the "debug" level log message equals "Bugsnag loaded"
 
 Scenario: Exception reported when inside Notify release stage array
     When I run "ArrayEnabledReleaseStageScenario"


### PR DESCRIPTION
## Goal

Improves performance by discarding unwanted automatic data as early as possible. In the happy case (where an error/session is discarded) then this will remove any overhead from gathering stacktraces/metadata, which should be a significant saving.

## Changeset

The changeset has a lot of altered imports/reorganized tests so may be easier to view via the individual commits.

- Moved `ImmutableConfig` to `com.bugsnag.android.internal` and consolidated all logic for discarding automatically captured data. This involved renaming and documenting some existing methods.
- Made `ImmutableConfig` public (note it's under the `internal` package)
- Moved existing checks to _before_ the instantiation of the `Event` object. This now takes place at the point of error capture, and checks whether the `Throwable` itself is within the `discardClasses` or the `errorClass` for ANRs/JS/NDK errors
- Moved checks to _before_ the `Session` is instantiated, which avoids the collection of app/device metadata in `SessionTracker`
- Avoided logging when events/sessions are discarded as this can be a hot path and writing to Logcat could become a bottleneck - E2E test assertions have been updated accordingly

## Testing

Enhanced unit test coverage for discard logic.

This also relies on the existing E2E tests, specifically `ignored_reports` and `release_stage`. It's worth noting that these tests aren't exhaustive but are good enough to confirm that the functionality is working correctly.