### PR TITLE
Avoid timeout in OkHttp integration test

### DIFF
--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/ComplexRequestIntegrationTest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/ComplexRequestIntegrationTest.kt
@@ -114,7 +114,7 @@ class ComplexRequestIntegrationTest {
             {
                 call.cancel()
             },
-            20, TimeUnit.MILLISECONDS
+            100, TimeUnit.MILLISECONDS
         )
 
         runCatching {


### PR DESCRIPTION
## Goal

Fixes a flake in an OkHttp integration test by increasing the timeout. This resolves the intermittent failure seen here:
https://buildkite.com/bugsnag/bugsnag-android/builds/5297#77625949-ac41-4ba7-a3c3-43b941c456a6