### PR TITLE
Support integer values in buildUuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Update project to build using Gradle/AGP 7
   [#1354](https://github.com/bugsnag/bugsnag-android/pull/1354)
 
+* Support integer values in buildUuid
+  [#1375](https://github.com/bugsnag/bugsnag-android/pull/1375)
+
 ## 5.12.0 (2021-08-26)
 
 * The `app.lowMemory` value always report the most recent `onTrimMemory`/`onLowMemory` status

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
@@ -16,7 +16,7 @@ import com.bugsnag.android.EndpointConfiguration
 import com.bugsnag.android.ErrorTypes
 import com.bugsnag.android.EventPayload
 import com.bugsnag.android.Logger
-import com.bugsnag.android.ManifestConfigLoader
+import com.bugsnag.android.ManifestConfigLoader.Companion.BUILD_UUID
 import com.bugsnag.android.NoopLogger
 import com.bugsnag.android.ThreadSendPolicy
 import com.bugsnag.android.errorApiHeaders
@@ -209,7 +209,7 @@ internal fun sanitiseConfiguration(
     }
 
     // populate buildUUID from manifest
-    val buildUuid = appInfo?.metaData?.getString(ManifestConfigLoader.BUILD_UUID)
+    val buildUuid = populateBuildUuid(appInfo)
 
     @Suppress("SENSELESS_COMPARISON")
     if (configuration.delivery == null) {
@@ -222,6 +222,16 @@ internal fun sanitiseConfiguration(
         appInfo,
         lazy { configuration.persistenceDirectory ?: appContext.cacheDir }
     )
+}
+
+private fun populateBuildUuid(appInfo: ApplicationInfo?): String? {
+    val bundle = appInfo?.metaData
+    return when {
+        bundle?.containsKey(BUILD_UUID) == true -> {
+            bundle.getString(BUILD_UUID) ?: bundle.getInt(BUILD_UUID).toString()
+        }
+        else -> null
+    }
 }
 
 internal const val RELEASE_STAGE_DEVELOPMENT = "development"

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.os.Bundle
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.internal.convertToImmutableConfig
 import com.bugsnag.android.internal.sanitiseConfiguration
@@ -18,6 +19,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.anyInt
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
 import java.nio.file.Files
 
@@ -162,7 +166,12 @@ internal class ImmutableConfigTest {
         `when`(context.packageName).thenReturn("com.example.foo")
         val appInfo = ApplicationInfo()
         appInfo.flags = ApplicationInfo.FLAG_DEBUGGABLE
-        `when`(packageManager.getApplicationInfo("com.example.foo", PackageManager.GET_META_DATA)).thenReturn(appInfo)
+        `when`(
+            packageManager.getApplicationInfo(
+                "com.example.foo",
+                PackageManager.GET_META_DATA
+            )
+        ).thenReturn(appInfo)
         `when`(context.packageManager).thenReturn(packageManager)
         val cacheDir = Files.createTempDirectory("foo").toFile()
         `when`(context.cacheDir).thenReturn(cacheDir)
@@ -202,5 +211,59 @@ internal class ImmutableConfigTest {
         assertEquals(55, config.versionCode)
         assertNotNull(config.delivery)
         assertEquals(cacheDir, config.persistenceDirectory.value)
+    }
+
+    @Test
+    fun sanitizeConfigBuildUuidString() {
+        `when`(context.packageName).thenReturn("com.example.foo")
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        // setup build uuid
+        val bundle = mock(Bundle::class.java)
+        `when`(bundle.containsKey("com.bugsnag.android.BUILD_UUID")).thenReturn(true)
+        `when`(bundle.getString("com.bugsnag.android.BUILD_UUID")).thenReturn("6533e9f7-0e98-40fe-84b4-0e4ed6df6866")
+        val appInfo = ApplicationInfo().apply { metaData = bundle }
+        `when`(packageManager.getApplicationInfo(anyString(), anyInt())).thenReturn(appInfo)
+
+        // validate build uuid
+        val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        val config = sanitiseConfiguration(context, seed, connectivity)
+        assertEquals("6533e9f7-0e98-40fe-84b4-0e4ed6df6866", config.buildUuid)
+    }
+
+    @Test
+    fun sanitizeConfigBuildUuidInt() {
+        `when`(context.packageName).thenReturn("com.example.foo")
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        // setup build uuid
+        val bundle = mock(Bundle::class.java)
+        `when`(bundle.containsKey("com.bugsnag.android.BUILD_UUID")).thenReturn(true)
+        `when`(bundle.getString("com.bugsnag.android.BUILD_UUID")).thenReturn(null)
+        `when`(bundle.getInt("com.bugsnag.android.BUILD_UUID")).thenReturn(590265330)
+        val appInfo = ApplicationInfo().apply { metaData = bundle }
+        `when`(packageManager.getApplicationInfo(anyString(), anyInt())).thenReturn(appInfo)
+
+        // validate build uuid
+        val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        val config = sanitiseConfiguration(context, seed, connectivity)
+        assertEquals("590265330", config.buildUuid)
+    }
+
+    @Test
+    fun sanitizeConfigNoBuildUuid() {
+        `when`(context.packageName).thenReturn("com.example.foo")
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        // setup build uuid
+        val bundle = mock(Bundle::class.java)
+        `when`(bundle.containsKey("com.bugsnag.android.BUILD_UUID")).thenReturn(false)
+        val appInfo = ApplicationInfo().apply { metaData = bundle }
+        `when`(packageManager.getApplicationInfo(anyString(), anyInt())).thenReturn(appInfo)
+
+        // validate build uuid
+        val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        val config = sanitiseConfiguration(context, seed, connectivity)
+        assertNull(config.buildUuid)
     }
 }


### PR DESCRIPTION
## Goal

Supports integer values in the buildUuid field rather than assuming the Bundle value will always be a string.

## Testing

Added unit tests and confirmed in the dashboard that an event with an int buildUuid symbolicates.
