### PR TITLE
Allow Client to be initialised with a Notifier

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -79,7 +79,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     final ClientObservable clientObservable;
     PluginClient pluginClient;
 
-    final Notifier notifier = new Notifier();
+    final Notifier notifier;
 
     @Nullable
     final LastRunInfo lastRunInfo;
@@ -116,6 +116,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     public Client(@NonNull Context androidContext, @NonNull final Configuration configuration) {
         ContextModule contextModule = new ContextModule(androidContext);
         appContext = contextModule.getCtx();
+
+        notifier = configuration.getNotifier();
 
         connectivity = new ConnectivityCompat(appContext, new Function2<Boolean, String, Unit>() {
             @Override
@@ -233,7 +235,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             DeliveryDelegate deliveryDelegate,
             LastRunInfoStore lastRunInfoStore,
             LaunchCrashTracker launchCrashTracker,
-            ExceptionHandler exceptionHandler
+            ExceptionHandler exceptionHandler,
+            Notifier notifier
     ) {
         this.immutableConfig = immutableConfig;
         this.metadataState = metadataState;
@@ -255,6 +258,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         this.launchCrashTracker = launchCrashTracker;
         this.lastRunInfo = null;
         this.exceptionHandler = exceptionHandler;
+        this.notifier = notifier;
     }
 
     void registerLifecycleCallbacks() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -49,6 +49,8 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     var projectPackages: Set<String> = emptySet()
     var persistenceDirectory: File? = null
 
+    val notifier: Notifier = Notifier()
+
     protected val plugins = HashSet<Plugin>()
 
     override fun addOnError(onError: OnErrorCallback) = callbackState.addOnError(onError)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -981,4 +981,8 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
     Set<Plugin> getPlugins() {
         return impl.getPlugins();
     }
+
+    Notifier getNotifier() {
+        return impl.getNotifier();
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -90,6 +90,9 @@ public class ClientFacadeTest {
     @Mock
     ExceptionHandler exceptionHandler;
 
+    @Mock
+    Notifier notifier;
+
     private Client client;
     private InterceptingLogger logger;
 
@@ -118,7 +121,8 @@ public class ClientFacadeTest {
                 deliveryDelegate,
                 lastRunInfoStore,
                 launchCrashTracker,
-                exceptionHandler
+                exceptionHandler,
+                notifier
         );
 
         // required fields for generating an event


### PR DESCRIPTION
## Goal
Allow plugins to set the `Notifier` details before the `Client` starts using them.

## Changeset
Add a new package-protected `Notifier` field to `Configuration`. This can be accessed by plugins (such as Unity) to set the details during `Client` initialisation.

## Testing
Relied on existing tests.