### PR TITLE
Alter react-native JSON serializers to use journal code

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Device.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Device.kt
@@ -88,5 +88,9 @@ open class Device internal constructor(
 
     override fun toStream(writer: JsonStream) = writer.value(toJournalSection())
 
-    override fun toJournalSection(): Map<String, Any?> = map
+    override fun toJournalSection(): Map<String, Any?> {
+        val copy = map.toMutableMap()
+        copy["cpuAbi"] = cpuAbi?.toList()
+        return copy
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeStackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeStackframe.kt
@@ -48,7 +48,7 @@ class NativeStackframe internal constructor(
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) = writer.value(toJournalSection())
 
-    override fun toJournalSection(): Map<String, Any?> = mapOf(
+    override fun toJournalSection(): Map<String, Any?> = mapOf<String, Any?>(
         JournalKeys.keyMethod to method,
         JournalKeys.keyFile to file,
         JournalKeys.keyLineNumber to lineNumber,
@@ -56,5 +56,5 @@ class NativeStackframe internal constructor(
         JournalKeys.keySymbolAddress to symbolAddress,
         JournalKeys.keyLoadAddress to loadAddress,
         JournalKeys.keyType to type?.desc
-    )
+    ).filterValues { it != null }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
@@ -103,5 +103,5 @@ class Stackframe : JsonStream.Streamable, Journalable {
             JournalKeys.keyColumnNumber to columnNumber,
             JournalKeys.keyCode to code,
             JournalKeys.keyType to type?.desc
-        )
+        ).filterValues { it != null }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -12,7 +12,7 @@ import java.util.List;
 @SuppressWarnings("ConstantConditions")
 public class Thread implements JsonStream.Streamable {
 
-    private final ThreadInternal impl;
+    final ThreadInternal impl;
     private final Logger logger;
 
     Thread(

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/AppSerializer.kt
@@ -2,17 +2,8 @@ package com.bugsnag.android
 
 internal class AppSerializer : MapSerializer<AppWithState> {
     override fun serialize(map: MutableMap<String, Any?>, app: AppWithState) {
-        map["type"] = app.type
-        map["binaryArch"] = app.binaryArch
-        map["buildUuid"] = app.buildUuid
-        map["codeBundleId"] = app.codeBundleId
-        map["duration"] = app.duration
-        map["durationInForeground"] = app.durationInForeground
-        map["id"] = app.id
-        map["inForeground"] = app.inForeground
-        map["isLaunching"] = app.isLaunching
-        map["releaseStage"] = app.releaseStage
-        map["version"] = app.version
-        map["versionCode"] = app.versionCode
+        map.putAll(app.toJournalSection())
+        map["buildUuid"] = map["buildUUID"]
+        map.remove("buildUUID")
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/DeviceSerializer.kt
@@ -1,25 +1,7 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.DateUtils
-
 internal class DeviceSerializer : MapSerializer<DeviceWithState> {
     override fun serialize(map: MutableMap<String, Any?>, device: DeviceWithState) {
-        map["cpuAbi"] = device.cpuAbi?.toList()
-        map["jailbroken"] = device.jailbroken
-        map["id"] = device.id
-        map["locale"] = device.locale
-        map["manufacturer"] = device.manufacturer
-        map["model"] = device.model
-        map["osName"] = device.osName
-        map["osVersion"] = device.osVersion
-        map["totalMemory"] = device.totalMemory
-        map["freeDisk"] = device.freeDisk
-        map["freeMemory"] = device.freeMemory
-        map["orientation"] = device.orientation
-
-        if (device.time != null) {
-            map["time"] = DateUtils.toIso8601(device.time!!)
-        }
-        map["runtimeVersions"] = device.runtimeVersions
+        map.putAll(device.toJournalSection())
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
@@ -1,22 +1,7 @@
 package com.bugsnag.android
 
-import java.util.Locale
-
 internal class ThreadSerializer : MapSerializer<Thread> {
     override fun serialize(map: MutableMap<String, Any?>, thread: Thread) {
-        map["id"] = thread.id
-        map["name"] = thread.name
-        map["type"] = thread.type.toString().toLowerCase(Locale.US)
-        map["errorReportingThread"] = thread.errorReportingThread
-        map["state"] = thread.state.descriptor
-
-        map["stacktrace"] = thread.stacktrace.map {
-            val frame = mutableMapOf<String, Any?>()
-            frame["method"] = it.method
-            frame["lineNumber"] = it.lineNumber
-            frame["file"] = it.file
-            frame["inProject"] = it.inProject
-            frame
-        }
+        map.putAll(thread.impl.toJournalSection())
     }
 }


### PR DESCRIPTION
## Goal

Updates the JSON serializers in the React Native module to use the journal code instead, which reduces duplication. This also  fixes a couple of issues in the journal implementation that were caught by the RN unit tests:

- null values are no longer added to the map for `Stackframe`
- the cpuAbi is serialized as a list rather than an array
- the key for buildUuid now matches the one used in the RN json


## Testing

Relied on existing unit test coverage