### PR TITLE
Memory mapped stream

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/MemoryMappedOutputStream.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/MemoryMappedOutputStream.kt
@@ -1,0 +1,63 @@
+package com.bugsnag.android.internal
+
+import java.io.File
+import java.io.OutputStream
+import java.io.RandomAccessFile
+import java.nio.BufferOverflowException
+import java.nio.MappedByteBuffer
+import java.nio.channels.FileChannel
+
+/**
+ * OutputStream wrapper around a shared memory file.
+ *
+ * Memory-mapped files are maintained by the operating system, and so they are guaranteed to match
+ * the last data written to the memory region, even if the app crashes.
+ *
+ * The memory mapped file is fixed to the length specified at instantiation, meaning that
+ * write() will throw java.nio.BufferOverflowException if the file is too full.
+ */
+class MemoryMappedOutputStream(
+    file: File,
+    private val bufferSize: Long,
+    private val clearedByteValue: Byte = 0
+) : OutputStream() {
+
+    private val raf: RandomAccessFile = RandomAccessFile(file, "rw")
+    private val memory: MappedByteBuffer =
+        raf.channel.map(FileChannel.MapMode.READ_WRITE, 0, bufferSize)
+
+    init {
+        raf.setLength(bufferSize)
+    }
+
+    fun clear() {
+        memory.rewind()
+        for (i in 1..bufferSize) {
+            memory.put(clearedByteValue)
+        }
+        memory.rewind()
+    }
+
+    override fun close() {
+        memory.force()
+        raf.close()
+    }
+
+    /**
+     * Write a byte value to the file.
+     * @throws java.nio.BufferOverflowException if the file is too full.
+     */
+    @Throws(BufferOverflowException::class)
+    override fun write(i: Int) {
+        memory.put(i.toByte())
+    }
+
+    /**
+     * Write a byte array to the file.
+     * @throws java.nio.BufferOverflowException if the file is too full.
+     */
+    @Throws(BufferOverflowException::class)
+    override fun write(b: ByteArray, off: Int, len: Int) {
+        memory.put(b, off, len)
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MemoryMappedOutputStreamTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MemoryMappedOutputStreamTest.kt
@@ -1,0 +1,124 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.internal.MemoryMappedOutputStream
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.nio.BufferOverflowException
+
+class MemoryMappedOutputStreamTest {
+    @Rule @JvmField
+    var folder: TemporaryFolder = TemporaryFolder()
+
+    @Test
+    fun testOpenClose() {
+        val file = folder.newFile("stream.memmapped")
+        val mm = MemoryMappedOutputStream(file, 4, clearedByteValue)
+        mm.close()
+        assertFileContents(file, byteArrayOf(0, 0, 0, 0))
+    }
+
+    @Test
+    fun testClear() {
+        val file = folder.newFile("stream.memmapped")
+        val mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.clear()
+        mm.close()
+        assertFileContents(file, byteArrayOf(0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11))
+    }
+
+    @Test
+    fun testFlush() {
+        val file = folder.newFile("stream.memmapped")
+        val mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.clear()
+        mm.write(0)
+        mm.flush()
+        assertFileContents(file, byteArrayOf(0x00, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11))
+    }
+
+    @Test
+    fun testWriteByte() {
+        val file = folder.newFile("stream.memmapped")
+        val mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.clear()
+        mm.write(0)
+        mm.close()
+        assertFileContents(file, byteArrayOf(0x00, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11))
+    }
+
+    @Test
+    fun testWriteBytes() {
+        val file = folder.newFile("stream.memmapped")
+        val mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.clear()
+        val bytes = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+        mm.write(bytes, 0, 5)
+        mm.close()
+        assertFileContents(file, byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x11, 0x11, 0x11, 0x11, 0x11))
+    }
+
+    @Test
+    fun testWriteBytesOffset() {
+        val file = folder.newFile("stream.memmapped")
+        val mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.clear()
+        val bytes = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+        mm.write(bytes, 2, 5)
+        mm.close()
+        assertFileContents(file, byteArrayOf(0x03, 0x04, 0x05, 0x06, 0x07, 0x11, 0x11, 0x11, 0x11, 0x11))
+    }
+
+    @Test(expected = BufferOverflowException::class)
+    fun testWriteOverflow() {
+        val file = folder.newFile("stream.memmapped")
+        val mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.clear()
+        val bytes = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+        mm.write(bytes, 0, 11)
+    }
+
+    @Test(expected = BufferOverflowException::class)
+    fun testWriteOverflowTwoSteps() {
+        val file = folder.newFile("stream.memmapped")
+        val mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.clear()
+        val bytes = byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
+        mm.write(bytes, 0, 5)
+        mm.write(bytes, 0, 6)
+    }
+
+    @Test
+    fun testShrinkSize() {
+        val file = folder.newFile("stream.memmapped")
+        var mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.clear()
+        mm.write(0)
+        mm.close()
+        mm = MemoryMappedOutputStream(file, 5, clearedByteValue)
+        mm.close()
+        assertFileContents(file, byteArrayOf(0x00, 0x11, 0x11, 0x11, 0x11))
+    }
+
+    @Test
+    fun testGrowSize() {
+        val file = folder.newFile("stream.memmapped")
+        var mm = MemoryMappedOutputStream(file, 5, clearedByteValue)
+        mm.clear()
+        mm.write(0)
+        mm.close()
+        mm = MemoryMappedOutputStream(file, 10, clearedByteValue)
+        mm.close()
+        assertFileContents(file, byteArrayOf(0x00, 0x11, 0x11, 0x11, 0x11, 0, 0, 0, 0, 0))
+    }
+
+    private fun assertFileContents(file: File, expectedContents: ByteArray) {
+        val observedContents = file.readBytes()
+        Assert.assertArrayEquals(expectedContents, observedContents)
+    }
+
+    // Can be any arbitrary value
+    val clearedByteValue = 0x11.toByte()
+}


### PR DESCRIPTION
## Goal

Part of PLAT-6961

This adds an OutputStream that writes to a memory mapped file. Memory mapped files are guaranteed to be consistent with the last memory write, even if the app crashes (because the memory mapping is maintained by the OS, not the app).

This allows us to always serialize the latest document changes, regardless of app conditions, and recover all journal entries on app relaunch.

## Testing

Added unit tests for the memory mapped stream.
