### PR TITLE
Deserialize user from bugsnag journal

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -15,6 +15,7 @@
     <ID>LongParameterList:DeviceDataCollector.kt$DeviceDataCollector$( private val connectivity: Connectivity, private val appContext: Context, resources: Resources, private val deviceId: String?, private val buildInfo: DeviceBuildInfo, private val dataDirectory: File, rootDetector: RootDetector, private val bgTaskService: BackgroundTaskService, private val logger: Logger )</ID>
     <ID>LongParameterList:DeviceWithState.kt$DeviceWithState$( buildInfo: DeviceBuildInfo, jailbroken: Boolean?, id: String?, locale: String?, totalMemory: Long?, runtimeVersions: MutableMap&lt;String, Any>, /** * The number of free bytes of storage available on the device */ var freeDisk: Long?, /** * The number of free bytes of memory available on the device */ var freeMemory: Long?, /** * The orientation of the device when the event occurred: either portrait or landscape */ var orientation: String?, /** * The timestamp on the device when the event occurred */ var time: Date? )</ID>
     <ID>LongParameterList:EventFilenameInfo.kt$EventFilenameInfo.Companion$( obj: Any, uuid: String = UUID.randomUUID().toString(), apiKey: String?, timestamp: Long = System.currentTimeMillis(), config: ImmutableConfig, isLaunching: Boolean? = null )</ID>
+    <ID>LongParameterList:EventInternal.kt$EventInternal$( apiKey: String, breadcrumbs: MutableList&lt;Breadcrumb> = mutableListOf(), discardClasses: Set&lt;String> = setOf(), errors: MutableList&lt;Error> = mutableListOf(), metadata: Metadata = Metadata(), originalError: Throwable? = null, projectPackages: Collection&lt;String> = setOf(), severityReason: SeverityReason = SeverityReason.newInstance(SeverityReason.REASON_HANDLED_EXCEPTION), threads: MutableList&lt;Thread> = mutableListOf(), user: User = User() )</ID>
     <ID>LongParameterList:EventStorageModule.kt$EventStorageModule$( contextModule: ContextModule, configModule: ConfigModule, dataCollectionModule: DataCollectionModule, bgTaskService: BackgroundTaskService, trackerModule: TrackerModule, systemServiceModule: SystemServiceModule, notifier: Notifier )</ID>
     <ID>LongParameterList:StateEvent.kt$StateEvent.Install$( @JvmField val apiKey: String, @JvmField val autoDetectNdkCrashes: Boolean, @JvmField val appVersion: String?, @JvmField val buildUuid: String?, @JvmField val releaseStage: String?, @JvmField val lastRunInfoPath: String, @JvmField val consecutiveLaunchCrashes: Int )</ID>
     <ID>LongParameterList:ThreadState.kt$ThreadState$( stackTraces: MutableMap&lt;java.lang.Thread, Array&lt;StackTraceElement>>, currentThread: java.lang.Thread, exc: Throwable?, isUnhandled: Boolean, projectPackages: Collection&lt;String>, logger: Logger )</ID>
@@ -29,7 +30,6 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityInternal(severity: Severity)</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityReason(@SeverityReason.SeverityReasonType reason: String)</ID>
     <ID>RethrowCaughtException:JsonHelper.kt$JsonHelper.Companion$throw ex</ID>
-    <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?&gt; ): DeliveryStatus</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?> ): DeliveryStatus</ID>
     <ID>SwallowedException:ConnectivityCompat.kt$ConnectivityLegacy$catch (e: NullPointerException) { // in some rare cases we get a remote NullPointerException via Parcel.readException null }</ID>
     <ID>SwallowedException:ContextExtensions.kt$catch (exc: RuntimeException) { null }</ID>
@@ -44,6 +44,5 @@
     <ID>SwallowedException:PluginClient.kt$PluginClient$catch (exc: ClassNotFoundException) { logger.d("Plugin '$clz' is not on the classpath - functionality will not be enabled.") null }</ID>
     <ID>UnnecessaryAbstractClass:DependencyModule.kt$DependencyModule</ID>
     <ID>UnusedPrivateMember:ThreadStateTest.kt$ThreadStateTest$private val configuration = generateImmutableConfig()</ID>
-    <ID>VariableNaming:EventInternal.kt$EventInternal$/** * @return user information associated with this Event */ internal var _user = User(null, null, null)</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackerConfinementTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackerConfinementTest.kt
@@ -27,7 +27,7 @@ internal class SessionTrackerConfinementTest {
 
         // send 20 sessions
         repeat(SESSION_CONFINEMENT_ATTEMPTS) { count ->
-            client.sessionTracker.startNewSession(Date(0), User("$count"), false)
+            client.sessionTracker.startNewSession(Date(0), User("$count", null, null), false)
         }
         retainingDelivery.latch.await(1, TimeUnit.SECONDS)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -3,16 +3,60 @@ package com.bugsnag.android
 import com.bugsnag.android.internal.ImmutableConfig
 import java.io.IOException
 
-internal class EventInternal @JvmOverloads internal constructor(
-    val originalError: Throwable? = null,
-    config: ImmutableConfig,
-    private var severityReason: SeverityReason,
-    data: Metadata = Metadata()
-) : JsonStream.Streamable, MetadataAware, UserAware {
+internal class EventInternal : JsonStream.Streamable, MetadataAware, UserAware {
 
-    val metadata: Metadata = data.copy()
-    private val discardClasses: Set<String> = config.discardClasses.toSet()
-    private val projectPackages = config.projectPackages
+    @JvmOverloads
+    internal constructor(
+        originalError: Throwable? = null,
+        config: ImmutableConfig,
+        severityReason: SeverityReason,
+        data: Metadata = Metadata()
+    ) : this(
+        config.apiKey,
+        mutableListOf(),
+        config.discardClasses.toSet(),
+        when (originalError) {
+            null -> mutableListOf()
+            else -> Error.createError(originalError, config.projectPackages, config.logger)
+        },
+        data.copy(),
+        originalError,
+        config.projectPackages,
+        severityReason,
+        ThreadState(originalError, severityReason.unhandled, config).threads,
+        User()
+    )
+
+    internal constructor(
+        apiKey: String,
+        breadcrumbs: MutableList<Breadcrumb> = mutableListOf(),
+        discardClasses: Set<String> = setOf(),
+        errors: MutableList<Error> = mutableListOf(),
+        metadata: Metadata = Metadata(),
+        originalError: Throwable? = null,
+        projectPackages: Collection<String> = setOf(),
+        severityReason: SeverityReason = SeverityReason.newInstance(SeverityReason.REASON_HANDLED_EXCEPTION),
+        threads: MutableList<Thread> = mutableListOf(),
+        user: User = User()
+    ) {
+        this.apiKey = apiKey
+        this.breadcrumbs = breadcrumbs
+        this.discardClasses = discardClasses
+        this.errors = errors
+        this.metadata = metadata
+        this.originalError = originalError
+        this.projectPackages = projectPackages
+        this.severityReason = severityReason
+        this.threads = threads
+        this.userImpl = user
+    }
+
+    val originalError: Throwable?
+    private var severityReason: SeverityReason
+
+    val metadata: Metadata
+    private val discardClasses: Set<String>
+    private val projectPackages: Collection<String>
 
     @JvmField
     internal var session: Session? = null
@@ -23,34 +67,29 @@ internal class EventInternal @JvmOverloads internal constructor(
             severityReason.currentSeverity = value
         }
 
-    var apiKey: String = config.apiKey
+    var apiKey: String
     lateinit var app: AppWithState
     lateinit var device: DeviceWithState
-    var breadcrumbs: MutableList<Breadcrumb> = mutableListOf()
     var unhandled: Boolean
         get() = severityReason.unhandled
         set(value) {
             severityReason.unhandled = value
         }
-    val unhandledOverridden: Boolean
-        get() = severityReason.unhandledOverridden
 
-    val originalUnhandled: Boolean
-        get() = severityReason.originalUnhandled
-
-    var errors: MutableList<Error> = when (originalError) {
-        null -> mutableListOf()
-        else -> Error.createError(originalError, config.projectPackages, config.logger)
-    }
-
-    var threads: MutableList<Thread> = ThreadState(originalError, unhandled, config).threads
+    var breadcrumbs: MutableList<Breadcrumb>
+    var errors: MutableList<Error>
+    var threads: MutableList<Thread>
     var groupingHash: String? = null
     var context: String? = null
 
     /**
      * @return user information associated with this Event
      */
-    internal var _user = User(null, null, null)
+    internal var userImpl: User
+
+    fun getUnhandledOverridden(): Boolean = severityReason.unhandledOverridden
+
+    fun getOriginalUnhandled(): Boolean = severityReason.originalUnhandled
 
     protected fun shouldDiscardClass(): Boolean {
         return when {
@@ -93,7 +132,7 @@ internal class EventInternal @JvmOverloads internal constructor(
         writer.endArray()
 
         // Write user info
-        writer.name("user").value(_user)
+        writer.name("user").value(userImpl)
 
         // Write diagnostics
         writer.name("app").value(app)
@@ -150,12 +189,13 @@ internal class EventInternal @JvmOverloads internal constructor(
     fun getSeverityReasonType(): String = severityReason.severityReasonType
 
     override fun setUser(id: String?, email: String?, name: String?) {
-        _user = User(id, email, name)
+        userImpl = User(id, email, name)
     }
 
-    override fun getUser() = _user
+    override fun getUser() = userImpl
 
-    override fun addMetadata(section: String, value: Map<String, Any?>) = metadata.addMetadata(section, value)
+    override fun addMetadata(section: String, value: Map<String, Any?>) =
+        metadata.addMetadata(section, value)
 
     override fun addMetadata(section: String, key: String, value: Any?) =
         metadata.addMetadata(section, key, value)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapper.kt
@@ -1,8 +1,9 @@
 package com.bugsnag.android.internal.journal
 
 import com.bugsnag.android.BugsnagJournal
-import com.bugsnag.android.Event
+import com.bugsnag.android.EventInternal
 import com.bugsnag.android.Logger
+import com.bugsnag.android.User
 import java.io.File
 
 /**
@@ -12,18 +13,51 @@ internal class BugsnagJournalEventMapper(
     private val logger: Logger
 ) {
 
-    fun convertToEvent(baseDocumentPath: File): Event? {
+    fun convertToEvent(baseDocumentPath: File): EventInternal? {
         return try {
-            val map = BugsnagJournal.loadPreviousDocument(baseDocumentPath)
-            convertToEvent(map)
+            when (val map = BugsnagJournal.loadPreviousDocument(baseDocumentPath)) {
+                null -> null
+                else -> convertToEvent(map)
+            }
         } catch (exc: Throwable) {
             logger.e("Failed to load journal, skipping event", exc)
             null
         }
     }
 
-    fun convertToEvent(map: Map<in String, Any>?): Event? {
+    fun convertToEvent(map: Map<in String, Any?>): EventInternal? {
+        return try {
+            convertToEventImpl(map)
+        } catch (exc: Throwable) {
+            logger.e("Failed to deserialize journal, skipping event", exc)
+            null
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun convertToEventImpl(map: Map<in String, Any?>): EventInternal {
         logger.d("Read previous journal, contents=$map")
-        return null
+        val apiKey: String = map.readJournalEntry("apiKey")
+        val event = EventInternal(apiKey)
+
+        // populate user
+        val userMap: Map<String, String?> = map.readJournalEntry("user")
+        event.userImpl = User(userMap)
+        return event
+    }
+
+    /**
+     * Convenience method for getting an entry from a Map in the expected type, which
+     * throws useful error messages if the expected type is not there.
+     */
+    private inline fun <reified T> Map<*, *>.readJournalEntry(key: String): T {
+        check(containsKey(key)) {
+            "Journal does not contain entry for '$key'"
+        }
+        val value = requireNotNull(get(key))
+        check(value is T) {
+            "Journal entry for '$key' not of expected type, found ${value.javaClass.name}"
+        }
+        return value
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -131,6 +131,7 @@ public class ClientFacadeTest {
 
         // required fields for generating an event
         when(metadataState.getMetadata()).thenReturn(new Metadata());
+        when(immutableConfig.getApiKey()).thenReturn("api-key");
         when(immutableConfig.getLogger()).thenReturn(logger);
         when(immutableConfig.getSendThreads()).thenReturn(ThreadSendPolicy.ALWAYS);
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
@@ -30,13 +30,13 @@ internal class EventApiTest {
 
     @Test
     fun getUser() {
-        assertEquals(event.impl._user, event.getUser())
+        assertEquals(event.impl.userImpl, event.getUser())
     }
 
     @Test
     fun setUser() {
         event.setUser("99", "boo@example.com", "Boo")
-        assertEquals(User("99", "boo@example.com", "Boo"), event.impl._user)
+        assertEquals(User("99", "boo@example.com", "Boo"), event.impl.userImpl)
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapperTest.kt
@@ -1,20 +1,36 @@
 package com.bugsnag.android.internal.journal
 
 import com.bugsnag.android.NoopLogger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
 class BugsnagJournalEventMapperTest {
 
     @Test
-    fun nullMapNullEvent() {
-        val mapper = BugsnagJournalEventMapper(NoopLogger)
-        assertNull(mapper.convertToEvent(null))
-    }
-
-    @Test
     fun emptyMapNullEvent() {
         val mapper = BugsnagJournalEventMapper(NoopLogger)
         assertNull(mapper.convertToEvent(emptyMap()))
+    }
+
+    @Test
+    fun populatedEvent() {
+        val mapper = BugsnagJournalEventMapper(NoopLogger)
+        val map = mapOf(
+            "apiKey" to "my-api-key",
+            "user" to mapOf(
+                "id" to "123",
+                "name" to "Boog Snoog",
+                "email" to "hello@example.com"
+            )
+        )
+        val event = mapper.convertToEvent(map)
+        checkNotNull(event)
+        val user = event.getUser()
+        assertNotNull(user)
+        assertEquals("123", user.id)
+        assertEquals("Boog Snoog", user.name)
+        assertEquals("hello@example.com", user.email)
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/UserDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/UserDeserializer.java
@@ -5,10 +5,7 @@ import java.util.Map;
 class UserDeserializer implements MapDeserializer<User> {
     @Override
     public User deserialize(Map<String, Object> map) {
-        return new User(
-                MapUtils.<String>getOrNull(map, "id"),
-                MapUtils.<String>getOrNull(map, "email"),
-                MapUtils.<String>getOrNull(map, "name")
-        );
+        @SuppressWarnings({"unchecked", "rawtypes"}) Map<String, String> data = (Map) map;
+        return new User(data);
     }
 }


### PR DESCRIPTION
## Goal

Deserializes the `user` value from the Bugsnag journal entry. This has been achieved by altering the `User` class to [delegate its properties to a map](https://kotlinlang.org/docs/delegated-properties.html#storing-properties-in-a-map), and adding another constructor to `EventInternal` that provides default values.

## Changeset

- Added secondary constructor to `EventInternal` that sets default values
- Converted `User` to have its properties backed by a map. This will be rolled out to other classes on the `Event` interface where appropriate in future changesets
- Updated react native deserialization to use new constructor
- Loaded user from the bugsnag journal

## Testing

Added unit test coverage.