### PR TITLE
React Native: allow serializing enabledBreadcrumbTypes as null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Handle interrupt when shutting down executors
   [#1315](https://github.com/bugsnag/bugsnag-android/pull/1315)
 
+* React Native: allow serializing enabledBreadcrumbTypes as null
+  [#1316](https://github.com/bugsnag/bugsnag-android/pull/1316)
+
 ## 5.9.5 (2021-06-25)
 
 * Unity: Properly handle ANRs after multiple calls to autoNotify and autoDetectAnrs

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
@@ -35,12 +35,13 @@ class ConfigSerializer implements MapSerializer<ImmutableConfig> {
     }
 
     private Collection<String> serializeBreadrumbTypes(ImmutableConfig config) {
-        Collection<String> crumbTypes = new HashSet<>();
         Set<BreadcrumbType> types = config.getEnabledBreadcrumbTypes();
-        if (types != null) {
-            for (BreadcrumbType type : types) {
-                crumbTypes.add(type.toString());
-            }
+        if (types == null) {
+            return null;
+        }
+        Collection<String> crumbTypes = new HashSet<>();
+        for (BreadcrumbType type : types) {
+            crumbTypes.add(type.toString());
         }
         return crumbTypes;
     }


### PR DESCRIPTION
## Goal

Serializes `enabledBreadcrumbTypes` as `null` when it is null in config, rather than as an empty list. The specification states that null is equivalent to having specified automatic capture of all breadcrumb types.

## Testing

Verified using the RN test fixtures that an automatic breadcrumb is sent through when the `enabledBreadcrumbTypes` is null:

<img width="384" alt="Screenshot 2021-07-13 at 10 58 27" src="https://user-images.githubusercontent.com/11800640/125433049-4d52e51b-08f8-42d4-9797-7de5581c9dc1.png">
