### PR TITLE
fix(lowMemory): align the app.lowMemory field for JVM and NDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* The `app.lowMemory` value always report the most recent `onTrimMemory`/`onLowMemory` status
+  [#1342](https://github.com/bugsnag/bugsnag-android/pull/1342)
+
 ## 5.11.0 (2021-08-05)
 
 ### Enhancements

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
@@ -47,8 +47,7 @@ class AppDataCollectorTest {
             client.immutableConfig,
             client.sessionTracker,
             am,
-            client.launchCrashTracker,
-            NoopLogger
+            client.launchCrashTracker
         )
         val app = collector.getAppDataMetadata()
         assertNull(app["backgroundWorkRestricted"])
@@ -67,8 +66,7 @@ class AppDataCollectorTest {
             client.immutableConfig,
             client.sessionTracker,
             am,
-            client.launchCrashTracker,
-            NoopLogger
+            client.launchCrashTracker
         )
         client.context = "Some Custom Context"
         client.sessionTracker.updateForegroundTracker("MyActivity", true, 0L)
@@ -90,8 +88,7 @@ class AppDataCollectorTest {
             client.immutableConfig,
             client.sessionTracker,
             am,
-            client.launchCrashTracker,
-            NoopLogger
+            client.launchCrashTracker
         )
         val app = collector.getAppDataMetadata()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -19,9 +19,13 @@ internal class AppDataCollector(
     private val config: ImmutableConfig,
     private val sessionTracker: SessionTracker,
     private val activityManager: ActivityManager?,
-    private val launchCrashTracker: LaunchCrashTracker,
-    private val logger: Logger
+    private val launchCrashTracker: LaunchCrashTracker
 ) {
+    /**
+     * Is the app considered to be an a low-memory state as defined by
+     * [android.content.ComponentCallbacks]
+     */
+    var isLowMemory: Boolean = false
     var codeBundleId: String? = null
 
     private val packageName: String = appContext.packageName
@@ -52,7 +56,7 @@ internal class AppDataCollector(
         map["name"] = appName
         map["activeScreen"] = sessionTracker.contextActivity
         map["memoryUsage"] = getMemoryUsage()
-        map["lowMemory"] = isLowMemory()
+        map["lowMemory"] = isLowMemory
 
         bgWorkRestricted?.let {
             map["backgroundWorkRestricted"] = bgWorkRestricted
@@ -84,22 +88,6 @@ internal class AppDataCollector(
         } else {
             null
         }
-    }
-
-    /**
-     * Check if the device is currently running low on memory.
-     */
-    private fun isLowMemory(): Boolean? {
-        try {
-            if (activityManager != null) {
-                val memInfo = ActivityManager.MemoryInfo()
-                activityManager.getMemoryInfo(memInfo)
-                return memInfo.lowMemory
-            }
-        } catch (exception: Exception) {
-            logger.w("Could not check lowMemory status")
-        }
-        return null
     }
 
     fun setBinaryArch(binaryArch: String) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -340,6 +340,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                 }, new Function1<Boolean, Unit>() {
                     @Override
                     public Unit invoke(Boolean isLowMemory) {
+                        appDataCollector.setLowMemory(Boolean.TRUE.equals(isLowMemory));
                         clientObservable.postMemoryTrimEvent(isLowMemory);
                         return null;
                     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientComponentCallbacks.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientComponentCallbacks.kt
@@ -1,13 +1,13 @@
 package com.bugsnag.android
 
-import android.content.ComponentCallbacks
+import android.content.ComponentCallbacks2
 import android.content.res.Configuration
 
 internal class ClientComponentCallbacks(
     private val deviceDataCollector: DeviceDataCollector,
     private val cb: (oldOrientation: String?, newOrientation: String?) -> Unit,
     val callback: (Boolean) -> Unit
-) : ComponentCallbacks {
+) : ComponentCallbacks2 {
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         val oldOrientation = deviceDataCollector.getOrientationAsString()
@@ -16,6 +16,10 @@ internal class ClientComponentCallbacks(
             val newOrientation = deviceDataCollector.getOrientationAsString()
             cb(oldOrientation, newOrientation)
         }
+    }
+
+    override fun onTrimMemory(level: Int) {
+        callback(level >= ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
     }
 
     override fun onLowMemory() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DataCollectionModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DataCollectionModule.kt
@@ -33,8 +33,7 @@ internal class DataCollectionModule(
             cfg,
             trackerModule.sessionTracker,
             systemServiceModule.activityManager,
-            trackerModule.launchCrashTracker,
-            logger
+            trackerModule.launchCrashTracker
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/AppDataCollectorForegroundTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/AppDataCollectorForegroundTest.kt
@@ -41,8 +41,7 @@ class AppDataCollectorForegroundTest {
             BugsnagTestUtils.generateImmutableConfig(),
             sessionTracker,
             null,
-            launchCrashTracker,
-            NoopLogger
+            launchCrashTracker
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/AppDataCollectorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/AppDataCollectorSerializationTest.kt
@@ -50,8 +50,7 @@ internal class AppDataCollectorSerializationTest {
                 convert(config),
                 sessionTracker,
                 am,
-                launchCrashTracker,
-                NoopLogger
+                launchCrashTracker
             )
             appData.codeBundleId = "foo-99"
             appData.setBinaryArch("x86")

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/AppMetadataSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/AppMetadataSerializationTest.kt
@@ -50,8 +50,7 @@ internal class AppMetadataSerializationTest {
                 convertToImmutableConfig(config, null, null, ApplicationInfo()),
                 sessionTracker,
                 am,
-                launchCrashTracker,
-                NoopLogger
+                launchCrashTracker
             )
             appData.codeBundleId = "foo-99"
             appData.setBinaryArch("x86")

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientComponentCallbacksMemoryCallbackTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientComponentCallbacksMemoryCallbackTest.kt
@@ -1,0 +1,77 @@
+package com.bugsnag.android
+
+import android.content.ComponentCallbacks2
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ClientComponentCallbacksMemoryCallbackTest {
+
+    @Mock
+    internal lateinit var deviceDataCollector: DeviceDataCollector
+    private lateinit var clientComponentCallbacks: ClientComponentCallbacks
+
+    private var isLowMemory: Boolean? = null
+
+    @Before
+    fun setUp() {
+        clientComponentCallbacks = ClientComponentCallbacks(
+            deviceDataCollector,
+            { _: String?, _: String? -> },
+            this::isLowMemory::set
+        )
+        isLowMemory = null
+    }
+
+    @Test
+    fun testLegacyLowMemory() {
+        clientComponentCallbacks.onLowMemory()
+        assertEquals(true, isLowMemory)
+    }
+
+    @Test
+    fun trimMemoryRunningModerate() {
+        clientComponentCallbacks.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE)
+        assertEquals(false, isLowMemory)
+    }
+
+    @Test
+    fun trimMemoryRunningLow() {
+        clientComponentCallbacks.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW)
+        assertEquals(false, isLowMemory)
+    }
+
+    @Test
+    fun trimMemoryRunningCritical() {
+        clientComponentCallbacks.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL)
+        assertEquals(false, isLowMemory)
+    }
+
+    @Test
+    fun trimMemoryUiHidden() {
+        clientComponentCallbacks.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
+        assertEquals(false, isLowMemory)
+    }
+
+    @Test
+    fun trimMemoryBackground() {
+        clientComponentCallbacks.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
+        assertEquals(false, isLowMemory)
+    }
+
+    @Test
+    fun trimMemoryModerate() {
+        clientComponentCallbacks.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_MODERATE)
+        assertEquals(false, isLowMemory)
+    }
+
+    @Test
+    fun trimMemoryComplete() {
+        clientComponentCallbacks.onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
+        assertEquals(true, isLowMemory)
+    }
+}


### PR DESCRIPTION
## Goal
The `app.lowMemory` attribute should be reported in the same way for all errors.

## Design
Cache the most recent value sent to `ComponentCallbacks.onLowMemory` and `ComponentCallbacks2.onTrimMemory` in the `AppDataCollector` and report that value instead of looking-up the value at crash-time.

When we receive a trim memory event that indicates any state less than [COMPLETE](https://developer.android.com/reference/android/content/ComponentCallbacks2#TRIM_MEMORY_COMPLETE) we set the cached lowMemory state to `false`.

## Testing
Manual testing for both native and JVM crashes, and a new unit test to cover the mapping between memory-trim values and the `lowMemory` flag.