### PR TITLE
Add E2E test for strictmode VM policy violation detection

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
+import android.os.Build
 import android.os.StrictMode
 import com.bugsnag.android.Configuration
 import java.io.File
@@ -16,13 +17,20 @@ internal class StrictModeDiscScenario(
 
     override fun startScenario() {
         super.startScenario()
-        StrictMode.setThreadPolicy(
-            StrictMode.ThreadPolicy.Builder()
-                .detectDiskWrites()
-                .penaltyDeath()
-                .build()
-        )
+        setupBugsnagStrictModeDetection()
         val file = File(context.cacheDir, "fake")
         file.writeBytes("test".toByteArray())
+    }
+
+    private fun setupBugsnagStrictModeDetection() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectDiskWrites()
+                    .penaltyDeath()
+                    .build()
+            )
+        }
+        // Android 9 not supported as of yet
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeFileUriExposeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeFileUriExposeScenario.kt
@@ -1,0 +1,47 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.StrictMode
+import android.os.StrictMode.VmPolicy
+import com.bugsnag.android.Configuration
+import java.io.File
+
+/**
+ * Generates a strictmode exception caused by exposing a file URI
+ */
+internal class StrictModeFileUriExposeScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+
+    @SuppressLint("SdCardPath")
+    override fun startScenario() {
+        super.startScenario()
+        setupBugsnagStrictModeDetection()
+
+        // expose a file URI to another app, triggering a StrictMode violation.
+        // https://developer.android.com/reference/android/os/StrictMode.VmPolicy.Builder#detectFileUriExposure()
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            val fileUri = Uri.fromFile(File("/sdcard/bus.jpg"))
+            setDataAndType(fileUri, "image/jpeg")
+        }
+        context.startActivity(intent)
+    }
+
+    private fun setupBugsnagStrictModeDetection() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            StrictMode.setVmPolicy(
+                VmPolicy.Builder()
+                    .detectFileUriExposure()
+                    .penaltyDeath() // raises SIGKILL on Android <9
+                    .build()
+            )
+        }
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
+import android.os.Build
 import android.os.StrictMode
 import com.bugsnag.android.Configuration
 import java.net.HttpURLConnection
@@ -17,15 +18,21 @@ internal class StrictModeNetworkScenario(
 
     override fun startScenario() {
         super.startScenario()
-        StrictMode.setThreadPolicy(
-            StrictMode.ThreadPolicy.Builder()
-                .detectNetwork()
-                .penaltyDeath()
-                .build()
-        )
-
+        setupBugsnagStrictModeDetection()
         val urlConnection = URL("http://example.com").openConnection() as HttpURLConnection
         urlConnection.doOutput = true
         urlConnection.responseMessage
+    }
+
+    private fun setupBugsnagStrictModeDetection() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectNetwork()
+                    .penaltyDeath()
+                    .build()
+            )
+        }
+        // Android 9 not supported as of yet
     }
 }

--- a/features/full_tests/batch_2/strict_mode.feature
+++ b/features/full_tests/batch_2/strict_mode.feature
@@ -18,3 +18,10 @@ Scenario: StrictMode Network on Main Thread violation
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
     And the event "metaData.StrictMode.Violation" equals "NetworkOperation"
+
+# In Android <9 StrictMode kills VM policy violations with SIGKILL, so no requests are received.
+@skip_above_android_8
+Scenario: StrictMode Activity leak violation
+    When I run "StrictModeFileUriExposeScenario" and relaunch the app
+    And I configure Bugsnag for "StrictModeFileUriExposeScenario"
+    Then I should receive no requests


### PR DESCRIPTION
## Goal

Adds a new E2E test that triggers a StrictMode VmPolicy violation, specifically leaking a file URI. This currently only runs on Android <9, which [kills the app with a SIGKILL](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/os/StrictMode.java;l=2308?q=strictmode).

A later changeset will alter these tests to use `penaltyListener()` to call `Bugsnag.notify()` - for now the test simply asserts that no requests are sent.