### PR TITLE
migrate ndk reports for the new threads property

### DIFF
--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/ThreadSerializationTest.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/ThreadSerializationTest.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.ndk
+
+import org.junit.Assert
+import org.junit.Test
+
+class ThreadSerializationTest {
+
+    companion object {
+        init {
+            System.loadLibrary("bugsnag-ndk")
+            System.loadLibrary("bugsnag-ndk-test")
+        }
+    }
+
+    external fun run(): String
+
+    @Test
+    fun testPassesNativeSuite() {
+        val expected = loadJson("thread_serialization.json")
+        val json = run()
+        Assert.assertEquals(expected, json)
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/thread_serialization.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/thread_serialization.json
@@ -1,0 +1,1 @@
+[{"id":1234,"name":"Binder 1","state":"R","type":"c"}]

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -34,7 +34,7 @@
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
-#define BUGSNAG_EVENT_VERSION 6
+#define BUGSNAG_EVENT_VERSION 7
 
 #ifdef __cplusplus
 extern "C" {

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -24,6 +24,13 @@
  */
 #define BUGSNAG_DEFAULT_EX_TYPE "c"
 #endif
+#ifndef BUGSNAG_THREADS_MAX
+/**
+ * Maximum number of threads recorded for an event. Configures a default if not
+ * defined.
+ */
+#define BUGSNAG_THREADS_MAX 255
+#endif
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
@@ -179,6 +186,12 @@ typedef struct {
 } bsg_notifier;
 
 typedef struct {
+  pid_t id;
+  char name[16];
+  char state;
+} bsg_thread;
+
+typedef struct {
   bsg_notifier notifier;
   bsg_app_info app;
   bsg_device_info device;
@@ -202,6 +215,9 @@ typedef struct {
   char grouping_hash[64];
   bool unhandled;
   char api_key[64];
+
+  int thread_count;
+  bsg_thread threads[BUGSNAG_THREADS_MAX];
 } bugsnag_event;
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -253,6 +253,32 @@ typedef struct {
   char api_key[64];
 } bugsnag_report_v5;
 
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
+} bugsnag_report_v6;
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -43,6 +43,7 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
 void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
                          JSON_Array *stacktrace);
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
+void bsg_serialize_threads(const bugsnag_event *event, JSON_Array *threads);
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 
 int bsg_calculate_total_crumbs(int old_count);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -222,3 +222,14 @@ JNIEXPORT jstring JNICALL Java_com_bugsnag_android_ndk_ExceptionSerializationTes
     return (*env)->NewStringUTF(env, string);
 
 }
+
+JNIEXPORT jstring JNICALL
+Java_com_bugsnag_android_ndk_ThreadSerializationTest_run(JNIEnv *env, jobject thiz) {
+    bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+    loadThreadTestCase(event);
+    JSON_Value *threads_val = json_value_init_array();
+    JSON_Array *threads_array = json_value_get_array(threads_val);
+    bsg_serialize_threads(event, threads_array);
+    char *string = json_serialize_to_string(threads_val);
+    return (*env)->NewStringUTF(env, string);
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -177,6 +177,14 @@ bugsnag_stackframe *loadStackframeTestCase() {
     return data;
 }
 
+void loadThreadTestCase(bugsnag_event *event) {
+    event->thread_count = 1;
+    bsg_thread *thread = &event->threads[0];
+    strcpy(thread->name, "Binder 1");
+    thread->state = 'R';
+    thread->id = 1234;
+}
+
 void loadExceptionTestCase(bugsnag_event *event) {
     bsg_error *data = &event->error;
     strcpy(data->errorClass, "signal");

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
@@ -21,5 +21,6 @@ void loadContextTestCase(bugsnag_event *event);
 void loadSessionTestCase(bugsnag_event *event);
 void loadSeverityReasonTestCase(bugsnag_event *event);
 void loadBreadcrumbsTestCase(bugsnag_event *event);
+void loadThreadTestCase(bugsnag_event *event);
 bugsnag_stackframe *loadStackframeTestCase();
 void loadExceptionTestCase(bugsnag_event *event);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -141,6 +141,56 @@ void generate_basic_report(bugsnag_event *event) {
   strcpy(event->notifier.name, "Test Notifier");
 }
 
+bugsnag_report_v5 *bsg_generate_report_v5(void) {
+  bugsnag_report_v5 *event = calloc(1, sizeof(bugsnag_report_v5));
+  strcpy(event->grouping_hash, "foo-hash");
+  strcpy(event->api_key, "5d1e5fbd39a74caa1200142706a90b20");
+  strcpy(event->context, "SomeActivity");
+  strcpy(event->error.errorClass, "SIGBUS");
+  strcpy(event->error.errorMessage, "POSIX is serious about oncoming traffic");
+  event->error.stacktrace[0].frame_address = 454379;
+  event->error.stacktrace[1].frame_address = 342334;
+  event->error.frame_count = 2;
+  strcpy(event->error.type, "C");
+  strcpy(event->error.stacktrace[0].method, "makinBacon");
+  strcpy(event->app.id, "com.example.PhotoSnapPlus");
+  strcpy(event->app.release_stage, "リリース");
+  strcpy(event->app.version, "2.0.52");
+  event->app.version_code = 57;
+  strcpy(event->app.build_uuid, "1234-9876-adfe");
+  strcpy(event->device.manufacturer, "HI-TEC™");
+  strcpy(event->device.model, "Rasseur");
+  strcpy(event->device.locale, "en_AU#Melbun");
+  strcpy(event->device.os_name, "android");
+  strcpy(event->user.email, "fenton@io.example.com");
+  strcpy(event->user.id, "fex");
+  event->device.total_memory = 234678100;
+  event->app.duration = 6502;
+  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
+  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
+  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
+  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.8);
+
+  bugsnag_breadcrumb *crumb1 = init_breadcrumb("decrease torque", "Moving laterally 26º",
+                                               BSG_CRUMB_STATE);
+  bugsnag_breadcrumb *crumb2 = init_breadcrumb("enable blasters", "this is a drill.",
+                                               BSG_CRUMB_USER);
+  memcpy(&event->breadcrumbs[0], crumb1, sizeof(bugsnag_breadcrumb));
+  memcpy(&event->breadcrumbs[1], crumb2, sizeof(bugsnag_breadcrumb));
+  event->crumb_count = 2;
+  event->crumb_first_index = 0;
+
+  event->handled_events = 1;
+  event->unhandled_events = 1;
+  strcpy(event->session_id, "f1ab");
+  strcpy(event->session_start, "2019-03-19T12:58:19+00:00");
+
+  strcpy(event->notifier.version, "1.0");
+  strcpy(event->notifier.url, "bugsnag.com");
+  strcpy(event->notifier.name, "Test Notifier");
+  return event;
+}
+
 bugsnag_report_v4 *bsg_generate_report_v4(void) {
   bugsnag_report_v4 *event = calloc(1, sizeof(bugsnag_report_v4));
   strcpy(event->grouping_hash, "foo-hash");
@@ -441,6 +491,7 @@ TEST test_report_v1_migration(void) {
   ASSERT_EQ(1, event->handled_events);
   ASSERT_EQ(1, event->unhandled_events);
   ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -495,6 +546,7 @@ TEST test_report_v2_migration(void) {
   ASSERT_STR_EQ("message", val->key);
   ASSERT_STR_EQ("Moving laterally 26º", val->value);
   ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -527,6 +579,7 @@ TEST test_report_v3_migration(void) {
   ASSERT_STR_EQ("POSIX is serious about oncoming traffic", event->error.errorMessage);
   ASSERT_STR_EQ("C", event->error.type);
   ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -556,6 +609,7 @@ TEST test_report_v4_migration(void) {
   ASSERT_STR_EQ("1234-9876-adfe", event->app.build_uuid);
   ASSERT_FALSE(event->app.in_foreground);
   ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -609,6 +663,8 @@ TEST test_report_v5_migration(void) {
     free(str);
   }
 
+  ASSERT_EQ(0, event->thread_count);
+
   free(generated_report);
   free(env);
   free(event);
@@ -640,6 +696,36 @@ TEST test_report_v5_migration_crumb_index(void) {
   ASSERT_STR_EQ("13", event->breadcrumbs[1].name);
   ASSERT_STR_EQ("26", event->breadcrumbs[14].name);
   ASSERT_STR_EQ("36", event->breadcrumbs[24].name);
+
+  free(generated_report);
+  free(env);
+  free(event);
+  PASS();
+}
+
+TEST test_report_v6_migration(void) {
+  bsg_environment *env = calloc(1, sizeof(bsg_environment));
+  env->report_header.version = 4;
+  env->report_header.big_endian = 1;
+  strcpy(env->report_header.os_build, "macOS Sierra");
+
+  bugsnag_report_v5 *generated_report = bsg_generate_report_v5();
+  memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v5));
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
+  bsg_serialize_report_v5_to_file(env, generated_report);
+
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
+  ASSERT(event != NULL);
+
+  // values are migrated correctly
+  ASSERT_STR_EQ("com.example.PhotoSnapPlus", event->app.id);
+  ASSERT_STR_EQ("リリース", event->app.release_stage);
+  ASSERT_STR_EQ("2.0.52", event->app.version);
+  ASSERT_EQ(57, event->app.version_code);
+  ASSERT_STR_EQ("1234-9876-adfe", event->app.build_uuid);
+  ASSERT_FALSE(event->app.in_foreground);
+  ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -835,5 +921,6 @@ SUITE(suite_struct_migration) {
   RUN_TEST(test_report_v4_migration);
   RUN_TEST(test_report_v5_migration);
   RUN_TEST(test_report_v5_migration_crumb_index);
+  RUN_TEST(test_report_v6_migration);
   RUN_TEST(test_migrate_app_v2);
 }


### PR DESCRIPTION
## Goal
Ensure that events stored by previous versions of the NDK plugin can be migrated to the new version, which includes space allocated for the `bsg_thread` structures.

## Design
As the new fields are at the end of the `bugsnag_event` structure - this migration is a simple copy operation (using `memcpy`) to allow for the expanded space where the threads will be stored. As we are using `calloc` no further action is required to zero the `thread_count`.

## Testing
Manually tested in the example app, and added migration unit tests.