### PR TITLE
Deserialize projectPackages from bugsnag journal

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
@@ -70,6 +70,9 @@ internal class BugsnagJournalEventMapper(
         sessionMap?.let {
             event.session = Session(it, logger)
         }
+
+        // populate projectPackages
+        event.projectPackages = map.readJournalEntry("projectPackages")
         return event
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -56,7 +56,7 @@ internal class EventInternal : JsonStream.Streamable, MetadataAware, UserAware {
 
     val metadata: Metadata
     private val discardClasses: Set<String>
-    private val projectPackages: Collection<String>
+    internal var projectPackages: Collection<String>
 
     @JvmField
     internal var session: Session? = null

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
@@ -110,7 +110,8 @@ internal class JournaledStateObserver(val client: Client, val journal: BugsnagJo
             Pair(JournalKeys.pathMetadataApp, appDataCollector.getAppDataMetadata()),
             Pair(JournalKeys.pathDevice, device),
             Pair(JournalKeys.pathMetadataDevice, deviceDataCollector.getDeviceMetadata()),
-            Pair(JournalKeys.pathUser, client.getUser().toJournalSection())
+            Pair(JournalKeys.pathUser, client.getUser().toJournalSection()),
+            Pair(JournalKeys.pathProjectPackages, client.config.projectPackages)
         )
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournalKeys.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournalKeys.kt
@@ -63,6 +63,7 @@ internal object JournalKeys {
     internal const val pathSession = "session"
     internal const val pathUser = "user"
     internal const val pathNotifier = "notifier"
+    internal const val pathProjectPackages = "projectPackages"
 
     // Composite paths
     internal const val pathAppInForeground = "$pathApp.$keyInForeground"

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
@@ -91,7 +91,8 @@ class BugsnagJournalEventMapperTest {
             ),
             "breadcrumbs" to breadcrumbs,
             "app" to app,
-            "device" to device
+            "device" to device,
+            "projectPackages" to listOf("com.example.bar")
         )
         journalMap = minimalJournalMap + mapOf(
             "context" to "ExampleActivity",
@@ -214,5 +215,8 @@ class BugsnagJournalEventMapperTest {
         assertEquals("8.0.0", device.osVersion)
         assertEquals("Android SDK built for x86", device.model)
         assertEquals("8b105fd3-88bc-4a31-8982-b725d1162d86", device.id)
+
+        // projectPackages
+        assertEquals(listOf("com.example.bar"), event.projectPackages)
     }
 }


### PR DESCRIPTION
## Goal

Deserializes projectPackages into an `Event` from entries stored in the journal.

## Testing

Added unit tests.