### PR TITLE
Add StateEvent for when notifier info is updated

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -79,6 +79,8 @@ public class ObserverInterfaceTest {
         assertNotNull(findMessageInQueue(StateEvent.UpdateUser.class));
         assertNotNull(findMessageInQueue(StateEvent.AddMetadata.class));
         assertNotNull(findMessageInQueue(StateEvent.UpdateContext.class));
+        assertNotNull(findMessageInQueue(StateEvent.UpdateMemoryTrimEvent.class));
+        assertNotNull(findMessageInQueue(StateEvent.UpdateNotifierInfo.class));
     }
 
     @Test
@@ -121,6 +123,12 @@ public class ObserverInterfaceTest {
         client.startSession();
         client.notify(new Exception("ruh roh"));
         assertNotNull(findMessageInQueue(StateEvent.NotifyHandled.class));
+    }
+
+    @Test
+    public void testNotifierInfoUpdate() {
+        client.setNotifier(new Notifier("foo"));
+        assertNotNull(findMessageInQueue(StateEvent.UpdateNotifierInfo.class));
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BaseObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BaseObservable.kt
@@ -43,4 +43,9 @@ internal open class BaseObservable {
      * instead.
      */
     fun updateState(event: StateEvent) = updateState { event }
+
+    /**
+     * Triggers the observer with a snapshot of the current state.
+     */
+    open fun emitObservableEvent() {}
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
@@ -135,6 +135,7 @@ internal class BugsnagJournal @JvmOverloads internal constructor (
          * @param baseDocumentPath The base path to load the journal data from
          * @return a map containing the document, or null if no journal exists at this path.
          */
+        @JvmStatic
         fun loadPreviousDocument(baseDocumentPath: File): MutableMap<in String, out Any>? {
             return JournaledDocument.loadDocumentContents(baseDocumentPath)
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagStateModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagStateModule.kt
@@ -14,6 +14,7 @@ internal class BugsnagStateModule(
 
     private val cfg = configModule.config
 
+    val notifierState = NotifierState()
     val clientObservable = ClientObservable()
 
     val callbackState = configuration.impl.callbackState.copy()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ContextState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ContextState.kt
@@ -32,5 +32,5 @@ internal class ContextState : BaseObservable() {
         return automaticContext.takeIf { it !== MANUAL } ?: manualContext
     }
 
-    fun emitObservableEvent() = updateState { StateEvent.UpdateContext(getContext()) }
+    override fun emitObservableEvent() = updateState { StateEvent.UpdateContext(getContext()) }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
@@ -58,6 +58,9 @@ internal class JournaledStateObserver(val client: Client, val journal: BugsnagJo
             is StateEvent.UpdateUser -> {
                 journal.addCommand(JournalKeys.pathUser, event.user.toJournalSection())
             }
+            is StateEvent.UpdateNotifierInfo -> {
+                journal.addCommand(JournalKeys.pathNotifier, event.notifier.toJournalSection())
+            }
             is StateEvent.UpdateMemoryTrimEvent -> {
                 journal.addCommand(JournalKeys.pathMetadataAppLowMemory, event.isLowMemory)
             }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MemoryTrimState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MemoryTrimState.kt
@@ -17,7 +17,7 @@ internal class MemoryTrimState : BaseObservable() {
         return true
     }
 
-    fun emitObservableEvent() {
+    override fun emitObservableEvent() {
         updateState {
             StateEvent.UpdateMemoryTrimEvent(
                 isLowMemory,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -40,7 +40,7 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) :
      * Fires the initial observable messages for all the metadata which has been added before an
      * Observer was added. This is used initially to populate the NDK with data.
      */
-    fun emitObservableEvent() {
+    override fun emitObservableEvent() {
         val sections = metadata.store.keys
 
         for (section in sections) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NotifierState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NotifierState.kt
@@ -1,0 +1,19 @@
+package com.bugsnag.android
+
+/**
+ * Tracks the current notifier information and allows observers to be notified whenever it changes.
+ */
+internal class NotifierState : BaseObservable() {
+
+    var notifier: Notifier = Notifier()
+        set(value) {
+            field = value
+            updateState { StateEvent.UpdateNotifierInfo(value) }
+        }
+
+    override fun emitObservableEvent() {
+        updateState {
+            StateEvent.UpdateNotifierInfo(notifier)
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -88,7 +88,8 @@ class SessionTracker extends BaseObservable {
             return null;
         }
         String id = UUID.randomUUID().toString();
-        Session session = new Session(id, date, user, autoCaptured, client.getNotifier(), logger);
+        Notifier notifier = client.getNotifierState().getNotifier();
+        Session session = new Session(id, date, user, autoCaptured, notifier, logger);
         currentSession.set(session);
         trackSessionIfNeeded(session);
         return session;
@@ -153,8 +154,9 @@ class SessionTracker extends BaseObservable {
         }
         Session session = null;
         if (date != null && sessionId != null) {
+            Notifier notifier = client.getNotifierState().getNotifier();
             session = new Session(sessionId, date, user, unhandledCount, handledCount,
-                    client.getNotifier(), logger);
+                    notifier, logger);
             notifySessionStartObserver(session);
         } else {
             updateState(StateEvent.PauseSession.INSTANCE);
@@ -249,7 +251,8 @@ class SessionTracker extends BaseObservable {
 
     void flushStoredSession(File storedFile) {
         logger.d("SessionTracker#flushStoredSession() - attempting delivery");
-        Session payload = new Session(storedFile, client.getNotifier(), logger);
+        Notifier notifier = client.getNotifierState().getNotifier();
+        Session payload = new Session(storedFile, notifier, logger);
 
         if (!payload.isV2Payload()) { // collect data here
             payload.setApp(client.getAppDataCollector().generateApp());

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
@@ -62,6 +62,8 @@ sealed class StateEvent { // JvmField allows direct field access optimizations
 
     class UpdateUser(@JvmField val user: User) : StateEvent()
 
+    class UpdateNotifierInfo(@JvmField val notifier: Notifier) : StateEvent()
+
     class UpdateMemoryTrimEvent(
         @JvmField val isLowMemory: Boolean,
         @JvmField val memoryTrimLevel: Int? = null,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/UserState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/UserState.kt
@@ -7,5 +7,5 @@ internal class UserState(user: User) : BaseObservable() {
             emitObservableEvent()
         }
 
-    fun emitObservableEvent() = updateState { StateEvent.UpdateUser(user) }
+    override fun emitObservableEvent() = updateState { StateEvent.UpdateUser(user) }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapper.kt
@@ -1,0 +1,29 @@
+package com.bugsnag.android.internal.journal
+
+import com.bugsnag.android.BugsnagJournal
+import com.bugsnag.android.Event
+import com.bugsnag.android.Logger
+import java.io.File
+
+/**
+ * Converts a Bugsnag journal entry into an Event.
+ */
+internal class BugsnagJournalEventMapper(
+    private val logger: Logger
+) {
+
+    fun convertToEvent(baseDocumentPath: File): Event? {
+        return try {
+            val map = BugsnagJournal.loadPreviousDocument(baseDocumentPath)
+            convertToEvent(map)
+        } catch (exc: Throwable) {
+            logger.e("Failed to load journal, skipping event", exc)
+            null
+        }
+    }
+
+    fun convertToEvent(map: Map<in String, Any>?): Event? {
+        logger.d("Read previous journal, contents=$map")
+        return null
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournalKeys.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournalKeys.kt
@@ -61,6 +61,7 @@ internal object JournalKeys {
     internal const val pathMetadata = keyMetadata
     internal const val pathSession = "session"
     internal const val pathUser = "user"
+    internal const val pathNotifier = "notifier"
 
     // Composite paths
     internal const val pathAppInForeground = "$pathApp.$keyInForeground"

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -46,6 +46,9 @@ public class ClientFacadeTest {
     UserState userState;
 
     @Mock
+    NotifierState notifierState;
+
+    @Mock
     ClientObservable clientObservable;
 
     @Mock
@@ -108,6 +111,7 @@ public class ClientFacadeTest {
                 contextState,
                 callbackState,
                 userState,
+                notifierState,
                 clientObservable,
                 appContext,
                 deviceDataCollector,
@@ -495,6 +499,7 @@ public class ClientFacadeTest {
         verify(contextState, times(1)).addObserver(observer);
         verify(deliveryDelegate, times(1)).addObserver(observer);
         verify(launchCrashTracker, times(1)).addObserver(observer);
+        verify(notifierState, times(1)).addObserver(observer);
     }
 
     @Test
@@ -514,6 +519,7 @@ public class ClientFacadeTest {
         verify(contextState, times(1)).removeObserver(observer);
         verify(deliveryDelegate, times(1)).removeObserver(observer);
         verify(launchCrashTracker, times(1)).removeObserver(observer);
+        verify(notifierState, times(1)).removeObserver(observer);
     }
 
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledStateObserverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledStateObserverTest.kt
@@ -372,4 +372,21 @@ internal class JournaledStateObserverTest {
         )
         BugsnagTestUtils.assertNormalizedEquals(expected, journal.document)
     }
+
+    @Test
+    fun testNotifierInfo() {
+        val journal = emptyJournal()
+        val observer = JournaledStateObserver(client, journal)
+        observer.onStateChange(StateEvent.UpdateNotifierInfo(Notifier(version = "1.2.3")))
+        val expected = BugsnagJournal.withInitialDocumentContents(
+            mapOf(
+                "notifier" to mapOf(
+                    "name" to "Android Bugsnag Notifier",
+                    "version" to "1.2.3",
+                    "url" to "https://bugsnag.com"
+                )
+            )
+        )
+        BugsnagTestUtils.assertNormalizedEquals(expected, journal.document)
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
@@ -52,7 +52,7 @@ internal class SessionTrackerPauseResumeTest {
 
     @Before
     fun setUp() {
-        `when`(client.getNotifier()).thenReturn(Notifier())
+        `when`(client.notifierState).thenReturn(NotifierState())
         `when`(client.getAppContext()).thenReturn(context)
         `when`(client.getAppDataCollector()).thenReturn(appDataCollector)
         `when`(client.config).thenReturn(cfg)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
@@ -64,7 +64,7 @@ public class SessionTrackerTest {
     @Before
     public void setUp() {
         contextState = new ContextState();
-        when(client.getNotifier()).thenReturn(new Notifier());
+        when(client.getNotifierState()).thenReturn(new NotifierState());
         when(client.getAppContext()).thenReturn(context);
         when(client.getAppDataCollector()).thenReturn(appDataCollector);
         when(client.getConfig()).thenReturn(cfg);

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapperTest.kt
@@ -1,0 +1,20 @@
+package com.bugsnag.android.internal.journal
+
+import com.bugsnag.android.NoopLogger
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BugsnagJournalEventMapperTest {
+
+    @Test
+    fun nullMapNullEvent() {
+        val mapper = BugsnagJournalEventMapper(NoopLogger)
+        assertNull(mapper.convertToEvent(null))
+    }
+
+    @Test
+    fun emptyMapNullEvent() {
+        val mapper = BugsnagJournalEventMapper(NoopLogger)
+        assertNull(mapper.convertToEvent(emptyMap()))
+    }
+}

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -47,11 +47,13 @@ class BugsnagReactNativePlugin : Plugin {
         engine?.let { client.addRuntimeVersionInfo("reactNativeJsEngine", it) }
 
         val jsVersion = env["notifierVersion"] as String
-        val notifier = client.notifier
-        notifier.name = "Bugsnag React Native"
-        notifier.url = "https://github.com/bugsnag/bugsnag-js"
-        notifier.version = jsVersion
-        notifier.dependencies = listOf(Notifier()) // depend on bugsnag-android
+        client.setNotifier(
+            Notifier(
+                "Bugsnag React Native",
+                jsVersion,
+                "https://github.com/bugsnag/bugsnag-js"
+            ).apply { dependencies = listOf(Notifier()) } // depend on bugsnag-android
+        )
     }
 
     private fun ignoreJavaScriptExceptions() {
@@ -74,7 +76,9 @@ class BugsnagReactNativePlugin : Plugin {
         // in this plugin. When a JS exception crashes the app, we get a duplicate
         // native exception for the same error so we ignore those once the JS layer
         // has started.
-        if (!ignoreJsExceptionCallbackAdded) { ignoreJavaScriptExceptions() }
+        if (!ignoreJsExceptionCallbackAdded) {
+            ignoreJavaScriptExceptions()
+        }
 
         val map = HashMap<String, Any?>()
         configSerializer.serialize(map, client.config)


### PR DESCRIPTION
## Goal

Adds a `StateEvent` that is triggered when the `Notifier` information is changed (RN/Unity). This also serializes the `Notifier` object to the journal.

## Changeset

- Created `Client#setNotifier()` and removed `Client#getNotifier()`
- Added a `NotifierState` class which emits a `StateEvent` when the value changes
- Updated `BaseObservable` to have `emitObservableEvent` as an overridable function
- Created `BugsnagJournalEventMapper`, which loads the journal as a map and in future will generate an event

## Testing

Added unit test coverage and manually verified that the bugsnag journal is logged out in an example app.