### PR TITLE
Handle interrupt when shutting down executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Respect manual setting of context
   [#1310](https://github.com/bugsnag/bugsnag-android/pull/1310)
 
+* Handle interrupt when shutting down executors
+  [#1315](https://github.com/bugsnag/bugsnag-android/pull/1315)
+
 ## 5.9.5 (2021-06-25)
 
 * Unity: Properly handle ANRs after multiple calls to autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BackgroundTaskService.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BackgroundTaskService.kt
@@ -164,11 +164,20 @@ internal class BackgroundTaskService(
         // shutdown the IO executor last.
         errorExecutor.shutdown()
         sessionExecutor.shutdown()
-        errorExecutor.awaitTermination(SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)
-        sessionExecutor.awaitTermination(SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)
+
+        errorExecutor.awaitTerminationSafe()
+        sessionExecutor.awaitTerminationSafe()
 
         // shutdown the IO executor last, waiting for any existing tasks to complete
         ioExecutor.shutdown()
-        ioExecutor.awaitTermination(SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)
+        ioExecutor.awaitTerminationSafe()
+    }
+
+    private fun ThreadPoolExecutor.awaitTerminationSafe() {
+        try {
+            awaitTermination(SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)
+        } catch (ignored: InterruptedException) {
+            // ignore interrupted exception as the JVM is shutting down
+        }
     }
 }


### PR DESCRIPTION
## Goal

Handles an `InterruptedException` which can be thrown when shutting down bugsnag's executors.

## Testing

Relied on existing test coverage.