### PR TITLE
Setup bugsnag-plugin-android-okhttp module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## TBD
 
+* Capture breadcrumbs for OkHttp network requests
+  [#1358](https://github.com/bugsnag/bugsnag-android/pull/1358)
+
 * Update project to build using Gradle/AGP 7
   [#1354](https://github.com/bugsnag/bugsnag-android/pull/1354)
 

--- a/bugsnag-plugin-android-okhttp/README.md
+++ b/bugsnag-plugin-android-okhttp/README.md
@@ -1,0 +1,10 @@
+# bugsnag-plugin-android-anr
+
+This module captures a breadcrumb for each network request made by OkHttp.
+
+## High-level Overview
+
+The module has a `compileOnly` dependency on OkHttp 4 and implements the `Plugin` and `EventListener`
+interfaces. The user should install the plugin while initializing Bugsnag and creating an
+`OkHttpClient`, and OkHttp's callbacks will then be used to automatically capture breadcrumbs
+for each request.

--- a/bugsnag-plugin-android-okhttp/README.md
+++ b/bugsnag-plugin-android-okhttp/README.md
@@ -1,4 +1,4 @@
-# bugsnag-plugin-android-anr
+# bugsnag-plugin-android-okhttp
 
 This module captures a breadcrumb for each network request made by OkHttp.
 

--- a/bugsnag-plugin-android-okhttp/build.gradle
+++ b/bugsnag-plugin-android-okhttp/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id("bugsnag-build-plugin")
+}
+
+apply plugin: "com.android.library"
+
+dependencies {
+    api(project(":bugsnag-android-core"))
+}
+
+apply from: "../gradle/kotlin.gradle"
+
+dependencies {
+    compileOnly("com.squareup.okhttp3:okhttp:4.9.0")
+}

--- a/bugsnag-plugin-android-okhttp/gradle.properties
+++ b/bugsnag-plugin-android-okhttp/gradle.properties
@@ -1,0 +1,2 @@
+pomName=Bugsnag Android OkHttp
+artefactId=bugsnag-plugin-android-okhttp

--- a/bugsnag-plugin-android-okhttp/proguard-rules.pro
+++ b/bugsnag-plugin-android-okhttp/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keepattributes LineNumberTable,SourceFile

--- a/bugsnag-plugin-android-okhttp/src/main/AndroidManifest.xml
+++ b/bugsnag-plugin-android-okhttp/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.bugsnag.android.okhttp" />

--- a/bugsnag-plugin-android-okhttp/src/main/java/com/bugsnag/android/okhttp/BugsnagOkHttpPlugin.kt
+++ b/bugsnag-plugin-android-okhttp/src/main/java/com/bugsnag/android/okhttp/BugsnagOkHttpPlugin.kt
@@ -1,0 +1,17 @@
+package com.bugsnag.android.okhttp
+
+import com.bugsnag.android.Client
+import com.bugsnag.android.Plugin
+import okhttp3.EventListener
+
+class BugsnagOkHttpPlugin : Plugin, EventListener() {
+
+    override fun load(client: Client) {
+        TODO("Not yet implemented")
+    }
+
+    override fun unload() {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/docs/NEW_MODULE_CHECKLIST.md
+++ b/docs/NEW_MODULE_CHECKLIST.md
@@ -1,0 +1,10 @@
+# New Module Checklist
+
+A checklist of sanity checks for creating new modules in the repository.
+
+1. Apply the `BugsnagBuildPlugin` to the new module and set plugin extension properties as necessary
+2. Add a `README.md` describing the module
+3. Ensure the module has consumer ProGuard rules (if necessary)
+4. Confirm that the package name is correct and that a POM/AAR is generated correctly
+5. Update the [Project Structure](PROJECT_STRUCTURE.md) docs
+6. Claim the module on Google Play SDK Console

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -9,6 +9,7 @@ The project consists of [6 Gradle modules](https://gradle.org/), which are linke
 - [bugsnag-android-core](../bugsnag-android-core/README.md) - contains the core functionality required to capture and deliver JVM errors to Bugsnag.
 - [bugsnag-plugin-android-ndk](../bugsnag-plugin-android-ndk/README.md) - contains optional functionality that installs signal handlers and captures NDK errors.
 - [bugsnag-plugin-android-anr](../bugsnag-plugin-android-ndk/README.md) - contains optional functionality that installs a signal handler to capture ANR errors.
+- [bugsnag-plugin-android-okhttp](../bugsnag-plugin-android-okhttp/README.md) - contains optional functionality that captures breadcrumbs for OkHttp requests.
 - [bugsnag-plugin-react-native](../bugsnag-plugin-react-native/README.md) - contains optional functionality that serializes information into a format that can be understood by the React Native bridge.
 - [bugsnag-android](../bugsnag-android/README.md) - an anchor package which allows users to pull in all the required modules.
 - [bugsnag-android-ndk](../bugsnag-android-ndk/README.md) - an anchor package which allows users to pull in all the required modules. Published for legacy reasons.

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,5 +16,6 @@ include(
     ":bugsnag-plugin-android-anr",
     ":bugsnag-plugin-android-ndk",
     ":bugsnag-plugin-react-native",
+    ":bugsnag-plugin-android-okhttp",
     ":bugsnag-benchmarks"
 )


### PR DESCRIPTION
## Goal

Adds a new module named `bugsnag-plugin-android-okhttp` which will capture breadcrumbs for requests made by OkHttp. This does not add any functionality as of yet and just adds boilerplate/internal documentation.