### PR TITLE
Replaced the suggested GPG key-server in RELEASING.md

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -91,11 +91,12 @@ Manual publishing is discouraged, but is possible in exceptional circumstances b
     nexusPassword=your-nexus-password
 
     # GPG key details
-    # Your key must be added to a public key server, such as http://keys.gnupg.net:
+    # See https://central.sonatype.org/publish/requirements/gpg/ for full documentation
+    # Your key must be added to a public key server, such as http://keyserver.ubuntu.com:
     # 1. Get your key id by running `gpg --list-keys --keyid-format=short`. It
     #    should be 8-character hexadecimal.
     # 2. Export your key using `gpg --armor --export <key-id>`
-    # 3. Upload to a server using `gpg --keyserver hkp://keys.gnupg.net --send-keys <key-id>`
+    # 3. Distribute your public key: `gpg --keyserver keyserver.ubuntu.com --send-keys`
     signing.keyId=<key-id>
     signing.password=your-gpg-key-passphrase
     signing.secretKeyRingFile=/Users/{username}/.gnupg/secring.gpg


### PR DESCRIPTION
## Goal
With keys.gnupg.net no longer being a valid upload target, this PR changes the `RELEASING` documentation to point to `keyserver.ubuntu.com` and also includes a link to the full Sonatype GPG documentation