### PR TITLE
Replace calls to String.format() with concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 * Avoid expensive set construction in Config constructor
   [#1289](https://github.com/bugsnag/bugsnag-android/pull/1289)
 
+* Replace calls to String.format() with concatenation
+  [#1293](https://github.com/bugsnag/bugsnag-android/pull/1293)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -310,9 +310,9 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
         if (launchDurationMillis >= MIN_LAUNCH_CRASH_THRESHOLD_MS) {
             impl.setLaunchDurationMillis(launchDurationMillis);
         } else {
-            getLogger().e(String.format(Locale.US, "Invalid configuration value detected. "
+            getLogger().e("Invalid configuration value detected. "
                     + "Option launchDurationMillis should be a positive long value."
-                    + "Supplied value is %d", launchDurationMillis));
+                    + "Supplied value is " + launchDurationMillis);
         }
     }
 
@@ -529,9 +529,9 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
         if (maxBreadcrumbs >= MIN_BREADCRUMBS && maxBreadcrumbs <= MAX_BREADCRUMBS) {
             impl.setMaxBreadcrumbs(maxBreadcrumbs);
         } else {
-            getLogger().e(String.format(Locale.US, "Invalid configuration value detected. "
+            getLogger().e("Invalid configuration value detected. "
                     + "Option maxBreadcrumbs should be an integer between 0-100. "
-                    + "Supplied value is %d", maxBreadcrumbs));
+                    + "Supplied value is " + maxBreadcrumbs);
         }
     }
 
@@ -555,9 +555,9 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
         if (maxPersistedEvents >= 0) {
             impl.setMaxPersistedEvents(maxPersistedEvents);
         } else {
-            getLogger().e(String.format(Locale.US, "Invalid configuration value detected. "
+            getLogger().e("Invalid configuration value detected. "
                     + "Option maxPersistedEvents should be a positive integer."
-                    + "Supplied value is %d", maxPersistedEvents));
+                    + "Supplied value is " + maxPersistedEvents);
         }
     }
 
@@ -581,9 +581,9 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
         if (maxPersistedSessions >= 0) {
             impl.setMaxPersistedSessions(maxPersistedSessions);
         } else {
-            getLogger().e(String.format(Locale.US, "Invalid configuration value detected. "
+            getLogger().e("Invalid configuration value detected. "
                     + "Option maxPersistedSessions should be a positive integer."
-                    + "Supplied value is %d", maxPersistedSessions));
+                    + "Supplied value is " + maxPersistedSessions);
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
@@ -187,7 +187,7 @@ internal class DeviceDataCollector(
         return if (displayMetrics != null) {
             val max = max(displayMetrics.widthPixels, displayMetrics.heightPixels)
             val min = min(displayMetrics.widthPixels, displayMetrics.heightPixels)
-            String.format(Locale.US, "%dx%d", max, min)
+            "${max}x$min"
         } else {
             null
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventFilenameInfo.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventFilenameInfo.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android
 
 import com.bugsnag.android.internal.ImmutableConfig
 import java.io.File
-import java.util.Locale
 import java.util.UUID
 
 /**
@@ -28,15 +27,7 @@ internal data class EventFilenameInfo(
      * "[timestamp]_[apiKey]_[errorTypes]_[UUID]_[startupcrash|not-jvm].json"
      */
     fun encode(): String {
-        return String.format(
-            Locale.US,
-            "%d_%s_%s_%s_%s.json",
-            timestamp,
-            apiKey,
-            serializeErrorTypeHeader(errorTypes),
-            uuid,
-            suffix
-        )
+        return "${timestamp}_${apiKey}_${serializeErrorTypeHeader(errorTypes)}_${uuid}_$suffix.json"
     }
 
     fun isLaunchCrashReport(): Boolean = suffix == STARTUP_CRASH

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -150,8 +150,8 @@ class EventStore extends FileStore {
 
     void flushReports(Collection<File> storedReports) {
         if (!storedReports.isEmpty()) {
-            logger.i(String.format(Locale.US,
-                    "Sending %d saved error(s) to Bugsnag", storedReports.size()));
+            int size = storedReports.size();
+            logger.i("Sending " + size + " saved error(s) to Bugsnag");
 
             for (File eventFile : storedReports) {
                 flushEventFile(eventFile);
@@ -202,14 +202,12 @@ class EventStore extends FileStore {
     String getFilename(Object object) {
         EventFilenameInfo eventInfo
                 = EventFilenameInfo.Companion.fromEvent(object, null, config);
-        String encodedInfo = eventInfo.encode();
-        return String.format(Locale.US, "%s", encodedInfo);
+        return eventInfo.encode();
     }
 
     String getNdkFilename(Object object, String apiKey) {
         EventFilenameInfo eventInfo
                 = EventFilenameInfo.Companion.fromEvent(object, apiKey, config);
-        String encodedInfo = eventInfo.encode();
-        return String.format(Locale.US, "%s", encodedInfo);
+        return eventInfo.encode();
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -104,8 +104,7 @@ abstract class FileStore {
                     out.close();
                 }
             } catch (Exception exception) {
-                logger.w(String.format("Failed to close unsent payload writer (%s) ",
-                        filename), exception);
+                logger.w("Failed to close unsent payload writer: " + filename, exception);
             }
             lock.unlock();
         }
@@ -130,7 +129,7 @@ abstract class FileStore {
             Writer out = new BufferedWriter(new OutputStreamWriter(fos, "UTF-8"));
             stream = new JsonStream(out);
             stream.value(streamable);
-            logger.i(String.format("Saved unsent payload to disk (%s) ", filename));
+            logger.i("Saved unsent payload to disk: " + filename);
             return filename;
         } catch (FileNotFoundException exc) {
             logger.w("Ignoring FileNotFoundException - unable to create file", exc);
@@ -168,8 +167,8 @@ abstract class FileStore {
                     File oldestFile = files.get(k);
 
                     if (!queuedFiles.contains(oldestFile)) {
-                        logger.w(String.format("Discarding oldest error as stored "
-                                + "error limit reached (%s)", oldestFile.getPath()));
+                        logger.w("Discarding oldest error as stored "
+                                + "error limit reached: " + oldestFile.getPath());
                         deleteStoredFiles(Collections.singleton(oldestFile));
                         files.remove(k);
                         k--;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -129,7 +129,7 @@ abstract class FileStore {
             Writer out = new BufferedWriter(new OutputStreamWriter(fos, "UTF-8"));
             stream = new JsonStream(out);
             stream.value(streamable);
-            logger.i("Saved unsent payload to disk: " + filename);
+            logger.i("Saved unsent payload to disk: '" + filename + '\'');
             return filename;
         } catch (FileNotFoundException exc) {
             logger.w("Ignoring FileNotFoundException - unable to create file", exc);
@@ -168,7 +168,7 @@ abstract class FileStore {
 
                     if (!queuedFiles.contains(oldestFile)) {
                         logger.w("Discarding oldest error as stored "
-                                + "error limit reached: " + oldestFile.getPath());
+                                + "error limit reached: '" + oldestFile.getPath() + '\'');
                         deleteStoredFiles(Collections.singleton(oldestFile));
                         files.remove(k);
                         k--;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
@@ -47,10 +47,7 @@ class SessionStore extends FileStore {
     @NonNull
     @Override
     String getFilename(Object object) {
-        return String.format(Locale.US,
-                "%s%d_v2.json",
-                UUID.randomUUID().toString(),
-                System.currentTimeMillis());
+        return UUID.randomUUID().toString() + System.currentTimeMillis() + "_v2.json";
     }
 
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SeverityReason.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SeverityReason.java
@@ -69,7 +69,7 @@ final class SeverityReason implements JsonStream.Streamable {
             case REASON_LOG:
                 return new SeverityReason(severityReasonType, severity, false, attrVal);
             default:
-                String msg = "Invalid argument for severityReason: " + severityReasonType;
+                String msg = "Invalid argument for severityReason: '" + severityReasonType + '\'';
                 throw new IllegalArgumentException(msg);
         }
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SeverityReason.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SeverityReason.java
@@ -69,8 +69,7 @@ final class SeverityReason implements JsonStream.Streamable {
             case REASON_LOG:
                 return new SeverityReason(severityReasonType, severity, false, attrVal);
             default:
-                String msg = String.format("Invalid argument '%s' for severityReason",
-                    severityReasonType);
+                String msg = "Invalid argument for severityReason: " + severityReasonType;
                 throw new IllegalArgumentException(msg);
         }
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SystemBroadcastReceiver.java
@@ -82,7 +82,7 @@ class SystemBroadcastReceiver extends BroadcastReceiver {
                     String val = valObj.toString();
 
                     if (isAndroidKey(key)) { // shorten the Intent action
-                        meta.put("Extra", String.format("%s: %s", shortAction, val));
+                        meta.put("Extra", shortAction + ": " + val);
                     } else {
                         meta.put(key, val);
                     }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeStackDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeStackDeserializer.java
@@ -46,7 +46,7 @@ class NativeStackDeserializer implements MapDeserializer<List<Stackframe>> {
         }
 
         String clz = MapUtils.getOrNull(map, "class");
-        String method = String.format("%s.%s", clz, methodName);
+        String method = clz + "." + methodName;
 
         // RN <0.63.2 doesn't add class, gracefully fallback by only reporting
         // method name. see https://github.com/facebook/react-native/pull/25014


### PR DESCRIPTION
## Goal

Replaces calls to `String.format` with concatenation. This was specifically found to be a problem in `DeviceDataCollector` which added ~1ms onto `Bugsnag.start()`, and profiling shows that using concatenation takes ~0.1ms instead.

As `String.format` isn't required in most cases throughout the codebase, it has been replaced with concatenation instead.

## Testing

Relied on existing test coverage.