### PR TITLE
Crash-time journal support

### DIFF
--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeBufferedWriterTest.java
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeBufferedWriterTest.java
@@ -1,0 +1,23 @@
+package com.bugsnag.android.ndk;
+
+import static com.bugsnag.android.ndk.VerifyUtilsKt.verifyNativeRun;
+
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class NativeBufferedWriterTest {
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("bugsnag-ndk-test");
+    }
+
+    public native int run(String path);
+
+    @Test
+    public void testPassesNativeSuite() throws Exception {
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        verifyNativeRun(run(folder.newFolder().toString()));
+        folder.delete();
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeCrashtimeJournalTest.java
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeCrashtimeJournalTest.java
@@ -1,0 +1,24 @@
+package com.bugsnag.android.ndk;
+
+import static com.bugsnag.android.ndk.VerifyUtilsKt.verifyNativeRun;
+
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class NativeCrashtimeJournalTest {
+
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("bugsnag-ndk-test");
+    }
+
+    public native int run(String path);
+
+    @Test
+    public void testPassesNativeSuite() throws Exception {
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        verifyNativeRun(run(folder.newFolder().toString()));
+        folder.delete();
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeNumberToStringTest.java
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeNumberToStringTest.java
@@ -1,0 +1,19 @@
+package com.bugsnag.android.ndk;
+
+import static com.bugsnag.android.ndk.VerifyUtilsKt.verifyNativeRun;
+
+import org.junit.Test;
+
+public class NativeNumberToStringTest {
+    static {
+        System.loadLibrary("bugsnag-ndk");
+        System.loadLibrary("bugsnag-ndk-test");
+    }
+
+    public native int run();
+
+    @Test
+    public void testPassesNativeSuite() throws Exception {
+        verifyNativeRun(run());
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -13,7 +13,10 @@ add_library( # Specifies the name of the library.
     jni/event.c
     jni/handlers/signal_handler.c
     jni/handlers/cpp_handler.cpp
+    jni/ctjournal.c
+    jni/utils/buffered_writer.c
     jni/utils/crash_info.c
+    jni/utils/number_to_string.c
     jni/utils/stack_unwinder.c
     jni/utils/stack_unwinder_libunwindstack.cpp
     jni/utils/stack_unwinder_libcorkscrew.c

--- a/bugsnag-plugin-android-ndk/src/main/jni/ctjournal.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/ctjournal.c
@@ -1,0 +1,460 @@
+#include "bugsnag_ndk.h"
+#include "utils/buffered_writer.h"
+#include "utils/number_to_string.h"
+#include "utils/string.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <math.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* Crash-time journal writing functions. These must be async-safe and fast,
+ * which is why they use low-level open() and write() for everything, and make
+ * no calls to formatted output functions like sprintf.
+ *
+ * Journal writing functions end writing just after the opening quote whenever
+ * strings are involved. So for example, a function that leads up to writing a
+ * map key will end just after the '"', not before. The same goes for higher
+ * level string writing functions (not including write_string, write_raw_string,
+ * write_raw_bytes, and write_raw_literal).
+ *
+ * There are two versions of some functions to handle the requirement to close a
+ * quoted string, or to set up for a map.
+ */
+
+/* IMPORTANT: Keep this consistent with:
+ * - bugsnag_breadcrumb_type in
+ *       bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+ * - BreadcrumbType in
+ *       bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbType.kt
+ */
+static const char *g_breadcrumb_types[] = {
+    "manual",     // BSG_CRUMB_MANUAL
+    "error",      // BSG_CRUMB_ERROR
+    "log",        // BSG_CRUMB_LOG
+    "navigation", // BSG_CRUMB_NAVIGATION
+    "process",    // BSG_CRUMB_PROCESS
+    "request",    // BSG_CRUMB_REQUEST
+    "state",      // BSG_CRUMB_STATE
+    "user",       // BSG_CRUMB_USER
+};
+static const int g_breadcrumb_types_count =
+    sizeof(g_breadcrumb_types) / sizeof(*g_breadcrumb_types);
+
+// The buffer size for the buffered writer
+#define BUFFER_SIZE (1024 * 128)
+
+// Implemented as defines to take advantage of compile-time size calculation
+// See write_raw_literal()
+#define PATH_METADATA_PREFIX "events.-1.metaData."
+#define PATH_NEXT_BREADCRUMB "events.-1.breadcrumbs."
+#define PATH_LAST_BREADCRUMB_METADATA_PREFIX                                   \
+  "events.-1.breadcrumbs.-1.metaData."
+#define PATH_USER "events.-1.user"
+#define KEY_ID "id"
+#define KEY_EMAIL "email"
+#define KEY_NAME "name"
+#define KEY_TIMESTAMP "timestamp"
+#define KEY_TYPE "type"
+
+/* The maximum number of significant digits when printing floats.
+ * 7 (6 + 1 whole digit in exp form) is the default used by the sprintf code.
+ */
+#define MAX_SIGNIFICANT_DIGITS 7
+
+// Single journal writer (there can only be one crash-time journal)
+static bsg_buffered_writer *g_writer;
+
+/**
+ * Convenience macro to stop the current function and return false if a call
+ * returns false.
+ */
+#define RETURN_ON_FALSE(...)                                                   \
+  do {                                                                         \
+    if (!(__VA_ARGS__)) {                                                      \
+      return false;                                                            \
+    }                                                                          \
+  } while (0)
+
+static inline bool write_raw_bytes(const char *bytes, size_t length) {
+  if (!g_writer->write(g_writer, bytes, length)) {
+    BUGSNAG_LOG("Error writing to journal at %s: %s", g_writer->path,
+                strerror(errno));
+    return false;
+  }
+  return true;
+}
+
+static inline bool flush_writer() {
+  if (!g_writer->flush(g_writer)) {
+    BUGSNAG_LOG("Error flushing to journal at %s: %s", g_writer->path,
+                strerror(errno));
+    return false;
+  }
+  return true;
+}
+
+static inline bool write_raw_string(const char *string) {
+  return write_raw_bytes(string, strlen(string));
+}
+
+/**
+ * This is implemented as a macro to take advantage of compile-time size
+ * calculations when passing in string literals.
+ */
+#define write_raw_literal(LITERAL_STRING)                                      \
+  write_raw_bytes((LITERAL_STRING), sizeof(LITERAL_STRING) - 1)
+
+// Marks which characters require escaping.
+static const bool escape_requiring_chars[0x100] = {
+    ['"'] = true,
+    ['\\'] = true,
+};
+
+static inline bool requires_escapes(const char *string) {
+  while (*string) {
+    if (escape_requiring_chars[*string]) {
+      return true;
+    }
+    string++;
+  }
+  return false;
+}
+
+static inline bool write_escaped(const char *string) {
+  // Use a small buffer size to avoid stack contention as this is the unlikely
+  // path.
+  char buff[50];
+  // Use a high-water value that takes into account escape char stuffing
+  const size_t buff_hiwater_marker = sizeof(buff) - 1;
+  size_t i_buff = 0;
+
+  while (*string) {
+    if (escape_requiring_chars[*string]) {
+      buff[i_buff++] = '\\';
+    }
+    buff[i_buff++] = *string;
+    if (i_buff >= buff_hiwater_marker) {
+      if (!write_raw_bytes(buff, i_buff)) {
+        return false;
+      }
+      i_buff = 0;
+    }
+    string++;
+  }
+
+  if (i_buff > 0) {
+    if (!write_raw_bytes(buff, i_buff)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+static inline bool write_string(const char *string) {
+  if (!requires_escapes(string)) {
+    return write_raw_bytes(string, strlen(string));
+  }
+  return write_escaped(string);
+}
+
+static inline bool write_boolean(bool value) {
+  if (value) {
+    return write_raw_literal("true");
+  } else {
+    return write_raw_literal("false");
+  }
+}
+
+static inline bool write_null() { return write_raw_literal("null"); }
+
+// Max significant digits + special chars for sign, exponent, etc.
+#define MAX_STRING_SIZE_FLOAT 22
+
+static inline bool write_double(double value) {
+  char buff[MAX_STRING_SIZE_FLOAT];
+  bsg_double_to_string(value, buff, MAX_SIGNIFICANT_DIGITS);
+  return write_raw_string(buff);
+}
+
+static inline bool write_journal_begin_common(const char *path,
+                                              const char *separator) {
+  RETURN_ON_FALSE(write_raw_literal("{\""));
+  RETURN_ON_FALSE(write_string(path));
+  return write_raw_string(separator);
+}
+
+static inline bool write_journal_begin_string(const char *path) {
+  return write_journal_begin_common(path, "\":\"");
+}
+
+static inline bool write_journal_begin_nonstring(const char *path) {
+  return write_journal_begin_common(path, "\":");
+}
+
+static inline bool write_journal_mapentry_string(const char *key,
+                                                 const char *value,
+                                                 bool hasMoreEntries) {
+  RETURN_ON_FALSE(write_string(key));
+  RETURN_ON_FALSE(write_raw_literal("\":\""));
+  RETURN_ON_FALSE(write_string(value));
+  if (hasMoreEntries) {
+    RETURN_ON_FALSE(write_raw_literal("\",\""));
+  } else {
+    RETURN_ON_FALSE(write_raw_literal("\""));
+  }
+  return true;
+}
+
+static inline bool write_journal_begin_map(const char *path) {
+  return write_journal_begin_common(path, "\":{\"");
+}
+
+static inline bool write_journal_end_string() {
+  return write_raw_bytes("\"}\0", 3);
+}
+
+static inline bool write_journal_end_nonstring() {
+  return write_raw_bytes("}\0", 2);
+}
+
+static inline bool write_journal_end_map() {
+  return write_raw_bytes("}}\0", 3);
+}
+
+static inline bool write_metadata_begin_common(const char *section,
+                                               const char *name,
+                                               const char *separator) {
+  RETURN_ON_FALSE(write_raw_literal("{\"" PATH_METADATA_PREFIX));
+  RETURN_ON_FALSE(write_string(section));
+  if (name != NULL) {
+    RETURN_ON_FALSE(write_raw_literal("."));
+    RETURN_ON_FALSE(write_string(name));
+  }
+  return write_raw_string(separator);
+}
+
+static inline bool write_metadata_begin_string(const char *section,
+                                               const char *name) {
+  return write_metadata_begin_common(section, name, "\":\"");
+}
+
+static inline bool write_metadata_begin_nonstring(const char *section,
+                                                  const char *name) {
+  return write_metadata_begin_common(section, name, "\":");
+}
+
+// API
+
+bool bsg_ctjournal_clear_value(const char *path) {
+  if (path == NULL) {
+    return false;
+  }
+
+  RETURN_ON_FALSE(write_journal_begin_nonstring(path));
+  RETURN_ON_FALSE(write_null());
+  RETURN_ON_FALSE(write_journal_end_nonstring());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_set_double(const char *path, double value) {
+  if (path == NULL) {
+    return false;
+  }
+
+  RETURN_ON_FALSE(write_journal_begin_nonstring(path));
+  RETURN_ON_FALSE(write_double(value));
+  RETURN_ON_FALSE(write_journal_end_nonstring());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_set_boolean(const char *path, bool value) {
+  if (path == NULL) {
+    return false;
+  }
+
+  RETURN_ON_FALSE(write_journal_begin_nonstring(path));
+  RETURN_ON_FALSE(write_boolean(value));
+  RETURN_ON_FALSE(write_journal_end_nonstring());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_set_string(const char *path, const char *value) {
+  if (path == NULL) {
+    return false;
+  }
+
+  if (value == NULL) {
+    return bsg_ctjournal_clear_value(path);
+  }
+
+  RETURN_ON_FALSE(write_journal_begin_string(path));
+  RETURN_ON_FALSE(write_string(value));
+  RETURN_ON_FALSE(write_journal_end_string());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_metadata_clear_section(const char *section) {
+  if (section == NULL) {
+    return false;
+  }
+
+  RETURN_ON_FALSE(write_metadata_begin_nonstring(section, NULL));
+  RETURN_ON_FALSE(write_null());
+  RETURN_ON_FALSE(write_journal_end_nonstring());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_metadata_clear_value(const char *section, const char *name) {
+  if (section == NULL || name == NULL) {
+    return false;
+  }
+
+  RETURN_ON_FALSE(write_metadata_begin_nonstring(section, name));
+  RETURN_ON_FALSE(write_null());
+  RETURN_ON_FALSE(write_journal_end_nonstring());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_metadata_set_boolean(const char *section, const char *name,
+                                        bool value) {
+  if (section == NULL || name == NULL) {
+    return false;
+  }
+
+  RETURN_ON_FALSE(write_metadata_begin_nonstring(section, name));
+  RETURN_ON_FALSE(write_boolean(value));
+  RETURN_ON_FALSE(write_journal_end_nonstring());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_metadata_set_double(const char *section, const char *name,
+                                       double value) {
+  if (section == NULL || name == NULL) {
+    return false;
+  }
+
+  RETURN_ON_FALSE(write_metadata_begin_nonstring(section, name));
+  RETURN_ON_FALSE(write_double(value));
+  RETURN_ON_FALSE(write_journal_end_nonstring());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_metadata_set_string(const char *section, const char *name,
+                                       const char *value) {
+  if (section == NULL || name == NULL) {
+    return false;
+  }
+
+  RETURN_ON_FALSE(write_metadata_begin_string(section, name));
+  RETURN_ON_FALSE(write_string(value));
+  RETURN_ON_FALSE(write_journal_end_string());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_set_user(const char *id, const char *email,
+                            const char *name) {
+  RETURN_ON_FALSE(write_journal_begin_map(PATH_USER));
+  RETURN_ON_FALSE(write_journal_mapentry_string(KEY_ID, id, true));
+  RETURN_ON_FALSE(write_journal_mapentry_string(KEY_EMAIL, email, true));
+  RETURN_ON_FALSE(write_journal_mapentry_string(KEY_NAME, name, false));
+  RETURN_ON_FALSE(write_journal_end_map());
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_add_breadcrumb(const bugsnag_breadcrumb *breadcrumb) {
+  if (breadcrumb->type >= g_breadcrumb_types_count) {
+    return false;
+  }
+
+  // We write this as a main journal entry + 1 entry per metadata value.
+
+  RETURN_ON_FALSE(write_journal_begin_map(PATH_NEXT_BREADCRUMB));
+  RETURN_ON_FALSE(
+      write_journal_mapentry_string(KEY_NAME, breadcrumb->name, true));
+  RETURN_ON_FALSE(write_journal_mapentry_string(KEY_TIMESTAMP,
+                                                breadcrumb->timestamp, true));
+  RETURN_ON_FALSE(write_journal_mapentry_string(
+      KEY_TYPE, g_breadcrumb_types[breadcrumb->type], false));
+  RETURN_ON_FALSE(write_journal_end_map());
+
+  for (int i = 0; i < breadcrumb->metadata.value_count; i++) {
+    const bsg_metadata_value *meta = &breadcrumb->metadata.values[i];
+    RETURN_ON_FALSE(write_raw_literal("{\""));
+    RETURN_ON_FALSE(write_raw_literal(PATH_LAST_BREADCRUMB_METADATA_PREFIX));
+    RETURN_ON_FALSE(write_string(meta->section));
+    RETURN_ON_FALSE(write_raw_literal("."));
+    RETURN_ON_FALSE(write_string(meta->name));
+
+    switch (meta->type) {
+    case BSG_METADATA_NONE_VALUE:
+      RETURN_ON_FALSE(write_raw_literal("\":"));
+      RETURN_ON_FALSE(write_null());
+      RETURN_ON_FALSE(write_journal_end_nonstring());
+      break;
+    case BSG_METADATA_BOOL_VALUE:
+      RETURN_ON_FALSE(write_raw_literal("\":"));
+      RETURN_ON_FALSE(write_boolean(meta->bool_value));
+      RETURN_ON_FALSE(write_journal_end_nonstring());
+      break;
+    case BSG_METADATA_CHAR_VALUE:
+      RETURN_ON_FALSE(write_raw_literal("\":\""));
+      RETURN_ON_FALSE(write_string(meta->char_value));
+      RETURN_ON_FALSE(write_journal_end_string());
+      break;
+    case BSG_METADATA_NUMBER_VALUE:
+      RETURN_ON_FALSE(write_raw_literal("\":"));
+      RETURN_ON_FALSE(write_double(meta->double_value));
+      RETURN_ON_FALSE(write_journal_end_nonstring());
+      break;
+    }
+  }
+
+  return flush_writer();
+}
+
+bool bsg_ctjournal_init(const char *journal_path) {
+  // We don't need strong concurrency protections here because we're only going
+  // to call this once. If it did get called more than once AND raced, we'd have
+  // an extra dangling fd and a small amount of leaked memory - no harm done.
+  if (g_writer != NULL) {
+    return true;
+  }
+
+  g_writer = bsg_buffered_writer_open(BUFFER_SIZE, journal_path);
+  if (g_writer == NULL) {
+    BUGSNAG_LOG("Could not open journal file %s: %s", journal_path,
+                strerror(errno));
+    return false;
+  }
+
+  // Initial journal info entry:
+  RETURN_ON_FALSE(write_raw_literal(
+      "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"));
+
+  return flush_writer();
+}
+
+/**
+ * For unit tests only: Reset the journal system.
+ */
+void bsg_ctjournal_test_reset() {
+  if (g_writer == NULL) {
+    return;
+  }
+
+  g_writer->dispose(g_writer);
+  g_writer = NULL;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/ctjournal.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/ctjournal.h
@@ -1,0 +1,108 @@
+#ifndef BUGSNAG_CTJOURNAL_H
+#define BUGSNAG_CTJOURNAL_H
+
+#include "event.h"
+#include <stdbool.h>
+
+/**
+ * Initialize the crash-time journal system.
+ *
+ * @param journal_path /path/to/myjournal.journal.crashtime
+ * @return True on success
+ */
+bool bsg_ctjournal_init(const char *journal_path);
+
+/**
+ * Write a journal entry to clear the value at path.
+ * @param path The path whose value to clear.
+ * @return True on success
+ */
+bool bsg_ctjournal_clear_value(const char *path);
+
+/**
+ * Set a double value at path.
+ * @param path The path to set.
+ * @param value The value to set.
+ * @return True on success
+ */
+bool bsg_ctjournal_set_double(const char *path, double value);
+
+/**
+ * Set a boolean value at path.
+ * @param path The path to set.
+ * @param value The value to set.
+ * @return True on success
+ */
+bool bsg_ctjournal_set_boolean(const char *path, bool value);
+
+/**
+ * Set a string value at path.
+ * @param path The path to set.
+ * @param value The value to set.
+ * @return True on success
+ */
+bool bsg_ctjournal_set_string(const char *path, const char *value);
+
+/**
+ * Clear an entire metadata section.
+ * @param section The section to clear.
+ * @return True on success
+ */
+bool bsg_ctjournal_metadata_clear_section(const char *section);
+
+/**
+ * Clear a metadata value from a section.
+ * @param section The section to clear from.
+ * @param name The name of the value to clear.
+ * @return True on success
+ */
+bool bsg_ctjournal_metadata_clear_value(const char *section, const char *name);
+
+/**
+ * Set a boolean metadata value.
+ * @param section The section to set a value inside.
+ * @param name The name of the value to set.
+ * @param value The value to set it to.
+ * @return True on success
+ */
+bool bsg_ctjournal_metadata_set_boolean(const char *section, const char *name,
+                                        bool value);
+
+/**
+ * Set a double metadata value.
+ * @param section The section to set a value inside.
+ * @param name The name of the value to set.
+ * @param value The value to set it to.
+ * @return True on success
+ */
+bool bsg_ctjournal_metadata_set_double(const char *section, const char *name,
+                                       double value);
+
+/**
+ * Set a string metadata value.
+ * @param section The section to set a value inside.
+ * @param name The name of the value to set.
+ * @param value The value to set it to.
+ * @return True on success
+ */
+bool bsg_ctjournal_metadata_set_string(const char *section, const char *name,
+                                       const char *value);
+
+/**
+ * Set the current user information
+ * @param id The user's ID
+ * @param email The user's email
+ * @param name The user's name
+ * @return True on success
+ */
+bool bsg_ctjournal_set_user(const char *id, const char *email,
+                            const char *name);
+
+/**
+ * Add a breadcrumb
+ * @param breadcrumb The breadcrumb to add
+ * @return True on success
+ */
+bool bsg_ctjournal_add_breadcrumb(const bugsnag_breadcrumb *breadcrumb);
+
+#endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.c
@@ -1,0 +1,120 @@
+#include "buffered_writer.h"
+#include "bugsnag_ndk.h"
+#include <fcntl.h>
+#include <inttypes.h>
+#include <malloc.h>
+#include <memory.h>
+#include <unistd.h>
+
+static bool bsg_buffered_writer_flush(struct bsg_buffered_writer *writer) {
+  const int fd = writer->fd;
+  const char *buff = writer->buffer;
+  int bytes_to_write = writer->pos;
+
+  if (bytes_to_write == 0) {
+    return true;
+  }
+
+  // Try a few times, then give up.
+  // write() will write less bytes on signal interruption, disk full, or
+  // resource limit.
+  for (int i = 0; i < 10; i++) {
+    int written_count = write(fd, buff, bytes_to_write);
+    if (written_count == bytes_to_write) {
+      writer->pos = 0;
+      return true;
+    }
+    if (written_count < 0) {
+      return false;
+    }
+    buff += written_count;
+    bytes_to_write -= written_count;
+  }
+
+  return false;
+}
+
+// The compiler keeps changing sizeof(size_t) on different platforms, which
+// breaks printf().
+#if __SIZEOF_SIZE_T__ == 8
+#define PRIsize_t PRIu64
+#else
+#define PRIsize_t PRIu32
+#endif
+
+static bool bsg_buffered_writer_write(struct bsg_buffered_writer *writer,
+                                      const char *data, size_t length) {
+  if (length > writer->size) {
+    BUGSNAG_LOG("Error: Attempted to write data size %" PRIsize_t
+                " into buffer size %" PRIsize_t,
+                length, writer->size);
+    return false;
+  }
+
+  if (length > writer->size - writer->pos) {
+    if (!writer->flush(writer)) {
+      return false;
+    }
+  }
+
+  memcpy(writer->buffer + writer->pos, data, length);
+  writer->pos += length;
+  return true;
+}
+
+static bool bsg_buffered_writer_close(bsg_buffered_writer *writer) {
+  writer->flush(writer);
+  if (close(writer->fd) < 0) {
+    return false;
+  }
+  free(writer->buffer);
+  free(writer->path);
+  free(writer);
+  return true;
+}
+
+bsg_buffered_writer *bsg_buffered_writer_open(size_t buffer_size,
+                                              const char *path) {
+  bsg_buffered_writer *writer = NULL;
+  int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY, 0600);
+  if (fd < 0) {
+    goto fail;
+  }
+
+  writer = calloc(1, sizeof(*writer));
+  if (writer == NULL) {
+    goto fail;
+  }
+
+  writer->buffer = calloc(1, buffer_size);
+  if (writer->buffer == NULL) {
+    goto fail;
+  }
+  writer->path = strdup(path);
+  if (writer->path == NULL) {
+    goto fail;
+  }
+
+  writer->fd = fd;
+  writer->size = buffer_size;
+  writer->write = bsg_buffered_writer_write;
+  writer->flush = bsg_buffered_writer_flush;
+  writer->dispose = bsg_buffered_writer_close;
+
+  return writer;
+
+fail:
+  if (fd > 0) {
+    close(fd);
+  }
+  if (writer != NULL) {
+    if (writer->buffer != NULL) {
+      free(writer->buffer);
+    }
+    if (writer->path != NULL) {
+      free(writer->path);
+    }
+    free(writer);
+  }
+  return NULL;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
@@ -1,0 +1,68 @@
+/**
+ * Async-safe buffered writer.
+ *
+ * This writer buffers up data and flushes to disk as needed, using primitive
+ * async-safe functions open(), close(), and write() under the hood.
+ */
+#ifndef BUGSNAG_BUFFERED_WRITER_H
+#define BUGSNAG_BUFFERED_WRITER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct bsg_buffered_writer {
+  int fd;
+  size_t size;
+  size_t pos;
+  char *path;
+  char *buffer;
+
+  /**
+   * Write to this writer. If the internal buffer size is exceeded, it will
+   * automatically flush to file.
+   *
+   * Note: This method is async-safe.
+   *
+   * @param writer This writer.
+   * @param data The data to write.
+   * @param length The length of the data to write.
+   * @return True on success. Check errno on error.
+   */
+  bool (*write)(struct bsg_buffered_writer *writer, const char *data,
+                size_t length);
+
+  /**
+   * Force a flush to file.
+   *
+   * Note: This method is async-safe.
+   *
+   * @param writer This writer.
+   * @return True on success. Check errno on error.
+   */
+  bool (*flush)(struct bsg_buffered_writer *writer);
+
+  /**
+   * Dispose of this writer, closing and freeing all resources. The pointer to
+   * writer will be invalid after this call.
+   *
+   * Note: This method is NOT async-safe!
+   *
+   * @param writer This writer.
+   * @return True on success. Check errno on error.
+   */
+  bool (*dispose)(struct bsg_buffered_writer *writer);
+} bsg_buffered_writer;
+
+/**
+ * Create a new buffered writer.
+ *
+ * Note: This function is NOT async-safe!
+ *
+ * @param buffer_size The size of the buffer to use.
+ * @param path The path of the file to write to.
+ * @return A buffered writer, or NULL on error. Check errno on error.
+ */
+bsg_buffered_writer *bsg_buffered_writer_open(size_t buffer_size,
+                                              const char *path);
+
+#endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/number_to_string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/number_to_string.c
@@ -1,0 +1,153 @@
+#include "number_to_string.h"
+#include <math.h>
+#include <string.h>
+
+// The following is copied from:
+// https://github.com/bugsnag/bugsnag-cocoa/blob/master/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c#L90
+
+// Max uint64 is 18446744073709551615
+#define MAX_UINT64_DIGITS 20
+
+size_t bsg_uint64_to_string(uint64_t value, char *dst) {
+  if (value == 0) {
+    dst[0] = '0';
+    dst[1] = 0;
+    return 1;
+  }
+
+  char buff[MAX_UINT64_DIGITS + 1];
+  buff[sizeof(buff) - 1] = 0;
+  size_t index = sizeof(buff) - 2;
+  for (;;) {
+    buff[index] = (value % 10) + '0';
+    value /= 10;
+    if (value == 0) {
+      break;
+    }
+    index--;
+  }
+
+  size_t length = sizeof(buff) - index;
+  memcpy(dst, buff + index, length);
+  return length - 1;
+}
+
+size_t bsg_int64_to_string(int64_t value, char *dst) {
+  if (value < 0) {
+    dst[0] = '-';
+    return bsg_uint64_to_string((uint64_t)-value, dst + 1) + 1;
+  }
+  return bsg_uint64_to_string((uint64_t)value, dst);
+}
+
+/**
+ * Convert a positive double to a string, allowing up to max_sig_digits.
+ * To reduce the complexity of this algorithm, values with an exponent
+ * other than 0 are always printed in exponential form.
+ *
+ * Values are rounded half-up.
+ *
+ * This function makes use of compiler intrinsic functions which, though not
+ * officially async-safe, are actually async-safe (no allocations, locks, etc).
+ *
+ * This function will write a maximum of 21 characters (including the NUL) to
+ * dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+static size_t positive_double_to_string(const double value, char *dst,
+                                        const int max_sig_digits) {
+  const char *const orig_dst = dst;
+
+  if (value == 0) {
+    dst[0] = '0';
+    dst[1] = 0;
+    return 1;
+  }
+
+  // isnan() is basically ((x) != (x))
+  if (isnan(value)) {
+    strcpy(dst, "nan");
+    return 3;
+  }
+
+  // isinf() is a compiler intrinsic.
+  if (isinf(value)) {
+    strcpy(dst, "inf");
+    return 3;
+  }
+
+  // log10() is a compiler intrinsic.
+  int exponent = (int)log10(value);
+  // Values < 1.0 must subtract 1 from exponent to handle zero wraparound.
+  if (value < 1.0) {
+    exponent--;
+  }
+
+  // pow() is a compiler intrinsic.
+  double normalized = value / pow(10, exponent);
+  // Special case for 0.1, 0.01, 0.001, etc giving a normalized value of 10.xyz.
+  // We use 9.999... because 10.0 converts to a value > 10 in ieee754 binary
+  // floats.
+  if (normalized > 9.99999999999999822364316059975) {
+    exponent++;
+    normalized = value / pow(10, exponent);
+  }
+
+  // Put all of the digits we'll use into an integer.
+  double digits_and_remainder = normalized * pow(10, max_sig_digits - 1);
+  uint64_t digits = (uint64_t)digits_and_remainder;
+  // Also round up if necessary (note: 0.5 is exact in both binary and decimal).
+  if (digits_and_remainder - (double)digits >= 0.5) {
+    digits++;
+    // Special case: Adding one bumps us to next magnitude.
+    if (digits >= (uint64_t)pow(10, max_sig_digits)) {
+      exponent++;
+      digits /= 10;
+    }
+  }
+
+  // Extract the fractional digits.
+  for (int i = max_sig_digits; i > 1; i--) {
+    dst[i] = digits % 10 + '0';
+    digits /= 10;
+  }
+  // Extract the single-digit whole part.
+  dst[0] = (char)digits + '0';
+  dst[1] = '.';
+
+  // Strip off trailing zeroes, and also the '.' if there is no fractional part.
+  int e_offset = max_sig_digits;
+  for (int i = max_sig_digits; i > 0; i--) {
+    if (dst[i] != '0') {
+      if (dst[i] == '.') {
+        e_offset = i;
+      } else {
+        e_offset = i + 1;
+      }
+      break;
+    }
+  }
+  dst += e_offset;
+
+  // Add the exponent if it's not 0.
+  if (exponent != 0) {
+    *dst++ = 'e';
+    if (exponent >= 0) {
+      *dst++ = '+';
+    }
+    dst += bsg_int64_to_string(exponent, dst);
+  } else {
+    *dst = 0;
+  }
+
+  return (size_t)(dst - orig_dst);
+}
+
+size_t bsg_double_to_string(double value, char *dst, int max_sig_digits) {
+  if (value < 0) {
+    dst[0] = '-';
+    return positive_double_to_string(-value, dst + 1, max_sig_digits) + 1;
+  }
+  return positive_double_to_string(value, dst, max_sig_digits);
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/number_to_string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/number_to_string.h
@@ -1,0 +1,44 @@
+/**
+ * Async-safe number to string conversion functions.
+ */
+
+#ifndef BUGSNAG_NUMBER_TO_STRING_H
+#define BUGSNAG_NUMBER_TO_STRING_H
+
+#include <stdint.h>
+
+/**
+ * Convert an unsigned integer to a string.
+ * This will write a maximum of 21 characters (including the NUL) to dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+size_t bsg_uint64_to_string(uint64_t value, char *dst);
+
+/**
+ * Convert an integer to a string.
+ * This will write a maximum of 22 characters (including the null terminator) to
+ * dst.
+ *
+ * Returns the length of the string written to dst (not including the null
+ * termination byte).
+ */
+size_t bsg_int64_to_string(int64_t value, char *dst);
+
+/**
+ * Convert a double to a string, allowing up to max_sig_digits. See
+ * positive_double_to_string() for important information about how this
+ * algorithm differs from sprintf.
+ *
+ * This function will write a maximum of 22 characters (including the NUL) to
+ * dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+size_t bsg_double_to_string(double value, char *dst, int max_sig_digits);
+
+// The default number of significant digits when printing floats, according to
+// sprintf().
+#define BSG_DEFAULT_SIGNIFICANT_DIGITS 7
+
+#endif

--- a/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
@@ -6,10 +6,14 @@ include_directories(
 )
 add_library(bugsnag-ndk-test SHARED
     cpp/main.c
+    cpp/test_utils_buffered_writer.c
+    cpp/test_utils_number_to_string.c
     cpp/test_utils_string.c
     cpp/test_utils_serialize.c
     cpp/test_serializer.c
     cpp/test_breadcrumbs.c
     cpp/test_bsg_event.c
+    cpp/test_ctjournal.c
+    cpp/test_helpers.c
 )
 target_link_libraries(bugsnag-ndk-test bugsnag-ndk)

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -5,10 +5,12 @@
 #include <greatest/greatest.h>
 #include <jni.h>
 
+#include <safejni.h>
 #include <utils/serializer.h>
 #include <stdlib.h>
 #include <utils/migrate.h>
 #include "test_serializer.h"
+#include "test_helpers.h"
 
 SUITE(suite_string_utils);
 SUITE(suite_json_serialization);
@@ -18,8 +20,19 @@ SUITE(suite_event_app_mutators);
 SUITE(suite_event_device_mutators);
 SUITE(suite_struct_to_file);
 SUITE(suite_struct_migration);
+SUITE(suite_ctjournal);
+SUITE(suite_buffered_writer);
+SUITE(suite_number_to_string);
 
 GREATEST_MAIN_DEFS();
+
+static TEST set_temporary_folder_path(JNIEnv *env, jstring path) {
+    test_temporary_folder_path = bsg_safe_get_string_utf_chars(env, path);
+    if (test_temporary_folder_path == NULL) {
+        FAILm("Error retrieving temporary folder string");
+    }
+    return GREATEST_TEST_RES_PASS;
+}
 
 /**
  * Runs a test suite using greatest.
@@ -221,4 +234,21 @@ JNIEXPORT jstring JNICALL Java_com_bugsnag_android_ndk_ExceptionSerializationTes
     char *string = json_serialize_to_string(event_val);
     return (*env)->NewStringUTF(env, string);
 
+}
+
+JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_NativeCrashtimeJournalTest_run(
+        JNIEnv *_env, jobject _this, jstring _temporary_folder) {
+    STOP_ON_FAIL(set_temporary_folder_path(_env, _temporary_folder));
+    return run_test_suite(suite_ctjournal);
+}
+
+JNIEXPORT jint JNICALL Java_com_bugsnag_android_ndk_NativeBufferedWriterTest_run(
+        JNIEnv *_env, jobject _this, jstring _temporary_folder) {
+    STOP_ON_FAIL(set_temporary_folder_path(_env, _temporary_folder));
+    return run_test_suite(suite_buffered_writer);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_bugsnag_android_ndk_NativeNumberToStringTest_run(JNIEnv *env, jobject thiz) {
+    return run_test_suite(suite_number_to_string);
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_ctjournal.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_ctjournal.c
@@ -1,0 +1,280 @@
+#include <greatest/greatest.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include "ctjournal.h"
+#include <ftw.h>
+#include <bugsnag_ndk.h>
+#include "test_helpers.h"
+#include <errno.h>
+
+void bsg_ctjournal_test_reset();
+static char journal_filename[PATH_MAX];
+
+static bool init_test() {
+    sprintf(journal_filename, "%s/bsg-test.journal.crashtime", test_temporary_folder_path);
+    bsg_ctjournal_test_reset();
+    return bsg_ctjournal_init(journal_filename);
+}
+
+static TEST expect_journal_contents(const char* expected_contents, int expected_length) {
+    return bsg_expect_file_contents(journal_filename, expected_contents, expected_length);
+}
+
+TEST test_ctjournal_init(void) {
+    ASSERT(init_test());
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_ctjournal_clear_value(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_clear_value("a.-1.b"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"a.-1.b\":null}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_ctjournal_clear_value_escaped(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_clear_value("a\\\"xx.-1.b"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"a\\\\\\\"xx.-1.b\":null}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_ctjournal_clear_value_escaped_long(void) {
+    // Deliberately blow out the internal buffer
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_clear_value("a\\\"xxqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq.-1.b"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"a\\\\\\\"xxqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq.-1.b\":null}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_ctjournal_set_double(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_set_double("a.-1.b", 1.5));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"a.-1.b\":1.5}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_ctjournal_set_bool(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_set_boolean("a.-1.b", true));
+    ASSERT(bsg_ctjournal_set_boolean("a.-1.c", false));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"a.-1.b\":true}\0"
+                                     "{\"a.-1.c\":false}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_ctjournal_set_string(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_set_string("a.-1.b", "test"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"a.-1.b\":\"test\"}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_ctjournal_set_string_escaped(void) {
+            ASSERT(init_test());
+            ASSERT(bsg_ctjournal_set_string("a.-1.b", "test\"\\"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"a.-1.b\":\"test\\\"\\\\\"}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+            PASS();
+}
+
+TEST test_metadata_clear_section(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_metadata_clear_section("mysection"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.metaData.mysection\":null}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_metadata_clear_value(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_metadata_clear_value("mysection", "myvalue"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.metaData.mysection.myvalue\":null}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_metadata_clear_value_escaped(void) {
+            ASSERT(init_test());
+            ASSERT(bsg_ctjournal_metadata_clear_value("my\\\"section", "my\\\"value"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.metaData.my\\\\\\\"section.my\\\\\\\"value\":null}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+            PASS();
+}
+
+TEST test_metadata_set_boolean(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_metadata_set_boolean("mysection", "myvalue", false));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.metaData.mysection.myvalue\":false}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_metadata_set_double(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_metadata_set_double("mysection", "myvalue", -6.194e+50));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.metaData.mysection.myvalue\":-6.194e+50}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_metadata_set_string(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_metadata_set_string("mysection", "myvalue", "fred"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.metaData.mysection.myvalue\":\"fred\"}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_metadata_set_string_escaped(void) {
+            ASSERT(init_test());
+            ASSERT(bsg_ctjournal_metadata_set_string("mysection", "myvalue", "f\\r\"ed"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.metaData.mysection.myvalue\":\"f\\\\r\\\"ed\"}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+            PASS();
+}
+
+TEST test_ctjournal_set_user(void) {
+    ASSERT(init_test());
+    ASSERT(bsg_ctjournal_set_user("myid", "myemail", "myname"));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.user\":{\"id\":\"myid\",\"email\":\"myemail\",\"name\":\"myname\"}}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_add_breadcrumb(void) {
+    ASSERT(init_test());
+    bugsnag_breadcrumb bc = {
+        name: "myname",
+        timestamp: "2021-06-02T08:56:06.106Z",
+        type: BSG_CRUMB_USER,
+        metadata: {
+        value_count: 4,
+        values: {
+                {
+                        name: "mybool",
+                        section: "mysection",
+                        type: BSG_METADATA_BOOL_VALUE,
+                        bool_value: true,
+                },
+                {
+                    name: "mynull",
+                    section: "mysection",
+                    type: BSG_METADATA_NONE_VALUE,
+                },
+                {
+                    name: "mynumber",
+                    section: "mysection",
+                    type: BSG_METADATA_NUMBER_VALUE,
+                    double_value: 3.91444e-20,
+                },
+                {
+                    name: "mystring",
+                    section: "mysection",
+                    type: BSG_METADATA_CHAR_VALUE,
+                    char_value: "a string",
+                },
+    }
+    }
+    };
+    ASSERT(bsg_ctjournal_add_breadcrumb(&bc));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.breadcrumbs.\":{\"name\":\"myname\",\"timestamp\":\"2021-06-02T08:56:06.106Z\",\"type\":\"user\"}}\0"
+                                     "{\"events.-1.breadcrumbs.-1.metaData.mysection.mybool\":true}\0"
+                                     "{\"events.-1.breadcrumbs.-1.metaData.mysection.mynull\":null}\0"
+                                     "{\"events.-1.breadcrumbs.-1.metaData.mysection.mynumber\":3.91444e-20}\0"
+                                     "{\"events.-1.breadcrumbs.-1.metaData.mysection.mystring\":\"a string\"}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+TEST test_add_breadcrumb_escaped(void) {
+    ASSERT(init_test());
+    bugsnag_breadcrumb bc = {
+            name: "my\\na\"me",
+            timestamp: "2021-06-02T08:56:06.106Z",
+            type: BSG_CRUMB_USER,
+            metadata: {
+                    value_count: 4,
+                    values: {
+                            {
+                                    name: "my\"b\\ool",
+                                    section: "my\\s\"ection",
+                                    type: BSG_METADATA_BOOL_VALUE,
+                                    bool_value: true,
+                            },
+                            {
+                                    name: "mynull",
+                                    section: "mysection",
+                                    type: BSG_METADATA_NONE_VALUE,
+                            },
+                            {
+                                    name: "mynumber",
+                                    section: "mysection",
+                                    type: BSG_METADATA_NUMBER_VALUE,
+                                    double_value: 3.91444e-20,
+                            },
+                            {
+                                    name: "mystring",
+                                    section: "mysection",
+                                    type: BSG_METADATA_CHAR_VALUE,
+                                    char_value: "\"a\" str\\ing",
+                            },
+                    }
+            }
+    };
+    ASSERT(bsg_ctjournal_add_breadcrumb(&bc));
+    const char expected_contents[] = "{\"*\":{\"type\":\"Bugsnag Journal\",\"version\":1}}\0"
+                                     "{\"events.-1.breadcrumbs.\":{\"name\":\"my\\\\na\\\"me\",\"timestamp\":\"2021-06-02T08:56:06.106Z\",\"type\":\"user\"}}\0"
+                                     "{\"events.-1.breadcrumbs.-1.metaData.my\\\\s\\\"ection.my\\\"b\\\\ool\":true}\0"
+                                     "{\"events.-1.breadcrumbs.-1.metaData.mysection.mynull\":null}\0"
+                                     "{\"events.-1.breadcrumbs.-1.metaData.mysection.mynumber\":3.91444e-20}\0"
+                                     "{\"events.-1.breadcrumbs.-1.metaData.mysection.mystring\":\"\\\"a\\\" str\\\\ing\"}\0";
+    STOP_ON_FAIL(expect_journal_contents(expected_contents, sizeof(expected_contents)-1));
+    PASS();
+}
+
+SUITE(suite_ctjournal) {
+    RUN_TEST(test_ctjournal_init);
+    RUN_TEST(test_ctjournal_clear_value);
+    RUN_TEST(test_ctjournal_clear_value_escaped);
+    RUN_TEST(test_ctjournal_clear_value_escaped_long);
+    RUN_TEST(test_ctjournal_set_double);
+    RUN_TEST(test_ctjournal_set_bool);
+    RUN_TEST(test_ctjournal_set_string);
+    RUN_TEST(test_ctjournal_set_string_escaped);
+    RUN_TEST(test_metadata_clear_section);
+    RUN_TEST(test_metadata_clear_value);
+    RUN_TEST(test_metadata_clear_value_escaped);
+    RUN_TEST(test_metadata_set_boolean);
+    RUN_TEST(test_metadata_set_double);
+    RUN_TEST(test_metadata_set_string);
+    RUN_TEST(test_metadata_set_string_escaped);
+    RUN_TEST(test_ctjournal_set_user);
+    RUN_TEST(test_add_breadcrumb);
+    RUN_TEST(test_add_breadcrumb_escaped);
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_helpers.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_helpers.c
@@ -1,0 +1,72 @@
+#include <errno.h>
+#include <bugsnag_ndk.h>
+#include "test_helpers.h"
+
+const char *test_temporary_folder_path;
+
+bool bsg_do_mem_contents_match(const char* mem1, int length1, const char* mem2, int length2) {
+    if (length1 != length2) {
+        return false;
+    }
+
+    for (int i = 0; i < length1; i++) {
+        if (mem1[i] != mem2[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static char hex_char(unsigned int ch) {
+    if (ch <= 9) {
+        return '0' + ch;
+    } else {
+        return 'a' + ch - 10;
+    }
+}
+
+const char* bsg_as_printable(const char* data, int length) {
+    char* new_contents = calloc(1, length*3+1);
+    int i_new = 0;
+    for(int i_old = 0; i_old < length; i_old++) {
+        unsigned char b = (unsigned char)data[i_old];
+        if((b >= ' ' && b <= '~') || b == '\r' || b == '\n' || b == '\t') {
+            new_contents[i_new++] = b;
+        } else {
+            new_contents[i_new++] = '\\';
+            new_contents[i_new++] = 'x';
+            new_contents[i_new++] = hex_char(b>>4);
+            new_contents[i_new++] = hex_char(b&15);
+        }
+    }
+    new_contents[i_new] = 0;
+    return new_contents;
+}
+
+int bsg_expect_file_contents(const char *path, const char *expected_contents, int expected_length) {
+    FILE *fp = fopen(path, "rb");
+    if (fp == NULL) {
+        BUGSNAG_LOG("TEST: Error opening file %s: %s\n", path, strerror(errno));
+        FAILm("bsg_expect_file_contents: Could not open file");
+    }
+    fseek(fp, 0L, SEEK_END);
+    int observed_length = ftell(fp);
+    fseek(fp, 0L, SEEK_SET);
+    char* observed_contents = calloc(1, observed_length);
+    if(observed_length > 0 && fread(observed_contents, observed_length, 1, fp) != 1) {
+        FAILm("bsg_expect_file_contents: Error reading file");
+    }
+
+    if (!bsg_do_mem_contents_match(expected_contents, expected_length, observed_contents, observed_length)) {
+        const char *printable_expected = bsg_as_printable(expected_contents, expected_length);
+        const char *printable_observed = bsg_as_printable(observed_contents, observed_length);
+        BUGSNAG_LOG("Expected contents of file %s to be [%s] but observed [%s]", path, printable_expected, printable_observed);
+        free((void*)printable_expected);
+        free((void*)printable_observed);
+        free(observed_contents);
+        FAILm("bsg_expect_file_contents: File contents did not match");
+    }
+    free(observed_contents);
+    PASS();
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_helpers.h
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_helpers.h
@@ -1,0 +1,60 @@
+#include <stdbool.h>
+#include <greatest/greatest.h>
+
+/**
+ * Temporary folder path for tests to play in. This must be set from the JNI entry point.
+ */
+extern const char *test_temporary_folder_path;
+
+/**
+ * Helper macro to pass along FAIL() directives and assertion failures from inside a sub-function.
+ * Simply have the sub-function return type int (or TEST if internal), then wrap the call:
+ *
+ *     STOP_ON_FAIL(my_sub_function(myargs));
+ */
+#define STOP_ON_FAIL(...) do { \
+    int res = __VA_ARGS__; \
+    if (res != GREATEST_TEST_RES_PASS) { \
+        return res; \
+    } \
+} \
+while(0)
+
+
+/**
+ * Check if two buffers match.
+ *
+ * @param mem1 The first buffer
+ * @param length1 The length of the first buffer
+ * @param mem2 The second buffer
+ * @param length2 The length of the second buffer
+ * @return True if the buffers match
+ */
+bool bsg_do_mem_contents_match(const char* mem1, int length1, const char* mem2, int length2);
+
+/**
+ * Convert a buffer to printable characters.
+ *
+ * Converts any non-printable or control characters besides CR,LF,TAB to their hex equivalents in
+ * the format "\xff"
+ *
+ * @param data The data to convert
+ * @param length The length of the data
+ * @return A printable version which must be freed.
+ */
+const char* bsg_as_printable(const char* data, int length);
+
+/**
+ * Verify that a file contains the expected contents.
+ * This will print out the differences to BUGSNAG_LOG() before returning a failure if the contents don't match.
+ *
+ * The easiest way to use this function is:
+ *
+ * STOP_ON_FAIL(bsg_expect_file_contents(file_path, expected_contents, length));
+ *
+ * @param path The path of the file to check.
+ * @param expected_contents The expected contents.
+ * @param expected_length Length of the expected contents.
+ * @return A test result.
+ */
+int bsg_expect_file_contents(const char *path, const char *expected_contents, int expected_length);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_buffered_writer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_buffered_writer.c
@@ -1,0 +1,66 @@
+#include <greatest/greatest.h>
+#include "utils/buffered_writer.h"
+#include "test_helpers.h"
+
+static char writer_filename[PATH_MAX];
+
+static void init_test() {
+    sprintf(writer_filename, "%s/writer.bin", test_temporary_folder_path);
+}
+
+TEST test_open_close(void) {
+    init_test();
+    bsg_buffered_writer *writer = bsg_buffered_writer_open(100, writer_filename);
+    ASSERT(writer != NULL);
+    ASSERT(writer->dispose(writer));
+    STOP_ON_FAIL(bsg_expect_file_contents(writer_filename, "", 0));
+    PASS();
+}
+
+TEST test_write_1_byte(void) {
+    init_test();
+    bsg_buffered_writer *writer = bsg_buffered_writer_open(100, writer_filename);
+    ASSERT(writer != NULL);
+    ASSERT(writer->write(writer, "1", 1));
+    ASSERT(writer->dispose(writer));
+    STOP_ON_FAIL(bsg_expect_file_contents(writer_filename, "1", 1));
+    PASS();
+}
+
+TEST test_write_multiple(void) {
+    init_test();
+    bsg_buffered_writer *writer = bsg_buffered_writer_open(10, writer_filename);
+    ASSERT(writer != NULL);
+    ASSERT(writer->write(writer, "1", 1));
+    ASSERT(writer->write(writer, "\x13\xff\x00.abc", 7));
+    ASSERT(writer->write(writer, "\nblah\n", 6));
+    ASSERT(writer->dispose(writer));
+    STOP_ON_FAIL(bsg_expect_file_contents(writer_filename, "1\x13\xff\x00.abc\nblah\n", 14));
+    PASS();
+}
+
+TEST test_write_same_size_as_buffer(void) {
+    init_test();
+    bsg_buffered_writer *writer = bsg_buffered_writer_open(10, writer_filename);
+    ASSERT(writer != NULL);
+    ASSERT(writer->write(writer, "1234567890", 10));
+    ASSERT(writer->dispose(writer));
+    STOP_ON_FAIL(bsg_expect_file_contents(writer_filename, "1234567890", 10));
+    PASS();
+}
+
+TEST test_write_too_big(void) {
+    init_test();
+    bsg_buffered_writer *writer = bsg_buffered_writer_open(10, writer_filename);
+    ASSERT(writer != NULL);
+    ASSERT_FALSE(writer->write(writer, "12345678901", 11));
+    PASS();
+}
+
+SUITE(suite_buffered_writer) {
+    RUN_TEST(test_open_close);
+    RUN_TEST(test_write_1_byte);
+    RUN_TEST(test_write_multiple);
+    RUN_TEST(test_write_same_size_as_buffer);
+    RUN_TEST(test_write_too_big);
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_number_to_string.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_number_to_string.c
@@ -1,0 +1,69 @@
+#include <greatest/greatest.h>
+#include "utils/number_to_string.h"
+#include "test_helpers.h"
+
+TEST test_uint_to_string(void) {
+    char buff[100];
+
+    ASSERT_EQ(1, bsg_uint64_to_string(0, buff));
+    ASSERT_STR_EQ("0", buff);
+
+    ASSERT_EQ(20, bsg_uint64_to_string(0xffffffffffffffff, buff));
+    ASSERT_STR_EQ("18446744073709551615", buff);
+
+    PASS();
+}
+
+TEST test_int_to_string(void) {
+    char buff[100];
+
+    ASSERT_EQ(1, bsg_int64_to_string(0, buff));
+    ASSERT_STR_EQ("0", buff);
+
+    ASSERT_EQ(1, bsg_int64_to_string(1, buff));
+    ASSERT_STR_EQ("1", buff);
+
+    ASSERT_EQ(2, bsg_int64_to_string(-1, buff));
+    ASSERT_STR_EQ("-1", buff);
+
+    ASSERT_EQ(19, bsg_int64_to_string(0x7fffffffffffffff, buff));
+    ASSERT_STR_EQ("9223372036854775807", buff);
+
+    ASSERT_EQ(20, bsg_int64_to_string(-0x8000000000000000, buff));
+    ASSERT_STR_EQ("-9223372036854775808", buff);
+
+    PASS();
+}
+
+TEST test_double_to_string(void) {
+    char buff[100];
+
+    ASSERT_EQ(1, bsg_double_to_string(0, buff, BSG_DEFAULT_SIGNIFICANT_DIGITS));
+    ASSERT_STR_EQ("0", buff);
+
+    ASSERT_EQ(1, bsg_double_to_string(1, buff, BSG_DEFAULT_SIGNIFICANT_DIGITS));
+    ASSERT_STR_EQ("1", buff);
+
+    ASSERT_EQ(2, bsg_double_to_string(-1, buff, BSG_DEFAULT_SIGNIFICANT_DIGITS));
+    ASSERT_STR_EQ("-1", buff);
+
+    ASSERT_EQ(3, bsg_double_to_string(1.5, buff, BSG_DEFAULT_SIGNIFICANT_DIGITS));
+    ASSERT_STR_EQ("1.5", buff);
+
+    ASSERT_EQ(6, bsg_double_to_string(-2.855, buff, BSG_DEFAULT_SIGNIFICANT_DIGITS));
+    ASSERT_STR_EQ("-2.855", buff);
+
+    ASSERT_EQ(11, bsg_double_to_string(6.95234e-20, buff, BSG_DEFAULT_SIGNIFICANT_DIGITS));
+    ASSERT_STR_EQ("6.95234e-20", buff);
+
+    ASSERT_EQ(13, bsg_double_to_string(-2.222594e+15, buff, BSG_DEFAULT_SIGNIFICANT_DIGITS));
+    ASSERT_STR_EQ("-2.222594e+15", buff);
+
+    PASS();
+}
+
+SUITE(suite_number_to_string) {
+    RUN_TEST(test_uint_to_string);
+    RUN_TEST(test_int_to_string);
+    RUN_TEST(test_double_to_string);
+}


### PR DESCRIPTION
## Goal

This PR implements the crash-time journal writing API for the journaling system

	| --------------------------------------------------------------- |
	|                          Journal API                            |
	| --------------------------------------------------------------- |
	| Journal       | Thread-safety | Shared Memory | File Management |
    | ------------- |               |               |                 |
	| Document Path |               |               |                 |
	| ----------------------------- |               | --------------- |
	|   Crash-time synchronization  |               | Crash-time API  |
	| --------------------------------------------------------------- |

## Design

Everything in this part must be async-safe, so we can't use JSON libraries to implement it. Fortunately, the journal format only uses a subset of JSON.

## Testing

Added more unit tests.
