### PR TITLE
Skip the startup_anr test on Android 10

### DIFF
--- a/features/full_tests/batch_1/startup_anr.feature
+++ b/features/full_tests/batch_1/startup_anr.feature
@@ -1,5 +1,6 @@
 Feature: onCreate ANR
 
+@skip_android_10
 Scenario: onCreate ANR is reported
   When I run "ConfigureStartupAnrScenario"
   And I relaunch the app after a crash


### PR DESCRIPTION
## Goal
Skip the startup ANR test on Android 10 until we can find a work-around or solution.
