### PR TITLE
Capture process name in Event payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 * React Native: allow serializing enabledBreadcrumbTypes as null
   [#1316](https://github.com/bugsnag/bugsnag-android/pull/1316)
 
+* Capture process name in Event payload
+  [#1318](https://github.com/bugsnag/bugsnag-android/pull/1318)
+
 ## 5.9.5 (2021-06-25)
 
 * Unity: Properly handle ANRs after multiple calls to autoNotify and autoDetectAnrs

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -35,7 +36,7 @@ class AppDataCollectorTest {
      * The flag is not set in the app metadata if the user has not enabled background restrictions
      */
     @Test
-    fun testNoBackgroundRestrictions() {
+    fun testDefaultValues() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             `when`(am.isBackgroundRestricted).thenReturn(false)
         }
@@ -52,6 +53,7 @@ class AppDataCollectorTest {
         )
         val app = collector.getAppDataMetadata()
         assertNull(app["backgroundWorkRestricted"])
+        assertEquals("com.bugsnag.android.core.test", app["processName"] as String)
     }
 
     /**

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -170,8 +170,9 @@ public class ClientTest {
     public void testAppDataMetadata() {
         client = generateClient();
         Map<String, Object> app = client.getAppDataCollector().getAppDataMetadata();
-        assertEquals(4, app.size());
+        assertEquals(5, app.size());
         assertEquals("Bugsnag Android Tests", app.get("name"));
+        assertEquals("com.bugsnag.android.core.test", app.get("processName"));
         assertNotNull(app.get("memoryUsage"));
         assertTrue(app.containsKey("activeScreen"));
         assertNotNull(app.get("lowMemory"));

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -452,6 +452,11 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                                     restricted);
   }
 
+  char process_name[64];
+  bsg_copy_map_value_string(env, jni_cache, data, "processName", process_name,
+                            sizeof(process_name));
+  bugsnag_event_add_metadata_string(event, "app", "processName", process_name);
+
   bsg_safe_delete_local_ref(env, data);
 }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
 import com.bugsnag.android.Logger
-import com.bugsnag.android.mazerunner.multiprocess.findCurrentProcessName
 import java.net.URL
 
 fun prepareConfig(
@@ -37,7 +36,6 @@ fun prepareConfig(
             mazerunnerHttpClient.postLog(logLevel, msg)
         }
     }
-    config.addMetadata("process", "name", findCurrentProcessName())
     return config
 }
 

--- a/features/full_tests/batch_1/multi_process.feature
+++ b/features/full_tests/batch_1/multi_process.feature
@@ -3,13 +3,13 @@ Feature: Reporting errors in multi process apps
 Scenario: Handled JVM error
     When I run "MultiProcessHandledExceptionScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.process.name"
+    And I sort the errors by "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "MultiProcessHandledExceptionScenario"
     And the event "unhandled" is false
-    And the error payload field "events.0.metaData.process.name" equals "com.bugsnag.android.mazerunner"
+    And the error payload field "events.0.metaData.app.processName" equals "com.bugsnag.android.mazerunner"
     And the error payload field "events.0.device.id" is stored as the value "first_device_id"
     And the error payload field "events.0.user.id" equals "2"
     And the error payload field "events.0.user.name" equals "MultiProcessHandledExceptionScenario"
@@ -21,7 +21,7 @@ Scenario: Handled JVM error
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "MultiProcessHandledExceptionScenario"
     And the event "unhandled" is false
-    And the error payload field "events.0.metaData.process.name" equals "com.example.bugsnag.android.mazerunner.multiprocess"
+    And the error payload field "events.0.metaData.app.processName" equals "com.example.bugsnag.android.mazerunner.multiprocess"
 
     # device ID is shared between processes
     And the error payload field "events.0.device.id" equals the stored value "first_device_id"
@@ -36,13 +36,13 @@ Scenario: Unhandled JVM error
     And I run "MultiProcessUnhandledExceptionScenario" and relaunch the app
     And I run "MultiProcessUnhandledExceptionScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.process.name"
+    And I sort the errors by "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "MultiProcessUnhandledExceptionScenario"
     And the event "unhandled" is true
-    And the error payload field "events.0.metaData.process.name" equals "com.bugsnag.android.mazerunner"
+    And the error payload field "events.0.metaData.app.processName" equals "com.bugsnag.android.mazerunner"
 
     Then I discard the oldest error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -50,19 +50,19 @@ Scenario: Unhandled JVM error
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "MultiProcessUnhandledExceptionScenario"
     And the event "unhandled" is true
-    And the error payload field "events.0.metaData.process.name" equals "com.example.bugsnag.android.mazerunner.multiprocess"
+    And the error payload field "events.0.metaData.app.processName" equals "com.example.bugsnag.android.mazerunner.multiprocess"
 
 Scenario: Handled NDK error
     When I run "MultiProcessHandledCXXErrorScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.process.name"
+    And I sort the errors by "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload contains a completed handled native report
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "activate"
     And the exception "message" equals "MultiProcessHandledCXXErrorScenario"
     And the event "unhandled" is false
-    And the error payload field "events.0.metaData.process.name" equals "com.bugsnag.android.mazerunner"
+    And the error payload field "events.0.metaData.app.processName" equals "com.bugsnag.android.mazerunner"
     And the error payload field "events.0.device.id" is stored as the value "first_device_id"
     And the error payload field "events.0.user.id" equals the stored value "first_device_id"
 
@@ -73,7 +73,7 @@ Scenario: Handled NDK error
     And the exception "errorClass" equals "activate"
     And the exception "message" equals "MultiProcessHandledCXXErrorScenario"
     And the event "unhandled" is false
-    And the error payload field "events.0.metaData.process.name" equals "com.example.bugsnag.android.mazerunner.multiprocess"
+    And the error payload field "events.0.metaData.app.processName" equals "com.example.bugsnag.android.mazerunner.multiprocess"
 
     # device ID is shared between processes
     And the error payload field "events.0.device.id" equals the stored value "first_device_id"
@@ -86,14 +86,14 @@ Scenario: Unhandled NDK error
     And I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the app
     And I run "MultiProcessUnhandledCXXErrorScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.process.name"
+    And I sort the errors by "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload contains a completed handled native report
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGABRT"
     And the exception "message" equals "Abort program"
     And the event "unhandled" is true
-    And the error payload field "events.0.metaData.process.name" equals "com.bugsnag.android.mazerunner"
+    And the error payload field "events.0.metaData.app.processName" equals "com.bugsnag.android.mazerunner"
     And the error payload field "events.0.device.id" is stored as the value "first_device_id"
     And the error payload field "events.0.user.id" equals "2"
     And the error payload field "events.0.user.name" equals "MultiProcessUnhandledCXXErrorScenario"
@@ -106,7 +106,7 @@ Scenario: Unhandled NDK error
     And the exception "errorClass" equals "SIGABRT"
     And the exception "message" equals "Abort program"
     And the event "unhandled" is true
-    And the error payload field "events.0.metaData.process.name" equals "com.example.bugsnag.android.mazerunner.multiprocess"
+    And the error payload field "events.0.metaData.app.processName" equals "com.example.bugsnag.android.mazerunner.multiprocess"
     And the error payload field "events.0.device.id" equals the stored value "first_device_id"
     And the error payload field "events.0.user.id" equals "1"
     And the error payload field "events.0.user.name" equals "MultiProcessUnhandledCXXErrorScenario"
@@ -115,13 +115,13 @@ Scenario: Unhandled NDK error
 Scenario: User/device information is migrated from SharedPreferences
     When I run "SharedPrefMigrationScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.process.name"
+    And I sort the errors by "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "SharedPrefMigrationScenario"
     And the event "unhandled" is false
-    And the error payload field "events.0.metaData.process.name" equals "com.bugsnag.android.mazerunner"
+    And the error payload field "events.0.metaData.app.processName" equals "com.bugsnag.android.mazerunner"
     And the error payload field "events.0.device.id" equals "267160a7-5cf2-42d4-be21-969f1573ecb0"
     And the error payload field "events.0.user.id" equals "3"
     And the error payload field "events.0.user.name" equals "SharedPrefMigrationScenario"
@@ -133,7 +133,7 @@ Scenario: User/device information is migrated from SharedPreferences
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "SharedPrefMigrationScenario"
     And the event "unhandled" is false
-    And the error payload field "events.0.metaData.process.name" equals "com.example.bugsnag.android.mazerunner.multiprocess"
+    And the error payload field "events.0.metaData.app.processName" equals "com.example.bugsnag.android.mazerunner.multiprocess"
 
     # device ID is shared between processes
     And the error payload field "events.0.device.id" equals "267160a7-5cf2-42d4-be21-969f1573ecb0"


### PR DESCRIPTION
## Goal

Captures the process name in the `Event` payload. This helps distinguish which process an error came from in multi-process apps. For API 28+ this uses `Application.processName()`, whereas for lower API levels reflection is used to access the same API using `ActivityThread`.

## Testing

Updated mazerunner tests to assert the process name is captured, and manually tested on API 16, 19, and 29 to confirm that each solution populates a valid value.