### PR TITLE
Use SystemClock.elapsedRealtime to track `app.durationInForeground`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Support integer values in buildUuid
   [#1375](https://github.com/bugsnag/bugsnag-android/pull/1375)
 
+* Use SystemClock.elapsedRealtime to track `app.durationInForeground`
+  [#1375](https://github.com/bugsnag/bugsnag-android/pull/1375)
+
 ## 5.12.0 (2021-08-26)
 
 * The `app.lowMemory` value always report the most recent `onTrimMemory`/`onLowMemory` status

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorForegroundTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorForegroundTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import android.content.Context
+import android.os.SystemClock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -26,22 +27,21 @@ class AppDataCollectorForegroundTest {
     @Mock
     internal lateinit var sessionTracker: SessionTracker
 
-    @Mock
-    internal lateinit var launchCrashTracker: LaunchCrashTracker
-
-    @Mock
-    internal lateinit var memoryTrimState: MemoryTrimState
-
+    private lateinit var launchCrashTracker: LaunchCrashTracker
+    private lateinit var memoryTrimState: MemoryTrimState
     private lateinit var appDataCollector: AppDataCollector
 
     @Before
     fun setUp() {
         `when`(appContext.packageName).thenReturn("test.package.name")
+        val config = BugsnagTestUtils.generateImmutableConfig()
+        launchCrashTracker = LaunchCrashTracker(config)
+        memoryTrimState = MemoryTrimState()
 
         appDataCollector = AppDataCollector(
             appContext,
             null,
-            BugsnagTestUtils.generateImmutableConfig(),
+            config,
             sessionTracker,
             null,
             launchCrashTracker,
@@ -54,7 +54,7 @@ class AppDataCollectorForegroundTest {
      */
     @Test
     fun durationInForeground() {
-        val time = System.currentTimeMillis()
+        val time = SystemClock.elapsedRealtime()
         val lastForegroundTime = time - 1000L
 
         `when`(sessionTracker.isInForeground).thenReturn(true)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -104,7 +104,7 @@ internal class AppDataCollector(
             return null
         }
 
-        val nowMs = System.currentTimeMillis()
+        val nowMs = SystemClock.elapsedRealtime()
         var durationMs: Long = 0
 
         val sessionStartTimeMs: Long = sessionTracker.lastEnteredForegroundMs

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -3,6 +3,8 @@ package com.bugsnag.android;
 import com.bugsnag.android.internal.DateUtils;
 import com.bugsnag.android.internal.ImmutableConfig;
 
+import android.os.SystemClock;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -320,11 +322,11 @@ class SessionTracker extends BaseObservable {
     }
 
     void onActivityStarted(String activityName) {
-        updateForegroundTracker(activityName, true, System.currentTimeMillis());
+        updateForegroundTracker(activityName, true, SystemClock.elapsedRealtime());
     }
 
     void onActivityStopped(String activityName) {
-        updateForegroundTracker(activityName, false, System.currentTimeMillis());
+        updateForegroundTracker(activityName, false, SystemClock.elapsedRealtime());
     }
 
     /**
@@ -350,7 +352,7 @@ class SessionTracker extends BaseObservable {
 
                 if (noActivityRunningForMs >= timeoutMs
                         && configuration.getAutoTrackSessions()) {
-                    startNewSession(new Date(nowMs), client.getUser(), true);
+                    startNewSession(new Date(), client.getUser(), true);
                 }
             }
             foregroundActivities.add(activityName);


### PR DESCRIPTION
## Goal

Uses `SystemClock.elapsedRealtime()` rather than `System.currentTimeMillis()` to track the `duration` and `durationInForeground` values. [SystemClock](https://developer.android.com/reference/android/os/SystemClock) is recommended for timing intervals as it is not affected by CPU power saving mode or the user altering the device time.

`System.currentTimeMillis()` is still used in the codebase elsewhere where accuracy is not as key - for example, adding a timestamp to the filename of persisted errors.

## Testing

Updated existing test coverage and manually tested to confirm that the values are correct.