### PR TITLE
Alter client observables

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -333,9 +333,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
      */
     @NonNull
     public List<Breadcrumb> getBreadcrumbs() {
-        return getBreadcrumbState().copy();
+        return impl.getBreadcrumbs();
     }
-
 
     /**
      * Adds a map of multiple metadata key-value pairs to the specified section.


### PR DESCRIPTION
## Goal

Alters observables to ensure there is less chance of them being missed from `addObserver/removeObserver`.

## Changeset

- Tweaked `getBreadcrumbs()` to call into `ClientInternal`
- Created an `observables` list in `ClientInternal` to reduce the chance of an observer being missed from `addObserver/removeObserver`
- Ensured `mkdirs()` is called so that persistenceDirectory always exists for the journal

## Testing

Relied on existing test coverage.