### PR TITLE
Optimize capture of thread traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 * Replace calls to String.format() with concatenation
   [#1293](https://github.com/bugsnag/bugsnag-android/pull/1293)
 
+* Optimize capture of thread traces
+  [#1300](https://github.com/bugsnag/bugsnag-android/pull/1300)
+
 ## 5.9.4 (2021-05-26)
 
 * Unity: add methods for setting autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
@@ -20,12 +20,10 @@ internal class Stacktrace : JsonStream.Streamable {
          * not.
          */
         fun inProject(className: String, projectPackages: Collection<String>): Boolean? {
-            for (packageName in projectPackages) {
-                if (className.startsWith(packageName)) {
-                    return true
-                }
+            return when {
+                projectPackages.any { className.startsWith(it) } -> true
+                else -> null
             }
-            return null
         }
     }
 
@@ -64,8 +62,9 @@ internal class Stacktrace : JsonStream.Streamable {
         logger: Logger
     ): Stackframe? {
         try {
+            val className = el.className
             val methodName = when {
-                el.className.isNotEmpty() -> el.className + "." + el.methodName
+                className.isNotEmpty() -> className + "." + el.methodName
                 else -> el.methodName
             }
 
@@ -73,7 +72,7 @@ internal class Stacktrace : JsonStream.Streamable {
                 methodName,
                 el.fileName ?: "Unknown",
                 el.lineNumber,
-                inProject(el.className, projectPackages)
+                inProject(className, projectPackages)
             )
         } catch (lineEx: Exception) {
             logger.w("Failed to serialize stacktrace", lineEx)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -12,7 +12,7 @@ internal class ThreadState @Suppress("LongParameterList") @JvmOverloads construc
     sendThreads: ThreadSendPolicy,
     projectPackages: Collection<String>,
     logger: Logger,
-    currentThread: java.lang.Thread = java.lang.Thread.currentThread(),
+    currentThread: java.lang.Thread? = null,
     stackTraces: MutableMap<java.lang.Thread, Array<StackTraceElement>>? = null
 ) : JsonStream.Streamable {
 
@@ -31,7 +31,7 @@ internal class ThreadState @Suppress("LongParameterList") @JvmOverloads construc
         threads = when {
             recordThreads -> captureThreadTrace(
                 stackTraces ?: java.lang.Thread.getAllStackTraces(),
-                currentThread,
+                currentThread ?: java.lang.Thread.currentThread(),
                 exc,
                 isUnhandled,
                 projectPackages,


### PR DESCRIPTION
## Goal

Adds some additional optimizations for capturing thread traces. Namely:

- Use `any()` rather than a for loop, which saves on iterator creation when the collection is empty and marginally improves performance
- Store the result of `getClassName()` to avoid multiple lookups
- Avoid calling `Thread.currentThread()` when `sendThreads` should not collect this information

## Testing

Relied on existing test coverage.