### PR TITLE
Deserialize metadata from bugsnag journal entries

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapper.kt
@@ -43,6 +43,12 @@ internal class BugsnagJournalEventMapper(
         // populate user
         val userMap: Map<String, String?> = map.readJournalEntry("user")
         event.userImpl = User(userMap)
+
+        // populate metadata
+        val metadataMap: Map<String, Map<String, Any?>> = map.readJournalEntry("metaData")
+        metadataMap.forEach { (key, value) ->
+            event.addMetadata(key, value)
+        }
         return event
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapperTest.kt
@@ -4,9 +4,43 @@ import com.bugsnag.android.NoopLogger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
 
 class BugsnagJournalEventMapperTest {
+
+    private lateinit var journalMap: Map<String, Any?>
+    private lateinit var fooSection: Map<String, Any?>
+    private lateinit var appSection: Map<String, Any?>
+
+    @Before
+    fun setUp() {
+        fooSection = mapOf(
+            "map" to mapOf(
+                "a" to "z"
+            ),
+            "array" to listOf(
+                "1", "2", "3"
+            )
+        )
+        appSection = mapOf(
+            "processName" to "com.example.bugsnag.android",
+            "memoryLimit" to 40265318449,
+            "lowMemory" to false
+        )
+        journalMap = mapOf(
+            "apiKey" to "my-api-key",
+            "user" to mapOf(
+                "id" to "123",
+                "name" to "Boog Snoog",
+                "email" to "hello@example.com"
+            ),
+            "metaData" to mapOf(
+                "app" to appSection,
+                "foo" to fooSection
+            )
+        )
+    }
 
     @Test
     fun emptyMapNullEvent() {
@@ -17,20 +51,18 @@ class BugsnagJournalEventMapperTest {
     @Test
     fun populatedEvent() {
         val mapper = BugsnagJournalEventMapper(NoopLogger)
-        val map = mapOf(
-            "apiKey" to "my-api-key",
-            "user" to mapOf(
-                "id" to "123",
-                "name" to "Boog Snoog",
-                "email" to "hello@example.com"
-            )
-        )
-        val event = mapper.convertToEvent(map)
+        val event = mapper.convertToEvent(journalMap)
         checkNotNull(event)
+
+        // user
         val user = event.getUser()
         assertNotNull(user)
         assertEquals("123", user.id)
         assertEquals("Boog Snoog", user.name)
         assertEquals("hello@example.com", user.email)
+
+        // metadata
+        assertEquals(appSection, event.getMetadata("app"))
+        assertEquals(fooSection, event.getMetadata("foo"))
     }
 }


### PR DESCRIPTION
## Goal

Deserializes metadata from any entries in the bugsnag journal and converts it into an `Event`.

## Testing

Added a unit test case.