### PR TITLE
fix: add binaryarch to all events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 * Enable ANR handling on immediately if started from the main thread
   [#1283](https://github.com/bugsnag/bugsnag-android/pull/1283)
 
+* Include `app.binaryArch` in all events
+  [#1287](https://github.com/bugsnag/bugsnag-android/pull/1287)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -16,6 +16,8 @@ internal class NdkPlugin : Plugin {
     private external fun enableCrashReporting()
     private external fun disableCrashReporting()
 
+    private external fun getBinaryArch(): String
+
     private var nativeBridge: NativeBridge? = null
     private var client: Client? = null
 
@@ -46,6 +48,7 @@ internal class NdkPlugin : Plugin {
             true
         }
         if (libraryLoader.isLoaded) {
+            client.setBinaryArch(getBinaryArch())
             nativeBridge = initNativeBridge(client)
         } else {
             client.logger.e(LOAD_ERR_MSG)

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -14,8 +14,6 @@
 
 static JNIEnv *bsg_global_jni_env = NULL;
 
-void bugsnag_set_binary_arch(JNIEnv *env);
-
 void bugsnag_start(JNIEnv *env) { bsg_global_jni_env = env; }
 
 void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
@@ -188,9 +186,6 @@ void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
   jname = bsg_byte_ary_from_string(env, name);
   jmessage = bsg_byte_ary_from_string(env, message);
 
-  // set application's binary arch
-  bugsnag_set_binary_arch(env);
-
   bsg_safe_call_static_void_method(env, interface_class, notify_method, jname,
                                    jmessage, jseverity, trace);
 
@@ -211,39 +206,6 @@ exit:
   bsg_safe_delete_local_ref(env, severity_class);
   bsg_safe_delete_local_ref(env, trace);
   bsg_safe_delete_local_ref(env, jseverity);
-}
-
-void bugsnag_set_binary_arch(JNIEnv *env) {
-  jclass interface_class = NULL;
-  jmethodID set_arch_method = NULL;
-  jstring arch = NULL;
-
-  // lookup com/bugsnag/android/NativeInterface
-  interface_class =
-      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
-  if (interface_class == NULL) {
-    goto exit;
-  }
-
-  // lookup NativeInterface.setBinaryArch()
-  set_arch_method = bsg_safe_get_static_method_id(
-      env, interface_class, "setBinaryArch", "(Ljava/lang/String;)V");
-  if (set_arch_method == NULL) {
-    goto exit;
-  }
-
-  // call NativeInterface.setBinaryArch()
-  arch = bsg_safe_new_string_utf(env, bsg_binary_arch());
-  if (arch != NULL) {
-    bsg_safe_call_static_void_method(env, interface_class, set_arch_method,
-                                     arch);
-  }
-
-  goto exit;
-
-exit:
-  bsg_safe_delete_local_ref(env, arch);
-  bsg_safe_delete_local_ref(env, interface_class);
 }
 
 void bugsnag_set_user_env(JNIEnv *env, const char *id, const char *email,

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -80,6 +80,22 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_NdkPlugin_disableCrashReporting(
   bsg_handler_uninstall_cpp();
 }
 
+JNIEXPORT jstring JNICALL
+Java_com_bugsnag_android_NdkPlugin_getBinaryArch(JNIEnv *env, jobject _this) {
+#if defined(__i386__)
+  const char *binary_arch = "x86";
+#elif defined(__x86_64__)
+  const char *binary_arch = "x86_64";
+#elif defined(__arm__)
+  const char *binary_arch = "arm32";
+#elif defined(__aarch64__)
+  const char *binary_arch = "arm64";
+#else
+  const char *binary_arch = "unknown";
+#endif
+  return bsg_safe_new_string_utf(env, binary_arch);
+}
+
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_enableCrashReporting(JNIEnv *env,
                                                                jobject _this) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -405,20 +405,6 @@ exit:
   bsg_safe_delete_local_ref(env, keylist);
 }
 
-char *bsg_binary_arch() {
-#if defined(__i386__)
-  return "x86";
-#elif defined(__x86_64__)
-  return "x86_64";
-#elif defined(__arm__)
-  return "arm32";
-#elif defined(__aarch64__)
-  return "arm64";
-#else
-  return "unknown";
-#endif
-}
-
 void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                            bugsnag_event *event) {
   jobject data = bsg_safe_call_static_object_method(
@@ -427,9 +413,9 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
     return;
   }
 
-  bsg_strncpy_safe(event->app.binary_arch, bsg_binary_arch(),
-                   sizeof(event->app.binary_arch));
-
+  bsg_copy_map_value_string(env, jni_cache, data, "binaryArch",
+                            event->app.binary_arch,
+                            sizeof(event->app.binary_arch));
   bsg_copy_map_value_string(env, jni_cache, data, "buildUUID",
                             event->app.build_uuid,
                             sizeof(event->app.build_uuid));

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
@@ -23,8 +23,6 @@ void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst,
 void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
                                  jobject metadata);
 
-char *bsg_binary_arch();
-
 char *bsg_os_name();
 
 #endif

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -30,6 +30,7 @@ Scenario: Notify caught Java exception with default configuration
     And the error payload field "events.0.threads.0.stacktrace.0.method" ends with "getThreadStackTrace"
 
     # App data
+    And the event binary arch field is valid
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
     And the event "app.releaseStage" equals "mazerunner"
@@ -179,6 +180,7 @@ Scenario: Handled C functionality
     And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"
 
     # App data
+    And the event binary arch field is valid
     And the event "app.buildUUID" is not null
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
     And the event "app.releaseStage" equals "mazerunner"

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -31,6 +31,7 @@ Scenario: Unhandled Java Exception with loaded configuration
     And the error payload field "events.0.threads.0.stacktrace.0.method" equals "com.bugsnag.android.mazerunner.scenarios.UnhandledJavaLoadedConfigScenario.startScenario"
 
     # App data
+    And the event binary arch field is valid
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
     And the event "app.releaseStage" equals "mazerunner"
@@ -122,6 +123,7 @@ Scenario: Signal raised with overwritten config
     And the error payload field "events.0.exceptions.0.stacktrace.0.lineNumber" is greater than 0
 
     # App data
+    And the event binary arch field is valid
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
     And the event "app.releaseStage" equals "CXXSignalSmokeScenario"
@@ -202,6 +204,7 @@ Scenario: C++ exception thrown with overwritten config
     And the error payload field "events.0.exceptions.0.stacktrace.0.lineNumber" is greater than 0
 
     # App data
+    And the event binary arch field is valid
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
     And the event "app.releaseStage" equals "CXXExceptionSmokeScenario"
@@ -277,6 +280,7 @@ Scenario: ANR detection
     And the event "exceptions.0.stacktrace.0.lineNumber" is not null
 
     # App data
+    And the event binary arch field is valid
     And the event "app.buildUUID" equals "test-7.5.3"
     And the event "app.id" equals "com.bugsnag.android.mazerunner"
     And the event "app.releaseStage" equals "mazerunner"

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -251,6 +251,13 @@ Then("the exception stacktrace matches the thread stacktrace") do
   end
 end
 
+Then("the event binary arch field is valid") do
+  arch = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.app.binaryArch")
+  assert_block "'#{arch}' is not a valid value for app.binaryArch" do
+    ["x86", "x86_64", "arm32", "arm64"].include? arch
+  end
+end
+
 # EventStore flushes multiple times on launch with access controlled via a semaphore,
 # which results in multiple similar log messages
 Then("Bugsnag confirms it has no errors to send") do


### PR DESCRIPTION
## Goal

Ensure the `app.binaryArch` field is set for every event. The field would only be set for particular NDK events but is generally useful everywhere for debugging.

PLAT-6813

## Design

The NDK plugin sets the binary arch property of the app data collector upon successful initialization of the native components. This way it should be present for all events.

## Changeset

* Added a new JNI function, `NdkPlugin.getBinaryArch()`, which returns the arch or `unknown` as a String.
* Removed now-unused functions for computing the binary arch, instead loading it from event data

## Testing

* Tested manually to verify the correct archs are sent, in addition to updating the smoke tests to expect the field