### PR TITLE
Add the journal type.

### DIFF
--- a/bugsnag-android-core/build.gradle
+++ b/bugsnag-android-core/build.gradle
@@ -11,6 +11,10 @@ bugsnagBuildOptions {
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.dokka"
 
+dependencies {
+    implementation 'com.dslplatform:dsl-json:1.9.8'
+}
+
 dokka {
     outputFormat = "html"
     outputDirectory = "$buildDir/dokka"

--- a/bugsnag-android-core/lint-baseline.xml
+++ b/bugsnag-android-core/lint-baseline.xml
@@ -1,4 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="5" by="lint 3.4.2" client="gradle" variant="all" version="3.4.2">
+<issues format="5" by="lint 4.1.1" client="gradle" variant="all" version="4.1.1">
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in com.dslplatform:dsl-json; not included in Android: `java.awt.geom`. Referenced from `com.dslplatform.json.DslJson`.">
+        <location
+            file="../../../../.gradle/caches/modules-2/files-2.1/com.dslplatform/dsl-json/1.9.8/33d30c7b113651e1b0d060f3f0af35fbf43f1403/dsl-json-1.9.8.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in com.dslplatform:dsl-json; not included in Android: `java.awt.image`. Referenced from `com.dslplatform.json.DslJson`.">
+        <location
+            file="../../../../.gradle/caches/modules-2/files-2.1/com.dslplatform/dsl-json/1.9.8/33d30c7b113651e1b0d060f3f0af35fbf43f1403/dsl-json-1.9.8.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in com.dslplatform:dsl-json; not included in Android: `java.awt`. Referenced from `com.dslplatform.json.DslJson`.">
+        <location
+            file="../../../../.gradle/caches/modules-2/files-2.1/com.dslplatform/dsl-json/1.9.8/33d30c7b113651e1b0d060f3f0af35fbf43f1403/dsl-json-1.9.8.jar"/>
+    </issue>
+
+    <issue
+        id="InvalidPackage"
+        message="Invalid package reference in com.dslplatform:dsl-json; not included in Android: `javax.imageio`. Referenced from `com.dslplatform.json.JavaGeomConverter`.">
+        <location
+            file="../../../../.gradle/caches/modules-2/files-2.1/com.dslplatform/dsl-json/1.9.8/33d30c7b113651e1b0d060f3f0af35fbf43f1403/dsl-json-1.9.8.jar"/>
+    </issue>
 
 </issues>

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -14,8 +14,12 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 final class BugsnagTestUtils {
 
@@ -131,5 +135,84 @@ final class BugsnagTestUtils {
 
     public static App generateApp() {
         return new App(generateImmutableConfig(), null, null, null, null, null);
+    }
+
+    /**
+     * "Normalize" a map by changing all numeric types to their largest forms.
+     * This is necessary for comparing the results of serialization/deserialization
+     * operations because we have no control over what types the codec will choose,
+     * and equals() takes into account the underlying type.
+     *
+     * @param map The map to normalize
+     * @param <K> The key type
+     * @param <V> The value type
+     * @return The normalized map
+     */
+    @SuppressWarnings("unchecked")
+    private static <K, V> Map<K, V> normalizedMap(Map<K, V> map) {
+        Map<K, V> newMap = new HashMap<>(map.size());
+        Set<Map.Entry<K, V>> set = map.entrySet();
+        for (Map.Entry<K, V> entry: set) {
+            K key = entry.getKey();
+            K normalizedKey = (K)normalized(key);
+            if (!key.equals(normalizedKey)) {
+                key = normalizedKey;
+            }
+            newMap.put(key, (V)normalized(entry.getValue()));
+        }
+        return newMap;
+    }
+
+    /**
+     * "Normalize" a list by changing all numeric types to their largest forms.
+     * This is necessary for comparing the results of serialization/deserialization
+     * operations because we have no control over what types the codec will choose,
+     * and equals() takes into account the underlying type.
+     *
+     * @param list The list to normalize
+     * @param <T> The element type
+     * @return The normalized list
+     */
+    @SuppressWarnings("unchecked")
+    private static <T> List<T> normalizedList(List<T> list) {
+        List<T> newList = new ArrayList<>(list.size());
+        for (T entry: list) {
+            newList.add((T)normalized(entry));
+        }
+        return newList;
+    }
+
+    /**
+     * "Normalize" an unknown value by changing all numeric types to their largest forms.
+     * This is necessary for comparing the results of serialization/deserialization
+     * operations because we have no control over what types the codec will choose,
+     * and equals() takes into account the underlying type.
+     *
+     * This function normalizes integers, floats, lists, and maps and their subobjects.
+     *
+     * @param obj The object to normalize.
+     * @return The normalized object (may be the same object passed in)
+     */
+    @SuppressWarnings("unchecked")
+    public static Object normalized(Object obj) {
+        if (obj instanceof Byte) {
+            return ((Byte)obj).longValue();
+        }
+        if (obj instanceof Short) {
+            return ((Short)obj).longValue();
+        }
+        if (obj instanceof Integer) {
+            return ((Integer)obj).longValue();
+        }
+        if (obj instanceof Float) {
+            return ((Float)obj).doubleValue();
+        }
+        if (obj instanceof Map) {
+            return normalizedMap((Map<Object, Object>)obj);
+        }
+        if (obj instanceof List) {
+            return normalizedList((List<Object>)obj);
+        }
+        return obj;
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/JournalCommandTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/JournalCommandTest.kt
@@ -1,0 +1,61 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.internal.Journal
+import com.dslplatform.json.DslJson
+import org.junit.Assert
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+
+class JournalCommandTest {
+    @Test
+    fun testSerializeBasic() {
+        assertSerializeDeserialize(
+            "{\"a\":1}\u0000",
+            Journal.Command("a", 1)
+        )
+        assertSerializeDeserialize(
+            "{\"a\":1.5}\u0000",
+            Journal.Command("a", 1.5)
+        )
+        assertSerializeDeserialize(
+            "{\"a\":\"x\"}\u0000",
+            Journal.Command("a", "x")
+        )
+        assertSerializeDeserialize(
+            "{\"a\":true}\u0000",
+            Journal.Command("a", true)
+        )
+        assertSerializeDeserialize(
+            "{\"a\":null}\u0000",
+            Journal.Command("a", null)
+        )
+    }
+
+    private fun serializeJournalEntry(entry: Journal.Command): String {
+        val os = ByteArrayOutputStream()
+        entry.serialize(os)
+        return os.toString(Charsets.UTF_8.name())
+    }
+
+    private fun deserializeJournalEntry(json: String): Journal.Command {
+        val dslJson = DslJson<MutableMap<String, Any>>()
+        val document = json.toByteArray(Charsets.UTF_8)
+        return Journal.deserializeCommand(dslJson, document)
+    }
+
+    private fun assertSerializeDeserialize(json: String, entry: Journal.Command) {
+        val expectedJson = json
+        val observedJson = serializeJournalEntry(entry)
+        Assert.assertEquals(expectedJson, observedJson)
+
+        val expectedEntry = entry
+        val observedEntry = deserializeJournalEntry(json)
+        assertEquivalent(expectedEntry, observedEntry)
+    }
+
+    private fun assertEquivalent(expected: Journal.Command, observed: Journal.Command) {
+        val expectedSerialized = serializeJournalEntry(expected)
+        val observedSerialized = serializeJournalEntry(observed)
+        Assert.assertEquals(expectedSerialized, observedSerialized)
+    }
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/JournalTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/JournalTest.kt
@@ -1,0 +1,189 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.internal.Journal
+import org.junit.Assert
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+
+class JournalTest {
+    @Test
+    fun testEmptyEverything() {
+        val journal = Journal()
+        val document = mutableMapOf<String, Any>()
+        val observed = journal.applyTo(document)
+        val expected = mutableMapOf<String, Any>()
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testBasicMap() {
+        val journal = Journal()
+        journal.add(Journal.Command("a", 1))
+        val document = mutableMapOf<String, Any>()
+        val observed = journal.applyTo(document)
+        val expected = mutableMapOf<String, Any>("a" to 1)
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testNonAscii() {
+        val journal = Journal()
+        journal.add(Journal.Command("猫", "cat (Japanese)"))
+        journal.add(Journal.Command("பூனை", "cat (Tamil)"))
+        val document = mutableMapOf<String, Any>()
+        val observed = journal.applyTo(document)
+        val expected = mutableMapOf<String, Any>(
+            "猫" to "cat (Japanese)",
+            "பூனை" to "cat (Tamil)"
+        )
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testLargeValues() {
+        val journal = Journal()
+        journal.add(Journal.Command("int", 1000000000000))
+        journal.add(Journal.Command("float", 1.3529104022e80))
+        val document = mutableMapOf<String, Any>()
+        val observed = journal.applyTo(document)
+        val expected = mutableMapOf<String, Any>(
+            "int" to 1000000000000,
+            "float" to 1.3529104022e80
+        )
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testSubmap() {
+        val journal = Journal()
+        journal.add(Journal.Command("a", mapOf(1 to 2)))
+        val document = mutableMapOf<String, Any>()
+        val observed = journal.applyTo(document)
+        val expected = mutableMapOf<String, Any>("a" to mutableMapOf(1 to 2))
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun testSublist() {
+        val journal = Journal()
+        journal.add(Journal.Command("a", listOf(1, 2)))
+        val document = mutableMapOf<String, Any>()
+        val observed = journal.applyTo(document)
+        val expected = mutableMapOf<String, Any>("a" to mutableListOf(1, 2))
+        Assert.assertEquals(expected, observed)
+    }
+
+    @Test
+    fun test1EntryJournal() {
+        assertSerializeDeserialize(
+            "{\"a\":1}\u0000".toByteArray(Charsets.UTF_8),
+            Journal.Command("a", 1)
+        )
+    }
+
+    @Test
+    fun test2EntryJournal() {
+        assertSerializeDeserialize(
+            "{\"a\":1}\u0000{\"b\":\"x\"}\u0000".toByteArray(Charsets.UTF_8),
+            Journal.Command("a", 1),
+            Journal.Command("b", "x")
+        )
+    }
+
+    @Test
+    fun testRunSerializedJournal() {
+        assertRunSerializedJournal(
+            initialDocument = mutableMapOf("q" to 100),
+            serializedJournal = "{\"a\":1}\u0000{\"b\":\"x\"}\u0000".toByteArray(Charsets.UTF_8),
+            expectedDocument = mutableMapOf("q" to 100, "a" to 1, "b" to "x")
+        )
+    }
+
+    @Test
+    fun testRunSerializedJournalWithEscapesDot() {
+        assertRunSerializedJournal(
+            initialDocument = mutableMapOf("q" to 100),
+            serializedJournal = "{\"f\\\\.oo.-1\":1}\u0000{\"b\":\"x\"}\u0000".toByteArray(Charsets.UTF_8),
+            expectedDocument = mutableMapOf(
+                "q" to 100,
+                "f.oo" to mutableListOf(1),
+                "b" to "x"
+            )
+        )
+    }
+
+    @Test
+    fun testRunSerializedJournalWithEscapesBackslash() {
+        assertRunSerializedJournal(
+            initialDocument = mutableMapOf("q" to 100),
+            serializedJournal = "{\"f\\\\\\\\oo.xyz\":1}\u0000{\"b\":\"x\"}\u0000".toByteArray(Charsets.UTF_8),
+            expectedDocument = mutableMapOf(
+                "q" to 100,
+                "f\\oo" to mutableMapOf("xyz" to 1),
+                "b" to "x"
+            )
+        )
+    }
+
+    @Test
+    fun testRunSerializedJournalDeep() {
+        assertRunSerializedJournal(
+            initialDocument = mutableMapOf("q" to 100),
+            serializedJournal = "{\"a.b.-1\":1}\u0000{\"b.-1.\":\"x\"}\u0000".toByteArray(Charsets.UTF_8),
+            expectedDocument = mutableMapOf(
+                "q" to 100,
+                "a" to mapOf<String, Any>("b" to listOf<Any>(1L)),
+                "b" to listOf<Any>(listOf<Any>("x"))
+            )
+        )
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun testDeserializeFail() {
+        deserialize(
+            "{\"a.\":10false}\u0000".toByteArray(Charsets.UTF_8)
+        )
+    }
+
+    private fun assertSerializeDeserialize(serialized: ByteArray, vararg entries: Journal.Command) {
+        val journal = Journal()
+        for (entry in entries) {
+            journal.add(entry)
+        }
+        val expectedBytes = serialized
+        val observedBytes = serialize(journal)
+        Assert.assertArrayEquals(expectedBytes, observedBytes)
+
+        val expectedEntry = journal
+        val observedEntry = deserialize(serialized)
+        assertEquivalent(expectedEntry, observedEntry)
+    }
+
+    private fun assertEquivalent(expected: Journal, observed: Journal) {
+        val expectedBytes = serialize(expected)
+        val observedBytes = serialize(observed)
+        Assert.assertArrayEquals(expectedBytes, observedBytes)
+    }
+
+    fun serialize(journal: Journal): ByteArray {
+        val outs = ByteArrayOutputStream()
+        journal.serialize(outs)
+        return outs.toByteArray()
+    }
+
+    fun deserialize(bytes: ByteArray): Journal {
+        return Journal.deserialize(bytes)
+    }
+
+    private fun assertRunSerializedJournal(
+        initialDocument: MutableMap<String, Any>,
+        serializedJournal: ByteArray,
+        expectedDocument: Any
+    ) {
+        val journal = deserialize(serializedJournal)
+        val observedDocument = journal.applyTo(initialDocument)
+        val expectedMap = BugsnagTestUtils.normalized(expectedDocument)
+        val observedMap = BugsnagTestUtils.normalized(observedDocument)
+        Assert.assertEquals(expectedMap, observedMap)
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/IOUtils.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/IOUtils.java
@@ -8,8 +8,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
-import java.net.HttpURLConnection;
-import java.net.URLConnection;
 
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 class IOUtils {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/Journal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/Journal.kt
@@ -1,0 +1,151 @@
+package com.bugsnag.android.internal
+
+import com.dslplatform.json.DslJson
+import java.io.IOException
+import java.io.OutputStream
+
+/**
+ * A journal represents a series of commands that will manipulate a document.
+ * Sometimes it's more efficient to serialize a base document and a list of modifications
+ * to be made to it rather than to re-serialize the entire document after every modification.
+ */
+class Journal {
+    private val commands: MutableList<Command> = mutableListOf()
+
+    /**
+     * Apply this journal to a document.
+     *
+     * This method goes through the journal entries one-by-one, applying their modification
+     * commands to the document. This is a destructive operation that will modify the document.
+     *
+     * Note: If a journal command replaces the root object, the resulting document will be a
+     * different object from the one passed in.
+     *
+     * @param document The document to apply to.
+     * @return The finished document (may be a different object from the one passed in).
+     */
+    fun applyTo(document: MutableMap<in String, out Any>): MutableMap<in String, out Any> {
+        return commands.fold(document) { doc, command -> command.apply(doc) }
+    }
+
+    /**
+     * Add a journal command to this journal
+     *
+     * @param command The journal command
+     */
+    fun add(command: Command) {
+        commands.add(command)
+    }
+
+    /**
+     * Clear the journal, removing all journal entries.
+     */
+    fun clear() {
+        commands.clear()
+    }
+
+    /**
+     * Serialize this journal to a stream.
+     *
+     * @param out The stream to serialize to.
+     * @throws IOException if an IO exception occurs.
+     */
+    @Throws(IOException::class)
+    fun serialize(out: OutputStream) {
+        for (command in commands) {
+            command.serialize(out)
+        }
+    }
+
+    /**
+     * Command represents a single journal command, consisting of:
+     * - a document path, which determines where in a document the change is to be made.
+     * - a value, which determines the change to be made.
+     *
+     * In general, a null value represents a delete, and a non-null value represents an insert or
+     * replace.
+     *
+     * @see DocumentPath for a description of how path strings work.
+     */
+    class Command(private val path: String, val value: Any?) {
+        private val documentPath: DocumentPath = DocumentPath(path)
+
+        /**
+         * Apply this journal command to a document.
+         *
+         * @param document The document to modify.
+         * @return The resulting document (may not be the same as the one passed in).
+         */
+        fun apply(document: MutableMap<in String, out Any>): MutableMap<in String, out Any> {
+            return documentPath.modifyDocument(document, value)
+        }
+
+        /**
+         * Serialize this command to an OutputStream
+         *
+         * @param out The stream
+         * @throws IOException If an IO exception occurs
+         */
+        @Throws(IOException::class)
+        fun serialize(out: OutputStream) {
+            dslJson.serialize(mutableMapOf(path to value), out)
+            out.write(0)
+        }
+    }
+
+    companion object {
+        // Only one global DslJson is needed, and is thread-safe
+        // Note: dsl-json adds about 150k to the final binary size.
+        internal val dslJson = DslJson<MutableMap<String, Any>>()
+
+        private const val NULL_BYTE = 0.toByte()
+
+        /**
+         * Deserialize an entire journal from a byte array.
+         *
+         * Note: This method will skip any journal command entries that fail to deserialize
+         * (corrupt, invalid, or malformed data) and generate log entries describing the problem(s).
+         *
+         * @param bytes The bytes to deserialize from
+         * @return The journal
+         */
+        fun deserialize(bytes: ByteArray): Journal {
+            val journal = Journal()
+            var currentStart = 0
+            for (i in bytes.indices) {
+                if (bytes[i] == NULL_BYTE) {
+                    try {
+                        val document = bytes.copyOfRange(currentStart, i)
+                        journal.add(deserializeCommand(dslJson, document))
+                        currentStart = i + 1
+                    } catch (exception: Exception) {
+                        throw IllegalStateException(
+                            "Could not deserialize journal entry: ${bytes.contentToString()}: $exception"
+                        )
+                    }
+                }
+            }
+            return journal
+        }
+
+        /**
+         * Deserialize a journal command from a byte buffer.
+         *
+         * @param document The document to deserialize from
+         * @return The journal command
+         * @throws IOException If an IO exception occurs
+         */
+        @Throws(IOException::class)
+        fun deserializeCommand(dslJson: DslJson<MutableMap<String, Any>>, document: ByteArray): Command {
+            @Suppress("UNCHECKED_CAST")
+            val map: MutableMap<String, Any>? = dslJson.deserialize(
+                MutableMap::class.java,
+                document,
+                document.size
+            ) as MutableMap<String, Any>?
+            require(!map.isNullOrEmpty()) { "Journal entry data is corrupt and could not be decoded" }
+            val mapEntry = map.entries.single()
+            return Command(mapEntry.key, mapEntry.value)
+        }
+    }
+}

--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/JournalBenchmarkTest.kt
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/JournalBenchmarkTest.kt
@@ -1,0 +1,51 @@
+package com.bugsnag.android.benchmark
+
+import android.app.Application
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.bugsnag.android.*
+import com.bugsnag.android.internal.Journal
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class JournalBenchmarkTest {
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    lateinit var client: Client
+    lateinit var ctx: Context
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext<Application>()
+        client = generateClient(ctx)
+    }
+
+    @Test
+    fun serializeJournal() {
+        val journal = Journal()
+        val entries = listOf<Journal.Command>(
+            Journal.Command("a", "b")
+        )
+
+        benchmarkRule.measureRepeated {
+            journal.clear()
+            val stream = benchmarkRule.scope.runWithTimingDisabled {
+                ByteArrayOutputStream()
+            }
+            stream.use {
+                for(entry in entries) {
+                    journal.add(entry)
+                }
+                journal.serialize(stream)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal

`Journal` section of the journaling system (PLAT-6711).

The journal stores entries composed of a document path and a value to apply at that path. This layer also handles serialization of the journal.

```
| --------------------------------------------------------------- |
|                          Journal API                            |
| --------------------------------------------------------------- |
| Journal       | Thread-safety | Shared Memory | File Management |
| ------------- |               |               |                 |
| Document Path |               |               |                 |
| ----------------------------- |               | --------------- |
|   Crash-time synchronization  |               | Crash-time API  |
| --------------------------------------------------------------- |
```
## Design

Serialization is done via the [dsl-json](https://github.com/ngs-doo/dsl-json) library since it is the [fastest](https://github.com/fabienrenaud/java-json-benchmark) currently, and it also bypasses the JVM string representation, storing directly as UTF-8 data to a byte array (which is useful since we need to store to `shared memory`).

Note: the dsl-json library adds 150k to the final app binary size.

## Testing

Unit tests for the new Journal and JournalEntry classes.


Do not review until https://github.com/bugsnag/bugsnag-android/pull/1306 is merged (this PR builds upon it).