### PR TITLE
Journal: DocumentPath

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPath.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPath.kt
@@ -1,0 +1,245 @@
+package com.bugsnag.android.internal
+
+/**
+ * DocumentPath records a path into a hierarchical acyclic document, and can be used to modify
+ * documents by navigating down the DAG and then applying a modification at that level.
+ *
+ * Paths are explained as follows in PLAT-6353:
+ *
+ * Paths follow a dotted notation similar to internet hostnames, such that each path component
+ * is separated by a dot '.' If a literal dot is required, the path supports an escaping
+ * mechanism using the backslash character:
+ *
+ * \. = literal dot
+ * \\ = literal backslash
+ *
+ * Path components are either integers or non-integers. Integers refer to the previous path
+ * component as a list, providing the index to look up. Non-integers refer to the previous path
+ * component as a map, providing the key to look up.
+ *
+ * For example: the path "foo.bar.3" refers to document root (always a map) with map key "foo",
+ * drilled down to map key "bar", drilled down to list index 3. i.e.
+ * {
+ *     "foo": {
+ *         "bar": [
+ *             "we expect something to be here (index 0)",
+ *             "we expect something to be here (index 1)",
+ *             "we expect something to be here (index 2)",
+ *             "the thing we're actually interested in (index 3)"
+ *         ]
+ *     }
+ * }
+ *
+ * Any nonexistent parts of the document are created on-demand as they are encountered while
+ * resolving paths (either as a list in the case of integer path components, or as a map for
+ * non-integers). In the case of lists, only index 0 of a nonexistent list is valid (in which
+ * case the list will be created, and the value stored at index 0).
+ *
+ * As well, the following special rules apply:
+ *
+ * - An empty path component refers to the document root, and causes the value to replace
+ * the entire document.
+ * - The integer path component -1 refers to the last index in the array, or index 0 if the
+ * array is empty or nonexistent.
+ * - If a path ends in a dot (e.g. events.exceptions.stacktrace.), It means that the last
+ * path entry (e.g. stacktrace) is to be treated as a list, and the value is to be appended
+ * to that list.
+ *
+ * The document to be modified must be serializable into JSON. The following types are supported:
+ * - null
+ * - boolean
+ * - integer (max 15 digits)
+ * - float
+ * - string
+ * - List(Object)
+ * - Map(String, Object)
+ */
+class DocumentPath(path: String) {
+    private val directives: List<DocumentPathDirective<Any>> = toPathDirectives(path)
+
+    /**
+     * Modify a document, setting this path in the document to the specified value.
+     *
+     * @param document The document to modify.
+     * @param value    The value to modify with.
+     * @return The modified document (may not be the same document that was passed in).
+     */
+    fun modifyDocument(document: MutableMap<in String, out Any>, value: Any?): MutableMap<in String, out Any> {
+        if (directives.isEmpty()) {
+            requireNotNull(value) { "Cannot replace entire document with null" }
+            require(value is MutableMap<*, *>) { "Value replacing document must be a mutable map" }
+            @Suppress("UNCHECKED_CAST")
+            return value as MutableMap<String, Any>
+        }
+        val filledInDocument = fillInMissingContainers(document, 0)
+        require(filledInDocument is MutableMap<*, *>) { "Document path must result in a top level map" }
+        @Suppress("UNCHECKED_CAST")
+        val updatedDocument = filledInDocument as MutableMap<String, Any>
+
+        applyValueToDocument(value, updatedDocument)
+        return updatedDocument
+    }
+
+    /**
+     * Fill in the document parts that will be navigated, but don't exist yet.
+     *
+     * For example, the path "foo.bar.1.-1" requires a document consisting of:
+     * - Map with key "foo" containing:
+     * - Map with key "bar" containing:
+     * - List with index 1 present, containing:
+     * - List where the last index is what we want to modify.
+     *
+     * Before we can modify the last index, we need to create all of the parent
+     * containers (if they don't exist yet). This function recursively descends
+     * the document, creating all necessary containers to make this path navigatable.
+     *
+     * @param parent The parent container (which might be null if it doesn't exist yet)
+     * @param index The index of the directive to use if a new container is necessary.
+     * @return The container that should be in place of the parent passed in (a list or a map).
+     */
+    private fun fillInMissingContainers(parent: Any?, index: Int): Any {
+        val directive = directives[index]
+        val updatedParent = parent ?: directive.newContainer()
+
+        if (index + 1 < directives.size) {
+            val result =
+                fillInMissingContainers(directive.getFromContainer(updatedParent), index + 1)
+            directive.setInContainer(updatedParent, result)
+        }
+        return updatedParent
+    }
+
+    /**
+     * Navigate down into a document's sub-containers, then apply the specified value.
+     *
+     * @param value The value to apply (null means delete)
+     * @param document the document to apply this value to.
+     */
+    private fun applyValueToDocument(value: Any?, document: MutableMap<String, Any>) {
+        // Directives 0 through n-1 navigate to where we want to edit the document.
+        var currentContainer: Any = document
+        for (i in 0 until directives.size - 1) {
+            val directive = directives[i]
+            currentContainer = directive.getFromContainer(currentContainer)!!
+        }
+
+        // Only the last directive does the actual setting.
+        val directive = directives.last()
+        directive.setInContainer(currentContainer, value)
+    }
+
+    companion object {
+
+        private const val ESCAPE_CHAR = '\\'
+        private const val PATH_SEPARATOR = '.'
+
+        /**
+         * Generate path directives from a path string.
+         */
+        internal fun toPathDirectives(path: String): List<DocumentPathDirective<Any>> {
+            if (path.isEmpty()) {
+                return emptyList()
+            }
+            val directives = ArrayList<DocumentPathDirective<*>>()
+            var requiresEscaping = false
+            var strBegin = 0
+            var i = 0
+            while (i < path.length) {
+                when (path[i]) {
+                    ESCAPE_CHAR -> {
+                        requiresEscaping = true
+                        i++
+                    }
+                    PATH_SEPARATOR -> {
+                        val pathComponent: String = when {
+                            requiresEscaping -> unescape(path, strBegin, i)
+                            else -> path.substring(strBegin, i)
+                        }
+                        directives.add(makeDirectiveFromPathComponent(pathComponent))
+                        strBegin = i + 1
+                        requiresEscaping = false
+                    }
+                    else -> {
+                    }
+                }
+                i++
+            }
+            if (strBegin < path.length) {
+                val pathComponent: String = when {
+                    requiresEscaping -> unescape(path, strBegin, path.length)
+                    else -> path.substring(strBegin)
+                }
+                directives.add(makeDirectiveFromPathComponent(pathComponent))
+            }
+            if (doesPathEndWithPathSeparator(path)) {
+                // A path ending in a dot implies a list insert.
+                directives.add(DocumentPathDirective.ListInsertDirective())
+            }
+            @Suppress("UNCHECKED_CAST")
+            return directives as MutableList<DocumentPathDirective<Any>>
+        }
+
+        /**
+         * Unescape a string.
+         */
+        private fun unescape(str: String, startOffset: Int, endOffset: Int): String {
+            val buff = StringBuilder(endOffset - startOffset)
+            var i = startOffset
+            while (i < endOffset) {
+                val ch = str[i]
+                if (ch == ESCAPE_CHAR) {
+                    i++
+                    require(i < endOffset) { "Path cannot end on an escape char '\\'" }
+                    buff.append(str[i])
+                } else {
+                    buff.append(ch)
+                }
+                i++
+            }
+            return buff.toString()
+        }
+
+        /**
+         * Check if the path string ends in a path separator '.'
+         *
+         * Note: This is 40% faster than using regex.
+         */
+        private fun doesPathEndWithPathSeparator(path: String): Boolean {
+            if (path[path.length - 1] != PATH_SEPARATOR) {
+                return false
+            }
+            if (path.length == 1) {
+                return true
+            }
+            var isUnescapedDot = true
+            for (i in path.length - 2 downTo 0) {
+                val ch = path[i]
+                isUnescapedDot = if (ch == ESCAPE_CHAR) {
+                    !isUnescapedDot
+                } else {
+                    break
+                }
+            }
+            return isUnescapedDot
+        }
+
+        /**
+         * Generate a path directive based on the data type in a path component:
+         *
+         * - String: Map key directive
+         * - Integer: List index directive
+         * - Value -1: Last list index directive
+         */
+        private fun makeDirectiveFromPathComponent(pathComponent: String): DocumentPathDirective<out Any> {
+            val index = pathComponent.toIntOrNull()
+            if (index != null) {
+                return if (index == -1) {
+                    DocumentPathDirective.ListLastIndexDirective()
+                } else {
+                    DocumentPathDirective.ListIndexDirective(index)
+                }
+            }
+            return DocumentPathDirective.MapKeyDirective(pathComponent)
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPathDirective.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPathDirective.kt
@@ -1,0 +1,111 @@
+package com.bugsnag.android.internal
+
+/**
+ * A directive determines how document path commands are interpreted. Making a container,
+ * getting from a container, or setting to a container will require different operations to
+ * complete, depending on the context.
+ */
+internal interface DocumentPathDirective<C> {
+
+    /**
+     * Make a new container at the current level.
+     *
+     * @return The new container.
+     */
+    fun newContainer(): C
+
+    /**
+     * Get an object from the container at the current level.
+     *
+     * @param container The container to get the object from.
+     * @return The resulting object, or null if not found.
+     */
+    fun getFromContainer(container: C): Any?
+
+    /**
+     * Set an object in a container at the current level.
+     *
+     * @param container The container to set a value in.
+     * @param value The value to set (can be null, which usually means "remove")
+     */
+    fun setInContainer(container: C, value: Any?)
+
+    /**
+     * Modifies a particular key in a map, or creates a new (String, Object) map.
+     * Setting null removes the value.
+     */
+    class MapKeyDirective(private val key: String) : DocumentPathDirective<MutableMap<String, in Any>> {
+        override fun newContainer(): MutableMap<String, in Any> {
+            return mutableMapOf()
+        }
+
+        override fun getFromContainer(container: MutableMap<String, in Any>): Any? {
+            return container[key]
+        }
+
+        override fun setInContainer(container: MutableMap<String, in Any>, value: Any?) {
+            if (value == null) {
+                container.remove(key)
+            } else {
+                container[key] = value
+            }
+        }
+    }
+
+    /**
+     * Modifies a list at the current level, or creates a new list.
+     * Setting null removes the item at the specified index.
+     */
+    open class ListIndexDirective(private val index: Int) : DocumentPathDirective<MutableList<in Any>> {
+        override fun newContainer(): MutableList<in Any> {
+            return mutableListOf()
+        }
+
+        override fun getFromContainer(container: MutableList<in Any>): Any? {
+            return container[index]
+        }
+
+        override fun setInContainer(container: MutableList<in Any>, value: Any?) {
+            container.removeAt(index)
+            if (value != null) {
+                container.add(index, value)
+            }
+        }
+    }
+
+    /**
+     * Special list directive for the last index in a list (-1).
+     * This directive inserts a new entry if one isn't present already when setting.
+     * Setting null deletes the last index (if present).
+     */
+    class ListLastIndexDirective : ListIndexDirective(0) {
+        override fun getFromContainer(container: MutableList<in Any>): Any? {
+            return container.lastOrNull()
+        }
+
+        override fun setInContainer(container: MutableList<in Any>, value: Any?) {
+            if (container.isNotEmpty()) {
+                container.removeAt(container.lastIndex)
+            }
+            if (value != null) {
+                container.add(value)
+            }
+        }
+    }
+
+    /**
+     * Special list directive for insert (path ends in .)
+     * This one always inserts a new entry on set, and always returns null on get.
+     * Setting null is an error.
+     */
+    class ListInsertDirective : ListIndexDirective(0) {
+        override fun getFromContainer(container: MutableList<in Any>): Any? {
+            return null
+        }
+
+        override fun setInContainer(container: MutableList<in Any>, value: Any?) {
+            requireNotNull(value) { "Cannot use null for last path insert value" }
+            container.add(value)
+        }
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
@@ -1,0 +1,198 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.internal.DocumentPath
+import org.junit.Assert
+import org.junit.Test
+import java.util.LinkedList
+
+class DocumentPathTest {
+    @Test
+    fun testReplaceDocument() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("")
+        val value = mapOf<String, Any>("a" to 1)
+        val expected = mapOf<String, Any>("a" to 1)
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapPut() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a")
+        val value = 1
+        val expected = mapOf<String, Any>("a" to 1)
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapModify() {
+        val document = mutableMapOf<String, Any>("a" to 1)
+        val docpath = DocumentPath("a")
+        val value = 2
+        val expected = mapOf<String, Any>("a" to 2)
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapDelete() {
+        val document = mutableMapOf<String, Any>("a" to 1)
+        val docpath = DocumentPath("a")
+        val value = null
+        val expected = mapOf<String, Any>()
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapLevel2Put() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a.b")
+        val value = 1
+        val expected = mapOf("a" to mapOf("b" to 1))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapLevel2PutEscapes() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a\\.x.b\\.y")
+        val value = 1
+        val expected = mapOf("a.x" to mapOf("b.y" to 1))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapLevel2PutEscapedBackslash() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a\\.x.b\\\\y")
+        val value = 1
+        val expected = mapOf("a.x" to mapOf("b\\y" to 1))
+
+        val obseved = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, obseved)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testBadEscape() {
+        DocumentPath("a\\.x.b\\.y\\")
+    }
+
+    @Test
+    fun testListAppendEmpty() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a.-1")
+        val value = 1
+        val expected = mapOf<String, Any>("a" to listOf<Any>(1))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testListDeleteLast() {
+        val document = mutableMapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(1, 2, 3)))
+        val docpath = DocumentPath("a.-1")
+        val value = null
+        val expected = mapOf<String, Any>("a" to listOf<Any>(1, 2))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testListAppendEmptyNull() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a.-1")
+        val value = null
+        val expected = mapOf<String, Any>("a" to listOf<Any>())
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testListReplace() {
+        val document = mutableMapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(1, 2, 3)))
+        val docpath = DocumentPath("a.0")
+        val value = 9
+        val expected = mapOf<String, Any>("a" to listOf<Any>(9, 2, 3))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testListDelete() {
+        val document = mutableMapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(1, 2, 3)))
+        val docpath = DocumentPath("a.0")
+        val value = null
+        val expected = mapOf<String, Any>("a" to listOf<Any>(2, 3))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testListReplaceLast() {
+        val document = mutableMapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(5, 4, 3, 2, 1)))
+        val docpath = DocumentPath("a.-1")
+        val value = 9
+        val expected = mapOf<String, Any>("a" to listOf<Any>(5, 4, 3, 2, 9))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testListCreateAndAppend() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a.")
+        val value = 1
+        val expected = mapOf<String, Any>("a" to listOf<Any>(1))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testListCreateAndAppendEscape() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a\\..")
+        val value = 1
+        val expected = mapOf<String, Any>("a." to listOf<Any>(1))
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testEscapeLastDot() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a\\.")
+        val value = 1
+        val expected = mapOf<String, Any>("a." to 1)
+
+        val observed = docpath.modifyDocument(document, value)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testLastDotNull() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a.")
+        val value = null
+
+        docpath.modifyDocument(document, value)
+    }
+}

--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/DocumentPathBenchmarkTest.kt
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/DocumentPathBenchmarkTest.kt
@@ -1,0 +1,27 @@
+package com.bugsnag.android.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import com.bugsnag.android.internal.DocumentPath
+import org.junit.Rule
+import org.junit.Test
+
+class DocumentPathBenchmarkTest {
+
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    @Test
+    fun parseDocumentPath() {
+        benchmarkRule.measureRepeated {
+            DocumentPath("foo.bar.a.-1.3.")
+        }
+    }
+
+    @Test
+    fun parseDocumentPathWithEscapes() {
+        benchmarkRule.measureRepeated {
+            DocumentPath("a.b\\\\s\\.a.-1.3.")
+        }
+    }
+}


### PR DESCRIPTION
## Goal

DocumentPath parses a document path string into directives, which can then be used to modify a document at the desired depth and type.

This is a low-level, self-contained piece of the journal system (PLAT-6711). Overall structure:

	| --------------------------------------------------------------- |
	|                          Journal API                            |
	| --------------------------------------------------------------- |
	| Journal       | Thread-safety | Shared Memory | File Management |
    | ------------- |               |               |                 |
	| Document Path |               |               |                 |
	| ----------------------------- |               | --------------- |
	|   Crash-time synchronization  |               | Crash-time API  |
	| --------------------------------------------------------------- |

## Testing

Added unit tests for the new classes.
