### PR TITLE
Capture and report `Thread.state` for Android Runtime threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Capture and report Thread.state for Android Runtime threads
+  [#1367](https://github.com/bugsnag/bugsnag-android/pull/1367)
+
 ## 5.13.0 (2021-09-22)
 
 * Capture breadcrumbs for OkHttp network requests

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -20,7 +20,9 @@
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$429</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>
     <ID>MagicNumber:LastRunInfoStore.kt$LastRunInfoStore$3</ID>
+    <ID>MaxLineLength:EventSerializationTest.kt$EventSerializationTest.Companion$it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, Thread.State.RUNNABLE, stacktrace, NoopLogger))</ID>
     <ID>MaxLineLength:LastRunInfo.kt$LastRunInfo$return "LastRunInfo(consecutiveLaunchCrashes=$consecutiveLaunchCrashes, crashed=$crashed, crashedDuringLaunch=$crashedDuringLaunch)"</ID>
+    <ID>MaxLineLength:ThreadState.kt$ThreadState$Thread(thread.id, thread.name, ThreadType.ANDROID, errorThread, Thread.State.forThread(thread), stacktrace, logger)</ID>
     <ID>ProtectedMemberInFinalClass:ConfigInternal.kt$ConfigInternal$protected val plugins = HashSet&lt;Plugin>()</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun isAnr(event: Event): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun shouldDiscardClass(): Boolean</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -139,13 +139,24 @@ public class Thread implements JsonStream.Streamable {
      * a state could not be captured or mapped.
      */
     public enum State {
-        NEW,
-        BLOCKED,
-        RUNNABLE,
-        TERMINATED,
-        TIMED_WAITING,
-        WAITING,
-        UNKNOWN;
+        NEW("NEW"),
+        BLOCKED("BLOCKED"),
+        RUNNABLE("RUNNABLE"),
+        TERMINATED("TERMINATED"),
+        TIMED_WAITING("TIMED_WAITING"),
+        WAITING("WAITING"),
+        UNKNOWN("UNKNOWN");
+
+        private final String descriptor;
+
+        State(String descriptor) {
+            this.descriptor = descriptor;
+        }
+
+        @NonNull
+        public String getDescriptor() {
+            return descriptor;
+        }
 
         @NonNull
         public static State forThread(@NonNull java.lang.Thread thread) {
@@ -154,24 +165,26 @@ public class Thread implements JsonStream.Streamable {
         }
 
         /**
-         * An exception-safe wrapper for {@link #valueOf(String)} which also handles {@code null}
-         * names. This method is used in-preference to the standard {@code valueOf} as it will
-         * return {@link #UNKNOWN} instead of throwing an exception.
+         * Lookup the {@code State} for a given {@link #getDescriptor() descriptor} code. Unlike
+         * {@link #valueOf(String) valueOf}, this method will return {@link #UNKNOWN} is no
+         * matching {@code State} constant can be found.
          *
-         * @param name the name of the state constant to lookup
-         * @return the named {@link State} or {@link #UNKNOWN}
+         * @param descriptor a consistent descriptor of the state constant to lookup
+         * @return the requested {@link State} or {@link #UNKNOWN}
          */
         @NonNull
-        public static State byName(@Nullable String name) {
-            if (name == null) {
+        public static State byDescriptor(@Nullable String descriptor) {
+            if (descriptor == null) {
                 return UNKNOWN;
             }
 
-            try {
-                return valueOf(name);
-            } catch (IllegalArgumentException iae) {
-                return UNKNOWN;
+            for (State state : values()) {
+                if (state.getDescriptor().equals(descriptor)) {
+                    return state;
+                }
             }
+
+            return UNKNOWN;
         }
 
         @NonNull

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,9 +20,10 @@ public class Thread implements JsonStream.Streamable {
             @NonNull String name,
             @NonNull ThreadType type,
             boolean errorReportingThread,
+            @NonNull Thread.State state,
             @NonNull Stacktrace stacktrace,
             @NonNull Logger logger) {
-        this.impl = new ThreadInternal(id, name, type, errorReportingThread, stacktrace);
+        this.impl = new ThreadInternal(id, name, type, errorReportingThread, state, stacktrace);
         this.logger = logger;
     }
 
@@ -82,6 +84,25 @@ public class Thread implements JsonStream.Streamable {
     }
 
     /**
+     * Sets the state of thread (from {@link java.lang.Thread})
+     */
+    public void setState(@NonNull Thread.State threadState) {
+        if (threadState != null) {
+            impl.setState(threadState);
+        } else {
+            logNull("state");
+        }
+    }
+
+    /**
+     * Gets the state of the thread (from {@link java.lang.Thread})
+     */
+    @NonNull
+    public Thread.State getState() {
+        return impl.getState();
+    }
+
+    /**
      * Gets whether the thread was the thread that caused the event
      */
     public boolean getErrorReportingThread() {
@@ -110,5 +131,67 @@ public class Thread implements JsonStream.Streamable {
     @Override
     public void toStream(@NonNull JsonStream stream) throws IOException {
         impl.toStream(stream);
+    }
+
+    /**
+     * The state of a reported {@link Thread}. These states correspond directly to
+     * {@link java.lang.Thread.State}, except for {@code UNKNOWN} which indicates that
+     * a state could not be captured or mapped.
+     */
+    public enum State {
+        NEW,
+        BLOCKED,
+        RUNNABLE,
+        TERMINATED,
+        TIMED_WAITING,
+        WAITING,
+        UNKNOWN;
+
+        @NonNull
+        public static State forThread(@NonNull java.lang.Thread thread) {
+            java.lang.Thread.State state = thread.getState();
+            return getState(state);
+        }
+
+        /**
+         * An exception-safe wrapper for {@link #valueOf(String)} which also handles {@code null}
+         * names. This method is used in-preference to the standard {@code valueOf} as it will
+         * return {@link #UNKNOWN} instead of throwing an exception.
+         *
+         * @param name the name of the state constant to lookup
+         * @return the named {@link State} or {@link #UNKNOWN}
+         */
+        @NonNull
+        public static State byName(@Nullable String name) {
+            if (name == null) {
+                return UNKNOWN;
+            }
+
+            try {
+                return valueOf(name);
+            } catch (IllegalArgumentException iae) {
+                return UNKNOWN;
+            }
+        }
+
+        @NonNull
+        private static State getState(java.lang.Thread.State state) {
+            switch (state) {
+                case NEW:
+                    return NEW;
+                case BLOCKED:
+                    return BLOCKED;
+                case RUNNABLE:
+                    return RUNNABLE;
+                case TERMINATED:
+                    return TERMINATED;
+                case TIMED_WAITING:
+                    return TIMED_WAITING;
+                case WAITING:
+                    return WAITING;
+                default:
+                    return UNKNOWN;
+            }
+        }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -19,7 +19,7 @@ class ThreadInternal internal constructor(
         writer.name("id").value(id)
         writer.name("name").value(name)
         writer.name("type").value(type.desc)
-        writer.name("state").value(state.name)
+        writer.name("state").value(state.descriptor)
 
         writer.name("stacktrace")
         writer.beginArray()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -7,6 +7,7 @@ class ThreadInternal internal constructor(
     var name: String,
     var type: ThreadType,
     val isErrorReportingThread: Boolean,
+    var state: Thread.State,
     stacktrace: Stacktrace
 ) : JsonStream.Streamable {
 
@@ -18,6 +19,7 @@ class ThreadInternal internal constructor(
         writer.name("id").value(id)
         writer.name("name").value(name)
         writer.name("type").value(type.desc)
+        writer.name("state").value(state.name)
 
         writer.name("stacktrace")
         writer.beginArray()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -67,7 +67,7 @@ internal class ThreadState @Suppress("LongParameterList") @JvmOverloads construc
                 if (trace != null) {
                     val stacktrace = Stacktrace(trace, projectPackages, logger)
                     val errorThread = thread.id == currentThreadId
-                    Thread(thread.id, thread.name, ThreadType.ANDROID, errorThread, stacktrace, logger)
+                    Thread(thread.id, thread.name, ThreadType.ANDROID, errorThread, Thread.State.forThread(thread), stacktrace, logger)
                 } else {
                     null
                 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -40,7 +40,7 @@ internal class EventSerializationTest {
                 createEvent {
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
                     it.threads.clear()
-                    it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, stacktrace, NoopLogger))
+                    it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, Thread.State.RUNNABLE, stacktrace, NoopLogger))
                 },
 
                 // threads included

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -27,7 +27,15 @@ public class ThreadFacadeTest {
         logger = new InterceptingLogger();
         List<Stackframe> frames = Collections.emptyList();
         stacktrace = new Stacktrace(frames);
-        thread = new Thread(1, "thread-2", ThreadType.ANDROID, false, stacktrace, logger);
+        thread = new Thread(
+                1,
+                "thread-2",
+                ThreadType.ANDROID,
+                false,
+                Thread.State.RUNNABLE,
+                stacktrace,
+                logger
+        );
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
@@ -24,6 +24,7 @@ internal class ThreadSerializationTest {
                 "main-one",
                 ThreadType.ANDROID,
                 true,
+                Thread.State.RUNNABLE,
                 Stacktrace(
                     stacktrace,
                     emptySet(),
@@ -43,6 +44,7 @@ internal class ThreadSerializationTest {
                 "main-one",
                 ThreadType.ANDROID,
                 false,
+                Thread.State.RUNNABLE,
                 Stacktrace(
                     stacktrace1,
                     emptySet(),
@@ -76,6 +78,7 @@ internal class ThreadSerializationTest {
                 "main-one",
                 ThreadType.ANDROID,
                 true,
+                Thread.State.RUNNABLE,
                 trace,
                 NoopLogger
             )
@@ -98,6 +101,7 @@ internal class ThreadSerializationTest {
                 "main-one",
                 ThreadType.ANDROID,
                 false,
+                Thread.State.RUNNABLE,
                 trace,
                 NoopLogger
             )

--- a/bugsnag-android-core/src/test/resources/event_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_5.json
@@ -37,6 +37,7 @@
       "id": 5,
       "name": "main",
       "type": "android",
+      "state": "RUNNABLE",
       "stacktrace": [],
       "errorReportingThread": true
     }

--- a/bugsnag-android-core/src/test/resources/thread_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_0.json
@@ -2,6 +2,7 @@
   "id": 24,
   "name": "main-one",
   "type": "android",
+  "state": "RUNNABLE",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-android-core/src/test/resources/thread_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_1.json
@@ -2,6 +2,7 @@
   "id": 24,
   "name": "main-one",
   "type": "android",
+  "state": "RUNNABLE",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-android-core/src/test/resources/thread_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_2.json
@@ -2,6 +2,7 @@
   "id": 24,
   "name": "main-one",
   "type": "android",
+  "state": "RUNNABLE",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-android-core/src/test/resources/thread_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_3.json
@@ -2,6 +2,7 @@
   "id": 24,
   "name": "main-one",
   "type": "android",
+  "state": "RUNNABLE",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -32,6 +32,7 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
                 MapUtils.<String>getOrThrow(map, "name"),
                 ThreadType.valueOf(type.toUpperCase(Locale.US)),
                 errorReportingThread,
+                Thread.State.byName(MapUtils.<String>getOrThrow(map, "state")),
                 new Stacktrace(frames),
                 logger
         );

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -32,7 +32,7 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
                 MapUtils.<String>getOrThrow(map, "name"),
                 ThreadType.valueOf(type.toUpperCase(Locale.US)),
                 errorReportingThread,
-                Thread.State.byName(MapUtils.<String>getOrThrow(map, "state")),
+                Thread.State.byDescriptor(MapUtils.<String>getOrThrow(map, "state")),
                 new Stacktrace(frames),
                 logger
         );

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
@@ -8,6 +8,7 @@ internal class ThreadSerializer : MapSerializer<Thread> {
         map["name"] = thread.name
         map["type"] = thread.type.toString().toLowerCase(Locale.US)
         map["errorReportingThread"] = thread.errorReportingThread
+        map["state"] = thread.state.descriptor
 
         map["stacktrace"] = thread.stacktrace.map {
             val frame = mutableMapOf<String, Any?>()

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -56,6 +56,7 @@ class EventDeserializerTest {
         "id" to 52L,
         "type" to "reactnativejs",
         "name" to "thread-worker-02",
+        "state" to "RUNNABLE",
         "errorReportingThread" to true
     )
 

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadDeserializerTest.kt
@@ -25,6 +25,7 @@ class ThreadDeserializerTest {
         map["id"] = 52L
         map["type"] = "reactnativejs"
         map["name"] = "thread-worker-02"
+        map["state"] = "RUNNABLE"
         map["errorReportingThread"] = true
     }
 

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
@@ -37,7 +37,7 @@ public class ThreadSerializerTest {
         List<Stackframe> frames = Collections.singletonList(stackframe);
         Stacktrace stacktrace = new Stacktrace(frames);
         thread = new Thread(1, "fake-thread", ThreadType.ANDROID,
-                true, stacktrace, NoopLogger.INSTANCE);
+                true, Thread.State.RUNNABLE, stacktrace, NoopLogger.INSTANCE);
     }
 
     @Test


### PR DESCRIPTION
## Goal
Capture and report the [Thread.state](https://developer.android.com/reference/java/lang/Thread.State) of all captured threads to help in diagnosing issues.

This PR is a clone of https://github.com/bugsnag/bugsnag-android/pull/1367

## Design
To separate our implementation from any future platform changes or errors, a new Bugsnag `Thread.State` enum was introduced, reflecting the possible thread-states currently available on Android. The new enum also includes an `UNKNOWN` state which is used in cases where we either cannot capture or map the platform state.

## Testing
Manual testing with the Example app and a debug server. Updated existing unit tests and end-to-end tests to include checks for the new Thread.State field.