### PR TITLE
Align device and app memory metaData

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -170,7 +170,7 @@ public class ClientTest {
     public void testAppDataMetadata() {
         client = generateClient();
         Map<String, Object> app = client.getAppDataCollector().getAppDataMetadata();
-        assertEquals(6, app.size());
+        assertEquals(9, app.size());
         assertEquals("Bugsnag Android Tests", app.get("name"));
         assertEquals("com.bugsnag.android.core.test", app.get("processName"));
         assertNotNull(app.get("memoryUsage"));

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -52,9 +52,10 @@ internal class AppDataCollector(
         val map = HashMap<String, Any?>()
         map["name"] = appName
         map["activeScreen"] = sessionTracker.contextActivity
-        map["memoryUsage"] = getMemoryUsage()
         map["lowMemory"] = memoryTrimState.isLowMemory
         map["memoryTrimLevel"] = memoryTrimState.trimLevelDescription
+
+        populateRuntimeMemoryMetadata(map)
 
         bgWorkRestricted?.let {
             map["backgroundWorkRestricted"] = bgWorkRestricted
@@ -65,13 +66,14 @@ internal class AppDataCollector(
         return map
     }
 
-    /**
-     * Get the actual memory used by the VM (which may not be the total used
-     * by the app in the case of NDK usage).
-     */
-    private fun getMemoryUsage(): Long {
+    private fun populateRuntimeMemoryMetadata(map: MutableMap<String, Any?>) {
         val runtime = Runtime.getRuntime()
-        return runtime.totalMemory() - runtime.freeMemory()
+        val totalMemory = runtime.totalMemory()
+        val freeMemory = runtime.freeMemory()
+        map["memoryUsage"] = totalMemory - freeMemory
+        map["totalMemory"] = totalMemory
+        map["freeMemory"] = freeMemory
+        map["memoryLimit"] = runtime.maxMemory()
     }
 
     /**

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/AppMetadataSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/AppMetadataSerializationTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import com.bugsnag.android.internal.convertToImmutableConfig
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -58,7 +59,11 @@ internal class AppMetadataSerializationTest {
             appData.setBinaryArch("x86")
 
             val metadata = appData.getAppDataMetadata()
-            metadata.remove("memoryUsage")
+            assertNotNull(metadata.remove("memoryUsage"))
+            assertNotNull(metadata.remove("totalMemory"))
+            assertNotNull(metadata.remove("freeMemory"))
+            assertNotNull(metadata.remove("memoryLimit"))
+
             @Suppress("UNCHECKED_CAST")
             return generateSerializationTestCases("app_meta_data", metadata.toMap() as Map<String, Any>)
         }

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -457,6 +457,11 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                             sizeof(process_name));
   bugsnag_event_add_metadata_string(event, "app", "processName", process_name);
 
+  long total_memory =
+      bsg_get_map_value_long(env, jni_cache, data, "memoryLimit");
+  bugsnag_event_add_metadata_double(event, "app", "memoryLimit",
+                                    (double)total_memory);
+
   bsg_safe_delete_local_ref(env, data);
 }
 

--- a/features/full_tests/batch_2/native_crash_handling.feature
+++ b/features/full_tests/batch_2/native_crash_handling.feature
@@ -11,6 +11,8 @@ Scenario: Dereference a null pointer
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the event "app.binaryArch" is not null
+        And the event "app.memoryLimit" is not null
+        And the event "device.totalMemory" is not null
         And the error payload field "events.0.device.cpuAbi" is a non-empty array
 
     # This scenario will not pass on API levels < 18, as stack corruption

--- a/features/full_tests/batch_2/native_crash_handling.feature
+++ b/features/full_tests/batch_2/native_crash_handling.feature
@@ -11,9 +11,9 @@ Scenario: Dereference a null pointer
         And the event "severity" equals "error"
         And the event "unhandled" is true
         And the event "app.binaryArch" is not null
-        And the event "app.memoryLimit" is not null
         And the event "device.totalMemory" is not null
         And the error payload field "events.0.device.cpuAbi" is a non-empty array
+        And the error payload field "events.0.metaData.app.memoryLimit" is greater than 0
 
     # This scenario will not pass on API levels < 18, as stack corruption
     # is handled without calling atexit handlers, etc.

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -42,6 +42,9 @@ Scenario: Notify caught Java exception with default configuration
     And the event "app.inForeground" is true
     And the event "app.isLaunching" is true
     And the error payload field "events.0.metaData.app.memoryUsage" is greater than 0
+    And the error payload field "events.0.metaData.app.totalMemory" is greater than 0
+    And the error payload field "events.0.metaData.app.freeMemory" is greater than 0
+    And the error payload field "events.0.metaData.app.memoryLimit" is greater than 0
     And the event "metaData.app.name" equals "MazeRunner"
     And the event "metaData.app.lowMemory" is false
     And the event "metaData.app.memoryTrimLevel" equals "None"

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -43,6 +43,9 @@ Scenario: Unhandled Java Exception with loaded configuration
     And the event "app.inForeground" is true
     And the event "app.isLaunching" is true
     And the error payload field "events.0.metaData.app.memoryUsage" is greater than 0
+    And the error payload field "events.0.metaData.app.totalMemory" is greater than 0
+    And the error payload field "events.0.metaData.app.freeMemory" is greater than 0
+    And the error payload field "events.0.metaData.app.memoryLimit" is greater than 0
 
     # Metadata
     And the event "metaData.app.name" equals "MazeRunner"


### PR DESCRIPTION
## Goal
General improvements to the automatically reported memory metaData for both the `app` and `device` sections to make them more consistent with user expectations (for example: `device.totalMemory` should reflect the amount of physical memory installed on the device).

## Changeset
* app now reports ART / Java specific attributes (from `Runtime`): `memoryUsage`, `totalMemory`, `freeMemory`, and `memoryLimit`
* device reports `totalMemory` and `freeMemory` for the entire device
* `totalMemory` is considered a static value and is calculated on startup
* `totalMemory` and `memoryLimit` is reported for NDK errors

## Testing
Added the new attributes to existing tests, and manually tested the changes along with the new dashboard changes to correctly format the new attributes.