### PR TITLE
Support zero-param constructor for StrictMode detection

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagThreadViolationListener.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagThreadViolationListener.java
@@ -24,6 +24,10 @@ public class BugsnagThreadViolationListener implements OnThreadViolationListener
     private final Client client;
     private final OnThreadViolationListener listener;
 
+    public BugsnagThreadViolationListener() {
+        this(Bugsnag.getClient(), null);
+    }
+
     public BugsnagThreadViolationListener(@NonNull Client client) {
         this(client, null);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagVmViolationListener.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagVmViolationListener.java
@@ -24,6 +24,10 @@ public class BugsnagVmViolationListener implements OnVmViolationListener {
     private final Client client;
     private final OnVmViolationListener listener;
 
+    public BugsnagVmViolationListener() {
+        this(Bugsnag.getClient(), null);
+    }
+
     public BugsnagVmViolationListener(@NonNull Client client) {
         this(client, null);
     }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeDiscScenario.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import android.os.Build
 import android.os.StrictMode
-import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.BugsnagThreadViolationListener
 import com.bugsnag.android.Configuration
 import java.io.File
@@ -30,7 +29,7 @@ internal class StrictModeDiscScenario(
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             policy.penaltyDeath()
         } else {
-            val listener = BugsnagThreadViolationListener(Bugsnag.getClient())
+            val listener = BugsnagThreadViolationListener()
             policy.penaltyListener(context.mainExecutor, listener)
         }
         StrictMode.setThreadPolicy(policy.build())

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeFileUriExposeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeFileUriExposeScenario.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.StrictMode
 import android.os.StrictMode.VmPolicy
-import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.BugsnagVmViolationListener
 import com.bugsnag.android.Configuration
 import java.io.File
@@ -45,7 +44,7 @@ internal class StrictModeFileUriExposeScenario(
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             policy.penaltyDeath()
         } else {
-            val listener = BugsnagVmViolationListener(Bugsnag.getClient())
+            val listener = BugsnagVmViolationListener()
             policy.penaltyListener(context.mainExecutor, listener)
         }
         StrictMode.setVmPolicy(policy.build())


### PR DESCRIPTION
## Goal

Adds a zero-parameter constructor for the StrictMode listeners. This avoids users having to call `Bugsnag.getClient()` unnecessarily.

The other constructors have been left as-is to allow for multiple `Client` instantiation and setting chained listeners.