### PR TITLE
fix: remove double-applied address offsets

### DIFF
--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/exception_serialization.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/exception_serialization.json
@@ -1,1 +1,1 @@
-{"stacktrace":[{"frameAddress":536870912,"symbolAddress":369098752,"loadAddress":301989888,"lineNumber":52,"file":"foo.c","method":"bar()"}],"errorClass":"signal","message":"whoops something went wrong","type":"c"}
+{"stacktrace":[{"frameAddress":536870912,"symbolAddress":369098752,"loadAddress":301989888,"lineNumber":52,"isPC":true,"file":"foo.c","method":"bar()"}],"errorClass":"signal","message":"whoops something went wrong","type":"c"}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -31,7 +31,14 @@ void bsg_serialize_custom_metadata(const bugsnag_metadata metadata,
                                    JSON_Object *event_obj);
 void bsg_serialize_user(const bugsnag_user user, JSON_Object *event_obj);
 void bsg_serialize_session(bugsnag_event *event, JSON_Object *event_obj);
-void bsg_serialize_stackframe(bugsnag_stackframe *stackframe,
+/**
+ * Append a JSON-serialized stackframe to an array
+ *
+ * @param stackframe the frame to serialize
+ * @param is_pc      true if the current frame is the program counter
+ * @param stacktrace the destination array
+ */
+void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
                               JSON_Array *stacktrace);
 void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
                          JSON_Array *stacktrace);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -203,7 +203,7 @@ JNIEXPORT jstring JNICALL Java_com_bugsnag_android_ndk_StackframeSerializationTe
     bugsnag_stackframe *frame = loadStackframeTestCase();
     JSON_Value *event_val = json_value_init_array();
     JSON_Array *event_obj = json_value_get_array(event_val);
-    bsg_serialize_stackframe(frame, event_obj);
+    bsg_serialize_stackframe(frame, false, event_obj);
     char *string = json_serialize_to_string(event_val);
     return (*env)->NewStringUTF(env, string);
 }

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -115,6 +115,7 @@ Scenario: Signal raised with overwritten config
 
     # Stacktrace validation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+    And the event stacktrace identifies the program counter
     And the event "exceptions.0.stacktrace.0.method" is not null
     And the event "exceptions.0.stacktrace.0.file" is not null
     And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is greater than 0
@@ -196,6 +197,7 @@ Scenario: C++ exception thrown with overwritten config
 
     # Stacktrace validation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+    And the event stacktrace identifies the program counter
     And the event "exceptions.0.stacktrace.0.method" is not null
     And the event "exceptions.0.stacktrace.0.file" is not null
     And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is greater than 0

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -261,6 +261,17 @@ Then("the event binary arch field is valid") do
   end
 end
 
+Then("the event stacktrace identifies the program counter") do
+  trace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.stacktrace")
+  trace.each_with_index do |frame, index|
+    if index == 0
+      assert_equal(frame["isPC"], true, "The first frame should be the program counter")
+    else
+      assert_equal(frame["isPC"], nil, "The #{index} frame should not be the program counter")
+    end
+  end
+end
+
 # EventStore flushes multiple times on launch with access controlled via a semaphore,
 # which results in multiple similar log messages
 Then("Bugsnag confirms it has no errors to send") do


### PR DESCRIPTION
## Goal

Fix a case where C/C++ events could be resolved to be 2-3 lines off from the actual source location, due to memory address offsets being applied twice. This change relies on the offset adjustment being performed server-side, using the program counter value to determine how much adjustment to apply.

PLAT-6861

## Changeset

Add a program counter indicator to native frames as needed

## Testing

- manual testing of events to determine the correct resolution of file/line info
- added new step to verify program counter flag is set