### PR TITLE
Deserialize breadcrumbs from bugsnag journal entries

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Breadcrumb.java
@@ -16,9 +16,13 @@ public class Breadcrumb implements JsonStream.Streamable {
     final BreadcrumbInternal impl;
     private final Logger logger;
 
-    Breadcrumb(@NonNull String message, @NonNull Logger logger) {
-        this.impl = new BreadcrumbInternal(message);
+    Breadcrumb(@NonNull BreadcrumbInternal impl, @NonNull Logger logger) {
+        this.impl = impl;
         this.logger = logger;
+    }
+
+    Breadcrumb(@NonNull String message, @NonNull Logger logger) {
+        this(new BreadcrumbInternal(message), logger);
     }
 
     Breadcrumb(@NonNull String message,
@@ -26,8 +30,7 @@ public class Breadcrumb implements JsonStream.Streamable {
                @Nullable Map<String, Object> metadata,
                @NonNull Date timestamp,
                @NonNull Logger logger) {
-        this.impl = new BreadcrumbInternal(message, type, metadata, timestamp);
-        this.logger = logger;
+        this(new BreadcrumbInternal(message, type, metadata, timestamp), logger);
     }
 
     private void logNull(String property) {
@@ -39,7 +42,7 @@ public class Breadcrumb implements JsonStream.Streamable {
      */
     public void setMessage(@NonNull String message) {
         if (message != null) {
-            impl.message = message;
+            impl.setMessage(message);
         } else {
             logNull("message");
         }
@@ -50,7 +53,7 @@ public class Breadcrumb implements JsonStream.Streamable {
      */
     @NonNull
     public String getMessage() {
-        return impl.message;
+        return impl.getMessage();
     }
 
     /**
@@ -59,7 +62,7 @@ public class Breadcrumb implements JsonStream.Streamable {
      */
     public void setType(@NonNull BreadcrumbType type) {
         if (type != null) {
-            impl.type = type;
+            impl.setType(type);
         } else {
             logNull("type");
         }
@@ -71,14 +74,14 @@ public class Breadcrumb implements JsonStream.Streamable {
      */
     @NonNull
     public BreadcrumbType getType() {
-        return impl.type;
+        return impl.getType();
     }
 
     /**
      * Sets diagnostic data relating to the breadcrumb
      */
     public void setMetadata(@Nullable Map<String, Object> metadata) {
-        impl.metadata = metadata;
+        impl.setMetadata(metadata);
     }
 
     /**
@@ -86,7 +89,7 @@ public class Breadcrumb implements JsonStream.Streamable {
      */
     @Nullable
     public Map<String, Object> getMetadata() {
-        return impl.metadata;
+        return impl.getMetadata();
     }
 
     /**
@@ -94,12 +97,12 @@ public class Breadcrumb implements JsonStream.Streamable {
      */
     @NonNull
     public Date getTimestamp() {
-        return impl.timestamp;
+        return impl.getTimestamp();
     }
 
     @NonNull
     String getStringTimestamp() {
-        return DateUtils.toIso8601(impl.timestamp);
+        return DateUtils.toIso8601(impl.getTimestamp());
     }
 
     @Override

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbInternal.kt
@@ -9,17 +9,35 @@ import java.util.Date
  * attached to a crash to help diagnose what events lead to the error.
  */
 internal class BreadcrumbInternal internal constructor(
-    @JvmField var message: String,
-    @JvmField var type: BreadcrumbType,
-    @JvmField var metadata: MutableMap<String, Any?>?,
-    @JvmField val timestamp: Date = Date()
+    data: MutableMap<String, Any?> = mutableMapOf()
 ) : JsonStream.Streamable { // JvmField allows direct field access optimizations
+
+    private val map: MutableMap<String, Any?> = data.withDefault { null }
+
+    val timestamp: Date by map
+    var metadata: MutableMap<String, Any?>? by map
+    var type: BreadcrumbType by map
+    var message: String by map
 
     internal constructor(message: String) : this(
         message,
         BreadcrumbType.MANUAL,
         mutableMapOf(),
         Date()
+    )
+
+    internal constructor(
+        message: String,
+        type: BreadcrumbType,
+        metadata: MutableMap<String, Any?>?,
+        timestamp: Date = Date()
+    ) : this(
+        mutableMapOf(
+            "message" to message,
+            "type" to type,
+            "timestamp" to timestamp,
+            "metadata" to metadata
+        )
     )
 
     @Throws(IOException::class)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -7,7 +7,6 @@ import com.bugsnag.android.internal.StateObserver;
 import com.bugsnag.android.internal.dag.ConfigModule;
 import com.bugsnag.android.internal.dag.ContextModule;
 import com.bugsnag.android.internal.dag.SystemServiceModule;
-import com.bugsnag.android.internal.journal.BugsnagJournalEventMapper;
 
 import android.app.Application;
 import android.content.Context;

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalEventMapperTest.kt
@@ -1,6 +1,9 @@
 package com.bugsnag.android.internal.journal
 
+import com.bugsnag.android.BreadcrumbType
+import com.bugsnag.android.BugsnagJournalEventMapper
 import com.bugsnag.android.NoopLogger
+import com.bugsnag.android.internal.DateUtils
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -28,6 +31,23 @@ class BugsnagJournalEventMapperTest {
             "memoryLimit" to 40265318449,
             "lowMemory" to false
         )
+        val breadcrumbs = listOf(
+            mapOf(
+                "metaData" to emptyMap<String, Any?>(),
+                "name" to "Bugsnag loaded",
+                "type" to "state",
+                "timestamp" to "2021-09-28T10:31:09.092Z"
+            ),
+            mapOf(
+                "metaData" to mapOf(
+                    "hasConnection" to true,
+                    "networkState" to "wifi"
+                ),
+                "name" to "Connectivity changed",
+                "type" to "request",
+                "timestamp" to "2021-09-28T10:31:10.856Z"
+            )
+        )
         journalMap = mapOf(
             "apiKey" to "my-api-key",
             "user" to mapOf(
@@ -38,7 +58,8 @@ class BugsnagJournalEventMapperTest {
             "metaData" to mapOf(
                 "app" to appSection,
                 "foo" to fooSection
-            )
+            ),
+            "breadcrumbs" to breadcrumbs
         )
     }
 
@@ -64,5 +85,26 @@ class BugsnagJournalEventMapperTest {
         // metadata
         assertEquals(appSection, event.getMetadata("app"))
         assertEquals(fooSection, event.getMetadata("foo"))
+
+        // breadcrumbs
+        assertEquals(2, event.breadcrumbs.size)
+
+        with(event.breadcrumbs[0]) {
+            assertEquals("Bugsnag loaded", message)
+            assertEquals(BreadcrumbType.STATE, type)
+            assertEquals(DateUtils.fromIso8601("2021-09-28T10:31:09.092Z"), timestamp)
+            assertEquals(emptyMap<String, Any?>(), metadata)
+        }
+
+        with(event.breadcrumbs[1]) {
+            assertEquals("Connectivity changed", message)
+            assertEquals(BreadcrumbType.REQUEST, type)
+            assertEquals(DateUtils.fromIso8601("2021-09-28T10:31:10.856Z"), timestamp)
+            val expectedMetadata = mapOf(
+                "hasConnection" to true,
+                "networkState" to "wifi"
+            )
+            assertEquals(expectedMetadata, metadata)
+        }
     }
 }


### PR DESCRIPTION
## Goal

Deserializes breadcrumbs from any entries in the bugsnag journal and adds them onto an `Event`. This converts `BreadcrumbInternal` to use a `Map` as a property delegate.

## Testing

Added unit tests to cover the functionality.