### PR TITLE
Move example app AGP version to 3.6.4

### DIFF
--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.2"
+        classpath "com.android.tools.build:gradle:3.6.4"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.bugsnag:bugsnag-android-gradle-plugin:5.7.7"
     }


### PR DESCRIPTION
## Goal

Fixes the example app build on CI by reverting to an older version of AGP.