### PR TITLE
Add main journal API

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -26,6 +26,7 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?&gt; ): DeliveryStatus</ID>
     <ID>SwallowedException:AppDataCollector.kt$AppDataCollector$catch (exception: Exception) { logger.w("Could not check lowMemory status") }</ID>
+    <ID>SwallowedException:BugsnagMainJournal.kt$BugsnagMainJournal.Companion$catch (exc: IOException) { null }</ID>
     <ID>SwallowedException:ConnectivityCompat.kt$ConnectivityLegacy$catch (e: NullPointerException) { // in some rare cases we get a remote NullPointerException via Parcel.readException null }</ID>
     <ID>SwallowedException:ContextExtensions.kt$catch (exc: RuntimeException) { null }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exc: Exception) { false }</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagMainJournal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagMainJournal.kt
@@ -1,0 +1,171 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.internal.DocumentPath
+import com.bugsnag.android.internal.JournaledDocument
+import java.io.File
+import java.io.IOException
+import java.lang.IllegalStateException
+import java.lang.Thread
+import kotlin.concurrent.thread
+
+/**
+ * The main journal contains the document that will be sent to the back end whenever an event occurs.
+ * All changes to the document must be made via journal commands to ensure that they are preserved
+ * in the event of a crash.
+ *
+ * The single instance to be used in Bugsnag is "instance", and startInstance() must be called before
+ * using it.
+ */
+internal class BugsnagMainJournal internal constructor(
+    private val logger: Logger,
+    baseDocumentPath: File,
+    initialDocument: Map<String, Any>
+) {
+    internal val journal = JournaledDocument(
+        baseDocumentPath,
+        journalType,
+        journalVersion,
+        mmapBufferSize,
+        highWater,
+        initialDocument
+    )
+
+    /**
+     * The document in its current state (with all current journal entries applied).
+     * Do NOT modify any of the document's contents directly; information will be lost if you do.
+     * Use addCommand() instead to modify the document.
+     */
+    val document: Map<String, Any> get() = journal
+
+    /**
+     * Add a journal command.
+     *
+     * @param documentPath The path describing where in the document to set the value
+     * @param value The value to set
+     * @see DocumentPath
+     */
+    fun addCommand(documentPath: String, value: Any?) {
+        if (documentPath.isEmpty()) {
+            logger.e("addCommand called with empty path (replace entire document not allowed)")
+            return
+        }
+        try {
+            return journal.addCommand(documentPath, value)
+        } catch (exc: IOException) {
+            logger.e("Could not add journal command", exc)
+        }
+    }
+
+    /**
+     * Save a current document snapshot and clear the journal.
+     * You'll rarely need to call this since the housekeeping thread already snapshots periodically.
+     */
+    fun snapshot() {
+        try {
+            journal.snapshot()
+        } catch (exc: IOException) {
+            logger.e("Could not write journal snapshot", exc)
+        }
+    }
+
+    private fun beginSnapshotHousekeepingThread() {
+        thread {
+            while (true) {
+                try {
+                    journal.snapshotIfHighWater()
+                } catch (exc: IOException) {
+                    logger.e("Could not write journal snapshot; exiting housekeeping thread...", exc)
+                    break
+                }
+                Thread.sleep(highWaterPollingIntervalMS)
+            }
+        }
+    }
+
+    companion object {
+        // Top-level key where version info will be saved.
+        internal const val versionInfoKey = "version-info"
+        internal const val journalTypeKey = "type"
+        internal const val journalVersionKey = "version"
+
+        // The "type" of the main journal. This will probably never change.
+        internal const val journalType = "Bugsnag Android"
+
+        // Version of this journal. This will change for migration purposes.
+        internal const val journalVersion = 1
+
+        // Size of the on-disk memory-mapped buffer in bytes.
+        private const val mmapBufferSize = 100000L
+
+        // If the memory-mapped buffer fills beyond this many bytes, it gets auto-snapshotted.
+        // Note: The size of mmapBufferSize and highWater have no effect on snapshot runtime cost.
+        private const val highWater = 50000L
+
+        // Polling interval in milliseconds for the high water check thread.
+        private const val highWaterPollingIntervalMS = 200L
+
+        /**
+         * The global instance of the main journal.
+         * You must call startInstance() before accessing this.
+         */
+        val instance: BugsnagMainJournal
+            get() = if (hasInitialized) {
+                mainJournal
+            } else {
+                throw IllegalStateException("Must call startInstance() before accessing instance")
+            }
+
+        /**
+         * Start the main journal at the specified base path.
+         * Any existing journal at this location will be overwritten.
+         *
+         * NOTE: This must be called once (and only once) before accessing instance.
+         *
+         * @param logger A logger
+         * @param baseDocumentPath Path to a filename that will be used as the basis for all journal and snapshot files
+         * @param initialDocument The initial contents of the document. This will be deep copied.
+         * @return The contents of the previous journal (if any)
+         */
+        fun startInstance(
+            logger: Logger,
+            baseDocumentPath: File,
+            initialDocument: Map<String, Any>
+        ): MutableMap<in String, out Any>? {
+            synchronized(this) {
+                if (hasInitialized) {
+                    return null
+                }
+
+                val previousContents = try {
+                    loadPrevious(baseDocumentPath)
+                } catch (exc: IOException) {
+                    null
+                }
+
+                val journal = BugsnagMainJournal(logger, baseDocumentPath, initialDocument)
+                mainJournal = journal
+                hasInitialized = true
+                journal.beginSnapshotHousekeepingThread()
+                return previousContents
+            }
+        }
+
+        internal var hasInitialized = false
+        internal lateinit var mainJournal: BugsnagMainJournal
+
+        // Internal to keep it accessible to unit tests
+        internal fun loadPrevious(baseDocumentPath: File): MutableMap<in String, out Any> {
+            return JournaledDocument.loadDocumentContents(baseDocumentPath)
+        }
+
+        // Internal to keep it accessible to unit tests
+        internal fun initialDocumentContents(document: Map<String, Any>): Map<String, Any> {
+            val docWithVersionInfo = document.toMutableMap()
+            docWithVersionInfo[versionInfoKey] = mapOf(
+                journalTypeKey to journalType,
+                journalVersionKey to journalVersion
+            )
+            return docWithVersionInfo
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ConcurrentContainers.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ConcurrentContainers.kt
@@ -1,0 +1,36 @@
+package com.bugsnag.android.internal
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Deep convert containers to their concurrent counterparts.
+ */
+internal fun Any?.asConcurrent(): Any? = when (this) {
+    is Map<*, *> -> {
+        @Suppress("UNCHECKED_CAST")
+        val concurrentMap = this as? ConcurrentMap<Any?, Any?> ?: ConcurrentHashMap(this)
+
+        this.forEach {
+            when (val entry = it.value) {
+                is Map<*, *> -> concurrentMap[it.key] = entry.asConcurrent()
+                is List<*> -> concurrentMap[it.key] = entry.asConcurrent()
+            }
+        }
+        concurrentMap
+    }
+    is List<*> -> {
+        @Suppress("UNCHECKED_CAST")
+        val concurrentList = this as? CopyOnWriteArrayList<Any?> ?: CopyOnWriteArrayList(this)
+
+        for (i in this.indices) {
+            when (val entry = this[i]) {
+                is Map<*, *> -> concurrentList[i] = entry.asConcurrent()
+                is List<*> -> concurrentList[i] = entry.asConcurrent()
+            }
+        }
+        concurrentList
+    }
+    else -> this
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPath.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/DocumentPath.kt
@@ -64,12 +64,12 @@ class DocumentPath(path: String) {
      * @param value    The value to modify with.
      * @return The modified document (may not be the same document that was passed in).
      */
-    fun modifyDocument(document: MutableMap<in String, out Any>, value: Any?): MutableMap<in String, out Any> {
+    fun modifyDocument(document: MutableMap<in String, out Any>, value: Any?): MutableMap<String, Any> {
         if (directives.isEmpty()) {
-            requireNotNull(value) { "Cannot replace entire document with null" }
-            require(value is MutableMap<*, *>) { "Value replacing document must be a mutable map" }
+            val concurrentValue = value.asConcurrent()
+            require(concurrentValue is MutableMap<*, *>) { "Value replacing document must be a map" }
             @Suppress("UNCHECKED_CAST")
-            return value as MutableMap<String, Any>
+            return concurrentValue as MutableMap<String, Any>
         }
         val filledInDocument = fillInMissingContainers(document, 0)
         require(filledInDocument is MutableMap<*, *>) { "Document path must result in a top level map" }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/Journal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/Journal.kt
@@ -85,7 +85,7 @@ class Journal(val type: String, val version: Int) {
          * @param document The document to modify.
          * @return The resulting document (may not be the same as the one passed in).
          */
-        fun apply(document: MutableMap<in String, out Any>): MutableMap<in String, out Any> {
+        fun apply(document: MutableMap<in String, out Any>): MutableMap<String, Any> {
             return documentPath.modifyDocument(document, value)
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/JsonHelper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/JsonHelper.kt
@@ -19,6 +19,12 @@ class JsonHelper private constructor() {
         }
 
         fun serialize(value: Any, file: File) {
+            val parentFile = file.parentFile
+            if (parentFile != null && !parentFile.exists()) {
+                if (!parentFile.mkdirs()) {
+                    throw FileSystemException(file, null, "Could not create parent dirs of file")
+                }
+            }
             try {
                 FileOutputStream(file).use { stream -> dslJson.serialize(value, stream) }
             } catch (ex: IOException) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagMainJournalTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagMainJournalTest.kt
@@ -1,0 +1,123 @@
+package com.bugsnag.android
+
+import org.junit.Assert
+import org.junit.ClassRule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class BugsnagMainJournalTest {
+    companion object {
+        @ClassRule
+        @JvmField
+        val folder: TemporaryFolder = TemporaryFolder()
+    }
+    private val baseDocumentPath by lazy { File(folder.root, "mydocument") }
+
+    // Simulate a fresh journal since we can't actually reinitialize it.
+    private fun beginClean(): MutableMap<in String, out Any>? {
+        val oldContents = BugsnagMainJournal.startInstance(NoopLogger, baseDocumentPath, mapOf())
+        BugsnagMainJournal.instance.journal.addCommand("", BugsnagMainJournal.initialDocumentContents(mapOf()))
+        BugsnagMainJournal.instance.snapshot()
+        return oldContents
+    }
+
+    private fun loadFromDisk(): MutableMap<in String, out Any> {
+        return BugsnagMainJournal.loadPrevious(baseDocumentPath)
+    }
+
+    @Test
+    fun testOldDocumentMustRunFirst() {
+        // We can only test that the first run returns null since we can only initialize once.
+        // Testing for existing journal contents requires E2E tests.
+        val oldDocument = beginClean()
+        Assert.assertNull(oldDocument)
+    }
+
+    @Test
+    fun testInitialDocumentContents() {
+        val observedDocument = BugsnagMainJournal.initialDocumentContents(mapOf())
+        val expectedDocument = mapOf<String, Any>(
+            BugsnagMainJournal.versionInfoKey to mapOf(
+                BugsnagMainJournal.journalTypeKey to BugsnagMainJournal.journalType,
+                BugsnagMainJournal.journalVersionKey to BugsnagMainJournal.journalVersion
+            )
+        )
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(observedDocument)
+        )
+    }
+
+    @Test
+    fun testEmptyDocument() {
+        beginClean()
+
+        BugsnagMainJournal.instance.snapshot()
+        val observedDocument = loadFromDisk()
+        val expectedDocument = BugsnagMainJournal.initialDocumentContents(mapOf())
+
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(observedDocument)
+        )
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(BugsnagMainJournal.instance.document)
+        )
+    }
+
+    @Test
+    fun testJournalEntry() {
+        beginClean()
+        BugsnagMainJournal.instance.addCommand("x", 100)
+
+        BugsnagMainJournal.instance.snapshot()
+        val observedDocument = loadFromDisk()
+        val expectedDocument = HashMap(BugsnagMainJournal.initialDocumentContents(mapOf()))
+        expectedDocument["x"] = 100
+
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(observedDocument)
+        )
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(BugsnagMainJournal.instance.document)
+        )
+    }
+
+    @Test
+    fun testManyJournalEntries() {
+        beginClean()
+        BugsnagMainJournal.instance.addCommand("one hundred", 100)
+        BugsnagMainJournal.instance.addCommand("three\\.four\\.five\\.slash\\\\slash.-1", "x")
+        BugsnagMainJournal.instance.addCommand("x.-1.x", listOf(1, "foo"))
+        BugsnagMainJournal.instance.addCommand("x.-1.y", mapOf("a" to "b"))
+
+        BugsnagMainJournal.instance.snapshot()
+        val observedDocument = loadFromDisk()
+        val expectedDocument = HashMap(BugsnagMainJournal.initialDocumentContents(mapOf()))
+        expectedDocument["one hundred"] = 100
+        expectedDocument["three.four.five.slash\\slash"] = listOf(
+            "x"
+        )
+        expectedDocument["x"] = listOf(
+            mapOf(
+                "x" to listOf(1, "foo"),
+                "y" to mapOf(
+                    "a" to "b"
+                )
+            )
+        )
+
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(observedDocument)
+        )
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(BugsnagMainJournal.instance.document)
+        )
+    }
+}


### PR DESCRIPTION
## Goal

This is the top-level API to the journal system:

	| --------------------------------------------------------------- |
	|                          Journal API                            |
	| --------------------------------------------------------------- |
	| Journal       | Thread-safety | Shared Memory | File Management |
    | ------------- |               |               |                 |
	| Document Path |               |               |                 |
	| ----------------------------- |               | --------------- |
	|   Crash-time synchronization  |               | Crash-time API  |
	| --------------------------------------------------------------- |


## Design

The journal at this layer is considered to be a read-only map that can only be modified via journal commands. There is an automatic housekeeping thread that snapshots the journal whenever it grows too big.

The top-level API is deliberately small and opinionated. Read access to the document is via the `Map` interface, modifications are via the `addCommand()` method, and there is also a `snapshot()` method for extenuating circumstances.

All opinionated configuration is set in BugsnagMainJournal's companion object, which we can tweak as needs arise. It cannot be changed by the end user.

This API will be initialized from `Client`, and will be accessed directly by the various systems that contribute data to the Bugsnag reports.

## Testing

Added top-level unit tests. The next phase will involve connecting the existing systems to the journal, which will affect their E2E tests.
