### PR TITLE
Setup OkHttp MockWebServer unit tests

### DIFF
--- a/bugsnag-plugin-android-okhttp/build.gradle
+++ b/bugsnag-plugin-android-okhttp/build.gradle
@@ -11,5 +11,6 @@ dependencies {
 apply from: "../gradle/kotlin.gradle"
 
 dependencies {
-    compileOnly("com.squareup.okhttp3:okhttp:4.9.0")
+    compileOnly("com.squareup.okhttp3:okhttp:4.9.1")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
 }

--- a/bugsnag-plugin-android-okhttp/lint-baseline.xml
+++ b/bugsnag-plugin-android-okhttp/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.0.2" type="baseline" client="gradle" name="AGP (7.0.2)" variant="all" version="7.0.2">
+
+</issues>

--- a/bugsnag-plugin-android-okhttp/src/main/java/com/bugsnag/android/okhttp/BugsnagOkHttpPlugin.kt
+++ b/bugsnag-plugin-android-okhttp/src/main/java/com/bugsnag/android/okhttp/BugsnagOkHttpPlugin.kt
@@ -7,11 +7,8 @@ import okhttp3.EventListener
 class BugsnagOkHttpPlugin : Plugin, EventListener() {
 
     override fun load(client: Client) {
-        TODO("Not yet implemented")
     }
 
     override fun unload() {
-        TODO("Not yet implemented")
     }
-
 }

--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/okhttp/BasicNetworkBreadcrumbTest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/okhttp/BasicNetworkBreadcrumbTest.kt
@@ -1,0 +1,29 @@
+package com.bugsnag.android.okhttp
+
+import com.bugsnag.android.Client
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class BasicNetworkBreadcrumbTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Test
+    fun testBreadcrumbCaptured() {
+        // prepare the request + response
+        val request = Request.Builder()
+        val mockResponse = MockResponse().setBody("hello, world!")
+
+        // make the request and verify what was sent
+        makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        // TODO verify the breadcrumb once implementation complete
+        // verify(client, times(1)).leaveBreadcrumb(anyString(), anyMap(), any())
+    }
+}

--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/okhttp/NetworkBreadcrumbRequest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/okhttp/NetworkBreadcrumbRequest.kt
@@ -1,0 +1,39 @@
+package com.bugsnag.android.okhttp
+
+import com.bugsnag.android.Client
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.mockito.Mockito
+
+/**
+ * Makes a HTTP request to a MockWebServer that returns a mocked response. A
+ * BugsnagOkHttpPlugin is loaded which means that any completed network request should
+ * correspond to a breadcrumb being left on the Client.
+ */
+internal fun makeNetworkBreadcrumbRequest(
+    client: Client,
+    request: Request.Builder,
+    response: MockResponse,
+    path: String = "/test"
+) {
+    val server = MockWebServer().apply {
+        enqueue(response)
+        start()
+    }
+    val baseUrl = server.url(path)
+    val plugin = BugsnagOkHttpPlugin().apply {
+        load(client)
+    }
+    val okHttpClient = OkHttpClient.Builder()
+        .eventListener(plugin)
+        .build()
+
+    // assert that leaveBreadcrumb has not been called
+    Mockito.verify(client, Mockito.times(0))
+        .leaveBreadcrumb(Mockito.anyString(), Mockito.anyMap(), Mockito.any())
+
+    okHttpClient.newCall(request.url(baseUrl).build()).execute()
+    server.shutdown()
+}


### PR DESCRIPTION
## Goal

Creates a unit test that uses [MockWebServer](https://github.com/square/okhttp/tree/master/mockwebserver) to simulate network requests. This will be used to test the implementation of network breadcrumbs by confirming that `leaveBreadcrumb` is called on the `Client`.