### PR TITLE
Explain why the startup_anr.feature is skipped on Android 10

### DIFF
--- a/features/full_tests/batch_1/startup_anr.feature
+++ b/features/full_tests/batch_1/startup_anr.feature
@@ -1,5 +1,8 @@
 Feature: onCreate ANR
 
+# Android 10 Note: Android 10 devices appear to allow much longer times for startup without an ANR
+# and then terminate the "misbehaving" app with a KILL (9) signal (almost like the ANR code doesn't
+# fire at all). Since we can't cover a KILL signal in a test, we skip Android 10.
 @skip_android_10
 Scenario: onCreate ANR is reported
   When I run "ConfigureStartupAnrScenario"


### PR DESCRIPTION
## Goal
Explain why we skip the startup ANR Mazerunner test on Android 10 devices