### PR TITLE
Add Bugsnag listeners for StrictMode violation detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Enhancements
+
+* Add Bugsnag listeners for StrictMode violation detection
+  [#1331](https://github.com/bugsnag/bugsnag-android/pull/1331)
+
 ### Bug fixes
 
 * Address pre-existing StrictMode violations

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -25,6 +25,7 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun isAnr(event: Event): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun shouldDiscardClass(): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>
+    <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityReason(@SeverityReason.SeverityReasonType reason: String)</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?&gt; ): DeliveryStatus</ID>
     <ID>SwallowedException:AppDataCollector.kt$AppDataCollector$catch (exception: Exception) { logger.w("Could not check lowMemory status") }</ID>
     <ID>SwallowedException:ConnectivityCompat.kt$ConnectivityLegacy$catch (e: NullPointerException) { // in some rare cases we get a remote NullPointerException via Parcel.readException null }</ID>

--- a/bugsnag-android-core/src/androidTest/java/android/os/strictmode/FakeStrictModeViolation.kt
+++ b/bugsnag-android-core/src/androidTest/java/android/os/strictmode/FakeStrictModeViolation.kt
@@ -1,0 +1,3 @@
+package android.os.strictmode
+
+internal class FakeStrictModeViolation : Violation()

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StrictModeViolationTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StrictModeViolationTest.kt
@@ -1,0 +1,88 @@
+package com.bugsnag.android
+
+import android.content.Context
+import android.os.Build
+import android.os.strictmode.FakeStrictModeViolation
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.filters.SdkSuppress
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class StrictModeViolationTest {
+
+    private lateinit var context: Context
+    private lateinit var config: Configuration
+    private lateinit var client: Client
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        config = BugsnagTestUtils.generateConfiguration()
+        client = Client(context, config)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
+    fun testThreadViolationCapture() {
+        val listener = BugsnagThreadViolationListener(client)
+        var event: Event? = null
+        client.addOnError(
+            OnErrorCallback {
+                event = it
+                true
+            }
+        )
+
+        // trigger a violation and assert it is converted to an event
+        listener.onThreadViolation(FakeStrictModeViolation())
+        val payload = checkNotNull(event)
+        assertEquals(Severity.INFO, payload.severity)
+
+        // validate error object
+        val err = payload.errors.single()
+        assertEquals("StrictMode policy violation detected: ThreadPolicy", err.errorMessage)
+        assertEquals("android.os.strictmode.FakeStrictModeViolation", err.errorClass)
+        assertEquals(ErrorType.ANDROID, err.type)
+
+        // validate first stackframe
+        val frame = err.stacktrace.first()
+        assertEquals(
+            "com.bugsnag.android.StrictModeViolationTest.testThreadViolationCapture",
+            frame.method
+        )
+        assertEquals("StrictModeViolationTest.kt", frame.file)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
+    fun testVmViolationCapture() {
+        val listener = BugsnagVmViolationListener(client)
+        var event: Event? = null
+        client.addOnError(
+            OnErrorCallback {
+                event = it
+                true
+            }
+        )
+
+        // trigger a violation and assert it is converted to an event
+        listener.onVmViolation(FakeStrictModeViolation())
+        val payload = checkNotNull(event)
+        assertEquals(Severity.INFO, payload.severity)
+
+        // validate error object
+        val err = payload.errors.single()
+        assertEquals("StrictMode policy violation detected: VmPolicy", err.errorMessage)
+        assertEquals("android.os.strictmode.FakeStrictModeViolation", err.errorClass)
+        assertEquals(ErrorType.ANDROID, err.type)
+
+        // validate first stackframe
+        val frame = err.stacktrace.first()
+        assertEquals(
+            "com.bugsnag.android.StrictModeViolationTest.testVmViolationCapture",
+            frame.method
+        )
+        assertEquals("StrictModeViolationTest.kt", frame.file)
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagThreadViolationListener.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagThreadViolationListener.java
@@ -1,0 +1,48 @@
+package com.bugsnag.android;
+
+import android.os.Build;
+import android.os.StrictMode.OnThreadViolationListener;
+import android.os.strictmode.Violation;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+/**
+ * Sends an error report to Bugsnag for each StrictMode thread policy violation that occurs in
+ * your app.
+ * <p></p>
+ * You should use this class by instantiating Bugsnag in the normal way and then set the
+ * StrictMode policy with
+ * {@link android.os.StrictMode.ThreadPolicy.Builder#penaltyListener
+ * (Executor, OnThreadViolationListener)}.
+ * This functionality is only supported on API 28+.
+ */
+@RequiresApi(api = Build.VERSION_CODES.P)
+public class BugsnagThreadViolationListener implements OnThreadViolationListener {
+
+    private final Client client;
+    private final OnThreadViolationListener listener;
+
+    public BugsnagThreadViolationListener(@NonNull Client client) {
+        this(client, null);
+    }
+
+    public BugsnagThreadViolationListener(@NonNull Client client,
+                                          @Nullable OnThreadViolationListener listener) {
+        this.client = client;
+        this.listener = listener;
+    }
+
+    @Override
+    public void onThreadViolation(@NonNull Violation violation) {
+        if (client != null) {
+            client.notify(violation, new StrictModeOnErrorCallback(
+                    "StrictMode policy violation detected: ThreadPolicy"
+            ));
+        }
+        if (listener != null) {
+            listener.onThreadViolation(violation);
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagVmViolationListener.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagVmViolationListener.java
@@ -1,0 +1,48 @@
+package com.bugsnag.android;
+
+import android.os.Build;
+import android.os.StrictMode.OnVmViolationListener;
+import android.os.strictmode.Violation;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+/**
+ * Sends an error report to Bugsnag for each StrictMode VM policy violation that occurs in
+ * your app.
+ * <p></p>
+ * You should use this class by instantiating Bugsnag in the normal way and then set the
+ * StrictMode policy with
+ * {@link android.os.StrictMode.VmPolicy.Builder#penaltyListener
+ * (Executor, OnVmViolationListener)}.
+ * This functionality is only supported on API 28+.
+ */
+@RequiresApi(api = Build.VERSION_CODES.P)
+public class BugsnagVmViolationListener implements OnVmViolationListener {
+
+    private final Client client;
+    private final OnVmViolationListener listener;
+
+    public BugsnagVmViolationListener(@NonNull Client client) {
+        this(client, null);
+    }
+
+    public BugsnagVmViolationListener(@NonNull Client client,
+                                      @Nullable OnVmViolationListener listener) {
+        this.client = client;
+        this.listener = listener;
+    }
+
+    @Override
+    public void onVmViolation(@NonNull Violation violation) {
+        if (client != null) {
+            client.notify(violation, new StrictModeOnErrorCallback(
+                    "StrictMode policy violation detected: VmPolicy"
+            ));
+        }
+        if (listener != null) {
+            listener.onVmViolation(violation);
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -320,6 +320,10 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware {
         impl.updateSeverityInternal(severity);
     }
 
+    protected void updateSeverityReason(@NonNull @SeverityReason.SeverityReasonType String reason) {
+        impl.updateSeverityReason(reason);
+    }
+
     void setApp(@NonNull AppWithState app) {
         impl.setApp(app);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -130,12 +130,21 @@ internal class EventInternal @JvmOverloads internal constructor(
     }
 
     protected fun updateSeverityInternal(severity: Severity) {
-        severityReason = SeverityReason.newInstance(
+        severityReason = SeverityReason(
             severityReason.severityReasonType,
             severity,
+            severityReason.unhandled,
             severityReason.attributeValue
         )
-        this.severity = severity
+    }
+
+    protected fun updateSeverityReason(@SeverityReason.SeverityReasonType reason: String) {
+        severityReason = SeverityReason(
+            reason,
+            severityReason.currentSeverity,
+            severityReason.unhandled,
+            severityReason.attributeValue
+        )
     }
 
     fun getSeverityReasonType(): String = severityReason.severityReasonType

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StrictModeOnErrorCallback.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StrictModeOnErrorCallback.kt
@@ -1,0 +1,11 @@
+package com.bugsnag.android
+
+internal class StrictModeOnErrorCallback(private val errMsg: String) : OnErrorCallback {
+    override fun onError(event: Event): Boolean {
+        event.updateSeverityInternal(Severity.INFO)
+        event.updateSeverityReason(SeverityReason.REASON_STRICT_MODE)
+        val error = event.errors.firstOrNull()
+        error?.errorMessage = errMsg
+        return true
+    }
+}

--- a/bugsnag-android-core/src/test/java/android/os/strictmode/FakeStrictModeViolation.kt
+++ b/bugsnag-android-core/src/test/java/android/os/strictmode/FakeStrictModeViolation.kt
@@ -1,0 +1,3 @@
+package android.os.strictmode
+
+internal class FakeStrictModeViolation : Violation()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventTest.java
@@ -184,4 +184,20 @@ public class EventTest {
         String severityReasonType = event.getImpl().getSeverityReasonType();
         assertEquals(SeverityReason.REASON_HANDLED_EXCEPTION, severityReasonType);
     }
+
+    @Test
+    public void testSeverityReasonInternalOverload() {
+        RuntimeException exc = new RuntimeException("Something went wrong");
+        Event event = new Event(exc, config, severityReason, NoopLogger.INSTANCE);
+
+        String severityReasonType = event.getImpl().getSeverityReasonType();
+        assertEquals(SeverityReason.REASON_HANDLED_EXCEPTION, severityReasonType);
+        assertEquals(Severity.WARNING, event.getSeverity());
+
+        event.updateSeverityInternal(Severity.INFO);
+        event.updateSeverityReason(SeverityReason.REASON_STRICT_MODE);
+        severityReasonType = event.getImpl().getSeverityReasonType();
+        assertEquals(SeverityReason.REASON_STRICT_MODE, severityReasonType);
+        assertEquals(Severity.INFO, event.getSeverity());
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StrictModeChainedListenerTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StrictModeChainedListenerTest.kt
@@ -1,0 +1,41 @@
+package com.bugsnag.android
+
+import android.os.strictmode.FakeStrictModeViolation
+import android.os.strictmode.Violation
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+/**
+ * Asserts that the chained listener is called if it has been set.
+ */
+@RunWith(MockitoJUnitRunner::class)
+class StrictModeChainedListenerTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Test
+    fun testChainedThreadListener() {
+        var violation: Violation? = null
+        val listener = BugsnagThreadViolationListener(client) {
+            violation = it
+        }
+        val expected = FakeStrictModeViolation()
+        listener.onThreadViolation(expected)
+        assertSame(expected, violation)
+    }
+
+    @Test
+    fun testChainedVmListener() {
+        var violation: Violation? = null
+        val listener = BugsnagVmViolationListener(client) {
+            violation = it
+        }
+        val expected = FakeStrictModeViolation()
+        listener.onVmViolation(expected)
+        assertSame(expected, violation)
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StrictModeFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StrictModeFacadeTest.java
@@ -1,0 +1,26 @@
+package com.bugsnag.android;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+/**
+ * Ensures that Bugsnag's API surface is able to deal with any unexpected null input that might
+ * cause the SDK to crash.
+ */
+public class StrictModeFacadeTest {
+
+    @Test
+    public void testInvalidThreadListener() {
+        BugsnagThreadViolationListener listener = new BugsnagThreadViolationListener(null);
+        listener.onThreadViolation(null);
+        assertNotNull(listener);
+    }
+
+    @Test
+    public void testInvalidVmListener() {
+        BugsnagVmViolationListener listener = new BugsnagVmViolationListener(null);
+        listener.onVmViolation(null);
+        assertNotNull(listener);
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
@@ -3,6 +3,8 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import android.os.Build
 import android.os.StrictMode
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.BugsnagThreadViolationListener
 import com.bugsnag.android.Configuration
 import java.io.File
 
@@ -23,14 +25,14 @@ internal class StrictModeDiscScenario(
     }
 
     private fun setupBugsnagStrictModeDetection() {
+        val policy = StrictMode.ThreadPolicy.Builder().detectDiskWrites()
+
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-            StrictMode.setThreadPolicy(
-                StrictMode.ThreadPolicy.Builder()
-                    .detectDiskWrites()
-                    .penaltyDeath()
-                    .build()
-            )
+            policy.penaltyDeath()
+        } else {
+            val listener = BugsnagThreadViolationListener(Bugsnag.getClient())
+            policy.penaltyListener(context.mainExecutor, listener)
         }
-        // Android 9 not supported as of yet
+        StrictMode.setThreadPolicy(policy.build())
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeNetworkScenario.kt
@@ -20,7 +20,6 @@ internal class StrictModeNetworkScenario(
         super.startScenario()
         setupBugsnagStrictModeDetection()
         val urlConnection = URL("http://example.com").openConnection() as HttpURLConnection
-        urlConnection.doOutput = true
         urlConnection.responseMessage
     }
 
@@ -33,6 +32,5 @@ internal class StrictModeNetworkScenario(
                     .build()
             )
         }
-        // Android 9 not supported as of yet
     }
 }

--- a/features/full_tests/batch_2/strict_mode_legacy.feature
+++ b/features/full_tests/batch_2/strict_mode_legacy.feature
@@ -1,6 +1,5 @@
-Feature: Reporting Strict Mode Exceptions
+Feature: Reporting Strict Mode Violations
 
-# These scenarios are being skipped on Android 9 until ROAD-757 is resolved
 @skip_above_android_8
 Scenario: StrictMode DiscWrite violation
     When I run "StrictModeDiscScenario" and relaunch the app
@@ -9,6 +8,7 @@ Scenario: StrictMode DiscWrite violation
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
     And the event "metaData.StrictMode.Violation" equals "DiskWrite"
+    And the event "severityReason.type" equals "strictMode"
 
 @skip_above_android_8
 Scenario: StrictMode Network on Main Thread violation
@@ -18,6 +18,7 @@ Scenario: StrictMode Network on Main Thread violation
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
     And the event "metaData.StrictMode.Violation" equals "NetworkOperation"
+    And the event "severityReason.type" equals "strictMode"
 
 # In Android <9 StrictMode kills VM policy violations with SIGKILL, so no requests are received.
 @skip_above_android_8

--- a/features/full_tests/batch_2/strict_mode_violations.feature
+++ b/features/full_tests/batch_2/strict_mode_violations.feature
@@ -1,0 +1,51 @@
+Feature: Reporting Strict Mode Violations
+
+@skip_below_android_9
+Scenario: StrictMode Exposed File URI violation
+    When I run "StrictModeFileUriExposeScenario" and relaunch the app
+    And I configure Bugsnag for "StrictModeFileUriExposeScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "android.os.strictmode.FileUriExposedViolation"
+    And the exception "message" equals "StrictMode policy violation detected: VmPolicy"
+    And the event "unhandled" is false
+    And the event "severity" equals "info"
+    And the event "severityReason.type" equals "strictMode"
+    And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+    And the event "exceptions.0.stacktrace.0.method" equals "android.os.StrictMode.onFileUriExposed"
+    And the event "exceptions.0.stacktrace.0.file" equals "StrictMode.java"
+
+@skip_below_android_9
+Scenario: StrictMode DiscWrite violation
+    When I run "StrictModeDiscScenario" and relaunch the app
+    And I configure Bugsnag for "StrictModeDiscScenario"
+    And I wait to receive 2 errors
+
+    # First violation (triggered by opening FileOutputStream)
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "android.os.strictmode.DiskWriteViolation"
+    And the exception "message" equals "StrictMode policy violation detected: ThreadPolicy"
+    And the event "unhandled" is false
+    And the event "severity" equals "info"
+    And the event "severityReason.type" equals "strictMode"
+    And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+
+    And the exception "stacktrace.1.method" equals one of:
+        | libcore.io.BlockGuardOs.open |
+        | java.io.FileOutputStream.<init> |
+
+    And the exception "stacktrace.1.file" equals one of:
+        | BlockGuardOs.java |
+        | FileOutputStream.java |
+
+    # Second violation (triggered by writing to FileOutputStream)
+    And I discard the oldest error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "android.os.strictmode.DiskWriteViolation"
+    And the exception "message" equals "StrictMode policy violation detected: ThreadPolicy"
+    And the event "unhandled" is false
+    And the event "severity" equals "info"
+    And the event "severityReason.type" equals "strictMode"
+    And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+    And the event "exceptions.0.stacktrace.1.method" equals "libcore.io.BlockGuardOs.write"
+    And the event "exceptions.0.stacktrace.1.file" equals "BlockGuardOs.java"

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -174,7 +174,7 @@ Scenario: Handled C functionality
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event "unhandled" is false
     And the event "severity" equals "error"
-    And the event "severityReason.type" equals "userCallbackSetSeverity"
+    And the event "severityReason.type" equals "handledException"
     And the event "severityReason.unhandledOverridden" is false
     And the error payload field "events.0.projectPackages" is a non-empty array
     And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"


### PR DESCRIPTION
## Goal

Adds `BugsnagThreadViolationListener` and `BugsnagVmViolationListener` to the public API. These classes implement StrictMode listeners and will call `Bugsnag.notify` if set as part of a [StrictMode policy](https://developer.android.com/reference/android/os/StrictMode).

By default, errors will be captured with a INFO severity level, a 'strictMode' severity reason, and an error message denoting whether it was a thread/vm policy violation. The classes supports chaining of listeners if a user desires this.

Note: this enforces that `Bugsnag.start()` must always be instantiated before setting the StrictMode listener. This was seen as preferable since otherwise a StrictMode violation might occur before bugsnag is initialized, and lead to `Bugsnag.getClient()` throwing an exception.

## Changeset

- Added `BugsnagThreadViolationListener` and `BugsnagVmViolationListener` to the public API
- Fixed bug in `updateSeverityInternal` which set the `severityReason` to `userCallbackSetSeverity`
- Added unit test coverage for new classes (including dealing with unexpected null inputs)
- Improved E2E test coverage for StrictMode scenarios so that on Android 9 they use the new APIs
