### PR TITLE
Use ring buffer to store breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 * Cache results from PackageManager
   [#1288](https://github.com/bugsnag/bugsnag-android/pull/1288)
 
+* Use ring buffer to store breadcrumbs
+  [#1286](https://github.com/bugsnag/bugsnag-android/pull/1286)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbFilterTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbFilterTest.kt
@@ -24,8 +24,7 @@ class BreadcrumbFilterTest {
         client = generateClient(configuration)
 
         client.leaveBreadcrumb("Hello World")
-
-        assertEquals(1, client.breadcrumbState.store.size)
+        assertEquals(1, client.breadcrumbState.copy().size)
     }
 
     @Test
@@ -36,6 +35,6 @@ class BreadcrumbFilterTest {
 
         client.leaveBreadcrumb("Hello World")
 
-        assertEquals(1, client.breadcrumbState.store.size)
+        assertEquals(1, client.breadcrumbState.copy().size)
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -31,7 +31,7 @@ class BreadcrumbStateTest {
     fun testClientMethods() {
         client = generateClient()
         client!!.leaveBreadcrumb("Hello World")
-        val store = client!!.breadcrumbState.store
+        val store = client!!.breadcrumbState.copy()
         var count = 0
 
         for (breadcrumb in store) {

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -76,14 +76,14 @@ public class ClientTest {
         config.setEnabledBreadcrumbTypes(new HashSet<>(breadcrumbTypes));
         config.setMaxBreadcrumbs(2);
         client = generateClient(config);
-        assertEquals(0, client.breadcrumbState.getStore().size());
+        assertEquals(0, client.breadcrumbState.copy().size());
 
         client.leaveBreadcrumb("test");
         client.leaveBreadcrumb("another");
         client.leaveBreadcrumb("yet another");
-        assertEquals(2, client.breadcrumbState.getStore().size());
+        assertEquals(2, client.breadcrumbState.copy().size());
 
-        Breadcrumb poll = client.breadcrumbState.getStore().poll();
+        Breadcrumb poll = client.breadcrumbState.copy().get(0);
         assertEquals(BreadcrumbType.MANUAL, poll.getType());
         assertEquals("another", poll.getMessage());
     }
@@ -129,7 +129,7 @@ public class ClientTest {
         client = generateClient();
         client.leaveBreadcrumb("Hello World");
         List<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
-        List<Breadcrumb> store = new ArrayList<>(client.breadcrumbState.getStore());
+        List<Breadcrumb> store = new ArrayList<>(client.breadcrumbState.copy());
         assertEquals(store, breadcrumbs);
         assertNotSame(store, breadcrumbs);
     }
@@ -153,8 +153,8 @@ public class ClientTest {
 
         breadcrumbs.clear(); // only the copy should be cleared
         assertTrue(breadcrumbs.isEmpty());
-        assertEquals(1, client.breadcrumbState.getStore().size());
-        assertEquals("Manual breadcrumb", client.breadcrumbState.getStore().remove().getMessage());
+        assertEquals(1, client.breadcrumbState.copy().size());
+        assertEquals("Manual breadcrumb", client.breadcrumbState.copy().get(0).getMessage());
     }
 
     @Test

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbCallbackStateTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/OnBreadcrumbCallbackStateTest.java
@@ -34,7 +34,7 @@ public class OnBreadcrumbCallbackStateTest {
         breadcrumbTypes.add(BreadcrumbType.USER);
         configuration.setEnabledBreadcrumbTypes(breadcrumbTypes);
         client = generateClient(configuration);
-        assertEquals(0, client.breadcrumbState.getStore().size());
+        assertEquals(0, client.breadcrumbState.copy().size());
     }
 
     @After
@@ -45,7 +45,7 @@ public class OnBreadcrumbCallbackStateTest {
     @Test
     public void noCallback() {
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, client.breadcrumbState.getStore().size());
+        assertEquals(1, client.breadcrumbState.copy().size());
     }
 
     @Test
@@ -57,7 +57,7 @@ public class OnBreadcrumbCallbackStateTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(0, client.breadcrumbState.getStore().size());
+        assertEquals(0, client.breadcrumbState.copy().size());
     }
 
     @Test
@@ -69,7 +69,7 @@ public class OnBreadcrumbCallbackStateTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, client.breadcrumbState.getStore().size());
+        assertEquals(1, client.breadcrumbState.copy().size());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class OnBreadcrumbCallbackStateTest {
             }
         });
         client.leaveBreadcrumb("Hello");
-        assertEquals(0, client.breadcrumbState.getStore().size());
+        assertEquals(0, client.breadcrumbState.copy().size());
     }
 
     @Test
@@ -161,7 +161,7 @@ public class OnBreadcrumbCallbackStateTest {
         client.leaveBreadcrumb("Hello");
         client.removeOnBreadcrumb(cb);
         client.leaveBreadcrumb("Hello");
-        assertEquals(1, client.breadcrumbState.getStore().size());
+        assertEquals(1, client.breadcrumbState.copy().size());
     }
 
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -1,41 +1,41 @@
 package com.bugsnag.android
 
 import java.io.IOException
-import java.util.Queue
-import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 
+/**
+ * Stores breadcrumbs added to the [Client] in a ring buffer. If the number of breadcrumbs exceeds
+ * the maximum configured limit then the oldest breadcrumb in the ring buffer will be overwritten.
+ *
+ * When the breadcrumbs are required for generation of an event a [List] is constructed and
+ * breadcrumbs added in the order of their addition.
+ */
 internal class BreadcrumbState(
-    maxBreadcrumbs: Int,
-    val callbackState: CallbackState,
-    val logger: Logger
+    private val maxBreadcrumbs: Int,
+    private val callbackState: CallbackState,
+    private val logger: Logger
 ) : BaseObservable(), JsonStream.Streamable {
 
-    val store: Queue<Breadcrumb> = ConcurrentLinkedQueue()
+    /*
+     * We use the `index` as both a pointer to the tail of our ring-buffer, and also as "cheat"
+     * semaphore. When the ring-buffer is being copied - the index is set to a negative number,
+     * which is an invalid array-index. By masking the `expected` value in a `compareAndSet` with
+     * `validIndexMask`: the CAS operation will only succeed if it wouldn't interrupt a concurrent
+     * `copy()` call.
+     */
+    private val validIndexMask: Int = Int.MAX_VALUE
 
-    private val maxBreadcrumbs: Int
-
-    init {
-        when {
-            maxBreadcrumbs > 0 -> this.maxBreadcrumbs = maxBreadcrumbs
-            else -> this.maxBreadcrumbs = 0
-        }
-    }
-
-    @Throws(IOException::class)
-    override fun toStream(writer: JsonStream) {
-        pruneBreadcrumbs()
-        writer.beginArray()
-        store.forEach { it.toStream(writer) }
-        writer.endArray()
-    }
+    private val store = arrayOfNulls<Breadcrumb?>(maxBreadcrumbs)
+    private val index = AtomicInteger(0)
 
     fun add(breadcrumb: Breadcrumb) {
-        if (!callbackState.runOnBreadcrumbTasks(breadcrumb, logger)) {
+        if (maxBreadcrumbs == 0 || !callbackState.runOnBreadcrumbTasks(breadcrumb, logger)) {
             return
         }
 
-        store.add(breadcrumb)
-        pruneBreadcrumbs()
+        // store the breadcrumb in the ring buffer
+        val position = getBreadcrumbIndex()
+        store[position] = breadcrumb
 
         updateState {
             // use direct field access to avoid overhead of accessor method
@@ -48,10 +48,49 @@ internal class BreadcrumbState(
         }
     }
 
-    private fun pruneBreadcrumbs() {
-        // Remove oldest breadcrumbState until new max size reached
-        while (store.size > maxBreadcrumbs) {
-            store.poll()
+    /**
+     * Retrieves the index in the ring buffer where the breadcrumb should be stored.
+     */
+    private fun getBreadcrumbIndex(): Int {
+        while (true) {
+            val currentValue = index.get() and validIndexMask
+            val nextValue = (currentValue + 1) % maxBreadcrumbs
+            if (index.compareAndSet(currentValue, nextValue)) {
+                return currentValue
+            }
         }
+    }
+
+    /**
+     * Creates a copy of the breadcrumbs in the order of their addition.
+     */
+    fun copy(): List<Breadcrumb> {
+        if (maxBreadcrumbs == 0) {
+            return emptyList()
+        }
+
+        // Set a negative value that stops any other thread from adding a breadcrumb.
+        // This handles reentrancy by waiting here until the old value has been reset.
+        var tail = -1
+        while (tail == -1) {
+            tail = index.getAndSet(-1)
+        }
+
+        try {
+            val result = arrayOfNulls<Breadcrumb>(maxBreadcrumbs)
+            store.copyInto(result, 0, tail, maxBreadcrumbs)
+            store.copyInto(result, maxBreadcrumbs - tail, 0, tail)
+            return result.filterNotNull()
+        } finally {
+            index.set(tail)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun toStream(writer: JsonStream) {
+        val crumbs = copy()
+        writer.beginArray()
+        crumbs.forEach { it.toStream(writer) }
+        writer.endArray()
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -711,7 +711,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         event.addMetadata("app", appDataCollector.getAppDataMetadata());
 
         // Attach breadcrumbState to the event
-        event.setBreadcrumbs(new ArrayList<>(breadcrumbState.getStore()));
+        event.setBreadcrumbs(breadcrumbState.copy());
 
         // Attach user info to the event
         User user = userState.getUser();
@@ -765,7 +765,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @NonNull
     public List<Breadcrumb> getBreadcrumbs() {
-        return new ArrayList<>(breadcrumbState.getStore());
+        return breadcrumbState.copy();
     }
 
     @NonNull

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -148,7 +148,7 @@ public class ClientFacadeTest {
         when(appDataCollector.generateAppWithState()).thenReturn(app);
         when(appDataCollector.getAppDataMetadata()).thenReturn(new HashMap<String, Object>());
 
-        when(breadcrumbState.getStore()).thenReturn(new ArrayDeque<Breadcrumb>());
+        when(breadcrumbState.copy()).thenReturn(new ArrayList<Breadcrumb>());
         when(userState.getUser()).thenReturn(new User());
         when(callbackState.runOnErrorTasks(any(Event.class), any(Logger.class))).thenReturn(true);
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -111,7 +111,7 @@ internal class DeliveryDelegateTest {
         assertEquals(DeliveryStatus.DELIVERED, status)
         assertEquals("Sent 1 new event to Bugsnag", logger.msg)
 
-        val breadcrumb = requireNotNull(breadcrumbState.store.peek())
+        val breadcrumb = requireNotNull(breadcrumbState.copy().first())
         assertEquals(BreadcrumbType.ERROR, breadcrumb.type)
         assertEquals("java.lang.RuntimeException", breadcrumb.message)
         assertEquals("java.lang.RuntimeException", breadcrumb.metadata!!["errorClass"])

--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/CriticalPathBenchmarkTest.kt
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/CriticalPathBenchmarkTest.kt
@@ -95,6 +95,19 @@ class CriticalPathBenchmarkTest {
     }
 
     /**
+     * Make a copy of breadcrumbs on the Client (required when generating events)
+     */
+    @Test
+    fun copyBreadcrumbs() {
+        repeat(201) { count ->
+            client.leaveBreadcrumb("Hello world $count")
+        }
+        benchmarkRule.measureRepeated {
+            client.breadcrumbs
+        }
+    }
+
+    /**
      * Add a single value to the Client metadata
      */
     @Test


### PR DESCRIPTION
## Goal

Breadcrumbs are stored in a `ConcurrentLinkedQueue` and then trimmed as they are added. This was identified as an area where performance could potentially be improved as over an application's lifecycle thousands of breadcrumbs might be added to Bugsnag.

## Changeset

`BreadcrumbState` has been altered to use a ring buffer instead of a `ConcurrentLinkedQueue`. Every time a breadcrumb is added an index is incremented by one, and the breadcrumb is stored in a backing array. If the number of breadcrumbs logged is greater than `config.maxBreadcrumbs` then the implementation wraps around to zero and overwrites the oldest breadcrumb added.

When an error is captured breadcrumbs must be added to an `Event` in the order in which they were captured. Previously this was a case of transforming a `Queue` into a `List` but using a ring buffer means that the breadcrumbs can be out of order. The solution chosen here is to create two sublists based on the position of the most recent breadcrumb and then combine them together.

## Performance improvements

Adding 1000 breadcrumbs to the store took ~9ms with these changes, and ~56ms without, a difference of ~45ms.

The `BreadcrumbState#copy()` implementation has added on ~0.5ms to the `Bugsnag.notify()` call.

<img width="1059" alt="changes_add_crumbs" src="https://user-images.githubusercontent.com/11800640/123110986-7d451780-d434-11eb-950e-95b2f87d41f8.png">

<img width="1059" alt="baseline_crumbs" src="https://user-images.githubusercontent.com/11800640/122942000-c9795480-d36d-11eb-820e-52a0dda776c7.png">

## Tradeoffs of this changeset

There are a couple of tradeoffs made with this changeset:

- `BreadcrumbState#copy()` does not sort elements or use synchronisation, so in rare cases this could lead to some breadcrumbs being ordered incorrectly. Sorting the collection was profiled as being expensive, but this is something that could potentially be added in if needed.
- This increases the time taken to execute `Bugsnag.notify()`, by the equivalent of adding ~11 breadcrumbs. This feels like a reasonable trade off as breadcrumbs should typically be added much more frequently than `Bugsnag.notify()` is called.

## Testing

Updated existing test coverage to match new method signatures, and added additional unit test cases for the ring buffer wrapping round. Additionally added a benchmark test for copying breadcrumbs (which happens whenever an event is generated).