### PR TITLE
Introduce the `bsg_thread` structure in the NDK plugin

### DIFF
--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/ThreadSerializationTest.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/ThreadSerializationTest.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.ndk
+
+import org.junit.Assert
+import org.junit.Test
+
+class ThreadSerializationTest {
+
+    companion object {
+        init {
+            System.loadLibrary("bugsnag-ndk")
+            System.loadLibrary("bugsnag-ndk-test")
+        }
+    }
+
+    external fun run(): String
+
+    @Test
+    fun testPassesNativeSuite() {
+        val expected = loadJson("thread_serialization.json")
+        val json = run()
+        Assert.assertEquals(expected, json)
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/thread_serialization.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/thread_serialization.json
@@ -1,0 +1,1 @@
+[{"id":1234,"name":"Binder 1","state":"R","type":"c"}]

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -24,6 +24,13 @@
  */
 #define BUGSNAG_DEFAULT_EX_TYPE "c"
 #endif
+#ifndef BUGSNAG_THREADS_MAX
+/**
+ * Maximum number of threads recorded for an event. Configures a default if not
+ * defined.
+ */
+#define BUGSNAG_THREADS_MAX 255
+#endif
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
@@ -179,6 +186,12 @@ typedef struct {
 } bsg_notifier;
 
 typedef struct {
+  pid_t id;
+  char name[16];
+  char state;
+} bsg_thread;
+
+typedef struct {
   bsg_notifier notifier;
   bsg_app_info app;
   bsg_device_info device;
@@ -202,6 +215,9 @@ typedef struct {
   char grouping_hash[64];
   bool unhandled;
   char api_key[64];
+
+  int thread_count;
+  bsg_thread threads[BUGSNAG_THREADS_MAX];
 } bugsnag_event;
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -757,6 +757,27 @@ void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs) {
   }
 }
 
+void bsg_serialize_threads(const bugsnag_event *event, JSON_Array *threads) {
+  if (event->thread_count <= 0) {
+    return;
+  }
+
+  char status_buffer[2];
+  status_buffer[1] = 0; // null terminator
+  for (int index = 0; index < event->thread_count; index++) {
+    JSON_Value *thread_val = json_value_init_object();
+    JSON_Object *json_thread = json_value_get_object(thread_val);
+    json_array_append_value(threads, thread_val);
+
+    const bsg_thread *thread = &event->threads[index];
+    status_buffer[0] = thread->state;
+    json_object_set_number(json_thread, "id", (double)thread->id);
+    json_object_set_string(json_thread, "name", thread->name);
+    json_object_set_string(json_thread, "state", status_buffer);
+    json_object_set_string(json_thread, "type", "c");
+  }
+}
+
 char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   JSON_Value *event_val = json_value_init_object();
   JSON_Object *event_obj = json_value_get_object(event_val);
@@ -766,10 +787,13 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   JSON_Array *exceptions = json_value_get_array(exceptions_val);
   JSON_Value *ex_val = json_value_init_object();
   JSON_Object *exception = json_value_get_object(ex_val);
+  JSON_Value *threads_val = json_value_init_array();
+  JSON_Array *threads = json_value_get_array(threads_val);
   JSON_Value *stack_val = json_value_init_array();
   JSON_Array *stacktrace = json_value_get_array(stack_val);
   json_object_set_value(event_obj, "exceptions", exceptions_val);
   json_object_set_value(event_obj, "breadcrumbs", crumbs_val);
+  json_object_set_value(event_obj, "threads", threads_val);
   json_object_set_value(exception, "stacktrace", stack_val);
   json_array_append_value(exceptions, ex_val);
   char *serialized_string = NULL;
@@ -786,6 +810,7 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
     bsg_serialize_session(event, event_obj);
     bsg_serialize_error(event->error, exception, stacktrace);
     bsg_serialize_breadcrumbs(event, crumbs);
+    bsg_serialize_threads(event, threads);
 
     serialized_string = json_serialize_to_string(event_val);
     json_value_free(event_val);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -43,6 +43,7 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
 void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
                          JSON_Array *stacktrace);
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
+void bsg_serialize_threads(const bugsnag_event *event, JSON_Array *threads);
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 
 int bsg_calculate_total_crumbs(int old_count);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -222,3 +222,14 @@ JNIEXPORT jstring JNICALL Java_com_bugsnag_android_ndk_ExceptionSerializationTes
     return (*env)->NewStringUTF(env, string);
 
 }
+
+JNIEXPORT jstring JNICALL
+Java_com_bugsnag_android_ndk_ThreadSerializationTest_run(JNIEnv *env, jobject thiz) {
+    bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+    loadThreadTestCase(event);
+    JSON_Value *threads_val = json_value_init_array();
+    JSON_Array *threads_array = json_value_get_array(threads_val);
+    bsg_serialize_threads(event, threads_array);
+    char *string = json_serialize_to_string(threads_val);
+    return (*env)->NewStringUTF(env, string);
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -177,6 +177,14 @@ bugsnag_stackframe *loadStackframeTestCase() {
     return data;
 }
 
+void loadThreadTestCase(bugsnag_event *event) {
+    event->thread_count = 1;
+    bsg_thread *thread = &event->threads[0];
+    strcpy(thread->name, "Binder 1");
+    thread->state = 'R';
+    thread->id = 1234;
+}
+
 void loadExceptionTestCase(bugsnag_event *event) {
     bsg_error *data = &event->error;
     strcpy(data->errorClass, "signal");

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
@@ -21,5 +21,6 @@ void loadContextTestCase(bugsnag_event *event);
 void loadSessionTestCase(bugsnag_event *event);
 void loadSeverityReasonTestCase(bugsnag_event *event);
 void loadBreadcrumbsTestCase(bugsnag_event *event);
+void loadThreadTestCase(bugsnag_event *event);
 bugsnag_stackframe *loadStackframeTestCase();
 void loadExceptionTestCase(bugsnag_event *event);


### PR DESCRIPTION
## Goal
Create and integrate a new structure to carry the NDK thread state information that we will report, not including the required data migration (which is in a separate task). A fixed-size array of `bsg_thread`s are included in `bugsnag_event` and are serialized into our standard JSON payload.

## Testing
A new unit test was added to test that the new model serializes to JSON correctly.