### PR TITLE
Increased default breadcrumb collection limit to 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Update project to build using Gradle/AGP 7
   [#1354](https://github.com/bugsnag/bugsnag-android/pull/1354)
 
+* Increased default breadcrumb collection limit to 50
+  [#1366](https://github.com/bugsnag/bugsnag-android/pull/1366)
+
 ## 5.12.0 (2021-08-26)
 
 * The `app.lowMemory` value always report the most recent `onTrimMemory`/`onLowMemory` status

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -45,7 +45,7 @@ class ManifestConfigLoaderTest {
             assertEquals(setOf("password"), redactedKeys)
 
             // misc
-            assertEquals(maxBreadcrumbs, 25)
+            assertEquals(maxBreadcrumbs, 50)
             assertEquals(maxPersistedEvents, 32)
             assertEquals(maxPersistedSessions, 128)
             assertTrue(sendLaunchCrashesSynchronously)
@@ -83,7 +83,7 @@ class ManifestConfigLoaderTest {
             putString("com.bugsnag.android.REDACTED_KEYS", "password,auth,foo")
 
             // misc
-            putInt("com.bugsnag.android.MAX_BREADCRUMBS", 50)
+            putInt("com.bugsnag.android.MAX_BREADCRUMBS", 75)
             putInt("com.bugsnag.android.MAX_PERSISTED_EVENTS", 52)
             putInt("com.bugsnag.android.MAX_PERSISTED_SESSIONS", 64)
             putInt("com.bugsnag.android.LAUNCH_DURATION_MILLIS", 7000)
@@ -117,7 +117,7 @@ class ManifestConfigLoaderTest {
             assertEquals(setOf("password", "auth", "foo"), redactedKeys)
 
             // misc
-            assertEquals(maxBreadcrumbs, 50)
+            assertEquals(maxBreadcrumbs, 75)
             assertEquals(maxPersistedEvents, 52)
             assertEquals(maxPersistedSessions, 64)
             @Suppress("DEPRECATION")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -79,7 +79,7 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     }
 
     companion object {
-        private const val DEFAULT_MAX_BREADCRUMBS = 25
+        private const val DEFAULT_MAX_BREADCRUMBS = 50
         private const val DEFAULT_MAX_PERSISTED_SESSIONS = 128
         private const val DEFAULT_MAX_PERSISTED_EVENTS = 32
         private const val DEFAULT_LAUNCH_CRASH_THRESHOLD_MS: Long = 5000

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -513,7 +513,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
      * Sets the maximum number of breadcrumbs which will be stored. Once the threshold is reached,
      * the oldest breadcrumbs will be deleted.
      *
-     * By default, 25 breadcrumbs are stored: this can be amended up to a maximum of 100.
+     * By default, 50 breadcrumbs are stored: this can be amended up to a maximum of 100.
      */
     public int getMaxBreadcrumbs() {
         return impl.getMaxBreadcrumbs();
@@ -523,7 +523,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
      * Sets the maximum number of breadcrumbs which will be stored. Once the threshold is reached,
      * the oldest breadcrumbs will be deleted.
      *
-     * By default, 25 breadcrumbs are stored: this can be amended up to a maximum of 100.
+     * By default, 50 breadcrumbs are stored: this can be amended up to a maximum of 100.
      */
     public void setMaxBreadcrumbs(int maxBreadcrumbs) {
         if (maxBreadcrumbs >= MIN_BREADCRUMBS && maxBreadcrumbs <= MAX_BREADCRUMBS) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BreadcrumbStateTest.kt
@@ -196,16 +196,16 @@ class BreadcrumbStateTest {
     @Test
     fun testMaxBreadcrumbAccessors() {
         val config = generateConfiguration()
+        assertEquals(50, config.maxBreadcrumbs)
+
+        config.maxBreadcrumbs = 25
         assertEquals(25, config.maxBreadcrumbs)
 
-        config.maxBreadcrumbs = 50
-        assertEquals(50, config.maxBreadcrumbs)
-
         config.maxBreadcrumbs = Int.MAX_VALUE
-        assertEquals(50, config.maxBreadcrumbs)
+        assertEquals(25, config.maxBreadcrumbs)
 
         config.maxBreadcrumbs = -5
-        assertEquals(50, config.maxBreadcrumbs)
+        assertEquals(25, config.maxBreadcrumbs)
     }
 
     /**

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -545,9 +545,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
     return;
   }
   bsg_request_env_write_lock();
-  bugsnag_event event = bsg_global_env->next_event;
-  bugsnag_event_set_user(&bsg_global_env->next_event, value, event.user.email,
-                         event.user.name);
+  bugsnag_event *event = &bsg_global_env->next_event;
+  bugsnag_user user = bugsnag_event_get_user(event);
+  bugsnag_event_set_user(event, value, user.email, user.name);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
     bsg_safe_release_string_utf_chars(env, new_value, value);
@@ -564,9 +564,9 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserName(
     return;
   }
   bsg_request_env_write_lock();
-  bugsnag_event event = bsg_global_env->next_event;
-  bugsnag_event_set_user(&bsg_global_env->next_event, event.user.id,
-                         event.user.email, value);
+  bugsnag_event *event = &bsg_global_env->next_event;
+  bugsnag_user user = bugsnag_event_get_user(event);
+  bugsnag_event_set_user(event, user.id, user.email, value);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
     bsg_safe_release_string_utf_chars(env, new_value, value);
@@ -585,9 +585,9 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateUserEmail(JNIEnv *env,
     return;
   }
   bsg_request_env_write_lock();
-  bugsnag_event event = bsg_global_env->next_event;
-  bugsnag_event_set_user(&bsg_global_env->next_event, event.user.id, value,
-                         event.user.name);
+  bugsnag_event *event = &bsg_global_env->next_event;
+  bugsnag_user user = bugsnag_event_get_user(event);
+  bugsnag_event_set_user(event, user.id, value, user.name);
   bsg_release_env_write_lock();
   if (new_value != NULL) {
     bsg_safe_release_string_utf_chars(env, new_value, value);

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -16,7 +16,7 @@
 /**
  *  Max number of breadcrumbs in an event. Configures a default if not defined.
  */
-#define BUGSNAG_CRUMBS_MAX 25
+#define BUGSNAG_CRUMBS_MAX 50
 #endif
 #ifndef BUGSNAG_DEFAULT_EX_TYPE
 /**
@@ -27,7 +27,7 @@
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
-#define BUGSNAG_EVENT_VERSION 5
+#define BUGSNAG_EVENT_VERSION 6
 
 #ifdef __cplusplus
 extern "C" {

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -7,6 +7,10 @@
 #define V1_BUGSNAG_CRUMBS_MAX 30
 #endif
 
+#ifndef V2_BUGSNAG_CRUMBS_MAX
+#define V2_BUGSNAG_CRUMBS_MAX 25
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -184,7 +188,7 @@ typedef struct {
   // Breadcrumbs are a ring; the first index moves as the
   // structure is filled and replaced.
   int crumb_first_index;
-  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+  bugsnag_breadcrumb breadcrumbs[V2_BUGSNAG_CRUMBS_MAX];
 
   char context[64];
   bugsnag_severity severity;
@@ -209,7 +213,7 @@ typedef struct {
   // Breadcrumbs are a ring; the first index moves as the
   // structure is filled and replaced.
   int crumb_first_index;
-  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+  bugsnag_breadcrumb breadcrumbs[V2_BUGSNAG_CRUMBS_MAX];
 
   char context[64];
   bugsnag_severity severity;
@@ -222,6 +226,32 @@ typedef struct {
   bool unhandled;
   char api_key[64];
 } bugsnag_report_v4;
+
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[V2_BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
+} bugsnag_report_v5;
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_breadcrumbs.c
@@ -52,19 +52,19 @@ TEST test_add_breadcrumbs_over_max(void) {
     free(format);
   }
 
-  // assertions assume that the crumb count is always 25
+  // assertions assume that the crumb count is always 50
   ASSERT_EQ(BUGSNAG_CRUMBS_MAX, event->crumb_count);
   ASSERT_EQ(14, event->crumb_first_index);
 
-  ASSERT(strcmp("crumb: 50", event->breadcrumbs[0].name) == 0);
-  ASSERT(strcmp("crumb: 51", event->breadcrumbs[1].name) == 0);
-  ASSERT(strcmp("crumb: 52", event->breadcrumbs[2].name) == 0);
-  ASSERT(strcmp("crumb: 53", event->breadcrumbs[3].name) == 0);
+  ASSERT_STR_EQ("crumb: 50", event->breadcrumbs[0].name);
+  ASSERT_STR_EQ("crumb: 51", event->breadcrumbs[1].name);
+  ASSERT_STR_EQ("crumb: 52", event->breadcrumbs[2].name);
+  ASSERT_STR_EQ("crumb: 53", event->breadcrumbs[3].name);
 
-  ASSERT(strcmp("crumb: 63", event->breadcrumbs[13].name) == 0);
-  ASSERT(strcmp("crumb: 39", event->breadcrumbs[14].name) == 0);
-  ASSERT(strcmp("crumb: 40", event->breadcrumbs[15].name) == 0);
-  ASSERT(strcmp("crumb: 41", event->breadcrumbs[16].name) == 0);
+  ASSERT_STR_EQ("crumb: 63", event->breadcrumbs[13].name);
+  ASSERT_STR_EQ("crumb: 14", event->breadcrumbs[14].name);
+  ASSERT_STR_EQ("crumb: 15", event->breadcrumbs[15].name);
+  ASSERT_STR_EQ("crumb: 16", event->breadcrumbs[16].name);
   free(event);
   PASS();
 }
@@ -74,8 +74,8 @@ TEST test_bsg_calculate_total_crumbs(void) {
   ASSERT_EQ(5, bsg_calculate_total_crumbs(5));
   ASSERT_EQ(22, bsg_calculate_total_crumbs(22));
   ASSERT_EQ(25, bsg_calculate_total_crumbs(25));
-  ASSERT_EQ(25, bsg_calculate_total_crumbs(26));
-  ASSERT_EQ(25, bsg_calculate_total_crumbs(30));
+  ASSERT_EQ(50, bsg_calculate_total_crumbs(51));
+  ASSERT_EQ(50, bsg_calculate_total_crumbs(55));
   PASS();
 }
 


### PR DESCRIPTION
## Goal

Increases the default number of breadcrumbs collected to 50. This is required now that network breadcrumbs are anticipated to capture several more requests in a typical application, which would lead to increased breadcrumb churn at 25 items.

## Changeset

- Increased JVM and NDK limits to 50
- Added a migration to copy breadcrumbs correctly from the old `bugsnag_event` struct to the new one
- Altered setting of NDK user information, which was broken by increasing the breadcrumb array size in the struct

## Testing

Updated existing test assertions. Added extra test cases for the NDK struct migration, which cover the first index in the ring buffer starting at 0 and non-zero values.