### PR TITLE
Bump gradle/AGP dependencies

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -16,7 +16,7 @@ steps:
   - label: ':android: Build Example App'
     depends_on: "android-ci"
     timeout_in_minutes: 5
-    command: 'cd examples/sdk-app-example && ./gradlew assembleRelease'
+    command: 'cd examples/sdk-app-example && ./gradlew clean assembleRelease'
     plugins:
       docker-compose#v3.7.0:
         run: android-ci

--- a/examples/sdk-app-example/app/build.gradle
+++ b/examples/sdk-app-example/app/build.gradle
@@ -40,9 +40,8 @@ android {
 dependencies {
     implementation "com.bugsnag:bugsnag-android:5.10.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "androidx.core:core-ktx:1.3.2"
-    implementation "com.google.android.material:material:1.2.1"
+    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "com.google.android.material:material:1.4.0"
 }
 
 apply plugin: "com.bugsnag.android.gradle"

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.6.4"
+        classpath "com.android.tools.build:gradle:4.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.bugsnag:bugsnag-android-gradle-plugin:5.7.7"
     }

--- a/examples/sdk-app-example/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/sdk-app-example/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jul 16 09:48:14 BST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Goal

Bumps Gradle/AGP in the example app to the latest available versions without updating all the way to AGP 7.

The example app requires a clean assemble to workaround an apparent bug in AGP/Gradle which would throw a `ZipException` as some build cache exists.