### PR TITLE
Add E2E tests for crash-time on_error callback

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorTrueScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalOnErrorTrueScenario.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+
+class CXXSignalOnErrorTrueScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        System.loadLibrary("bugsnag-ndk")
+        System.loadLibrary("cxx-scenarios-bugsnag")
+    }
+
+    external fun crash()
+
+    override fun startScenario() {
+        super.startScenario()
+        crash()
+    }
+}

--- a/features/full_tests/batch_2/native_on_error.feature
+++ b/features/full_tests/batch_2/native_on_error.feature
@@ -1,5 +1,63 @@
 Feature: Native on error callbacks are invoked
 
+    Scenario: on_error alters error report information
+        When I run "CXXSignalOnErrorTrueScenario" and relaunch the app
+        And I configure Bugsnag for "CXXSignalOnErrorTrueScenario"
+        And I wait to receive an error
+
+        # app
+        And the event "app.binaryArch" equals "custom_binary_arch"
+        And the event "app.buildUUID" equals "custom_build_uuid"
+        And the event "app.duration" equals 100
+        And the event "app.durationInForeground" equals 200
+        And the event "app.id" equals "custom_app_id"
+        And the event "app.inForeground" is false
+        And the event "app.isLaunching" is false
+        And the event "app.releaseStage" equals "custom_release_stage"
+        And the event "app.type" equals "custom_type"
+        And the event "app.version" equals "custom_version"
+        And the event "app.versionCode" equals 56
+
+        # device
+        And the event "device.jailbroken" is true
+        And the event "device.id" equals "custom_device_id"
+        And the event "device.locale" equals "zh_HK"
+        And the event "device.manufacturer" equals "custom_manufacturer"
+        And the event "device.model" equals "custom_model"
+        And the event "device.osVersion" equals "custom_os_version"
+        And the event "device.totalMemory" equals 99999999
+        And the event "device.orientation" equals "custom_orientation"
+        And the event "device.time" equals "1970-01-01T04:10:00Z"
+        And the event "device.osName" equals "custom_os_name"
+
+        # user
+        And the event "user.id" equals "custom_id"
+        And the event "user.email" equals "custom_email"
+        And the event "user.name" equals "custom_name"
+
+        # metadata
+        And the event "metaData.custom.double" equals 5
+        And the event "metaData.custom2.string" equals "some_value"
+        And the event "metaData.custom3.bool" is false
+
+        # stacktrace
+        And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
+        And the event "exceptions.0.stacktrace.0.method" equals "bar()"
+        And the event "exceptions.0.stacktrace.0.file" equals "foo.cpp"
+        And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" equals 20
+        And the error payload field "events.0.exceptions.0.stacktrace.0.loadAddress" equals 40
+        And the error payload field "events.0.exceptions.0.stacktrace.0.symbolAddress" equals 60
+        And the error payload field "events.0.exceptions.0.stacktrace.0.lineNumber" equals 28
+
+        # error
+        And the exception "errorClass" equals "custom_error_class"
+        And the exception "message" equals "custom_error_message"
+
+        # misc
+        And the event "severity" equals "info"
+        And the event "unhandled" is false
+        And the event "groupingHash" equals "custom_grouping_hash"
+
     Scenario: on_error returning false prevents C signal being reported
         When I run "CXXSignalOnErrorFalseScenario" and relaunch the app
         And I configure Bugsnag for "CXXSignalOnErrorFalseScenario"


### PR DESCRIPTION
## Goal

Adds an E2E test that verifies the `on_error` callback which runs at crash-time alters the payload sent to Bugsnag. The test validates that fields such as `app/device/user/metadata/error` can be overridden from within a signal handler. This will serve as a regression test once fatal NDK errors are sent from the Bugsnag journal.

