### PR TITLE
Increase instrumentation test timeout

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -55,24 +55,10 @@ steps:
       - docker-compose#v3.7.0:
           run: android-sizer
 
-  - label: ':android: Android 7 Instrumentation tests'
-    depends_on:
-      - "android-ci"
-    timeout_in_minutes: 30
-    command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
-    plugins:
-      - docker-compose#v3.7.0:
-          run: android-ci
-    env:
-      INSTRUMENTATION_DEVICES: '["Google Pixel-7.1"]'
-      TEST_APK_LOCATION: 'bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk'
-    concurrency: 9
-    concurrency_group: 'browserstack-app'
-
   - label: ':android: Android 9 Instrumentation tests'
     depends_on:
       - "android-ci"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
     plugins:
       - docker-compose#v3.7.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -157,7 +157,7 @@ steps:
     key: 'core-instrumentation-tests'
     depends_on:
       - "android-ci"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -172,7 +172,7 @@ steps:
     key: 'ndk-instrumentation-tests'
     depends_on:
       - "android-ci"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
     plugins:
       - docker-compose#v3.7.0:
@@ -187,7 +187,7 @@ steps:
     key: 'perf-benchmarks'
     depends_on:
       - "android-ci"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     command: ./scripts/build-instrumentation-tests.sh && ./scripts/run-instrumentation-test.sh
     plugins:
       - docker-compose#v3.7.0:

--- a/scripts/run-instrumentation-test.sh
+++ b/scripts/run-instrumentation-test.sh
@@ -58,7 +58,7 @@ status_response=$(curl -s -u "$BROWSER_STACK_USERNAME:$BROWSER_STACK_ACCESS_KEY"
 status=$(echo "$status_response" | jq -r ".status")
 
 WAIT_COUNT=0
-until [ "$status" == "\"done\"" ] || [ "$status" == "\"error\"" ] || [ "$status" == "\"failed\"" ] || [ $WAIT_COUNT -eq 100 ]; do
+until [ "$status" == "\"done\"" ] || [ "$status" == "\"error\"" ] || [ "$status" == "\"failed\"" ] || [ $WAIT_COUNT -eq 240 ]; do
     echo "Android Tests [$(timestamp)]: Current test status: $status, Time waited: $((WAIT_COUNT * 15))"
     ((WAIT_COUNT++))
     sleep 15


### PR DESCRIPTION
## Goal.

Increase timeout for the instrumentations tests as they have been very variable recently (I've also raised a support ticket with BrowserStack).

## Changeset

Increased timeout and remove duplication of step from the pipeline files.

## Testing

Covered by CI.