### PR TITLE
Fix flaky instrumentation test

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -127,7 +127,7 @@ public class ClientTest {
     @Test
     public void testClientBreadcrumbRetrieval() {
         Configuration config = new Configuration("api-key");
-        config.setEnabledBreadcrumbTypes(Collections.EMPTY_SET);
+        config.setEnabledBreadcrumbTypes(Collections.emptySet());
         client = generateClient(config);
         client.leaveBreadcrumb("Hello World");
         List<Breadcrumb> breadcrumbs = client.getBreadcrumbs();

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -126,7 +126,9 @@ public class ClientTest {
 
     @Test
     public void testClientBreadcrumbRetrieval() {
-        client = generateClient();
+        Configuration config = new Configuration("api-key");
+        config.setEnabledBreadcrumbTypes(Collections.EMPTY_SET);
+        client = generateClient(config);
         client.leaveBreadcrumb("Hello World");
         List<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
         List<Breadcrumb> store = new ArrayList<>(client.breadcrumbState.copy());

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -127,7 +127,7 @@ public class ClientTest {
     @Test
     public void testClientBreadcrumbRetrieval() {
         Configuration config = new Configuration("api-key");
-        config.setEnabledBreadcrumbTypes(Collections.emptySet());
+        config.setEnabledBreadcrumbTypes(Collections.<BreadcrumbType>emptySet());
         client = generateClient(config);
         client.leaveBreadcrumb("Hello World");
         List<Breadcrumb> breadcrumbs = client.getBreadcrumbs();


### PR DESCRIPTION
## Goal

Fixes an instrumentation test that was failing on CI. This could occur because connectivity changes (which trigger automatic breadcrumbs) could happen at anytime, which alters the breadcrumbs reported by `Client`. It seems that this has been exacerbated by changes to how breadcrumbs are copied in #1286. As the test isn't asserting anything specific about automatic breadcrumbs, this disables them.