### PR TITLE
6711 journal metadata

### DIFF
--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/JournalBenchmarkTest.kt
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/JournalBenchmarkTest.kt
@@ -19,8 +19,8 @@ class JournalBenchmarkTest {
     @get:Rule
     val benchmarkRule = BenchmarkRule()
 
-    lateinit var client: Client
-    lateinit var ctx: Context
+    private lateinit var client: Client
+    private lateinit var ctx: Context
 
     @Before
     fun setUp() {
@@ -30,8 +30,8 @@ class JournalBenchmarkTest {
 
     @Test
     fun serializeJournal() {
-        val journal = Journal()
-        val entries = listOf<Journal.Command>(
+        val journal = Journal("Bugsnag state",1)
+        val entries = listOf(
             Journal.Command("a", "b")
         )
 


### PR DESCRIPTION
## Goal

Part of PLAT-6711. This PR adds the metadata field to the journal, to support backwards compatibility when changes occur.

## Design

This PR only affects the Journal portion.

```
| --------------------------------------------------------------- |
|                          Journal API                            |
| --------------------------------------------------------------- |
| Journal       | Thread-safety | Shared Memory | File Management |
| ------------- |               |               |                 |
| Document Path |               |               |                 |
| ----------------------------- |               | --------------- |
|   Crash-time synchronization  |               | Crash-time API  |
| --------------------------------------------------------------- |
```

## Testing

Added more unit tests to the journal tests for the metadata portion.
