### PR TITLE
Parse event JSON for OnSendCallback

### DIFF
--- a/bugsnag-android-core/build.gradle
+++ b/bugsnag-android-core/build.gradle
@@ -9,6 +9,10 @@ bugsnagBuildOptions {
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.dokka"
 
+dependencies {
+    implementation 'com.dslplatform:dsl-json:1.9.8'
+}
+
 dokkaHtml.configure {
     dokkaSourceSets {
         named("main") {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -179,7 +179,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
         registerLifecycleCallbacks();
 
         EventStorageModule eventStorageModule = new EventStorageModule(contextModule, configModule,
-                dataCollectionModule, bgTaskService, trackerModule, systemServiceModule, notifier);
+                dataCollectionModule, bgTaskService, trackerModule, systemServiceModule, notifier,
+                callbackState);
         eventStorageModule.resolveDependencies(bgTaskService, TaskType.IO);
         eventStore = eventStorageModule.getEventStore();
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStorageModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStorageModule.kt
@@ -15,7 +15,8 @@ internal class EventStorageModule(
     bgTaskService: BackgroundTaskService,
     trackerModule: TrackerModule,
     systemServiceModule: SystemServiceModule,
-    notifier: Notifier
+    notifier: Notifier,
+    callbackState: CallbackState
 ) : DependencyModule() {
 
     private val cfg = configModule.config
@@ -34,5 +35,5 @@ internal class EventStorageModule(
         )
     }
 
-    val eventStore by future { EventStore(cfg, cfg.logger, notifier, bgTaskService, delegate) }
+    val eventStore by future { EventStore(cfg, cfg.logger, notifier, bgTaskService, delegate, callbackState) }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -1,9 +1,10 @@
 package com.bugsnag.android;
 
-import com.bugsnag.android.internal.ImmutableConfig;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.bugsnag.android.internal.MarshalledEventSource;
+import com.bugsnag.android.internal.ImmutableConfig;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ class EventStore extends FileStore {
     private final Delegate delegate;
     private final Notifier notifier;
     private final BackgroundTaskService bgTaskSevice;
+    private final CallbackState callbackState;
     final Logger logger;
 
     static final Comparator<File> EVENT_COMPARATOR = new Comparator<File>() {
@@ -51,7 +53,8 @@ class EventStore extends FileStore {
                @NonNull Logger logger,
                Notifier notifier,
                BackgroundTaskService bgTaskSevice,
-               Delegate delegate) {
+               Delegate delegate,
+               CallbackState callbackState) {
         super(new File(config.getPersistenceDirectory().getValue(), "bugsnag-errors"),
                 config.getMaxPersistedEvents(),
                 EVENT_COMPARATOR,
@@ -62,6 +65,7 @@ class EventStore extends FileStore {
         this.delegate = delegate;
         this.notifier = notifier;
         this.bgTaskSevice = bgTaskSevice;
+        this.callbackState = callbackState;
     }
 
     /**
@@ -162,30 +166,60 @@ class EventStore extends FileStore {
         try {
             EventFilenameInfo eventInfo = EventFilenameInfo.Companion.fromFile(eventFile, config);
             String apiKey = eventInfo.getApiKey();
-            EventPayload payload = new EventPayload(apiKey, null, eventFile, notifier, config);
-            DeliveryParams deliveryParams = config.getErrorApiDeliveryParams(payload);
-            Delivery delivery = config.getDelivery();
-            DeliveryStatus deliveryStatus = delivery.deliver(payload, deliveryParams);
+            EventPayload payload = createEventPayload(eventFile, apiKey);
 
-            switch (deliveryStatus) {
-                case DELIVERED:
-                    deleteStoredFiles(Collections.singleton(eventFile));
-                    logger.i("Deleting sent error file " + eventFile.getName());
-                    break;
-                case UNDELIVERED:
-                    cancelQueuedFiles(Collections.singleton(eventFile));
-                    logger.w("Could not send previously saved error(s)"
-                            + " to Bugsnag, will try again later");
-                    break;
-                case FAILURE:
-                    Exception exc = new RuntimeException("Failed to deliver event payload");
-                    handleEventFlushFailure(exc, eventFile);
-                    break;
-                default:
-                    break;
+            if (payload == null) {
+                deleteStoredFiles(Collections.singleton(eventFile));
+            } else {
+                deliverEventPayload(eventFile, payload);
             }
         } catch (Exception exception) {
             handleEventFlushFailure(exception, eventFile);
+        }
+    }
+
+    private void deliverEventPayload(File eventFile, EventPayload payload) {
+        DeliveryParams deliveryParams = config.getErrorApiDeliveryParams(payload);
+        Delivery delivery = config.getDelivery();
+        DeliveryStatus deliveryStatus = delivery.deliver(payload, deliveryParams);
+
+        switch (deliveryStatus) {
+            case DELIVERED:
+                deleteStoredFiles(Collections.singleton(eventFile));
+                logger.i("Deleting sent error file " + eventFile.getName());
+                break;
+            case UNDELIVERED:
+                cancelQueuedFiles(Collections.singleton(eventFile));
+                logger.w("Could not send previously saved error(s)"
+                        + " to Bugsnag, will try again later");
+                break;
+            case FAILURE:
+                Exception exc = new RuntimeException("Failed to deliver event payload");
+                handleEventFlushFailure(exc, eventFile);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Nullable
+    private EventPayload createEventPayload(File eventFile, String apiKey) {
+        MarshalledEventSource eventSource = new MarshalledEventSource(eventFile);
+
+        try {
+            if (!callbackState.runOnSendTasks(eventSource, logger)) {
+                // do not send the payload at all, we must block sending
+                return null;
+            }
+        } catch (Exception ioe) {
+            eventSource.clear();
+        }
+
+        Event processedEvent = eventSource.getEvent();
+        if (processedEvent != null) {
+            return new EventPayload(apiKey, eventSource.getEvent(), null, notifier, config);
+        } else {
+            return new EventPayload(apiKey, null, eventFile, notifier, config);
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/JsonHelper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/JsonHelper.kt
@@ -1,0 +1,60 @@
+package com.bugsnag.android.internal
+
+import com.dslplatform.json.DslJson
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+internal object JsonHelper {
+    // Only one global DslJson is needed, and is thread-safe
+    // Note: dsl-json adds about 150k to the final binary size.
+    private val dslJson = DslJson<MutableMap<String, Any>>()
+
+    fun serialize(value: Any, stream: OutputStream) {
+        dslJson.serialize(value, stream)
+    }
+
+    fun serialize(value: Any, file: File) {
+        val parentFile = file.parentFile
+        if (parentFile != null && !parentFile.exists()) {
+            if (!parentFile.mkdirs()) {
+                throw FileSystemException(file, null, "Could not create parent dirs of file")
+            }
+        }
+        try {
+            file.outputStream().use { stream -> dslJson.serialize(value, stream) }
+        } catch (ex: IOException) {
+            throw IOException("Could not serialize JSON document to $file", ex)
+        }
+    }
+
+    fun deserialize(bytes: ByteArray): MutableMap<String, Any> {
+        val document = dslJson.deserialize(
+            MutableMap::class.java,
+            bytes,
+            bytes.size
+        )
+        requireNotNull(document) { "JSON document is invalid" }
+        @Suppress("UNCHECKED_CAST")
+        return document as MutableMap<String, Any>
+    }
+
+    fun deserialize(stream: InputStream): MutableMap<String, Any> {
+        val document = dslJson.deserialize(MutableMap::class.java, stream)
+        requireNotNull(document) { "JSON document is invalid" }
+        @Suppress("UNCHECKED_CAST")
+        return document as MutableMap<String, Any>
+    }
+
+    fun deserialize(file: File): MutableMap<String, Any> {
+        try {
+            file.inputStream().use { stream -> return deserialize(stream) }
+        } catch (ex: FileNotFoundException) {
+            throw ex
+        } catch (ex: IOException) {
+            throw IOException("Could not deserialize from $file", ex)
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/MarshalledEventSource.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/MarshalledEventSource.kt
@@ -1,0 +1,34 @@
+package com.bugsnag.android.internal
+
+import com.bugsnag.android.Event
+import java.io.File
+
+internal class MarshalledEventSource(private val eventFile: File) : () -> Event {
+
+    /**
+     * The parsed and possibly processed event. This field remains `null` if the `EventSource`
+     * is not used, and may not reflect the same data as is stored in `eventFile` (as the `Event`
+     * is mutable, and may have been modified after loading).
+     */
+    var event: Event? = null
+        private set
+
+    override fun invoke(): Event {
+        var unmarshalledEvent = event
+        if (unmarshalledEvent == null) {
+            unmarshalledEvent = unmarshall()
+            event = unmarshalledEvent
+        }
+
+        return unmarshalledEvent
+    }
+
+    fun clear() {
+        event = null
+    }
+
+    private fun unmarshall(): Event {
+        val json = JsonHelper.deserialize(eventFile)
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
## Goal
Provide an encapsulation point for the JSON content of an Event to be parsed when `OnSendCallback`s are registered and executed.

Fallback to sending the event file content directly if the file cannot be parsed, or no `OnSendCallback`s are present.

*This PR does not include the unmarshalling of the `Event` objects from the raw JSON*

## Design
The JSON parse is encapsulated in a new `EventStore` object - which is also used to determine whether unmarshalling was performed at all and therefore whether the raw file content should be relayed.

## Testing
Testing not yet applicable as this code should not complete