### PR TITLE
Add additional integration tests for network breadcrumbs

### DIFF
--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/CachedRequestIntegrationTest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/CachedRequestIntegrationTest.kt
@@ -1,0 +1,136 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.okhttp.BugsnagOkHttpPlugin
+import okhttp3.Cache
+import okhttp3.CacheControl
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+import java.nio.file.Files
+
+@RunWith(MockitoJUnitRunner::class)
+class CachedRequestIntegrationTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Captor
+    lateinit var mapCaptor: ArgumentCaptor<Map<String, Any>>
+
+    @Before
+    fun setup() {
+        Mockito.`when`(client.config).thenReturn(BugsnagTestUtils.generateImmutableConfig())
+    }
+
+    /**
+     * Performs a GET request that is served from the local cache
+     */
+    @Test
+    fun cachedGetRequest200() {
+        val body = "Hello, world!"
+        val response = MockResponse()
+            .setBody(body)
+            .addHeader("Cache-Control", "public")
+            .addHeader("Cache-Control", "max-age=3600")
+        val server = MockWebServer().apply {
+            enqueue(response)
+            start()
+        }
+        val url = server.url("/test")
+        val request = Request.Builder()
+            .url(url)
+            .addHeader("Cache-Control", "max-stale=86400")
+            .build()
+        val plugin = BugsnagOkHttpPlugin().apply { load(client) }
+
+        // create a client with a cache
+        val cache = Cache(Files.createTempDirectory("cache").toFile(), 1024 * 1024)
+        val okHttpClient = OkHttpClient.Builder()
+            .eventListener(plugin)
+            .cache(cache)
+            .build()
+
+        // make first request which hits network
+        verifyFirstRequest(okHttpClient, request, url)
+
+        // make second request which hits cache
+        verifySecondRequest(okHttpClient, request, url)
+        server.shutdown()
+    }
+
+    private fun verifyFirstRequest(
+        okHttpClient: OkHttpClient,
+        request: Request,
+        url: HttpUrl
+    ) {
+        val call = okHttpClient.newCall(request)
+        call.execute().use { response ->
+            assertEquals(200, response.code)
+            assertNull(response.cacheResponse)
+            assertNotNull(response.networkResponse)
+        }
+
+        // verify breadcrumb received for first request
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(200, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(13L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url.toString(), get("url"))
+        }
+    }
+
+    private fun verifySecondRequest(
+        okHttpClient: OkHttpClient,
+        request: Request,
+        url: HttpUrl
+    ) {
+        val forceCacheRequest = request.newBuilder().cacheControl(CacheControl.FORCE_CACHE).build()
+        val call = okHttpClient.newCall(forceCacheRequest)
+        call.execute().use { response ->
+            assertEquals(200, response.code)
+            assertNotNull(response.cacheResponse)
+            assertNull(response.networkResponse)
+        }
+
+        // verify breadcrumb received for first request
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(200, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(13L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url.toString(), get("url"))
+        }
+    }
+}

--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/ComplexRequestIntegrationTest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/ComplexRequestIntegrationTest.kt
@@ -1,0 +1,209 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.okhttp.BugsnagOkHttpPlugin
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyMap
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@RunWith(MockitoJUnitRunner::class)
+class ComplexRequestIntegrationTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Captor
+    lateinit var mapCaptor: ArgumentCaptor<Map<String, Any>>
+
+    @Before
+    fun setup() {
+        Mockito.`when`(client.config).thenReturn(BugsnagTestUtils.generateImmutableConfig())
+    }
+
+    /**
+     * Performs a GET request which receives a throttled response exceeding the Call's
+     * timeout duration
+     */
+    @Test
+    fun getRequestCallTimeOut() {
+        val request = Request.Builder()
+        val mockResponse = MockResponse().setBody("This request will fail")
+
+        // simulate Steve's network connection
+        mockResponse.setHeadersDelay(1, TimeUnit.SECONDS)
+        val url = makeNetworkBreadcrumbRequest(client, request, mockResponse) {
+            it.callTimeout(250, TimeUnit.MILLISECONDS)
+        }
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call error"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(0L, get("requestContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+            assertNull(get("status"))
+            assertNull(get("responseContentLength"))
+        }
+    }
+
+    /**
+     * Performs a GET request that times out due to the server not sending any response
+     */
+    @Test
+    fun socketTimeout() {
+        val request = Request.Builder()
+        val url = makeNetworkBreadcrumbRequest(client, request) {
+            it.callTimeout(250, TimeUnit.MILLISECONDS)
+        }
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call error"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(0L, get("requestContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url, get("url"))
+            assertNull(get("status"))
+            assertNull(get("responseContentLength"))
+        }
+    }
+
+    /**
+     * Performs a GET request but manually cancel it before it can complete
+     */
+    @Test
+    fun cancelledRequest() {
+        val server = MockWebServer().apply { start() }
+        val url = server.url("/test")
+        val request = Request.Builder().url(url).build()
+        val plugin = BugsnagOkHttpPlugin().apply { load(client) }
+
+        // make a request but then cancel it on another thread before completion
+        val okHttpClient = OkHttpClient.Builder().eventListener(plugin).build()
+        val call = okHttpClient.newCall(request)
+
+        Executors.newSingleThreadScheduledExecutor().schedule(
+            {
+                call.cancel()
+            },
+            20, TimeUnit.MILLISECONDS
+        )
+
+        runCatching {
+            call.execute().close()
+        }
+        server.shutdown()
+
+        // verify breadcrumb received
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call error"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(0L, get("requestContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url.toString(), get("url"))
+            assertNull(get("status"))
+            assertNull(get("responseContentLength"))
+        }
+    }
+
+    /**
+     * Performs a GET request that does not close an empty response body. This is captured
+     * as a breadcrumb regardless.
+     */
+    @Test
+    fun getRequestUnclosedBodyEmptyBody() {
+        val server = MockWebServer().apply {
+            enqueue(MockResponse())
+            start()
+        }
+        val url = server.url("/test")
+        val request = Request.Builder().url(url).build()
+        val plugin = BugsnagOkHttpPlugin().apply { load(client) }
+
+        // make a request but forget to close the body
+        val okHttpClient = OkHttpClient.Builder().eventListener(plugin).build()
+        val call = okHttpClient.newCall(request)
+        val body = checkNotNull(call.execute().body)
+        body.charStream()
+        server.shutdown()
+
+        // verify breadcrumb received
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(200, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(url.toString(), get("url"))
+        }
+    }
+
+    /**
+     * Performs a GET request that does not close the response body. This is a resource leak
+     * and no breadcrumb will be captured. See
+     * https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/#the-response-body-must-be-closed
+     */
+    @Test
+    fun getRequestUnclosedBody() {
+        val server = MockWebServer().apply {
+            enqueue(MockResponse().setBody("Plz close me"))
+            start()
+        }
+        val url = server.url("/test")
+        val request = Request.Builder().url(url).build()
+        val plugin = BugsnagOkHttpPlugin().apply { load(client) }
+
+        // make a request but forget to close the body
+        val okHttpClient = OkHttpClient.Builder().eventListener(plugin).build()
+        val call = okHttpClient.newCall(request)
+        val body = checkNotNull(call.execute().body)
+        body.charStream()
+        server.shutdown()
+
+        // verify breadcrumb received
+        verify(client, times(0)).leaveBreadcrumb(
+            anyString(),
+            anyMap(),
+            any()
+        )
+    }
+}

--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/RedirectedRequestIntegrationTest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/RedirectedRequestIntegrationTest.kt
@@ -1,0 +1,75 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.okhttp.BugsnagOkHttpPlugin
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class RedirectedRequestIntegrationTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Captor
+    lateinit var mapCaptor: ArgumentCaptor<Map<String, Any>>
+
+    @Before
+    fun setup() {
+        Mockito.`when`(client.config).thenReturn(BugsnagTestUtils.generateImmutableConfig())
+    }
+
+    /**
+     * Performs a GET request that follows a redirect. A breadcrumb is collected for the last call
+     * in the OkHttp chain.
+     */
+    @Test
+    fun getRequestRedirectSuccess() {
+        // create a redirect and then the actual response
+        val server = MockWebServer().apply {
+            enqueue(
+                MockResponse()
+                    .setResponseCode(301)
+                    .addHeader("Location", url("/foo"))
+            )
+            enqueue(MockResponse().setBody("hello, world!"))
+        }
+        val baseUrl = server.url("/test")
+        val plugin = BugsnagOkHttpPlugin().apply { load(client) }
+        val okHttpClient = OkHttpClient.Builder().eventListener(plugin).build()
+
+        val req = Request.Builder().url(baseUrl).build()
+        val execute = okHttpClient.newCall(req).execute()
+        execute.close()
+        server.shutdown()
+
+        verify(client, times(1)).leaveBreadcrumb(
+            eq("OkHttp call succeeded"),
+            mapCaptor.capture(),
+            eq(BreadcrumbType.REQUEST)
+        )
+        with(mapCaptor.value) {
+            assertEquals("GET", get("method"))
+            assertEquals(200, get("status"))
+            assertEquals(0L, get("requestContentLength"))
+            assertEquals(0L, get("responseContentLength"))
+            assertTrue(get("duration") is Long)
+            assertEquals(emptyMap<String, Any>(), get("urlParams"))
+            assertEquals(server.url("/test").toString(), get("url"))
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Adds some additional integration tests for network breadcrumbs, which cover the following scenarios:

- A request served from a local cache
- Requests that timeout
- A request that is cancelled
- Requests whose body is not closed, which is recommended against in the OkHttp documentation as it leaks resources and prevents the request from finishing
- A redirected request
