### PR TITLE
Enable AnrPlugin immediately if called on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 * Discard unwanted automatic data earlier where possible
   [#1280](https://github.com/bugsnag/bugsnag-android/pull/1280)
 
+* Enable ANR handling on immediately if started from the main thread
+  [#1283](https://github.com/bugsnag/bugsnag-android/pull/1283)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -48,15 +48,22 @@ internal class AnrPlugin : Plugin {
             performOneTimeSetup(client)
         }
         if (libraryLoader.isLoaded) {
-            Handler(Looper.getMainLooper()).post(
-                Runnable {
-                    enableAnrReporting()
-                    client.logger.i("Initialised ANR Plugin")
+            val mainLooper = Looper.getMainLooper()
+            if (Looper.myLooper() == mainLooper) {
+                initNativePlugin()
+            } else {
+                Handler(mainLooper).postAtFrontOfQueue {
+                    initNativePlugin()
                 }
-            )
+            }
         } else {
             client.logger.e(LOAD_ERR_MSG)
         }
+    }
+
+    private fun initNativePlugin() {
+        enableAnrReporting()
+        client.logger.i("Initialised ANR Plugin")
     }
 
     private fun performOneTimeSetup(client: Client) {

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
@@ -8,6 +8,7 @@ class MazerunnerApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        triggerStartupAnrIfRequired()
         setupNonSdkUsageStrictMode()
     }
 

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/StartupANRBehaviour.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/StartupANRBehaviour.kt
@@ -1,0 +1,42 @@
+package com.bugsnag.android.mazerunner
+
+import android.app.Application
+import android.content.Context
+import android.util.Log
+import com.bugsnag.android.Bugsnag
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+fun Application.triggerStartupAnrIfRequired() {
+    val prefs = getSharedPreferences("AnrPreferences", Context.MODE_PRIVATE)
+    val startupDelay = prefs.getLong("onCreateDelay", 0)
+
+    if (startupDelay > 0L) {
+        // we remove the preference so that we don't affect any future startup
+        prefs.edit()
+            .remove("onCreateDelay")
+            .commit()
+
+        // we have to startup Bugsnag at this point
+        Bugsnag.start(this)
+
+        thread {
+            // This is a dirty hack to work around the limitations of our current testing
+            // systems - where external key-events are pushed through our main thread (which we
+            // are pausing to test for ANRs)
+
+            // if there is a startup delay, we assume we are testing ANRs and send a "BACK"
+            // key-press from the *system* in an attempt to cause an ANR
+            try {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1L))
+                Runtime.getRuntime()
+                    .exec("input keyevent 4")
+                    .waitFor()
+            } catch (ex: Exception) {
+                Log.w("StartupANR", "Couldn't send keyevent for BACK", ex)
+            }
+        }
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(startupDelay))
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ConfigureStartupAnrScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ConfigureStartupAnrScenario.kt
@@ -1,0 +1,25 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+import kotlin.system.exitProcess
+
+class ConfigureStartupAnrScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+    override fun startScenario() {
+        context.applicationContext
+            .getSharedPreferences("AnrPreferences", Context.MODE_PRIVATE)
+            .edit()
+            .putLong("onCreateDelay", STARTUP_DELAY)
+            .commit()
+
+        exitProcess(0)
+    }
+
+    companion object {
+        private const val STARTUP_DELAY = 430L
+    }
+}

--- a/features/full_tests/batch_1/startup_anr.feature
+++ b/features/full_tests/batch_1/startup_anr.feature
@@ -1,0 +1,9 @@
+Feature: onCreate ANR
+
+Scenario: onCreate ANR is reported
+  When I run "ConfigureStartupAnrScenario"
+  And I relaunch the app after a crash
+  And I wait for 30 seconds
+  And I clear any error dialogue
+  Then I wait to receive an error
+  And the exception "errorClass" equals "ANR"


### PR DESCRIPTION
## Goal
Enable AnrPlugin immediately if called on main thread so that Application Not Responding errors can be caught within the application startup.

## Changeset
In the `AnrPlugin` is started on the main-thread `Looper` it starts immediately. If the current thread is not the main, it dispatches the startup logic using `Handler.postAtFrontOfQueue` to ensure we miss as few startup events as possible.

## Testing
Added new test scenario to the Mazerunner fixture, and modified the `MazerunnerApp.onCreate` to allow startup ANRs to be simulated.

The Mazerunner scenario creates a `SharedPreferences` option (picked up in `MazerunnerApp.onCreate`) and forces the application to terminate.