### PR TITLE
Add JournaledDocument

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -30,6 +30,9 @@
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get battery status") }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get locationStatus") }</ID>
     <ID>SwallowedException:DeviceIdStore.kt$DeviceIdStore$catch (exc: OverlappingFileLockException) { Thread.sleep(FILE_LOCK_WAIT_MS) }</ID>
+    <ID>SwallowedException:JournaledDocument.kt$JournaledDocument$catch (ex: BufferOverflowException) { snapshot() command.serialize(journalStream) }</ID>
+    <ID>SwallowedException:JournaledDocument.kt$JournaledDocument.Companion$catch (ex: IOException) { // Ignored - there is no new snapshot or it's invalid }</ID>
+    <ID>SwallowedException:JournaledDocument.kt$JournaledDocument.Companion$catch (ex: IOException) { // The journal is corrupt; just return the document. return document }</ID>
     <ID>SwallowedException:PluginClient.kt$PluginClient$catch (exc: ClassNotFoundException) { logger.d("Plugin '$clz' is not on the classpath - functionality will not be enabled.") null }</ID>
     <ID>UnusedPrivateMember:ThreadStateTest.kt$ThreadStateTest$private val configuration = generateImmutableConfig()</ID>
     <ID>VarCouldBeVal:SystemBroadcastReceiverTest.kt$SystemBroadcastReceiverTest$var config = BugsnagTestUtils.generateConfiguration()</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/JournaledDocument.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/JournaledDocument.kt
@@ -1,0 +1,178 @@
+package com.bugsnag.android.internal
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.io.Closeable
+import java.io.File
+import java.io.IOException
+import java.lang.IllegalStateException
+import java.nio.BufferOverflowException
+import java.util.function.BiConsumer
+
+/**
+ * A document with journal backing.
+ * Document snapshots are persisted to files, and journal entries are persisted to a memory-mapped
+ * file.
+ *
+ * Changes to the document must me made only via journal commands. Do not modify the document or any
+ * of its sub-components directly!
+ */
+class JournaledDocument
+/**
+ * Constructor.
+ * Upon construction, this document will have associated snapshot and journal files.
+ *
+ * @param baseDocumentPath The base path + filename to derive snapshot and journal names from.
+ * @param journalType A string identifying the type of journal (used for verification when the
+ *                    journal is reloaded)
+ * @param version The journal type version (to support migration)
+ * @param bufferSize The size of the shared memory buffer (and thus the maximum size of the journal)
+ * @param initialDocument The initial document contents (will be shallow copied)
+ */
+constructor(
+    baseDocumentPath: File,
+    journalType: String,
+    version: Int,
+    bufferSize: Long,
+    initialDocument: MutableMap<String, Any>
+) : Map<String, Any>, Closeable {
+    private val journalPath = getJournalPath(baseDocumentPath)
+    private val snapshotPath = getSnapshotPath(baseDocumentPath)
+    private val newSnapshotPath = getNewSnapshotPath(baseDocumentPath)
+
+    private val document = initialDocument.toMutableMap()
+    private val journal = Journal(journalType, version)
+    private val journalStream = MemoryMappedOutputStream(journalPath, bufferSize, clearedByteValue)
+    private var isOpen = true
+
+    init {
+        // Make sure any leftover files from the last instance at this path are gone.
+        newSnapshotPath.delete()
+        snapshot()
+    }
+
+    /**
+     * Add a journal command.
+     *
+     * This will first serialize the command to shared memory. If the memory is too full,
+     * it will create a snapshot to free up some room and try a second time.
+     * Next, it will apply the command to the document, and then add it to the journal itself.
+     */
+    fun addCommand(command: Journal.Command) {
+        if (!isOpen) {
+            throw IllegalStateException("Cannot add commands to a closed document")
+        }
+        try {
+            command.serialize(journalStream)
+        } catch (ex: BufferOverflowException) {
+            snapshot()
+            command.serialize(journalStream)
+        }
+        command.apply(document)
+        journal.add(command)
+    }
+
+    /**
+     * Save a current document snapshot and clear the journal
+     */
+    fun snapshot() {
+        if (!isOpen) {
+            throw IllegalStateException("Cannot snapshot a closed document")
+        }
+        JsonHelper.serialize(document, newSnapshotPath)
+        journal.clear()
+        journalStream.clear()
+        journal.serialize(journalStream)
+        newSnapshotPath.renameTo(snapshotPath)
+    }
+
+    /**
+     * Close the journal backing this document. All further modifications will throw exceptions.
+     */
+    override fun close() {
+        journalStream.close()
+        isOpen = false
+    }
+
+    override val entries: Set<Map.Entry<String, Any>> get() = document.entries
+    override val keys: Set<String> get() = document.keys
+    override val size: Int get() = document.size
+    override val values: Collection<Any> get() = document.values
+    override fun containsKey(key: String): Boolean { return document.containsKey(key) }
+    override fun containsValue(value: Any): Boolean { return document.containsValue(value) }
+    @RequiresApi(Build.VERSION_CODES.N)
+    override fun forEach(action: BiConsumer<in String, in Any>) { document.forEach(action) }
+    override fun get(key: String): Any? { return document[key] }
+    @RequiresApi(Build.VERSION_CODES.N)
+    override fun getOrDefault(key: String, defaultValue: Any): Any { return document.getOrDefault(key, defaultValue) }
+    override fun isEmpty(): Boolean { return document.isEmpty() }
+
+    companion object {
+        // 0x99 is guaranteed to be an invalid UTF-8 start byte
+        const val clearedByteValue: Byte = 0x99.toByte()
+
+        internal fun getSnapshotPath(basePath: File): File {
+            return File(basePath.path + ".snapshot")
+        }
+
+        internal fun getNewSnapshotPath(basePath: File): File {
+            return File(basePath.path + ".snapshot.new")
+        }
+
+        internal fun getJournalPath(basePath: File): File {
+            return File(basePath.path + ".journal")
+        }
+
+        /**
+         * Check if a journal-backed document exists at this base path.
+         *
+         * @param baseDocumentPath The base path + filename to derive snapshot and journal names from.
+         * @return true if document files exist at this base path.
+         */
+        fun documentExists(baseDocumentPath: File): Boolean {
+            return getNewSnapshotPath(baseDocumentPath).exists() || getSnapshotPath(baseDocumentPath).exists()
+        }
+
+        /**
+         * Return the equivalent MutableMap<String, Any> that matches the document on disk with the
+         * journal on disk applied.
+         *
+         * Because of the many states the files can be in after a crash, this function checks the
+         * files in a very specific way:
+         * - Check for a ".snapshot.new" file and just return that if it's valid.
+         * - Otherwise load the ".snapshot" file, which must be valid.
+         *   - Attempt to load the ".journal" file, and apply it if it's valid.
+         *   - Return the finished document.
+         *
+         * @param baseDocumentPath The base path + filename to derive snapshot and journal names from.
+         * @return The document.
+         */
+        fun loadDocumentContents(baseDocumentPath: File): MutableMap<in String, out Any> {
+            val journalPath = getJournalPath(baseDocumentPath)
+            val snapshotPath = getSnapshotPath(baseDocumentPath)
+            val newSnapshotPath = getNewSnapshotPath(baseDocumentPath)
+
+            // The "new" snapshot might exist but also might be invalid.
+            try {
+                return JsonHelper.deserialize(newSnapshotPath)
+            } catch (ex: IOException) {
+                // Ignored - there is no new snapshot or it's invalid
+            }
+
+            // The base snapshot must exist and must be valid.
+            val document = JsonHelper.deserialize(snapshotPath)
+
+            // The journal might not be valid.
+            val journal: Journal
+            try {
+                journal = Journal.deserialize(journalPath)
+            } catch (ex: IOException) {
+                // The journal is corrupt; just return the document.
+                return document
+            }
+
+            // A valid journal must run without error.
+            return journal.applyTo(document)
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/JsonHelper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/JsonHelper.kt
@@ -32,14 +32,14 @@ class JsonHelper private constructor() {
                 bytes,
                 bytes.size
             )
-            require(!document.isNullOrEmpty()) { "JSON document is invalid" }
+            requireNotNull(document) { "JSON document is invalid" }
             @Suppress("UNCHECKED_CAST")
             return document as MutableMap<String, Any>
         }
 
         fun deserialize(stream: InputStream): MutableMap<String, Any> {
             val document = dslJson.deserialize(MutableMap::class.java, stream)
-            require(!document.isNullOrEmpty()) { "JSON document is invalid" }
+            requireNotNull(document) { "JSON document is invalid" }
             @Suppress("UNCHECKED_CAST")
             return document as MutableMap<String, Any>
         }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledDocumentTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledDocumentTest.kt
@@ -1,0 +1,212 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.internal.Journal
+import com.bugsnag.android.internal.JournaledDocument
+import com.bugsnag.android.internal.JsonHelper
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class JournaledDocumentTest {
+    @Rule
+    @JvmField
+    var folder: TemporaryFolder = TemporaryFolder()
+
+    @Test
+    fun testEmptyDocumentEmptyJournal() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = 100L
+        val document = JournaledDocument(baseDocumentPath, standardType, standardVersion, bufferSize, mutableMapOf())
+        document.close()
+
+        assertReloadedDocument(baseDocumentPath, mutableMapOf())
+        assertJournalContents(baseDocumentPath, bufferSize, standardJournalInfoSerialized.toByteArray(Charsets.UTF_8))
+        assertSnapshotContents(baseDocumentPath, mutableMapOf())
+    }
+
+    @Test
+    fun testNonEmptyDocumentEmptyJournal() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = 100L
+        val document = JournaledDocument(
+            baseDocumentPath,
+            standardType,
+            standardVersion,
+            bufferSize,
+            mutableMapOf("a" to 1)
+        )
+        document.close()
+
+        assertReloadedDocument(baseDocumentPath, mutableMapOf("a" to 1))
+        assertJournalContents(baseDocumentPath, bufferSize, standardJournalInfoSerialized.toByteArray(Charsets.UTF_8))
+        assertSnapshotContents(baseDocumentPath, mutableMapOf("a" to 1))
+    }
+
+    @Test
+    fun testEmptyDocumentNonEmptyJournal() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = 100L
+        val document = JournaledDocument(baseDocumentPath, standardType, standardVersion, bufferSize, mutableMapOf())
+        document.addCommand(Journal.Command("a.-1.b", "test"))
+        document.close()
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "a" to mutableListOf(
+                    mutableMapOf("b" to "test")
+                )
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            (standardJournalInfoSerialized + "{\"a.-1.b\":\"test\"}\u0000").toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(baseDocumentPath, mutableMapOf())
+    }
+
+    @Test
+    fun testNonEmptyDocumentNonEmptyJournal() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = 100L
+        val document = JournaledDocument(
+            baseDocumentPath,
+            standardType,
+            standardVersion,
+            bufferSize,
+            mutableMapOf("x" to 9)
+        )
+        document.addCommand(Journal.Command("a.-1.b", "test"))
+        // The in-memory document is updated immediately.
+        Assert.assertEquals("test", ((document["a"] as List<*>)[0] as Map<*, *>)["b"])
+        // The journal is force-flushed when closed or the app terminates for any reason.
+        document.close()
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "a" to mutableListOf(
+                    mutableMapOf("b" to "test")
+                ),
+                "x" to 9
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            (standardJournalInfoSerialized + "{\"a.-1.b\":\"test\"}\u0000").toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(baseDocumentPath, mutableMapOf("x" to 9))
+    }
+
+    @Test
+    fun testOverflow() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = standardJournalInfoSerialized.length + 10L
+        val document = JournaledDocument(
+            baseDocumentPath,
+            standardType,
+            standardVersion,
+            bufferSize,
+            mutableMapOf("x" to 9)
+        )
+        document.addCommand(Journal.Command("a", 1))
+        document.addCommand(Journal.Command("b", 2))
+        document.close()
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "a" to 1,
+                "b" to 2,
+                "x" to 9
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            (standardJournalInfoSerialized + "{\"b\":2}\u0000").toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(
+            baseDocumentPath,
+            mutableMapOf(
+                "a" to 1,
+                "x" to 9
+            )
+        )
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun testModifyAfterClose() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = standardJournalInfoSerialized.length + 10L
+        val document = JournaledDocument(
+            baseDocumentPath,
+            standardType,
+            standardVersion,
+            bufferSize,
+            mutableMapOf("x" to 9)
+        )
+        document.addCommand(Journal.Command("a", 1))
+        document.addCommand(Journal.Command("b", 2))
+        document.close()
+        document.addCommand(Journal.Command("c", 3))
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun testSnapshotAfterClose() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = standardJournalInfoSerialized.length + 10L
+        val document = JournaledDocument(
+            baseDocumentPath,
+            standardType,
+            standardVersion,
+            bufferSize,
+            mutableMapOf("x" to 9)
+        )
+        document.addCommand(Journal.Command("a", 1))
+        document.addCommand(Journal.Command("b", 2))
+        document.close()
+        document.snapshot()
+    }
+
+    private fun assertReloadedDocument(file: File, expectedDocument: MutableMap<String, Any>) {
+        val observedDocument = JournaledDocument.loadDocumentContents(file)
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(observedDocument)
+        )
+    }
+
+    private fun assertFileContents(file: File, expectedContents: ByteArray) {
+        val observedContents = file.readBytes()
+        Assert.assertArrayEquals(expectedContents, observedContents)
+    }
+
+    private fun assertJournalContents(file: File, size: Long, expected: ByteArray) {
+        val expectedContents = ByteArray(size.toInt())
+        expectedContents.fill(clearedByteValue)
+        expected.copyInto(expectedContents)
+        val journalPath = File("${file.path}.journal")
+        assertFileContents(journalPath, expectedContents)
+    }
+
+    private fun assertSnapshotContents(file: File, expectedSnapshot: MutableMap<String, Any>) {
+        val snapshotPath = File("${file.path}.snapshot")
+        val observedSnapshot = JsonHelper.deserialize(snapshotPath)
+
+        val expectedMap = BugsnagTestUtils.normalized(expectedSnapshot)
+        val observedMap = BugsnagTestUtils.normalized(observedSnapshot)
+        Assert.assertEquals(expectedMap, observedMap)
+    }
+
+    companion object {
+        const val standardType = "Bugsnag state"
+        const val standardVersion = 1
+        const val clearedByteValue = JournaledDocument.clearedByteValue
+        const val standardJournalInfoSerialized = "{\"*\":{\"type\":\"Bugsnag state\",\"version\":1}}\u0000"
+    }
+}


### PR DESCRIPTION
## Goal

JournaledDocument uses Journal and MemoryMappedOutputStream to build a journal-backed document.

## Design

Document changes are made via journal commands, which are serialized to the memory-mapped file that MemoryMappedOutputStream writes to. Thus, the document is recoverable no matter when the app crashes.

The document contents can be fetched the same as any `Map<String, Any>`.

## Testing

Added unit tests for JournaledDocument
