### PR TITLE
Add `Breadcrumbs` for `onTrimMemory` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Added the `app.memoryTrimLevel` metadata to report a description of the latest `onTrimMemory` status
   [#1344](https://github.com/bugsnag/bugsnag-android/pull/1344)
 
+* Added `STATE` Breadcrumbs for `onTrimMemory` events
+  [#1345](https://github.com/bugsnag/bugsnag-android/pull/1345)
+
 ## 5.11.0 (2021-08-05)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -344,7 +344,16 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                     @Override
                     public Unit invoke(Boolean isLowMemory, Integer memoryTrimLevel) {
                         memoryTrimState.setLowMemory(Boolean.TRUE.equals(isLowMemory));
-                        memoryTrimState.setMemoryTrimLevel(memoryTrimLevel);
+                        if (memoryTrimState.updateMemoryTrimLevel(memoryTrimLevel)) {
+                            leaveAutoBreadcrumb(
+                                    "Trim Memory",
+                                    BreadcrumbType.STATE,
+                                    Collections.<String, Object>singletonMap(
+                                            "trimLevel", memoryTrimState.getTrimLevelDescription()
+                                    )
+                            );
+                        }
+
                         memoryTrimState.emitObservableEvent();
                         return null;
                     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MemoryTrimState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MemoryTrimState.kt
@@ -8,6 +8,15 @@ internal class MemoryTrimState : BaseObservable() {
 
     val trimLevelDescription: String get() = descriptionFor(memoryTrimLevel)
 
+    fun updateMemoryTrimLevel(newTrimLevel: Int?): Boolean {
+        if (memoryTrimLevel == newTrimLevel) {
+            return false
+        }
+
+        memoryTrimLevel = newTrimLevel
+        return true
+    }
+
     fun emitObservableEvent() {
         updateState {
             StateEvent.UpdateMemoryTrimEvent(

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MemoryTrimStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MemoryTrimStateTest.kt
@@ -1,0 +1,52 @@
+package com.bugsnag.android
+
+import android.content.ComponentCallbacks2
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class MemoryTrimStateTest {
+
+    lateinit var memoryTrimState: MemoryTrimState
+
+    @Before
+    fun setUp() {
+        memoryTrimState = MemoryTrimState()
+    }
+
+    @Test
+    fun memoryTrimLevelDescriptions() {
+        memoryTrimState.memoryTrimLevel = ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE
+        assertEquals("Running moderate", memoryTrimState.trimLevelDescription)
+
+        memoryTrimState.memoryTrimLevel = ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
+        assertEquals("Running low", memoryTrimState.trimLevelDescription)
+
+        memoryTrimState.memoryTrimLevel = ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
+        assertEquals("Running critical", memoryTrimState.trimLevelDescription)
+
+        memoryTrimState.memoryTrimLevel = ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+        assertEquals("UI hidden", memoryTrimState.trimLevelDescription)
+
+        memoryTrimState.memoryTrimLevel = ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
+        assertEquals("Background", memoryTrimState.trimLevelDescription)
+
+        memoryTrimState.memoryTrimLevel = ComponentCallbacks2.TRIM_MEMORY_MODERATE
+        assertEquals("Moderate", memoryTrimState.trimLevelDescription)
+
+        memoryTrimState.memoryTrimLevel = ComponentCallbacks2.TRIM_MEMORY_COMPLETE
+        assertEquals("Complete", memoryTrimState.trimLevelDescription)
+
+        memoryTrimState.memoryTrimLevel = null
+        assertEquals("None", memoryTrimState.trimLevelDescription)
+    }
+
+    @Test
+    fun unknownMemoryTrimLevel() {
+        memoryTrimState.memoryTrimLevel = ComponentCallbacks2.TRIM_MEMORY_COMPLETE + 1
+        assertEquals(
+            "Unknown (${memoryTrimState.memoryTrimLevel})",
+            memoryTrimState.trimLevelDescription
+        )
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/UpdateMemoryTrimLevelTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/UpdateMemoryTrimLevelTest.kt
@@ -1,0 +1,49 @@
+package com.bugsnag.android
+
+import android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE
+import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
+import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+internal class UpdateMemoryTrimLevelTest {
+
+    lateinit var memoryTrimState: MemoryTrimState
+
+    @Before
+    fun setUp() {
+        memoryTrimState = MemoryTrimState()
+    }
+
+    @Test
+    fun updateFromNull() {
+        assertNull(memoryTrimState.memoryTrimLevel)
+        assertTrue(memoryTrimState.updateMemoryTrimLevel(TRIM_MEMORY_COMPLETE))
+        assertEquals(TRIM_MEMORY_COMPLETE, memoryTrimState.memoryTrimLevel)
+    }
+
+    @Test
+    fun updateWithoutChange() {
+        assertTrue(memoryTrimState.updateMemoryTrimLevel(TRIM_MEMORY_COMPLETE))
+        assertFalse(memoryTrimState.updateMemoryTrimLevel(TRIM_MEMORY_COMPLETE))
+    }
+
+    @Test
+    fun multipleChanges() {
+        assertTrue(memoryTrimState.updateMemoryTrimLevel(TRIM_MEMORY_COMPLETE))
+        assertTrue(memoryTrimState.updateMemoryTrimLevel(TRIM_MEMORY_RUNNING_LOW))
+        assertTrue(memoryTrimState.updateMemoryTrimLevel(TRIM_MEMORY_RUNNING_MODERATE))
+        assertEquals(TRIM_MEMORY_RUNNING_MODERATE, memoryTrimState.memoryTrimLevel)
+    }
+
+    @Test
+    fun updateToNull() {
+        assertTrue(memoryTrimState.updateMemoryTrimLevel(TRIM_MEMORY_COMPLETE))
+        assertTrue(memoryTrimState.updateMemoryTrimLevel(null))
+        assertNull(memoryTrimState.memoryTrimLevel)
+    }
+}


### PR DESCRIPTION
## Goal
Leave Breadcrumbs for `onTrimMemory` events, with the `memoryTrimLevel` as metadata.

## Testing
Manual testing, and new unit tests for the `MemoryTrimState`.