### PR TITLE
Avoid expensive set construction in Config constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
 * Use ring buffer to store breadcrumbs
   [#1286](https://github.com/bugsnag/bugsnag-android/pull/1286)
 
+* Avoid expensive set construction in Config constructor
+  [#1289](https://github.com/bugsnag/bugsnag-android/pull/1289)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -19,7 +19,7 @@
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>
     <ID>MagicNumber:LastRunInfoStore.kt$LastRunInfoStore$3</ID>
     <ID>MaxLineLength:LastRunInfo.kt$LastRunInfo$return "LastRunInfo(consecutiveLaunchCrashes=$consecutiveLaunchCrashes, crashed=$crashed, crashedDuringLaunch=$crashedDuringLaunch)"</ID>
-    <ID>ProtectedMemberInFinalClass:ConfigInternal.kt$ConfigInternal$protected val plugins = mutableSetOf&lt;Plugin&gt;()</ID>
+    <ID>ProtectedMemberInFinalClass:ConfigInternal.kt$ConfigInternal$protected val plugins = HashSet&lt;Plugin&gt;()</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun isAnr(event: Event): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun shouldDiscardClass(): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -37,19 +37,19 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     var maxPersistedSessions: Int = DEFAULT_MAX_PERSISTED_SESSIONS
     var context: String? = null
 
-    var redactedKeys: Set<String> = metadataState.metadata.redactedKeys
+    var redactedKeys: Set<String>
+        get() = metadataState.metadata.redactedKeys
         set(value) {
             metadataState.metadata.redactedKeys = value
-            field = value
         }
 
     var discardClasses: Set<String> = emptySet()
     var enabledReleaseStages: Set<String>? = null
-    var enabledBreadcrumbTypes: Set<BreadcrumbType>? = BreadcrumbType.values().toSet()
+    var enabledBreadcrumbTypes: Set<BreadcrumbType>? = null
     var projectPackages: Set<String> = emptySet()
     var persistenceDirectory: File? = null
 
-    protected val plugins = mutableSetOf<Plugin>()
+    protected val plugins = HashSet<Plugin>()
 
     override fun addOnError(onError: OnErrorCallback) = callbackState.addOnError(onError)
     override fun removeOnError(onError: OnErrorCallback) = callbackState.removeOnError(onError)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -83,7 +83,7 @@ internal class ImmutableConfigTest {
             assertEquals(seed.maxPersistedEvents, maxPersistedEvents)
             assertEquals(seed.maxPersistedSessions, maxPersistedSessions)
             assertEquals(seed.persistUser, persistUser)
-            assertEquals(seed.enabledBreadcrumbTypes, BreadcrumbType.values().toSet())
+            assertNull(seed.enabledBreadcrumbTypes)
             assertNotNull(persistenceDirectory)
         }
     }


### PR DESCRIPTION
## Goal

Initializing `Configuration` was taking more time than it needed to due to the construction of some unnecessary sets. The `toSet()` implementation in Kotlin seems like it can be particularly slow in some circumstances, as it constructs a `LinkedHashSet`. This is unnecessary for the purposes of `Configuration`.

## Changeset

- Avoided creation of unnecessary field for `redactedKeys`
- Initialized `plugins` with a `HashSet` rather than a `LinkedHashSet`
- Set `enabledBreadcrumbTypes` to `null` rather than constructing a set - this has the same behaviour as setting all the values

Without these optimizations `Configuration` took ~38ms to initialize, whereas with them it took ~9ms. It's worth noting that this only seems to be on a cold start, suggesting that there is some one-off work required when the JVM is initialized. Therefore the differences don't show up in the automated benchmarks and have been manually profiled instead.

<img width="967" alt="before_changes" src="https://user-images.githubusercontent.com/11800640/123251824-893be280-d4e3-11eb-95d0-996593fe7176.png">
<img width="1206" alt="after_changes" src="https://user-images.githubusercontent.com/11800640/123251827-89d47900-d4e3-11eb-8d6f-0be64b146103.png">

## Testing

Relied on existing test coverage.