### PR TITLE
v5.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.14.0 (2021-09-29)
+
+### Enhancements 
+
+* Capture and report thread state (running, sleeping, etc.) for Android Runtime and Native threads
+  [#1367](https://github.com/bugsnag/bugsnag-android/pull/1367)
+  [#1390](https://github.com/bugsnag/bugsnag-android/pull/1390)
+
 ## 5.13.0 (2021-09-22)
 
 * Capture breadcrumbs for OkHttp network requests
@@ -18,7 +26,7 @@
   [#1375](https://github.com/bugsnag/bugsnag-android/pull/1375)
 
 * Use SystemClock.elapsedRealtime to track `app.durationInForeground`
-  [#1375](https://github.com/bugsnag/bugsnag-android/pull/1375)
+  [#1378](https://github.com/bugsnag/bugsnag-android/pull/1378)
 
 ## 5.12.0 (2021-08-26)
 

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -14,13 +14,15 @@
     <ID>LongParameterList:DeviceWithState.kt$DeviceWithState$( buildInfo: DeviceBuildInfo, jailbroken: Boolean?, id: String?, locale: String?, totalMemory: Long?, runtimeVersions: MutableMap&lt;String, Any>, /** * The number of free bytes of storage available on the device */ var freeDisk: Long?, /** * The number of free bytes of memory available on the device */ var freeMemory: Long?, /** * The orientation of the device when the event occurred: either portrait or landscape */ var orientation: String?, /** * The timestamp on the device when the event occurred */ var time: Date? )</ID>
     <ID>LongParameterList:EventFilenameInfo.kt$EventFilenameInfo.Companion$( obj: Any, uuid: String = UUID.randomUUID().toString(), apiKey: String?, timestamp: Long = System.currentTimeMillis(), config: ImmutableConfig, isLaunching: Boolean? = null )</ID>
     <ID>LongParameterList:EventStorageModule.kt$EventStorageModule$( contextModule: ContextModule, configModule: ConfigModule, dataCollectionModule: DataCollectionModule, bgTaskService: BackgroundTaskService, trackerModule: TrackerModule, systemServiceModule: SystemServiceModule, notifier: Notifier )</ID>
-    <ID>LongParameterList:StateEvent.kt$StateEvent.Install$( @JvmField val apiKey: String, @JvmField val autoDetectNdkCrashes: Boolean, @JvmField val appVersion: String?, @JvmField val buildUuid: String?, @JvmField val releaseStage: String?, @JvmField val lastRunInfoPath: String, @JvmField val consecutiveLaunchCrashes: Int )</ID>
+    <ID>LongParameterList:StateEvent.kt$StateEvent.Install$( @JvmField val apiKey: String, @JvmField val autoDetectNdkCrashes: Boolean, @JvmField val appVersion: String?, @JvmField val buildUuid: String?, @JvmField val releaseStage: String?, @JvmField val lastRunInfoPath: String, @JvmField val consecutiveLaunchCrashes: Int, @JvmField val sendThreads: ThreadSendPolicy )</ID>
     <ID>LongParameterList:ThreadState.kt$ThreadState$( stackTraces: MutableMap&lt;java.lang.Thread, Array&lt;StackTraceElement>>, currentThread: java.lang.Thread, exc: Throwable?, isUnhandled: Boolean, projectPackages: Collection&lt;String>, logger: Logger )</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$299</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$429</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>
     <ID>MagicNumber:LastRunInfoStore.kt$LastRunInfoStore$3</ID>
+    <ID>MaxLineLength:EventSerializationTest.kt$EventSerializationTest.Companion$it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, Thread.State.RUNNABLE, stacktrace, NoopLogger))</ID>
     <ID>MaxLineLength:LastRunInfo.kt$LastRunInfo$return "LastRunInfo(consecutiveLaunchCrashes=$consecutiveLaunchCrashes, crashed=$crashed, crashedDuringLaunch=$crashedDuringLaunch)"</ID>
+    <ID>MaxLineLength:ThreadState.kt$ThreadState$Thread(thread.id, thread.name, ThreadType.ANDROID, errorThread, Thread.State.forThread(thread), stacktrace, logger)</ID>
     <ID>ProtectedMemberInFinalClass:ConfigInternal.kt$ConfigInternal$protected val plugins = HashSet&lt;Plugin>()</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun isAnr(event: Event): Boolean</ID>
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun shouldDiscardClass(): Boolean</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -79,7 +79,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     final ClientObservable clientObservable;
     PluginClient pluginClient;
 
-    final Notifier notifier = new Notifier();
+    final Notifier notifier;
 
     @Nullable
     final LastRunInfo lastRunInfo;
@@ -116,6 +116,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
     public Client(@NonNull Context androidContext, @NonNull final Configuration configuration) {
         ContextModule contextModule = new ContextModule(androidContext);
         appContext = contextModule.getCtx();
+
+        notifier = configuration.getNotifier();
 
         connectivity = new ConnectivityCompat(appContext, new Function2<Boolean, String, Unit>() {
             @Override
@@ -233,7 +235,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
             DeliveryDelegate deliveryDelegate,
             LastRunInfoStore lastRunInfoStore,
             LaunchCrashTracker launchCrashTracker,
-            ExceptionHandler exceptionHandler
+            ExceptionHandler exceptionHandler,
+            Notifier notifier
     ) {
         this.immutableConfig = immutableConfig;
         this.metadataState = metadataState;
@@ -255,6 +258,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         this.launchCrashTracker = launchCrashTracker;
         this.lastRunInfo = null;
         this.exceptionHandler = exceptionHandler;
+        this.notifier = notifier;
     }
 
     void registerLifecycleCallbacks() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
@@ -21,7 +21,8 @@ internal class ClientObservable : BaseObservable() {
                 conf.buildUuid,
                 conf.releaseStage,
                 lastRunInfoPath,
-                consecutiveLaunchCrashes
+                consecutiveLaunchCrashes,
+                conf.sendThreads
             )
         }
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -49,6 +49,8 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
     var projectPackages: Set<String> = emptySet()
     var persistenceDirectory: File? = null
 
+    val notifier: Notifier = Notifier()
+
     protected val plugins = HashSet<Plugin>()
 
     override fun addOnError(onError: OnErrorCallback) = callbackState.addOnError(onError)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -981,4 +981,8 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
     Set<Plugin> getPlugins() {
         return impl.getPlugins();
     }
+
+    Notifier getNotifier() {
+        return impl.getNotifier();
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,7 +7,7 @@ import java.io.IOException
  */
 class Notifier @JvmOverloads constructor(
     var name: String = "Android Bugsnag Notifier",
-    var version: String = "5.13.0",
+    var version: String = "5.14.0",
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
@@ -9,7 +9,8 @@ sealed class StateEvent { // JvmField allows direct field access optimizations
         @JvmField val buildUuid: String?,
         @JvmField val releaseStage: String?,
         @JvmField val lastRunInfoPath: String,
-        @JvmField val consecutiveLaunchCrashes: Int
+        @JvmField val consecutiveLaunchCrashes: Int,
+        @JvmField val sendThreads: ThreadSendPolicy
     ) : StateEvent()
 
     object DeliverPending : StateEvent()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -7,6 +7,7 @@ class ThreadInternal internal constructor(
     var name: String,
     var type: ThreadType,
     val isErrorReportingThread: Boolean,
+    var state: Thread.State,
     stacktrace: Stacktrace
 ) : JsonStream.Streamable {
 
@@ -18,6 +19,7 @@ class ThreadInternal internal constructor(
         writer.name("id").value(id)
         writer.name("name").value(name)
         writer.name("type").value(type.desc)
+        writer.name("state").value(state.descriptor)
 
         writer.name("stacktrace")
         writer.beginArray()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadState.kt
@@ -67,7 +67,7 @@ internal class ThreadState @Suppress("LongParameterList") @JvmOverloads construc
                 if (trace != null) {
                     val stacktrace = Stacktrace(trace, projectPackages, logger)
                     val errorThread = thread.id == currentThreadId
-                    Thread(thread.id, thread.name, ThreadType.ANDROID, errorThread, stacktrace, logger)
+                    Thread(thread.id, thread.name, ThreadType.ANDROID, errorThread, Thread.State.forThread(thread), stacktrace, logger)
                 } else {
                     null
                 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -90,6 +90,9 @@ public class ClientFacadeTest {
     @Mock
     ExceptionHandler exceptionHandler;
 
+    @Mock
+    Notifier notifier;
+
     private Client client;
     private InterceptingLogger logger;
 
@@ -118,7 +121,8 @@ public class ClientFacadeTest {
                 deliveryDelegate,
                 lastRunInfoStore,
                 launchCrashTracker,
-                exceptionHandler
+                exceptionHandler,
+                notifier
         );
 
         // required fields for generating an event

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -40,7 +40,7 @@ internal class EventSerializationTest {
                 createEvent {
                     val stacktrace = Stacktrace(arrayOf(), emptySet(), NoopLogger)
                     it.threads.clear()
-                    it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, stacktrace, NoopLogger))
+                    it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, Thread.State.RUNNABLE, stacktrace, NoopLogger))
                 },
 
                 // threads included

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -27,7 +27,15 @@ public class ThreadFacadeTest {
         logger = new InterceptingLogger();
         List<Stackframe> frames = Collections.emptyList();
         stacktrace = new Stacktrace(frames);
-        thread = new Thread(1, "thread-2", ThreadType.ANDROID, false, stacktrace, logger);
+        thread = new Thread(
+                1,
+                "thread-2",
+                ThreadType.ANDROID,
+                false,
+                Thread.State.RUNNABLE,
+                stacktrace,
+                logger
+        );
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
@@ -24,6 +24,7 @@ internal class ThreadSerializationTest {
                 "main-one",
                 ThreadType.ANDROID,
                 true,
+                Thread.State.RUNNABLE,
                 Stacktrace(
                     stacktrace,
                     emptySet(),
@@ -43,6 +44,7 @@ internal class ThreadSerializationTest {
                 "main-one",
                 ThreadType.ANDROID,
                 false,
+                Thread.State.RUNNABLE,
                 Stacktrace(
                     stacktrace1,
                     emptySet(),
@@ -76,6 +78,7 @@ internal class ThreadSerializationTest {
                 "main-one",
                 ThreadType.ANDROID,
                 true,
+                Thread.State.RUNNABLE,
                 trace,
                 NoopLogger
             )
@@ -98,6 +101,7 @@ internal class ThreadSerializationTest {
                 "main-one",
                 ThreadType.ANDROID,
                 false,
+                Thread.State.RUNNABLE,
                 trace,
                 NoopLogger
             )

--- a/bugsnag-android-core/src/test/resources/event_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_5.json
@@ -37,6 +37,7 @@
       "id": 5,
       "name": "main",
       "type": "android",
+      "state": "RUNNABLE",
       "stacktrace": [],
       "errorReportingThread": true
     }

--- a/bugsnag-android-core/src/test/resources/thread_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_0.json
@@ -2,6 +2,7 @@
   "id": 24,
   "name": "main-one",
   "type": "android",
+  "state": "RUNNABLE",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-android-core/src/test/resources/thread_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_1.json
@@ -2,6 +2,7 @@
   "id": 24,
   "name": "main-one",
   "type": "android",
+  "state": "RUNNABLE",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-android-core/src/test/resources/thread_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_2.json
@@ -2,6 +2,7 @@
   "id": 24,
   "name": "main-one",
   "type": "android",
+  "state": "RUNNABLE",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-android-core/src/test/resources/thread_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_3.json
@@ -2,6 +2,7 @@
   "id": 24,
   "name": "main-one",
   "type": "android",
+  "state": "RUNNABLE",
   "stacktrace": [
     {
       "method": "run_func",

--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -3,7 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>ComplexMethod:NativeBridge.kt$NativeBridge$override fun onStateChange(event: StateEvent)</ID>
-    <ID>LongParameterList:NativeBridge.kt$NativeBridge$( apiKey: String, reportingDirectory: String, lastRunInfoPath: String, consecutiveLaunchCrashes: Int, autoDetectNdkCrashes: Boolean, apiLevel: Int, is32bit: Boolean, appVersion: String, buildUuid: String, releaseStage: String )</ID>
+    <ID>LongParameterList:NativeBridge.kt$NativeBridge$( apiKey: String, reportingDirectory: String, lastRunInfoPath: String, consecutiveLaunchCrashes: Int, autoDetectNdkCrashes: Boolean, apiLevel: Int, is32bit: Boolean, threadSendPolicy: Int )</ID>
     <ID>NestedBlockDepth:NativeBridge.kt$NativeBridge$private fun deliverPendingReports()</ID>
     <ID>TooManyFunctions:NativeBridge.kt$NativeBridge : StateObserver</ID>
   </CurrentIssues>

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/ThreadSerializationTest.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/ThreadSerializationTest.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.ndk
+
+import org.junit.Assert
+import org.junit.Test
+
+class ThreadSerializationTest {
+
+    companion object {
+        init {
+            System.loadLibrary("bugsnag-ndk")
+            System.loadLibrary("bugsnag-ndk-test")
+        }
+    }
+
+    external fun run(): String
+
+    @Test
+    fun testPassesNativeSuite() {
+        val expected = loadJson("thread_serialization.json")
+        val json = run()
+        Assert.assertEquals(expected, json)
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/thread_serialization.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/thread_serialization.json
@@ -1,0 +1,1 @@
+[{"id":1234,"name":"Binder 1","state":"Running","type":"c"}]

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library( # Specifies the name of the library.
     jni/utils/stack_unwinder_simple.c
     jni/utils/serializer.c
     jni/utils/string.c
+    jni/utils/threads.c
     jni/deps/parson/parson.c
              )
 

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -48,9 +48,7 @@ class NativeBridge : StateObserver {
         autoDetectNdkCrashes: Boolean,
         apiLevel: Int,
         is32bit: Boolean,
-        appVersion: String,
-        buildUuid: String,
-        releaseStage: String
+        threadSendPolicy: Int
     )
 
     external fun startedSession(
@@ -172,9 +170,7 @@ class NativeBridge : StateObserver {
                     arg.autoDetectNdkCrashes,
                     Build.VERSION.SDK_INT,
                     is32bit,
-                    makeSafe(arg.appVersion ?: ""),
-                    makeSafe(arg.buildUuid ?: ""),
-                    makeSafe(arg.releaseStage ?: "")
+                    arg.sendThreads.ordinal
                 )
                 installed.set(true)
             }

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -134,7 +134,8 @@ void bsg_update_next_run_info(bsg_environment *env) {
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
     JNIEnv *env, jobject _this, jstring _api_key, jstring _event_path,
     jstring _last_run_info_path, jint consecutive_launch_crashes,
-    jboolean auto_detect_ndk_crashes, jint _api_level, jboolean is32bit) {
+    jboolean auto_detect_ndk_crashes, jint _api_level, jboolean is32bit,
+    jint send_threads) {
   bsg_environment *bugsnag_env = calloc(1, sizeof(bsg_environment));
   bsg_set_unwind_types((int)_api_level, (bool)is32bit,
                        &bugsnag_env->signal_unwind_style,
@@ -143,6 +144,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
       htonl(47) == 47; // potentially too clever, see man 3 htonl
   bugsnag_env->report_header.version = BUGSNAG_EVENT_VERSION;
   bugsnag_env->consecutive_launch_crashes = consecutive_launch_crashes;
+  bugsnag_env->send_threads = send_threads;
 
   // copy event path to env struct
   const char *event_path = bsg_safe_get_string_utf_chars(env, _event_path);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -73,6 +73,12 @@ typedef struct {
   bool crash_handled;
 
   bsg_on_error on_error;
+
+  /**
+   * Controls whether we should capture and serialize the state of all threads
+   * at the time of an error.
+   */
+  bsg_thread_send_policy send_threads;
 } bsg_environment;
 
 bsg_unwinder bsg_configured_unwind_style();

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -24,10 +24,17 @@
  */
 #define BUGSNAG_DEFAULT_EX_TYPE "c"
 #endif
+#ifndef BUGSNAG_THREADS_MAX
+/**
+ * Maximum number of threads recorded for an event. Configures a default if not
+ * defined.
+ */
+#define BUGSNAG_THREADS_MAX 255
+#endif
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
-#define BUGSNAG_EVENT_VERSION 6
+#define BUGSNAG_EVENT_VERSION 7
 
 #ifdef __cplusplus
 extern "C" {
@@ -179,6 +186,18 @@ typedef struct {
 } bsg_notifier;
 
 typedef struct {
+  pid_t id;
+  char name[16];
+  char state[13];
+} bsg_thread;
+
+typedef enum {
+  SEND_THREADS_ALWAYS = 0,
+  SEND_THREADS_UNHANDLED_ONLY = 1,
+  SEND_THREADS_NEVER = 2
+} bsg_thread_send_policy;
+
+typedef struct {
   bsg_notifier notifier;
   bsg_app_info app;
   bsg_device_info device;
@@ -202,6 +221,9 @@ typedef struct {
   char grouping_hash[64];
   bool unhandled;
   char api_key[64];
+
+  int thread_count;
+  bsg_thread threads[BUGSNAG_THREADS_MAX];
 } bugsnag_event;
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -8,6 +8,7 @@
 #include "../utils/crash_info.h"
 #include "../utils/serializer.h"
 #include "../utils/string.h"
+#include "../utils/threads.h"
 /**
  * Previously installed termination handler
  */
@@ -94,6 +95,13 @@ void bsg_handle_cpp_terminate() {
   bsg_global_env->next_event.error.frame_count =
       bsg_unwind_stack(bsg_global_env->unwind_style,
                        bsg_global_env->next_event.error.stacktrace, NULL, NULL);
+
+  if (bsg_global_env->send_threads != SEND_THREADS_NEVER) {
+    bsg_global_env->next_event.thread_count = bsg_capture_thread_states(
+        bsg_global_env->next_event.threads, BUGSNAG_THREADS_MAX);
+  } else {
+    bsg_global_env->next_event.thread_count = 0;
+  }
 
   std::type_info *tinfo = __cxxabiv1::__cxa_current_exception_type();
   if (tinfo != NULL) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -14,6 +14,7 @@
 #include "../utils/crash_info.h"
 #include "../utils/serializer.h"
 #include "../utils/string.h"
+#include "../utils/threads.h"
 #define BSG_HANDLED_SIGNAL_COUNT 6
 
 /**
@@ -184,6 +185,13 @@ void bsg_handle_signal(int signum, siginfo_t *info,
   bsg_global_env->next_event.error.frame_count = bsg_unwind_stack(
       bsg_global_env->signal_unwind_style,
       bsg_global_env->next_event.error.stacktrace, info, user_context);
+
+  if (bsg_global_env->send_threads != SEND_THREADS_NEVER) {
+    bsg_global_env->next_event.thread_count = bsg_capture_thread_states(
+        bsg_global_env->next_event.threads, BUGSNAG_THREADS_MAX);
+  } else {
+    bsg_global_env->next_event.thread_count = 0;
+  }
 
   for (int i = 0; i < BSG_HANDLED_SIGNAL_COUNT; i++) {
     const int signal = bsg_native_signals[i];

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -253,6 +253,32 @@ typedef struct {
   char api_key[64];
 } bugsnag_report_v5;
 
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
+} bugsnag_report_v6;
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -43,6 +43,7 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
 void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
                          JSON_Array *stacktrace);
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
+void bsg_serialize_threads(const bugsnag_event *event, JSON_Array *threads);
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 
 int bsg_calculate_total_crumbs(int old_count);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.c
@@ -1,0 +1,199 @@
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "string.h"
+#include "threads.h"
+
+/*
+ * We read thread states by scanning the tid list in `/proc/self/task`. Each
+ * subdirectory here represents a task (tid) within the current application, and
+ * each of these contains a `stat` file with the information we require.
+ *
+ * This behaviour needs to be async / signal-safe, which blocks us from using
+ * many of the standard libc filesystem functions. To work-around this we resort
+ * to Linux syscalls for the directory listing.
+ */
+
+#define TASK_STAT_PATH_PREFIX "/proc/self/task/"
+// we don't want the null-terminator in the length
+#define TASK_STAT_PATH_PREFIX_LEN (sizeof(TASK_STAT_PATH_PREFIX) - 1)
+#define TASK_STAT_PATH_SUFFIX "/stat"
+
+// in theory we could optimise this - since all paths have a common prefix
+static void path_for_tid_stat(char *dest, const char *tid) {
+  size_t tidlen = bsg_strlen(tid);
+  size_t remaining = MAX_STAT_PATH_LENGTH;
+  bsg_strncpy(dest, TASK_STAT_PATH_PREFIX, remaining);
+  remaining -= TASK_STAT_PATH_PREFIX_LEN;
+  bsg_strncpy(&dest[TASK_STAT_PATH_PREFIX_LEN], tid, remaining);
+  remaining -= tidlen;
+  bsg_strncpy(&dest[TASK_STAT_PATH_PREFIX_LEN + tidlen], TASK_STAT_PATH_SUFFIX,
+              remaining);
+}
+
+/**
+ * Possible task states as defined in:
+ * https://github.com/torvalds/linux/blob/v5.13/fs/proc/array.c#L132-L143
+ */
+static const char *const task_state_array[] = {
+    "R running", "S sleeping", "D disk sleep", "T stopped", "t tracing stop",
+    "X dead",    "Z zombie",   "P parked",     "I idle",
+};
+
+static void get_task_state_description(const char code, char *dest) {
+  for (size_t index = 0; index < (sizeof(task_state_array) / sizeof(char *));
+       index++) {
+    if (task_state_array[index][0] == code) {
+      bsg_strcpy(dest, &task_state_array[index][2]);
+      return;
+    }
+  }
+
+  // if we reached here we failed to map the code, store the single-character
+  // code as a fallback
+  dest[0] = code;
+  dest[1] = '\0';
+}
+
+/**
+ * Parses the content of a /proc/self/task/{tid}/stat file, as documented in:
+ * https://man7.org/linux/man-pages/man5/proc.5.html
+ *
+ * We are only interested in the first three fields which are the:
+ * 1) TID   (numeric)
+ * 2) Name  (in parenthesis)
+ * 3) State (single character)
+ *
+ * Unfortunately thread names can contain spaces, making tools like `strtok`
+ * unsuitable for this process. As a result we parse using a simple single pass
+ * state-based loop.
+ *
+ * *WARNING* `content` is modified by this method under normal operation
+ *
+ * @return true if the thread-data was parsed, false if not
+ */
+static bool parse_stat_content(bsg_thread *dest, char *content, size_t len) {
+  enum stat_parse_state {
+    PARSE_ID,
+    PARSE_NAME_START,
+    PARSE_NAME_CONTENT,
+    PARSE_NAME_END,
+    PARSE_STATUS,
+    PARSE_DONE
+  };
+
+  enum stat_parse_state state = PARSE_ID;
+
+  size_t i = 0;
+  size_t name_length = 0;
+  while (i < len) {
+    char current = content[i];
+
+    switch (state) {
+    case PARSE_ID:
+      if (current == ' ') {
+        // we create a terminator for the numeric parse
+        content[i] = '\0';
+        // atoi is async-safe, strtol is not guaranteed to be
+        dest->id = atoi(content);
+        state = PARSE_NAME_START;
+      }
+      break;
+    case PARSE_NAME_START:
+      if (current == '(') {
+        state = PARSE_NAME_CONTENT;
+      }
+      break;
+    case PARSE_NAME_CONTENT:
+      if (current == ')') {
+        state = PARSE_NAME_END;
+      } else if (name_length < sizeof(dest->name)) {
+        dest->name[name_length] = current;
+        name_length++;
+      }
+      break;
+    case PARSE_NAME_END:
+      dest->name[name_length] = '\0';
+      if (current == ' ') {
+        state = PARSE_STATUS;
+      }
+      break;
+    case PARSE_STATUS:
+      get_task_state_description(current, dest->state);
+      state = PARSE_DONE;
+      break;
+    case PARSE_DONE:
+      goto end;
+    }
+
+    i += 1;
+  }
+
+end:
+  // success if we hit the DONE marker
+  return state == PARSE_DONE;
+}
+
+/*
+ * Reads the /stat file fields we are looking for (TID, Name, State) into `dest`
+ * with a signal-safe approach.
+ */
+static bool read_thread_state(bsg_thread *dest, const char *tid) {
+  // we filter out anything not numeric
+  if (tid[0] < '0' || tid[0] > '9') {
+    return false;
+  }
+
+  char filename[MAX_STAT_PATH_LENGTH];
+  path_for_tid_stat(filename, tid);
+  // the content buffer for the stat file data, in the format:
+  // {tid} ({name}) {status}
+  // {tid}    = integer TID value
+  // {name}   = thread name char[16]
+  // {status} = single character
+  char content_buffer[64];
+  int stat_fd = open(filename, O_RDONLY);
+
+  if (stat_fd == 0) {
+    return false;
+  }
+
+  size_t len = read(stat_fd, content_buffer, sizeof(content_buffer));
+  bool parse_success = parse_stat_content(dest, content_buffer, len);
+  close(stat_fd);
+  return parse_success;
+}
+
+size_t bsg_capture_thread_states(bsg_thread *threads, size_t max_threads) {
+  size_t total_thread_count = 0;
+  struct dirent64 *entry;
+  char buffer[1024];
+  int available, offset;
+
+  int task_dir_fd = open("/proc/self/task", O_RDONLY | O_DIRECTORY);
+  if (task_dir_fd == 0) {
+    return 0;
+  }
+
+  while (total_thread_count < max_threads) {
+    available = syscall(SYS_getdents64, task_dir_fd, buffer, sizeof(buffer));
+    if (available <= 0) {
+      break;
+    }
+
+    for (offset = 0; offset < available && total_thread_count < max_threads;) {
+      entry = (struct dirent64 *)(buffer + offset);
+      if (read_thread_state(&threads[total_thread_count], entry->d_name)) {
+        total_thread_count += 1;
+      }
+
+      offset += entry->d_reclen;
+    }
+  }
+
+  close(task_dir_fd);
+
+  return total_thread_count;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.h
@@ -1,0 +1,19 @@
+#ifndef BUGSNAG_THREADS_H
+#define BUGSNAG_THREADS_H
+
+#include "../event.h"
+#include "build.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAX_STAT_PATH_LENGTH 64
+
+size_t bsg_capture_thread_states(bsg_thread *threads,
+                                 size_t max_threads) __asyncsafe;
+
+#ifdef __cplusplus
+}
+#endif
+#endif // BUGSNAG_THREADS_H

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -222,3 +222,14 @@ JNIEXPORT jstring JNICALL Java_com_bugsnag_android_ndk_ExceptionSerializationTes
     return (*env)->NewStringUTF(env, string);
 
 }
+
+JNIEXPORT jstring JNICALL
+Java_com_bugsnag_android_ndk_ThreadSerializationTest_run(JNIEnv *env, jobject thiz) {
+    bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+    loadThreadTestCase(event);
+    JSON_Value *threads_val = json_value_init_array();
+    JSON_Array *threads_array = json_value_get_array(threads_val);
+    bsg_serialize_threads(event, threads_array);
+    char *string = json_serialize_to_string(threads_val);
+    return (*env)->NewStringUTF(env, string);
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -177,6 +177,14 @@ bugsnag_stackframe *loadStackframeTestCase() {
     return data;
 }
 
+void loadThreadTestCase(bugsnag_event *event) {
+    event->thread_count = 1;
+    bsg_thread *thread = &event->threads[0];
+    strcpy(thread->name, "Binder 1");
+    strcpy(thread->state, "Running");
+    thread->id = 1234;
+}
+
 void loadExceptionTestCase(bugsnag_event *event) {
     bsg_error *data = &event->error;
     strcpy(data->errorClass, "signal");

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.h
@@ -21,5 +21,6 @@ void loadContextTestCase(bugsnag_event *event);
 void loadSessionTestCase(bugsnag_event *event);
 void loadSeverityReasonTestCase(bugsnag_event *event);
 void loadBreadcrumbsTestCase(bugsnag_event *event);
+void loadThreadTestCase(bugsnag_event *event);
 bugsnag_stackframe *loadStackframeTestCase();
 void loadExceptionTestCase(bugsnag_event *event);

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -141,6 +141,56 @@ void generate_basic_report(bugsnag_event *event) {
   strcpy(event->notifier.name, "Test Notifier");
 }
 
+bugsnag_report_v5 *bsg_generate_report_v5(void) {
+  bugsnag_report_v5 *event = calloc(1, sizeof(bugsnag_report_v5));
+  strcpy(event->grouping_hash, "foo-hash");
+  strcpy(event->api_key, "5d1e5fbd39a74caa1200142706a90b20");
+  strcpy(event->context, "SomeActivity");
+  strcpy(event->error.errorClass, "SIGBUS");
+  strcpy(event->error.errorMessage, "POSIX is serious about oncoming traffic");
+  event->error.stacktrace[0].frame_address = 454379;
+  event->error.stacktrace[1].frame_address = 342334;
+  event->error.frame_count = 2;
+  strcpy(event->error.type, "C");
+  strcpy(event->error.stacktrace[0].method, "makinBacon");
+  strcpy(event->app.id, "com.example.PhotoSnapPlus");
+  strcpy(event->app.release_stage, "リリース");
+  strcpy(event->app.version, "2.0.52");
+  event->app.version_code = 57;
+  strcpy(event->app.build_uuid, "1234-9876-adfe");
+  strcpy(event->device.manufacturer, "HI-TEC™");
+  strcpy(event->device.model, "Rasseur");
+  strcpy(event->device.locale, "en_AU#Melbun");
+  strcpy(event->device.os_name, "android");
+  strcpy(event->user.email, "fenton@io.example.com");
+  strcpy(event->user.id, "fex");
+  event->device.total_memory = 234678100;
+  event->app.duration = 6502;
+  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
+  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
+  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
+  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.8);
+
+  bugsnag_breadcrumb *crumb1 = init_breadcrumb("decrease torque", "Moving laterally 26º",
+                                               BSG_CRUMB_STATE);
+  bugsnag_breadcrumb *crumb2 = init_breadcrumb("enable blasters", "this is a drill.",
+                                               BSG_CRUMB_USER);
+  memcpy(&event->breadcrumbs[0], crumb1, sizeof(bugsnag_breadcrumb));
+  memcpy(&event->breadcrumbs[1], crumb2, sizeof(bugsnag_breadcrumb));
+  event->crumb_count = 2;
+  event->crumb_first_index = 0;
+
+  event->handled_events = 1;
+  event->unhandled_events = 1;
+  strcpy(event->session_id, "f1ab");
+  strcpy(event->session_start, "2019-03-19T12:58:19+00:00");
+
+  strcpy(event->notifier.version, "1.0");
+  strcpy(event->notifier.url, "bugsnag.com");
+  strcpy(event->notifier.name, "Test Notifier");
+  return event;
+}
+
 bugsnag_report_v4 *bsg_generate_report_v4(void) {
   bugsnag_report_v4 *event = calloc(1, sizeof(bugsnag_report_v4));
   strcpy(event->grouping_hash, "foo-hash");
@@ -370,7 +420,7 @@ char *test_read_last_run_info(const bsg_environment *env) {
   return buf;
 }
 
-test_last_run_info_serialization(void) {
+TEST test_last_run_info_serialization(void) {
   bsg_environment *env = calloc(1, sizeof(bsg_environment));
   strcpy(env->last_run_info_path, SERIALIZE_TEST_FILE);
   
@@ -441,6 +491,7 @@ TEST test_report_v1_migration(void) {
   ASSERT_EQ(1, event->handled_events);
   ASSERT_EQ(1, event->unhandled_events);
   ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -495,6 +546,7 @@ TEST test_report_v2_migration(void) {
   ASSERT_STR_EQ("message", val->key);
   ASSERT_STR_EQ("Moving laterally 26º", val->value);
   ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -527,6 +579,7 @@ TEST test_report_v3_migration(void) {
   ASSERT_STR_EQ("POSIX is serious about oncoming traffic", event->error.errorMessage);
   ASSERT_STR_EQ("C", event->error.type);
   ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -556,6 +609,7 @@ TEST test_report_v4_migration(void) {
   ASSERT_STR_EQ("1234-9876-adfe", event->app.build_uuid);
   ASSERT_FALSE(event->app.in_foreground);
   ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -609,6 +663,8 @@ TEST test_report_v5_migration(void) {
     free(str);
   }
 
+  ASSERT_EQ(0, event->thread_count);
+
   free(generated_report);
   free(env);
   free(event);
@@ -640,6 +696,36 @@ TEST test_report_v5_migration_crumb_index(void) {
   ASSERT_STR_EQ("13", event->breadcrumbs[1].name);
   ASSERT_STR_EQ("26", event->breadcrumbs[14].name);
   ASSERT_STR_EQ("36", event->breadcrumbs[24].name);
+
+  free(generated_report);
+  free(env);
+  free(event);
+  PASS();
+}
+
+TEST test_report_v6_migration(void) {
+  bsg_environment *env = calloc(1, sizeof(bsg_environment));
+  env->report_header.version = 4;
+  env->report_header.big_endian = 1;
+  strcpy(env->report_header.os_build, "macOS Sierra");
+
+  bugsnag_report_v5 *generated_report = bsg_generate_report_v5();
+  memcpy(&env->next_event, generated_report, sizeof(bugsnag_report_v5));
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
+  bsg_serialize_report_v5_to_file(env, generated_report);
+
+  bugsnag_event *event = bsg_deserialize_event_from_file(SERIALIZE_TEST_FILE);
+  ASSERT(event != NULL);
+
+  // values are migrated correctly
+  ASSERT_STR_EQ("com.example.PhotoSnapPlus", event->app.id);
+  ASSERT_STR_EQ("リリース", event->app.release_stage);
+  ASSERT_STR_EQ("2.0.52", event->app.version);
+  ASSERT_EQ(57, event->app.version_code);
+  ASSERT_STR_EQ("1234-9876-adfe", event->app.build_uuid);
+  ASSERT_FALSE(event->app.in_foreground);
+  ASSERT_FALSE(event->app.is_launching);
+  ASSERT_EQ(0, event->thread_count);
 
   free(generated_report);
   free(env);
@@ -835,5 +921,6 @@ SUITE(suite_struct_migration) {
   RUN_TEST(test_report_v4_migration);
   RUN_TEST(test_report_v5_migration);
   RUN_TEST(test_report_v5_migration_crumb_index);
+  RUN_TEST(test_report_v6_migration);
   RUN_TEST(test_migrate_app_v2);
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -32,6 +32,7 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
                 MapUtils.<String>getOrThrow(map, "name"),
                 ThreadType.valueOf(type.toUpperCase(Locale.US)),
                 errorReportingThread,
+                Thread.State.byDescriptor(MapUtils.<String>getOrThrow(map, "state")),
                 new Stacktrace(frames),
                 logger
         );

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadSerializer.kt
@@ -8,6 +8,7 @@ internal class ThreadSerializer : MapSerializer<Thread> {
         map["name"] = thread.name
         map["type"] = thread.type.toString().toLowerCase(Locale.US)
         map["errorReportingThread"] = thread.errorReportingThread
+        map["state"] = thread.state.descriptor
 
         map["stacktrace"] = thread.stacktrace.map {
             val frame = mutableMapOf<String, Any?>()

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -56,6 +56,7 @@ class EventDeserializerTest {
         "id" to 52L,
         "type" to "reactnativejs",
         "name" to "thread-worker-02",
+        "state" to "RUNNABLE",
         "errorReportingThread" to true
     )
 

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadDeserializerTest.kt
@@ -25,6 +25,7 @@ class ThreadDeserializerTest {
         map["id"] = 52L
         map["type"] = "reactnativejs"
         map["name"] = "thread-worker-02"
+        map["state"] = "RUNNABLE"
         map["errorReportingThread"] = true
     }
 

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
@@ -37,7 +37,7 @@ public class ThreadSerializerTest {
         List<Stackframe> frames = Collections.singletonList(stackframe);
         Stacktrace stacktrace = new Stacktrace(frames);
         thread = new Thread(1, "fake-thread", ThreadType.ANDROID,
-                true, stacktrace, NoopLogger.INSTANCE);
+                true, Thread.State.RUNNABLE, stacktrace, NoopLogger.INSTANCE);
     }
 
     @Test

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
@@ -309,4 +309,17 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXCrashLoopScenario_crash(JNIEnv 
   abort();
 }
 
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXCaptureThreadsScenario_crash(JNIEnv *env,
+                                                                              jobject instance) {
+  abort();
+}
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXCaptureThreadsNotifyScenario_activate(JNIEnv *env,
+                                                                                       jobject instance) {
+  bugsnag_notify_env(env, (char *)"activate",
+    (char *)"CXXCaptureThreadStatesNotifyScenario", BSG_SEVERITY_ERR);
+}
+
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCaptureThreadsNotifyScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCaptureThreadsNotifyScenario.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.ThreadSendPolicy
+
+class CXXCaptureThreadsNotifyScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+    companion object {
+        init {
+            System.loadLibrary("bugsnag-ndk")
+            System.loadLibrary("cxx-scenarios-bugsnag")
+        }
+    }
+
+    init {
+        if (!eventMetadata.isNullOrEmpty()) {
+            config.sendThreads = ThreadSendPolicy.valueOf(eventMetadata)
+        }
+    }
+
+    external fun activate()
+
+    override fun startScenario() {
+        super.startScenario()
+        activate()
+    }
+}

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCaptureThreadsScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCaptureThreadsScenario.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.ThreadSendPolicy
+
+class CXXCaptureThreadsScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+    companion object {
+        init {
+            System.loadLibrary("bugsnag-ndk")
+            System.loadLibrary("cxx-scenarios-bugsnag")
+        }
+    }
+
+    init {
+        if (!eventMetadata.isNullOrEmpty()) {
+            config.sendThreads = ThreadSendPolicy.valueOf(eventMetadata)
+        }
+    }
+
+    external fun crash()
+
+    override fun startScenario() {
+        super.startScenario()
+        crash()
+    }
+}

--- a/features/full_tests/batch_2/native_threads.feature
+++ b/features/full_tests/batch_2/native_threads.feature
@@ -1,0 +1,37 @@
+Feature: Capture native threads
+
+  Scenario: Reports native threads for Unhandled errors
+    When I run "CXXCaptureThreadsScenario" and relaunch the app
+    And I configure Bugsnag for "CXXCaptureThreadsScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed unhandled native report
+    And the error payload field "events.0.threads" is a non-empty array
+    And the error payload field "events.0.threads.0.state" is not null
+    And the error payload field "events.0.threads.0.name" is not null
+    And the error payload field "events.0.threads.0.id" is an integer
+
+  Scenario: Reports native threads for Unhandled errors where sendThreads is UNHANDLED_ONLY
+    When I configure the app to run in the "UNHANDLED_ONLY" state
+    And I run "CXXCaptureThreadsScenario" and relaunch the app
+    And I configure Bugsnag for "CXXCaptureThreadsScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed unhandled native report
+    And the error payload field "events.0.threads" is a non-empty array
+    And the error payload field "events.0.threads.0.state" is not null
+    And the error payload field "events.0.threads.0.name" is not null
+    And the error payload field "events.0.threads.0.id" is an integer
+
+  Scenario: No threads are reported when sendThreads is NEVER
+    When I configure the app to run in the "NEVER" state
+    And I run "CXXCaptureThreadsScenario" and relaunch the app
+    And I configure Bugsnag for "CXXCaptureThreadsScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the error payload field "events.0.threads" is an array with 0 elements
+
+  Scenario: No threads are reported for a handled errors where sendThreads is UNHANDLED_ONLY
+    When I configure the app to run in the "UNHANDLED_ONLY" state
+    And I run "CXXCaptureThreadsNotifyScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the error payload field "events.0.threads" is an array with 0 elements

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx4096m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
-VERSION_NAME=5.13.0
+VERSION_NAME=5.14.0
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git


### PR DESCRIPTION
* docs: correct changelog entry

* test: remove flaky test case

* Capture and report `Thread.state` for Android Runtime threads (#1372)

* feat(threads): capture and report `Thread.state` for Android Runtime threads

* fix(thread state): added nullability annotation to `Thread.State.getDescriptor`

* feat(unity): allow Client to be initialised with the Notifier details for reporting (#1386)

* Capture ndk thread states (#1390)

* feat(threads): add `bsg_thread` to the NDK plugin (#1371)

* migrate ndk reports for the new threads property (#1376)

* feat(threads): add `bsg_thread` to the NDK plugin

* feat(thread state): migrate v5 ndk reports to the new v6

* Capture native thread states (#1384)

* feat(thread state): capture and report native thread states in NDK crashes

* fix(native threads): native threads obey `Configuration.sendThreads`

* test(native threads): test scenarios for native thread reporting

* fix(native threads): map native thread-status codes to a descriptive string

* fix: updated CHANGELOG for native thread state reporting

* v5.14.0

* v5.14.0 - Changelog update

Co-authored-by: fractalwrench <fractalwrench@gmail.com>

## Goal

<!-- Why is this change necessary? -->

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->