### PR TITLE
task(nativeInterface): add getLastRunInfo method

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -441,7 +441,7 @@ public class NativeInterface {
      * Get the last run info object
      */
     @Nullable
-    public static LastRunInfo getLastRunInfo(){
+    public static LastRunInfo getLastRunInfo() {
         return getClient().getLastRunInfo();
     }
 


### PR DESCRIPTION
## Goal

Needed for making the Unity notifier spec complient and allowing access to the LastRunInfo object 

## Changeset

-add getLastRunInfo method to the NativeInterface class

## Testing

Manually tested