### PR TITLE
Resolve warnings about field designator extension

### DIFF
--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -26,7 +26,7 @@ SUITE(suite_number_to_string);
 
 GREATEST_MAIN_DEFS();
 
-static TEST set_temporary_folder_path(JNIEnv *env, jstring path) {
+TEST set_temporary_folder_path(JNIEnv *env, jstring path) {
     test_temporary_folder_path = bsg_safe_get_string_utf_chars(env, path);
     if (test_temporary_folder_path == NULL) {
         FAILm("Error retrieving temporary folder string");

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_ctjournal.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_ctjournal.c
@@ -17,7 +17,7 @@ static bool init_test() {
     return bsg_ctjournal_init(journal_filename);
 }
 
-static TEST expect_journal_contents(const char* expected_contents, int expected_length) {
+TEST expect_journal_contents(const char* expected_contents, int expected_length) {
     return bsg_expect_file_contents(journal_filename, expected_contents, expected_length);
 }
 
@@ -169,34 +169,34 @@ TEST test_ctjournal_set_user(void) {
 TEST test_add_breadcrumb(void) {
     ASSERT(init_test());
     bugsnag_breadcrumb bc = {
-        name: "myname",
-        timestamp: "2021-06-02T08:56:06.106Z",
-        type: BSG_CRUMB_USER,
-        metadata: {
-        value_count: 4,
-        values: {
+        .name =  "myname",
+        .timestamp =  "2021-06-02T08:56:06.106Z",
+        .type =  BSG_CRUMB_USER,
+        .metadata =  {
+        .value_count =  4,
+        .values =  {
                 {
-                        name: "mybool",
-                        section: "mysection",
-                        type: BSG_METADATA_BOOL_VALUE,
-                        bool_value: true,
+                        .name =  "mybool",
+                        .section =  "mysection",
+                        .type =  BSG_METADATA_BOOL_VALUE,
+                        .bool_value =  true,
                 },
                 {
-                    name: "mynull",
-                    section: "mysection",
-                    type: BSG_METADATA_NONE_VALUE,
+                    .name =  "mynull",
+                    .section =  "mysection",
+                    .type =  BSG_METADATA_NONE_VALUE,
                 },
                 {
-                    name: "mynumber",
-                    section: "mysection",
-                    type: BSG_METADATA_NUMBER_VALUE,
-                    double_value: 3.91444e-20,
+                    .name =  "mynumber",
+                    .section =  "mysection",
+                    .type =  BSG_METADATA_NUMBER_VALUE,
+                    .double_value =  3.91444e-20,
                 },
                 {
-                    name: "mystring",
-                    section: "mysection",
-                    type: BSG_METADATA_CHAR_VALUE,
-                    char_value: "a string",
+                    .name =  "mystring",
+                    .section =  "mysection",
+                    .type =  BSG_METADATA_CHAR_VALUE,
+                    .char_value =  "a string",
                 },
     }
     }
@@ -215,34 +215,34 @@ TEST test_add_breadcrumb(void) {
 TEST test_add_breadcrumb_escaped(void) {
     ASSERT(init_test());
     bugsnag_breadcrumb bc = {
-            name: "my\\na\"me",
-            timestamp: "2021-06-02T08:56:06.106Z",
-            type: BSG_CRUMB_USER,
-            metadata: {
-                    value_count: 4,
-                    values: {
+            .name =  "my\\na\"me",
+            .timestamp =  "2021-06-02T08:56:06.106Z",
+            .type =  BSG_CRUMB_USER,
+            .metadata =  {
+                    .value_count =  4,
+                    .values =  {
                             {
-                                    name: "my\"b\\ool",
-                                    section: "my\\s\"ection",
-                                    type: BSG_METADATA_BOOL_VALUE,
-                                    bool_value: true,
+                                    .name =  "my\"b\\ool",
+                                    .section =  "my\\s\"ection",
+                                    .type =  BSG_METADATA_BOOL_VALUE,
+                                    .bool_value =  true,
                             },
                             {
-                                    name: "mynull",
-                                    section: "mysection",
-                                    type: BSG_METADATA_NONE_VALUE,
+                                    .name =  "mynull",
+                                    .section =  "mysection",
+                                    .type =  BSG_METADATA_NONE_VALUE,
                             },
                             {
-                                    name: "mynumber",
-                                    section: "mysection",
-                                    type: BSG_METADATA_NUMBER_VALUE,
-                                    double_value: 3.91444e-20,
+                                    .name =  "mynumber",
+                                    .section =  "mysection",
+                                    .type =  BSG_METADATA_NUMBER_VALUE,
+                                    .double_value =  3.91444e-20,
                             },
                             {
-                                    name: "mystring",
-                                    section: "mysection",
-                                    type: BSG_METADATA_CHAR_VALUE,
-                                    char_value: "\"a\" str\\ing",
+                                    .name =  "mystring",
+                                    .section =  "mysection",
+                                    .type =  BSG_METADATA_CHAR_VALUE,
+                                    .char_value =  "\"a\" str\\ing",
                             },
                     }
             }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -370,7 +370,7 @@ char *test_read_last_run_info(const bsg_environment *env) {
   return buf;
 }
 
-test_last_run_info_serialization(void) {
+TEST test_last_run_info_serialization(void) {
   bsg_environment *env = calloc(1, sizeof(bsg_environment));
   strcpy(env->last_run_info_path, SERIALIZE_TEST_FILE);
   


### PR DESCRIPTION
## Goal

Resolves warnings in the NDK test code that have been introduced in the integration branch. Notably, the use of an old-style GNU field designator extension has been removed. The duplicate use of the `static` modifier and missing return types have also been addressed.