### PR TITLE
Avoid using regex to validate api key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 * Use direct field access when adding breadcrumbs and state updates
   [#1279](https://github.com/bugsnag/bugsnag-android/pull/1279)
 
+* Avoid using regex to validate api key
+  [#1282](https://github.com/bugsnag/bugsnag-android/pull/1282)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import java.io.File;
 import java.util.Locale;
@@ -19,7 +20,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
 
     private static final int MIN_BREADCRUMBS = 0;
     private static final int MAX_BREADCRUMBS = 100;
-    private static final String API_KEY_REGEX = "[A-Fa-f0-9]{32}";
+    private static final int VALID_API_KEY_LEN = 32;
     private static final long MIN_LAUNCH_CRASH_THRESHOLD_MS = 0;
 
     final ConfigInternal impl;
@@ -47,14 +48,29 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
     }
 
     private void validateApiKey(String value) {
-        if (Intrinsics.isEmpty(value)) {
+        if (isInvalidApiKey(value)) {
+            DebugLogger.INSTANCE.w("Invalid configuration. "
+                    + "apiKey should be a 32-character hexademical string, got " + value);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isInvalidApiKey(String apiKey) {
+        if (Intrinsics.isEmpty(apiKey)) {
             throw new IllegalArgumentException("No Bugsnag API Key set");
         }
-
-        if (!value.matches(API_KEY_REGEX)) {
-            DebugLogger.INSTANCE.w(String.format("Invalid configuration. apiKey should be a "
-                    + "32-character hexademical string, got \"%s\"", value));
+        if (apiKey.length() != VALID_API_KEY_LEN) {
+            return true;
         }
+        // check whether each character is hexadecimal (either a digit or a-f).
+        // this avoids using a regex to improve startup performance.
+        for (int k = 0; k < VALID_API_KEY_LEN; k++) {
+            char chr = apiKey.charAt(k);
+            if (!Character.isDigit(chr) && (chr < 'a' || chr > 'f')) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void logNull(String property) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyConfigValidationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyConfigValidationTest.kt
@@ -1,0 +1,53 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ApiKeyConfigValidationTest {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testEmptyApiKey() {
+        Configuration("")
+    }
+
+    @Test
+    fun testWrongSizeApiKey() {
+        val config = Configuration("abfe05f")
+        assertEquals("abfe05f", config.apiKey)
+    }
+
+    @Test
+    fun testNonHexApiKey() {
+        val config = Configuration("yej0492j55z92z2p")
+        assertEquals("yej0492j55z92z2p", config.apiKey)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSettingEmptyApiKey() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        config.apiKey = ""
+        assertEquals("", config.apiKey)
+    }
+
+    @Test
+    fun testSettingWrongSizeApiKey() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        config.apiKey = "abfe05f"
+        assertEquals("abfe05f", config.apiKey)
+    }
+
+    @Test
+    fun testSettingNonHexApiKey() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        config.apiKey = "yej0492j55z92z2p"
+        assertEquals("yej0492j55z92z2p", config.apiKey)
+    }
+
+    @Test
+    fun setApiKey() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        assertEquals("5d1ec5bd39a74caa1267142706a7fb21", config.apiKey)
+        config.apiKey = "000005bd39a74caa1267142706a7fb21"
+        assertEquals("000005bd39a74caa1267142706a7fb21", config.apiKey)
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyValidationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyValidationTest.kt
@@ -1,48 +1,37 @@
 package com.bugsnag.android
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ApiKeyValidationTest {
 
     @Test(expected = IllegalArgumentException::class)
+    fun testNullApiKey() {
+        Configuration.isInvalidApiKey(null)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
     fun testEmptyApiKey() {
-        Configuration("")
+        Configuration.isInvalidApiKey("")
     }
 
     @Test
     fun testWrongSizeApiKey() {
-        Configuration("abfe05f")
-    }
-
-    @Test
-    fun testNonHexApiKey() {
-        Configuration("yej0492j55z92z2p")
-    }
-
-    @Test(expected = IllegalArgumentException::class)
-    fun testSettingEmptyApiKey() {
-        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
-        config.apiKey = ""
-    }
-
-    @Test
-    fun testSettingWrongSizeApiKey() {
-        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
-        config.apiKey = "abfe05f"
+        assertTrue(Configuration.isInvalidApiKey("abfe05f"))
+        assertTrue(Configuration.isInvalidApiKey("5d1ec5bd39a74caa1267142706a7fb212"))
     }
 
     @Test
     fun testSettingNonHexApiKey() {
-        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
-        config.apiKey = "yej0492j55z92z2p"
+        assertTrue(Configuration.isInvalidApiKey("5d1ec5bd3Ga74caa1267142706a7fb21"))
+        assertTrue(Configuration.isInvalidApiKey("5d1ec5bd39a7%caa1267_42706P7fb212"))
+        assertFalse(Configuration.isInvalidApiKey("5d1ec5bd39a74caa1267142706a7fb21"))
     }
 
     @Test
     fun setApiKey() {
-        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
-        assertEquals("5d1ec5bd39a74caa1267142706a7fb21", config.apiKey)
-        config.apiKey = "000005bd39a74caa1267142706a7fb21"
-        assertEquals("000005bd39a74caa1267142706a7fb21", config.apiKey)
+        assertFalse(Configuration.isInvalidApiKey("5d1ec5bd39a74caa1267142706a7fb21"))
+        assertFalse(Configuration.isInvalidApiKey("000005bd39a74caa1267142706a7fb21"))
     }
 }


### PR DESCRIPTION
## Goal

The API key is currently validated using a regex, which was identified through profiling as taking ~3ms to compile and match. This alters the implementation so that it checks the string length and iterates through the characters instead. Additionally an expensive call to `String.format` has been replaced with concatenation.

## Testing

Increased unit test coverage and profiled example app to confirm that API key validation does not add on a large amount of time.