### PR TITLE
Make journal code internal and in separate package

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/App.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/App.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.internal.ImmutableConfig
-import com.bugsnag.android.internal.JournalKeys
-import com.bugsnag.android.internal.Journalable
+import com.bugsnag.android.internal.journal.JournalKeys
+import com.bugsnag.android.internal.journal.Journalable
 import java.io.IOException
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppWithState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppWithState.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.internal.ImmutableConfig
-import com.bugsnag.android.internal.JournalKeys
+import com.bugsnag.android.internal.journal.JournalKeys
 
 /**
  * Stateful information set by the notifier about your app can be found on this class. These values

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
@@ -1,8 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.DocumentPath
-import com.bugsnag.android.internal.JournalKeys
-import com.bugsnag.android.internal.JournaledDocument
+import com.bugsnag.android.internal.journal.JournalKeys
+import com.bugsnag.android.internal.journal.JournaledDocument
 import java.io.Closeable
 import java.io.File
 import java.io.IOException

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Device.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Device.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.JournalKeys
-import com.bugsnag.android.internal.Journalable
+import com.bugsnag.android.internal.journal.JournalKeys
+import com.bugsnag.android.internal.journal.Journalable
 
 /**
  * Stateless information set by the notifier about the device on which the event occurred can be

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceWithState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceWithState.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.internal.DateUtils
-import com.bugsnag.android.internal.JournalKeys
+import com.bugsnag.android.internal.journal.JournalKeys
 import java.util.Date
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.JournalKeys
 import com.bugsnag.android.internal.StateObserver
+import com.bugsnag.android.internal.journal.JournalKeys
 import java.util.Date
 
 internal class JournaledStateObserver(val client: Client, val journal: BugsnagJournal) : StateObserver {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
@@ -2,7 +2,7 @@
 
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.Journalable
+import com.bugsnag.android.internal.journal.Journalable
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeStackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeStackframe.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.JournalKeys
-import com.bugsnag.android.internal.Journalable
+import com.bugsnag.android.internal.journal.JournalKeys
+import com.bugsnag.android.internal.journal.Journalable
 import java.io.IOException
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.JournalKeys
-import com.bugsnag.android.internal.Journalable
+import com.bugsnag.android.internal.journal.JournalKeys
+import com.bugsnag.android.internal.journal.Journalable
 import java.io.IOException
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.JournalKeys
-import com.bugsnag.android.internal.Journalable
+import com.bugsnag.android.internal.journal.JournalKeys
+import com.bugsnag.android.internal.journal.Journalable
 import java.io.IOException
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.JournalKeys
-import com.bugsnag.android.internal.Journalable
+import com.bugsnag.android.internal.journal.JournalKeys
+import com.bugsnag.android.internal.journal.Journalable
 import java.io.IOException
 
 class ThreadInternal internal constructor(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/User.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/User.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android
 
 import android.util.JsonReader
-import com.bugsnag.android.internal.JournalKeys
-import com.bugsnag.android.internal.Journalable
+import com.bugsnag.android.internal.journal.JournalKeys
+import com.bugsnag.android.internal.journal.Journalable
 import java.io.IOException
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPath.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPath.kt
@@ -1,5 +1,6 @@
-package com.bugsnag.android.internal
+package com.bugsnag.android.internal.journal
 
+import com.bugsnag.android.internal.asConcurrent
 import java.lang.IllegalArgumentException
 
 /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPathDirective.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPathDirective.kt
@@ -1,5 +1,6 @@
-package com.bugsnag.android.internal
+package com.bugsnag.android.internal.journal
 
+import com.bugsnag.android.internal.asConcurrent
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -51,7 +52,8 @@ internal interface DocumentPathDirective<C> {
      * Modifies a particular key in a map, or creates a new (String, Object) map.
      * Setting null removes the value.
      */
-    open class MapKeyDirective(private val key: String) : DocumentPathDirective<MutableMap<String, in Any>> {
+    open class MapKeyDirective(private val key: String) :
+        DocumentPathDirective<MutableMap<String, in Any>> {
         override fun newContainer(): MutableMap<String, in Any> {
             return ConcurrentHashMap()
         }
@@ -87,7 +89,8 @@ internal interface DocumentPathDirective<C> {
      * Modifies a list at the current level, or creates a new list.
      * Setting null removes the item at the specified index.
      */
-    open class ListIndexDirective(private val index: Int) : DocumentPathDirective<MutableList<in Any>> {
+    open class ListIndexDirective(private val index: Int) :
+        DocumentPathDirective<MutableList<in Any>> {
         override fun newContainer(): MutableList<in Any> {
             return CopyOnWriteArrayList()
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/Journal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/Journal.kt
@@ -1,4 +1,4 @@
-package com.bugsnag.android.internal
+package com.bugsnag.android.internal.journal
 
 import java.io.File
 import java.io.IOException

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournalKeys.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournalKeys.kt
@@ -1,6 +1,6 @@
-package com.bugsnag.android.internal
+package com.bugsnag.android.internal.journal
 
-object JournalKeys {
+internal object JournalKeys {
     // Keys
     internal const val keyApp = "app"
     internal const val keyBinaryArch = "binaryArch"

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/Journalable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/Journalable.kt
@@ -1,4 +1,4 @@
-package com.bugsnag.android.internal
+package com.bugsnag.android.internal.journal
 
 interface Journalable {
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
@@ -1,7 +1,9 @@
-package com.bugsnag.android.internal
+package com.bugsnag.android.internal.journal
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.bugsnag.android.internal.MemoryMappedOutputStream
+import com.bugsnag.android.internal.asConcurrent
 import java.io.Closeable
 import java.io.File
 import java.io.FileNotFoundException
@@ -21,7 +23,7 @@ import java.util.function.BiConsumer
  * Changes to the document must me made only via journal commands. Do not modify the document or any
  * of its sub-components directly!
  */
-class JournaledDocument
+internal class JournaledDocument
 /**
  * Constructor.
  * Upon construction, this document will have associated snapshot and journal files.

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JsonHelper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JsonHelper.kt
@@ -1,4 +1,4 @@
-package com.bugsnag.android.internal
+package com.bugsnag.android.internal.journal
 
 import com.dslplatform.json.DslJson
 import java.io.File
@@ -9,7 +9,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 
-class JsonHelper private constructor() {
+internal class JsonHelper private constructor() {
     companion object {
         // Only one global DslJson is needed, and is thread-safe
         // Note: dsl-json adds about 150k to the final binary size.

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalTest.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.JournalKeys
+import com.bugsnag.android.internal.journal.JournalKeys
 import org.junit.Assert
 import org.junit.ClassRule
 import org.junit.Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.DocumentPath
+import com.bugsnag.android.internal.journal.DocumentPath
 import org.junit.Test
 import java.util.LinkedList
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournalCommandTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournalCommandTest.kt
@@ -1,6 +1,6 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.Journal
+import com.bugsnag.android.internal.journal.Journal
 import org.junit.Assert
 import org.junit.Test
 import java.io.ByteArrayOutputStream

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournalTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournalTest.kt
@@ -1,11 +1,12 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.Journal
+import com.bugsnag.android.internal.journal.Journal
 import org.junit.Assert
 import org.junit.Test
 import java.io.ByteArrayOutputStream
 
-class JournalTest {
+internal class JournalTest {
+
     @Test
     fun testEmptyEverything() {
         val journal = Journal(standardType, standardVersion)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledDocumentStressTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledDocumentStressTest.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.JournaledDocument
-import com.bugsnag.android.internal.JsonHelper
+import com.bugsnag.android.internal.journal.JournaledDocument
+import com.bugsnag.android.internal.journal.JsonHelper
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledDocumentTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledDocumentTest.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.Journal
-import com.bugsnag.android.internal.JournaledDocument
-import com.bugsnag.android.internal.JsonHelper
+import com.bugsnag.android.internal.journal.Journal
+import com.bugsnag.android.internal.journal.JournaledDocument
+import com.bugsnag.android.internal.journal.JsonHelper
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test

--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/DocumentPathBenchmarkTest.kt
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/DocumentPathBenchmarkTest.kt
@@ -2,11 +2,11 @@ package com.bugsnag.android.benchmark
 
 import androidx.benchmark.junit4.BenchmarkRule
 import androidx.benchmark.junit4.measureRepeated
-import com.bugsnag.android.internal.DocumentPath
+import com.bugsnag.android.internal.journal.DocumentPath
 import org.junit.Rule
 import org.junit.Test
 
-class DocumentPathBenchmarkTest {
+internal class DocumentPathBenchmarkTest {
 
     @get:Rule
     val benchmarkRule = BenchmarkRule()

--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/JournalBenchmarkTest.kt
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/benchmark/JournalBenchmarkTest.kt
@@ -7,7 +7,7 @@ import androidx.benchmark.junit4.measureRepeated
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.bugsnag.android.*
-import com.bugsnag.android.internal.Journal
+import com.bugsnag.android.internal.journal.Journal
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -15,7 +15,8 @@ import org.junit.runner.RunWith
 import java.io.ByteArrayOutputStream
 
 @RunWith(AndroidJUnit4::class)
-class JournalBenchmarkTest {
+internal class JournalBenchmarkTest {
+
     @get:Rule
     val benchmarkRule = BenchmarkRule()
 


### PR DESCRIPTION
## Goal

Moved the journalling code into a separate package named `com.bugsnag.android.internal.journal` where possible, as there are now a reasonable amount of classes. This also alters types to be `internal` where they do not need to be publicly visible.