### PR TITLE
Add simple integration tests for network breadcrumbs

### DIFF
--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/GetRequestIntegrationTest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/GetRequestIntegrationTest.kt
@@ -1,0 +1,171 @@
+package com.bugsnag.android
+
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class GetRequestIntegrationTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Captor
+    lateinit var mapCaptor: ArgumentCaptor<Map<String, Any>>
+
+    @Before
+    fun setup() {
+        Mockito.`when`(client.config).thenReturn(BugsnagTestUtils.generateImmutableConfig())
+    }
+
+    /**
+     * Performs a simple GET request with a 200 response.
+     */
+    @Test
+    fun getRequest200() {
+        val request = Request.Builder()
+        val mockResponse = MockResponse().setBody("hello, world!")
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(200, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+
+    /**
+     * Performs a GET request to a non-existent resource (404), that includes some URL params.
+     */
+    @Test
+    fun getRequest404() {
+        val request = Request.Builder()
+        val mockResponse = MockResponse().setResponseCode(404).setBody("Resource not found")
+        val path = "/a/9?lang=en&darkMode=true&count=5&password=apple123"
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse, path)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call failed"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(404, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(
+                mapOf(
+                    "lang" to "en",
+                    "darkMode" to "true",
+                    "count" to "5",
+                    "password" to "[REDACTED]"
+                ),
+                get("urlParams")
+            )
+            assertEquals(url.substringBefore("?"), get("url"))
+        }
+    }
+
+    /**
+     * Performs a GET request that triggers an internal server error.
+     */
+    @Test
+    fun getRequest500() {
+        val request = Request.Builder()
+        val mockResponse = MockResponse().setBody("Internal server error.").setResponseCode(500)
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call failed"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(500, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+
+    /**
+     * Verifies a long endpoint + URL params are not truncated
+     */
+    @Test
+    fun longEndpointNotTruncated() {
+        val request = Request.Builder()
+        val mockResponse = MockResponse()
+        val path = "/test/endpoints/fifty-nine/spaghetti/custom_resource/foo/123409/amp/shoot/" +
+            "the-biggest-bar.aspx?lang=en&highlighted=Hello%20World" +
+            "&something_very_very_very_very_very_long=something_very_very_very_very_very_big"
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse, path)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals(url.substringBefore("?"), get("url"))
+            assertEquals(
+                mapOf(
+                    "lang" to "en",
+                    "highlighted" to "Hello World",
+                    "something_very_very_very_very_very_long" to "something_very_very_very_very_very_big"
+                ),
+                get("urlParams")
+            )
+        }
+    }
+
+    /**
+     * Performs a simple HEAD request with a 429 response.
+     */
+    @Test
+    fun headRequest429() {
+        val request = Request.Builder().head()
+        val mockResponse = MockResponse().setResponseCode(429).setBody("Chill out!")
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call failed"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("HEAD", get("method"))
+            assertEquals(429, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+}

--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/PostRequestIntegrationTest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/PostRequestIntegrationTest.kt
@@ -1,0 +1,258 @@
+package com.bugsnag.android
+
+import okhttp3.FormBody
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.mockwebserver.MockResponse
+import okio.Buffer
+import okio.BufferedSink
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+import java.nio.charset.Charset
+
+/**
+ * Performs POST/PATCH/PUT/DELETE requests with bodies to verify network breadcrumbs are
+ * captured.
+ */
+@RunWith(MockitoJUnitRunner::class)
+class PostRequestIntegrationTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Captor
+    lateinit var mapCaptor: ArgumentCaptor<Map<String, Any>>
+
+    @Before
+    fun setup() {
+        Mockito.`when`(client.config).thenReturn(BugsnagTestUtils.generateImmutableConfig())
+    }
+
+    /**
+     * Sends a string in a POST request with a 200 response.
+     */
+    @Test
+    fun postRequest200() {
+        val body = """
+          /\_/\
+         ( o.o )
+          > ^ <"""
+
+        val mediaType = "text/plain; charset=utf-8".toMediaType()
+        val request = Request.Builder().post(body.toRequestBody(mediaType))
+        val mockResponse = MockResponse().setResponseCode(201).setBody("Meow")
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("POST", get("method"))
+            assertEquals(201, get("status"))
+            assertEquals(49L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+
+    /**
+     * Sends a form URL-encoded POST request with a 503 response.
+     */
+    @Test
+    fun formUrlPostRequest503() {
+        val body = FormBody.Builder()
+            .add("fruit", "apple")
+            .build()
+        val request = Request.Builder().post(body)
+        val mockResponse = MockResponse().setResponseCode(503).setBody("Service unavailable")
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call failed"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("POST", get("method"))
+            assertEquals(503, get("status"))
+            assertEquals(11L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+
+    /**
+     * Sends a POST request with a 200 response where the body is streamed.
+     */
+    @Test
+    fun postStreamedRequest200() {
+        val mediaType = "text/plain; charset=utf-8".toMediaType()
+        val body = object : RequestBody() {
+            override fun contentType() = mediaType
+
+            override fun writeTo(sink: BufferedSink) {
+                repeat(1000) {
+                    sink.writeUtf8("Number: $it\n")
+                }
+            }
+        }
+
+        val request = Request.Builder().post(body)
+        val buffer: Buffer = Buffer().writeString("OK", Charset.defaultCharset())
+        val mockResponse = MockResponse().setResponseCode(200).setBody(buffer)
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("POST", get("method"))
+            assertEquals(200, get("status"))
+            assertEquals(11890L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+
+    /**
+     * Sends a multipart POST request with a 202 response.
+     */
+    @Test
+    fun postMultipartRequest200() {
+        val body = MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("title", "Hello World")
+            .addFormDataPart("message", "Another bit with more detail")
+            .build()
+
+        val request = Request.Builder().post(body)
+        val mockResponse = MockResponse().setResponseCode(202)
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("POST", get("method"))
+            assertEquals(202, get("status"))
+            assertEquals(303L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+
+    /**
+     * Performs a PUT request that returns 200.
+     */
+    @Test
+    fun putRequest202() {
+        val body = """
+          /\_/\
+         ( o.o )
+          > ^ <"""
+
+        val mediaType = "text/plain; charset=utf-8".toMediaType()
+        val request = Request.Builder().put(body.toRequestBody(mediaType))
+        val mockResponse = MockResponse().setResponseCode(202).setBody("Putted")
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("PUT", get("method"))
+            assertEquals(202, get("status"))
+            assertEquals(49L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+
+    /**
+     * Performs a PATCH request that returns 200.
+     */
+    @Test
+    fun patchRequest202() {
+        val body = """
+          /\_/\
+         ( o.o )
+          > ^ <"""
+
+        val mediaType = "text/plain; charset=utf-8".toMediaType()
+        val request = Request.Builder().patch(body.toRequestBody(mediaType))
+        val mockResponse = MockResponse().setResponseCode(202).setBody("Patched")
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("PATCH", get("method"))
+            assertEquals(202, get("status"))
+            assertEquals(49L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+
+    /**
+     * Performs a DELETE request that returns 200.
+     */
+    @Test
+    fun deleteRequest200() {
+        val request = Request.Builder().delete()
+        val mockResponse = MockResponse().setResponseCode(200).setBody("Deleted")
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse)
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("DELETE", get("method"))
+            assertEquals(200, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Adds some integration tests to cover common scenarios for GET requests, and POST/PUT/PATCH/DELETE requests.