### PR TITLE
Handle NullPointerExceptions from getActiveNetworkInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Register system callbacks on background thread
   [#1292](https://github.com/bugsnag/bugsnag-android/pull/1292)
 
+* Fix rare NullPointerExceptions from ConnectivityManager
+  [1311](https://github.com/bugsnag/bugsnag-android/pull/1311)
+
 ## 5.9.5 (2021-06-25)
 
 * Unity: Properly handle ANRs after multiple calls to autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -25,6 +25,7 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?&gt; ): DeliveryStatus</ID>
     <ID>SwallowedException:AppDataCollector.kt$AppDataCollector$catch (exception: Exception) { logger.w("Could not check lowMemory status") }</ID>
+    <ID>SwallowedException:ConnectivityCompat.kt$ConnectivityLegacy$catch (e: NullPointerException) { // in some rare cases we get a remote NullPointerException via Parcel.readException null }</ID>
     <ID>SwallowedException:ContextExtensions.kt$catch (exc: RuntimeException) { null }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exc: Exception) { false }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get battery status") }</ID>
@@ -32,7 +33,6 @@
     <ID>SwallowedException:DeviceIdStore.kt$DeviceIdStore$catch (exc: OverlappingFileLockException) { Thread.sleep(FILE_LOCK_WAIT_MS) }</ID>
     <ID>SwallowedException:PluginClient.kt$PluginClient$catch (exc: ClassNotFoundException) { logger.d("Plugin '$clz' is not on the classpath - functionality will not be enabled.") null }</ID>
     <ID>UnusedPrivateMember:ThreadStateTest.kt$ThreadStateTest$private val configuration = generateImmutableConfig()</ID>
-    <ID>VarCouldBeVal:SystemBroadcastReceiverTest.kt$SystemBroadcastReceiverTest$var config = BugsnagTestUtils.generateConfiguration()</ID>
     <ID>VariableNaming:EventInternal.kt$EventInternal$/** * @return user information associated with this Event */ internal var _user = User(null, null, null)</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
@@ -61,6 +61,14 @@ internal class ConnectivityLegacy(
 
     private val changeReceiver = ConnectivityChangeReceiver(callback)
 
+    private val activeNetworkInfo: android.net.NetworkInfo?
+        get() = try {
+            cm.activeNetworkInfo
+        } catch (e: NullPointerException) {
+            // in some rare cases we get a remote NullPointerException via Parcel.readException
+            null
+        }
+
     override fun registerForNetworkChanges() {
         val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
         context.registerReceiverSafe(changeReceiver, intentFilter)
@@ -69,11 +77,11 @@ internal class ConnectivityLegacy(
     override fun unregisterForNetworkChanges() = context.unregisterReceiverSafe(changeReceiver)
 
     override fun hasNetworkConnection(): Boolean {
-        return cm.activeNetworkInfo?.isConnectedOrConnecting ?: false
+        return activeNetworkInfo?.isConnectedOrConnecting ?: false
     }
 
     override fun retrieveNetworkAccessState(): String {
-        return when (cm.activeNetworkInfo?.type) {
+        return when (activeNetworkInfo?.type) {
             null -> "none"
             ConnectivityManager.TYPE_WIFI -> "wifi"
             ConnectivityManager.TYPE_ETHERNET -> "ethernet"

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConnectivityLegacyTest.kt
@@ -75,4 +75,20 @@ class ConnectivityLegacyTest {
         Mockito.`when`(info.type).thenReturn(1)
         assertEquals("wifi", conn.retrieveNetworkAccessState())
     }
+
+    @Test
+    fun hasNetworkConnectionNullPointerException() {
+        val conn = ConnectivityLegacy(context, cm, null)
+
+        Mockito.`when`(cm.activeNetworkInfo).thenThrow(NullPointerException())
+        assertFalse(conn.hasNetworkConnection())
+    }
+
+    @Test
+    fun retrieveNetworkAccessStateNullPointerException() {
+        val conn = ConnectivityLegacy(context, cm, null)
+
+        Mockito.`when`(cm.activeNetworkInfo).thenThrow(NullPointerException())
+        assertEquals("none", conn.retrieveNetworkAccessState())
+    }
 }


### PR DESCRIPTION
## Goal
Handle cases where `ConnectivityManager.getActiveNetworkInfo` throws a NullPointerException instead of returning `null` (as expected).

## Design
Treat the `NullPointerException`s as `null` values, and leave all other exceptions to propagate as normal to avoid breaking existing error-handling logic.

## Testing
Tested using mocking in unit tests as this has only been seen in very limited real-world situations.