### PR TITLE
DocumentPath add/subtract support

### DIFF
--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -4,6 +4,7 @@ import com.bugsnag.android.internal.ImmutableConfig;
 import com.bugsnag.android.internal.ImmutableConfigKt;
 
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
 
 import java.io.File;
 import java.io.IOException;
@@ -193,5 +194,16 @@ final class BugsnagTestUtils {
             return normalizedList((List<Object>)obj);
         }
         return obj;
+    }
+
+    /**
+     * Assert equality on normalized deep copies of list & map containers so that different
+     * sized numeric fields containing the same value will be considered equal.
+     *
+     * @param expected The expected value
+     * @param observed The observed value
+     */
+    public static void assertNormalizedEquals(Object expected, Object observed) {
+        Assert.assertEquals(normalized(expected), normalized(observed));
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.internal.DocumentPath
-import org.junit.Assert
 import org.junit.Test
 import java.util.LinkedList
 
@@ -14,7 +13,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to 1)
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -25,7 +24,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to 1)
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -36,7 +35,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to 2)
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -47,7 +46,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>()
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -58,7 +57,62 @@ class DocumentPathTest {
         val expected = mapOf("a" to mapOf("b" to 1))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapAddEmpty() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a.b+")
+        val value = 1
+        val expected = mapOf("a" to mapOf("b" to 1))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapAddIntToInt() {
+        val document = mutableMapOf<String, Any>("a" to mapOf("b" to 1))
+        val docpath = DocumentPath("a.b+")
+        val value = 10
+        val expected = mapOf("a" to mapOf("b" to 11))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapAddIntToFloat() {
+        val document = mutableMapOf<String, Any>("a" to mapOf("b" to 1.5))
+        val docpath = DocumentPath("a.b+")
+        val value = 10
+        val expected = mapOf("a" to mapOf("b" to 11.5))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapAddFloatToInt() {
+        val document = mutableMapOf<String, Any>("a" to mapOf("b" to 5))
+        val docpath = DocumentPath("a.b+")
+        val value = 10.9
+        val expected = mapOf("a" to mapOf("b" to 15.9))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapAddFloatToFloat() {
+        val document = mutableMapOf<String, Any>("a" to mapOf("b" to 5.5))
+        val docpath = DocumentPath("a.b+")
+        val value = 10.9
+        val expected = mapOf("a" to mapOf("b" to 16.4))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -69,7 +123,7 @@ class DocumentPathTest {
         val expected = mapOf("a.x" to mapOf("b.y" to 1))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -79,13 +133,34 @@ class DocumentPathTest {
         val value = 1
         val expected = mapOf("a.x" to mapOf("b\\y" to 1))
 
-        val obseved = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, obseved)
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testMapEscapedPlus() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a\\.x.b\\+")
+        val value = 1
+        val expected = mapOf("a.x" to mapOf("b+" to 1))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testBadEscape() {
         DocumentPath("a\\.x.b\\.y\\")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testBarePlus() {
+        DocumentPath("a.+")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testBarePlusTopLevel() {
+        DocumentPath("+")
     }
 
     @Test
@@ -96,7 +171,29 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to listOf<Any>(1))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testListAddAppendEmpty() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a.-1+")
+        val value = 1
+        val expected = mapOf<String, Any>("a" to listOf<Any>(1))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testListAddAppend() {
+        val document = mutableMapOf<String, Any>("a" to listOf<Any>(1))
+        val docpath = DocumentPath("a.-1+")
+        val value = 50
+        val expected = mapOf<String, Any>("a" to listOf<Any>(51))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -107,7 +204,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to listOf<Any>(1, 2))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -118,7 +215,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to listOf<Any>())
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -129,7 +226,29 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to listOf<Any>(9, 2, 3))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testListAdd() {
+        val document = mutableMapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(1, 2, 3)))
+        val docpath = DocumentPath("a.0+")
+        val value = 9
+        val expected = mapOf<String, Any>("a" to listOf<Any>(10, 2, 3))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testListSubtract() {
+        val document = mutableMapOf<String, Any>("a" to LinkedList<Any>(listOf<Any>(1, 2, 3)))
+        val docpath = DocumentPath("a.0+")
+        val value = -9
+        val expected = mapOf<String, Any>("a" to listOf<Any>(-8, 2, 3))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -140,7 +259,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to listOf<Any>(2, 3))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -151,7 +270,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to listOf<Any>(5, 4, 3, 2, 9))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -162,7 +281,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a" to listOf<Any>(1))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -173,7 +292,7 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a." to listOf<Any>(1))
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test
@@ -184,7 +303,18 @@ class DocumentPathTest {
         val expected = mapOf<String, Any>("a." to 1)
 
         val observed = docpath.modifyDocument(document, value)
-        Assert.assertEquals(expected, observed)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testEscapePlus() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("a\\+")
+        val value = 1
+        val expected = mapOf<String, Any>("a+" to 1)
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
     @Test(expected = IllegalArgumentException::class)


### PR DESCRIPTION
## Goal

Sometimes numeric document values need to be changed relative to their current value (incremented, decremented, added to, subtracted from) - for example counters. These operations must be supported as atomic operations, without requiring access to the original value.

## Design

Add support for an "addition" operator: If `+` is appended to the last path component, treat that last component (with the ending `+` character removed) as an instruction that the (assumed numeric) value is to be added to the (assumed numeric) value currently in the document. If there is no value at that place in the document, the document's "existing" value is assumed to be 0.

Note: The `+` character can be escaped, in which case it doesn't represent an addition operator.

Examples:

```
Original document:  {"foo": {"bar": 5}}
Path command:       {"foo.bar+": -100}
Resulting document: {"foo": {"bar": -95}}
```

```
Original document:  {}
Path command:       {"foo.bar+": -100}
Resulting document: {"foo": {"bar": -100}}
```

<!-- Why was this approach used? -->

## Changeset

Added new DocumentPathDirectives to support addition, and updated the path parser to recognise `+`.

## Testing

Added more unit tests.
