### PR TITLE
Add E2E test for payloads with large amount of breadcrumb/metadata

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/cxx-scenarios/detekt-baseline.xml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>MagicNumber:CXXDelayedCrashScenario.kt$CXXDelayedCrashScenario$405</ID>
+    <ID>MagicNumber:CXXLargePayloadScenario.kt$CXXLargePayloadScenario$300</ID>
     <ID>MagicNumber:CXXSessionInfoCrashScenario.kt$CXXSessionInfoCrashScenario$3</ID>
     <ID>MagicNumber:CXXSessionInfoCrashScenario.kt$CXXSessionInfoCrashScenario$3837</ID>
     <ID>MagicNumber:CXXThrowSomethingOutsideReleaseStagesScenario.kt$CXXThrowSomethingOutsideReleaseStagesScenario$23</ID>

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/cxx-scenarios.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/cxx-scenarios.cpp
@@ -363,4 +363,9 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_UnhandledNdkAutoNotifyFalseScenario_crash(JNIEnv *env) {
   abort();
 }
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXLargePayloadScenario_crash(JNIEnv *env) {
+  abort();
+}
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXLargePayloadScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXLargePayloadScenario.kt
@@ -1,0 +1,35 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.log
+
+/**
+ * Sends a native crash to Bugsnag which has a large amount of metadata + breadcrumbs
+ * added at runtime.
+ */
+internal class CXXLargePayloadScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.enabledBreadcrumbTypes = emptySet()
+    }
+
+    private external fun crash()
+
+    override fun startScenario() {
+        super.startScenario()
+        log("Beginning to create a very large payload...")
+
+        repeat(300) { count ->
+            Bugsnag.leaveBreadcrumb("Breadcrumb $count")
+            Bugsnag.addMetadata("test", "key_$count", "$count")
+        }
+        log("Finished creating large payload")
+        crash()
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -9,6 +9,7 @@
     <ID>MagicNumber:BugsnagInitScenario.kt$BugsnagInitScenario$25</ID>
     <ID>MagicNumber:HandledKotlinSmokeScenario.kt$HandledKotlinSmokeScenario$999</ID>
     <ID>MagicNumber:JvmAnrSleepScenario.kt$JvmAnrSleepScenario$100000</ID>
+    <ID>MagicNumber:JvmLargePayloadScenario.kt$JvmLargePayloadScenario$1000</ID>
     <ID>MagicNumber:LoadConfigurationKotlinScenario.kt$LoadConfigurationKotlinScenario$10000</ID>
     <ID>MagicNumber:LoadConfigurationKotlinScenario.kt$LoadConfigurationKotlinScenario$98</ID>
     <ID>MagicNumber:ManualSessionSmokeScenario.kt$ManualSessionSmokeScenario$3</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmLargePayloadScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmLargePayloadScenario.kt
@@ -1,0 +1,30 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+/**
+ * Sends a handled exception to Bugsnag which has a large amount of metadata + breadcrumbs
+ * added at runtime.
+ */
+internal class JvmLargePayloadScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.enabledBreadcrumbTypes = emptySet()
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+
+        repeat(1000) { count ->
+            Bugsnag.leaveBreadcrumb("Breadcrumb $count")
+            Bugsnag.addMetadata("test", "key_$count", "$count")
+        }
+        Bugsnag.notify(generateException())
+    }
+}

--- a/features/full_tests/batch_2/large_payload.feature
+++ b/features/full_tests/batch_2/large_payload.feature
@@ -1,0 +1,39 @@
+Feature: Bugsnag can deal with a large amount of breadcrumbs/metadata
+
+    Scenario: JVM error handles large breadcrumbs/metadata
+        When I run "JvmLargePayloadScenario"
+        And I wait to receive an error
+        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+        And the error payload field "events" is an array with 1 elements
+        And the exception "errorClass" equals "java.lang.RuntimeException"
+        And the exception "message" equals "JvmLargePayloadScenario"
+
+        # Breadcrumbs
+        And the event "breadcrumbs.0.name" equals "Breadcrumb 950"
+        And the event "breadcrumbs.49.name" equals "Breadcrumb 999"
+        And the event "breadcrumbs.50" is null
+
+        # MetaData
+        And the event "metaData.test.key_0" equals "0"
+        And the event "metaData.test.key_100" equals "100"
+        And the event "metaData.test.key_500" equals "500"
+        And the event "metaData.test.key_999" equals "999"
+        And the event "metaData.test.key_1000" is null
+
+    Scenario: CXX error handles large breadcrumbs/metadata
+        When I run "CXXLargePayloadScenario" and relaunch the app
+        And I configure Bugsnag for "CXXLargePayloadScenario"
+        And I wait to receive an error
+        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+
+        # Breadcrumbs
+        And the event "breadcrumbs.0.name" equals "Breadcrumb 250"
+        And the event "breadcrumbs.49.name" equals "Breadcrumb 299"
+        And the event "breadcrumbs.50" is null
+
+        # MetaData
+        And the event "metaData.test.key_0" equals "0"
+        And the event "metaData.test.key_100" equals "100"
+        And the event "metaData.test.key_200" equals "200"
+        And the event "metaData.test.key_299" equals "299"
+        And the event "metaData.test.key_300" is null


### PR DESCRIPTION
## Goal

Adds an E2E test that ensures a payload has a large amount of metadata + breadcrumbs. This verifies that only 50 breadcrumbs are captured, and that the notifier can handle ~1000 pieces of metadata.