### PR TITLE
Introduce `OnSendCallback` interface and support functions

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -654,6 +654,22 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         }
     }
 
+    void addOnSend(@NonNull OnSendCallback onSend) {
+        if (onSend != null) {
+            callbackState.addOnSend(onSend);
+        } else {
+            logNull("addOnSend");
+        }
+    }
+
+    void removeOnSend(@NonNull OnSendCallback onSend) {
+        if (onSend != null) {
+            callbackState.removeOnSend(onSend);
+        } else {
+            logNull("removeOnSend");
+        }
+    }
+
     /**
      * Notify Bugsnag of a handled exception
      *

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -61,6 +61,8 @@ internal class ConfigInternal(var apiKey: String) : CallbackAware, MetadataAware
         callbackState.removeOnBreadcrumb(onBreadcrumb)
     override fun addOnSession(onSession: OnSessionCallback) = callbackState.addOnSession(onSession)
     override fun removeOnSession(onSession: OnSessionCallback) = callbackState.removeOnSession(onSession)
+    fun addOnSend(onSend: OnSendCallback) = callbackState.addOnSend(onSend)
+    fun removeOnSend(onSend: OnSendCallback) = callbackState.removeOnSend(onSend)
 
     override fun addMetadata(section: String, value: Map<String, Any?>) =
         metadataState.addMetadata(section, value)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -873,6 +873,22 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware {
         }
     }
 
+    void addOnSend(@NonNull OnSendCallback onSend) {
+        if (onSend != null) {
+            impl.addOnSend(onSend);
+        } else {
+            logNull("addOnSend");
+        }
+    }
+
+    void removeOnSend(@NonNull OnSendCallback onSend) {
+        if (onSend != null) {
+            impl.removeOnSend(onSend);
+        } else {
+            logNull("removeOnSend");
+        }
+    }
+
     /**
      * Adds a map of multiple metadata key-value pairs to the specified section.
      */

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/OnSendCallback.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/OnSendCallback.java
@@ -1,0 +1,12 @@
+package com.bugsnag.android;
+
+import androidx.annotation.NonNull;
+
+/**
+ * A callback to be invoked before an {@link Event} is uploaded to a server. Similar to
+ * {@link OnErrorCallback}, an {@code OnSendCallback} may modify the {@code Event}
+ * contents or even reject the entire payload by returning {@code false}.
+ */
+interface OnSendCallback {
+    boolean onSend(@NonNull Event event);
+}


### PR DESCRIPTION
## Goal
Introduce an `OnSendCallback` to be used by first-party plugins where `OnError` is not practical, and allow the callbacks to be registered either on `Client` or as part of a `Configuration`.

## Design
Introduce a package-protected `OnSendCallback` and the add / remove functions to capture and store them. These functions were not added to `CallbackAware` as this would force the functions to be declared `public` in `Client` and `Configuration`.

## Testing
Additional unit testing in `CallbackStateTest`