### PR TITLE
Add E2E scenario for persisted NDK struct

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/CMakeLists.txt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.4.1)
 
-add_library(cxx-scenarios-bugsnag SHARED
-        src/main/cpp/cxx-scenarios-bugsnag.cpp)
+add_library(
+        cxx-scenarios-bugsnag SHARED
+        src/main/cpp/cxx-scenarios-bugsnag.cpp
+        src/main/cpp/persist-struct.c
+)
+
+include_directories(cpp)
 
 add_library(lib_bugsnag SHARED IMPORTED)
 set(BUGSNAG_LIB_DIR

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/event.h
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/event.h
@@ -1,0 +1,319 @@
+#ifndef BUGSNAG_EVENT_H
+#define BUGSNAG_EVENT_H
+
+#ifndef BUGSNAG_METADATA_MAX
+/**
+ * Maximum number of values stored in metadata. Configures a default if not
+ * defined.
+ */
+#define BUGSNAG_METADATA_MAX 128
+#endif
+#ifndef BUGSNAG_CRUMBS_MAX
+/**
+ *  Max number of breadcrumbs in an event. Configures a default if not defined.
+ */
+#define BUGSNAG_CRUMBS_MAX 50
+#endif
+#ifndef BUGSNAG_DEFAULT_EX_TYPE
+/**
+ * Type assigned to exceptions. Configures a default if not defined.
+ */
+#define BUGSNAG_DEFAULT_EX_TYPE "c"
+#endif
+#ifndef BUGSNAG_THREADS_MAX
+/**
+ * Maximum number of threads recorded for an event. Configures a default if not
+ * defined.
+ */
+#define BUGSNAG_THREADS_MAX 255
+#endif
+/**
+ * Version of the bugsnag_event struct. Serialized to report header.
+ */
+#define BUGSNAG_EVENT_VERSION 7
+
+#define BUGSNAG_FRAMES_MAX 192
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************************
+ * (start) NDK-SPECIFIC BITS
+ *********************************/
+
+typedef enum {
+    BSG_LIBUNWIND,
+    BSG_LIBUNWINDSTACK,
+    BSG_LIBCORKSCREW,
+    BSG_CUSTOM_UNWIND,
+} bsg_unwinder;
+
+typedef struct {
+  char id[64];
+  char release_stage[64];
+  char type[32];
+  char version[32];
+  char active_screen[64];
+  int version_code;
+  char build_uuid[64];
+  time_t duration;
+  time_t duration_in_foreground;
+  /**
+   * The elapsed time in milliseconds between when the system clock starts and
+   * when bugsnag-ndk install() is called
+   */
+  time_t duration_ms_offset;
+  /**
+   * The elapsed time in the foreground in milliseconds between when the app
+   * first enters the foreground and when bugsnag-ndk install() is called, if
+   * the app is in the foreground when install() occurs and the app never enters
+   * the background. This value is zero in all other cases.
+   */
+  time_t duration_in_foreground_ms_offset;
+  bool in_foreground;
+  bool is_launching;
+  char binary_arch[32];
+} bsg_app_info;
+
+typedef struct {
+  char value[32];
+} bsg_cpu_abi;
+
+typedef struct {
+  int api_level;
+  int cpu_abi_count;
+  bsg_cpu_abi cpu_abi[8];
+  char orientation[32];
+  time_t time;
+  char id[64];
+  bool jailbroken;
+  char locale[32];
+  char manufacturer[64];
+  char model[64];
+  char os_build[64];
+  char os_version[64];
+  char os_name[64];
+  long total_memory;
+} bsg_device_info;
+
+/**
+ * Report versioning information, serialized to disk first in a report file,
+ * including system info for potential debugging
+ */
+typedef struct {
+  /**
+   * The value of BUGSNAG_EVENT_VERSION
+   */
+  int version;
+  /**
+   * 0 if big endian
+   */
+  int big_endian;
+  /**
+   * The value of device.runtimeVersions.osBuild
+   */
+  char os_build[64];
+} bsg_report_header;
+
+/**
+ * A single value in metadata
+ */
+typedef struct {
+  /**
+   * The key identifying this metadata entry
+   */
+  char name[32];
+  /**
+   * The metadata tab
+   */
+  char section[32];
+  /**
+   * The value type from bool, char, number
+   */
+  bugsnag_metadata_type type;
+
+  /**
+   * Value if type is BSG_BOOL_VALUE
+   */
+  bool bool_value;
+  /**
+   * Value if type is BSG_CHAR_VALUE
+   */
+  char char_value[64];
+  /**
+   * Value if type is BSG_DOUBLE_VALUE
+   */
+  double double_value;
+} bsg_metadata_value;
+
+typedef struct {
+  /** The number of values in use */
+  int value_count;
+  bsg_metadata_value values[BUGSNAG_METADATA_MAX];
+} bugsnag_metadata;
+
+/** a Bugsnag exception */
+typedef struct {
+  /** The exception name or stringified code */
+  char errorClass[64];
+  /** A description of what went wrong */
+  char errorMessage[256];
+  /** The variety of exception which needs to be processed by the pipeline */
+  char type[32];
+
+  /**
+   * The number of frames used in the stacktrace. Must be less than
+   * BUGSNAG_FRAMES_MAX.
+   */
+  ssize_t frame_count;
+  /**
+   * An ordered list of stack frames from the oldest to the most recent
+   */
+  bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+} bsg_error;
+
+typedef struct {
+  char name[64];
+  char timestamp[37];
+  bugsnag_breadcrumb_type type;
+
+  /**
+   * Key/value pairs of related information for debugging
+   */
+  bugsnag_metadata metadata;
+} bugsnag_breadcrumb;
+
+typedef struct {
+  char name[64];
+  char version[16];
+  char url[64];
+} bsg_notifier;
+
+typedef struct {
+  pid_t id;
+  char name[16];
+  char state[13];
+} bsg_thread;
+
+typedef enum {
+  SEND_THREADS_ALWAYS = 0,
+  SEND_THREADS_UNHANDLED_ONLY = 1,
+  SEND_THREADS_NEVER = 2
+} bsg_thread_send_policy;
+
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
+
+  int thread_count;
+  bsg_thread threads[BUGSNAG_THREADS_MAX];
+} bugsnag_event;
+
+void bugsnag_event_add_breadcrumb(bugsnag_event *event,
+                                  bugsnag_breadcrumb *crumb);
+void bugsnag_event_clear_breadcrumbs(bugsnag_event *event);
+void bugsnag_event_start_session(bugsnag_event *event, char *session_id,
+                                 char *started_at, int handled_count,
+                                 int unhandled_count);
+bool bugsnag_event_has_session(bugsnag_event *event);
+
+void bsg_add_metadata_value_double(bugsnag_metadata *metadata,
+                                   const char *section, const char *name,
+                                   double value);
+void bsg_add_metadata_value_str(bugsnag_metadata *metadata, const char *section,
+                                const char *name, const char *value);
+void bsg_add_metadata_value_bool(bugsnag_metadata *metadata,
+                                 const char *section, const char *name,
+                                 bool value);
+
+/*********************************
+ * (end) NDK-SPECIFIC BITS
+ *********************************/
+
+typedef struct {
+    /**
+     * Unwinding style used for signal-safe handling
+     */
+    bsg_unwinder signal_unwind_style;
+    /**
+     * Preferred unwinding style
+     */
+    bsg_unwinder unwind_style;
+    /**
+     * Records the version of the bugsnag NDK report being serialized to disk.
+     */
+    bsg_report_header report_header;
+    /**
+     * File path on disk where the next crash report will be written if needed.
+     */
+    char next_event_path[384];
+    /**
+     * File path on disk where the last run info will be written if needed.
+     */
+    char last_run_info_path[384];
+    /**
+     * The next value to be written to last run info if a crash occurs
+     */
+    char next_last_run_info[256];
+    /**
+     * The value of consecutiveLaunchCrashes, used when a crash occurs
+     */
+    int consecutive_launch_crashes;
+    /**
+     * Cache of static metadata and event info. Exception/time information is
+     * populated at crash time.
+     */
+    bugsnag_event next_event;
+    /**
+     * Time when installed
+     */
+    time_t start_time;
+    /**
+     * Time when last re-entering foreground
+     */
+    time_t foreground_start_time;
+    /**
+     * true if a crash is currently being handled. Disallows multiple crashes
+     * from being processed simultaneously
+     */
+    bool handling_crash;
+    /**
+     * true if a handler has completed crash handling
+     */
+    bool crash_handled;
+
+    bsg_on_error on_error;
+
+    /**
+     * Controls whether we should capture and serialize the state of all threads
+     * at the time of an error.
+     */
+    bsg_thread_send_policy send_threads;
+} bsg_environment;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/persist-struct.c
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/persist-struct.c
@@ -1,0 +1,104 @@
+#include <bugsnag.h>
+#include <jni.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include "event.h"
+
+bool bsg_serialize_event_to_file(bsg_environment *env);
+
+void populate_event(bugsnag_event *event) {
+    strcpy(event->api_key, "5d1e5fbd39a74caa1200142706a90b20");
+    strcpy(event->context, "SomeActivity");
+    strcpy(event->grouping_hash, "foo-hash");
+    event->unhandled = true;
+
+    // error
+    strcpy(event->error.errorClass, "SIGBUS");
+    strcpy(event->error.errorMessage, "POSIX is serious about oncoming traffic");
+    event->error.stacktrace[0].frame_address = 454379;
+    event->error.stacktrace[1].frame_address = 342334;
+    event->error.frame_count = 2;
+    strcpy(event->error.type, "c");
+    strcpy(event->error.stacktrace[0].method, "makinBacon");
+
+    // app
+    strcpy(event->app.id, "com.example.PhotoSnapPlus");
+    strcpy(event->app.type, "android");
+    strcpy(event->app.active_screen, "ExampleActivity");
+    strcpy(event->app.binary_arch, "x86");
+    strcpy(event->app.release_stage, "リリース");
+    strcpy(event->app.version, "2.0.52");
+    strcpy(event->app.build_uuid, "1234-9876-adfe");
+    event->app.version_code = 57;
+    event->app.duration = 6502;
+    event->app.duration_in_foreground = 3822;
+    event->app.duration_ms_offset = 20;
+    event->app.duration_in_foreground_ms_offset = 30;
+    event->app.in_foreground = true;
+    event->app.is_launching = true;
+
+    // device
+    strcpy(event->device.manufacturer, "HI-TEC™");
+    strcpy(event->device.model, "Rasseur");
+    strcpy(event->device.locale, "en_AU#Melbun");
+    strcpy(event->device.id, "device-id-123");
+    strcpy(event->device.orientation, "landscape");
+    strcpy(event->device.os_name, "android");
+    strcpy(event->device.os_build, "custom_build");
+    strcpy(event->device.os_version, "11.50.2");
+    event->device.total_memory = 234678100;
+    event->device.api_level = 27;
+    event->device.jailbroken = true;
+    event->device.time = 1509109234;
+    event->device.cpu_abi_count = 1;
+    strcpy(event->device.cpu_abi[0].value, "x86");
+
+    // user
+    strcpy(event->user.id, "fex");
+    strcpy(event->user.email, "fenton@io.example.com");
+    strcpy(event->user.name, "Fenton");
+
+    // metadata
+    bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
+    bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
+    bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
+    bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.8);
+
+    // session
+    event->handled_events = 2;
+    event->unhandled_events = 1;
+    strcpy(event->session_id, "f1ab");
+    strcpy(event->session_start, "2019-03-19T12:58:19+00:00");
+
+    // breadcrumbs
+    event->crumb_count = 0;
+    event->crumb_first_index = 0;
+    bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
+    crumb->type = BSG_CRUMB_STATE;
+    strcpy(crumb->name, "decrease torque");
+    strcpy(crumb->timestamp, "2018-08-29T21:41:39Z");
+    bsg_add_metadata_value_str(&crumb->metadata, "metaData", "message", "Moving laterally 26º");
+    bugsnag_event_add_breadcrumb(event, crumb);
+}
+
+/**
+ * Persists a struct to disk by using forward declarations of Bugsnag's internal NDK code.
+ */
+void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXPersistLegacyStructScenario_persistStruct(
+        JNIEnv *env,
+        jobject instance,
+        jstring path) {
+    bsg_environment *bsg = calloc(1, sizeof(bsg_environment));
+    bsg->report_header.big_endian = htonl(47) == 47;
+    bsg->report_header.version = BUGSNAG_EVENT_VERSION;
+
+    // set event path on environment
+    const char *event_path = (*env)->GetStringUTFChars(env, path, NULL);
+    sprintf(bsg->next_event_path, "%s", event_path);
+
+    // populate event then persist it
+    populate_event(&bsg->next_event);
+    bsg_serialize_event_to_file(bsg);
+}

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXPersistLegacyStructScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXPersistLegacyStructScenario.kt
@@ -1,0 +1,32 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.log
+import java.io.File
+import java.util.UUID
+
+/**
+ * Persists a legacy bsg_event struct on disk. When Bugsnag initializes this should be delivered
+ * as an Event.
+ */
+class CXXPersistLegacyStructScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    external fun persistStruct(path: String)
+
+    init {
+        System.loadLibrary("cxx-scenarios-bugsnag")
+        val parent = File(context.cacheDir, "bugsnag-native")
+        parent.mkdirs()
+        check(parent.isDirectory) { "bugsnag-native directory not setup correctly" }
+        val eventPath = File(parent, "${UUID.randomUUID()}.crash").absolutePath
+
+        log("Creating legacy struct on disk before Bugsnag initializes")
+        persistStruct(eventPath)
+        log("Created legacy struct at $eventPath")
+    }
+}

--- a/features/full_tests/batch_2/native_legacy_struct.feature
+++ b/features/full_tests/batch_2/native_legacy_struct.feature
@@ -1,0 +1,70 @@
+Feature: Legacy struct is converted to an error payload
+
+    Scenario: Sending a legacy NDK struct
+        When I run "CXXPersistLegacyStructScenario"
+        And I wait to receive an error
+        And the error payload field "apiKey" equals "5d1e5fbd39a74caa1200142706a90b20"
+        And the event "unhandled" is true
+        And the event "context" equals "SomeActivity"
+        And the event "groupingHash" equals "foo-hash"
+        And the event "severity" equals "error"
+
+        # error
+        And the event "exceptions.0.errorClass" equals "SIGBUS"
+        And the event "exceptions.0.message" equals "POSIX is serious about oncoming traffic"
+        And the event "exceptions.0.stacktrace.0.frameAddress" equals 454379
+        And the event "exceptions.0.stacktrace.1.frameAddress" equals 342334
+        And the event "exceptions.0.stacktrace.0.method" equals "makinBacon"
+        And the event "exceptions.0.type" equals "c"
+
+        # app
+        And the event "app.id" equals "com.example.PhotoSnapPlus"
+        And the event "app.type" equals "android"
+        And the event "app.binaryArch" equals "x86"
+        And the event "app.releaseStage" equals "リリース"
+        And the event "app.version" equals "2.0.52"
+        And the event "app.buildUUID" equals "1234-9876-adfe"
+        And the event "app.versionCode" equals 57
+        And the event "app.duration" equals 6502
+        And the event "app.durationInForeground" equals 3822
+        And the event "app.inForeground" is true
+        And the event "app.isLaunching" is true
+
+        # device
+        And the event "device.manufacturer" equals "HI-TEC™"
+        And the event "device.model" equals "Rasseur"
+        And the event "device.locale" equals "en_AU#Melbun"
+        And the event "device.id" equals "device-id-123"
+        And the event "device.orientation" equals "landscape"
+        And the event "device.osName" equals "android"
+        And the event "device.osVersion" equals "11.50.2"
+        And the event "device.totalMemory" equals 234678100
+        And the event "device.jailbroken" is true
+        And the event "device.time" equals "2017-10-27T13:00:34Z"
+        And the event "device.cpuAbi.0" equals "x86"
+        And the event "device.runtimeVersions.androidApiLevel" equals 27
+        And the event "device.runtimeVersions.osBuild" equals "custom_build"
+
+        # user
+        And the event "user.id" equals "fex"
+        And the event "user.email" equals "fenton@io.example.com"
+        And the event "user.name" equals "Fenton"
+
+        # metadata
+        And the event "metaData.app.activeScreen" equals "ExampleActivity"
+        And the event "metaData.metrics.experimentX" is false
+        And the event "metaData.metrics.subject" equals "percy"
+        And the event "metaData.app.weather" equals "rain"
+
+        # session
+        And the event "session.events.handled" equals 2
+        And the event "session.events.unhandled" equals 1
+        And the event "session.id" equals "f1ab"
+        And the event "session.startedAt" equals "2019-03-19T12:58:19+00:00"
+
+        # breadcrumbs
+        And the event "breadcrumbs.0.name" equals "decrease torque"
+        And the event "breadcrumbs.0.type" equals "state"
+        And the event "breadcrumbs.0.timestamp" equals "2018-08-29T21:41:39Z"
+        And the event "breadcrumbs.0.metaData.message" equals "Moving laterally 26º"
+        And the event "breadcrumbs.1" is null


### PR DESCRIPTION
## Goal

Adds an E2E scenario which verifies a `bsg_event` struct written to disk is delivered as an error payload.

This will verify that any legacy payloads are delivered correctly when the bugsnag journal replaces the struct mechanism.

## Changeset

- Copied `event.h` interface to test fixture to allow populating an event
- Added `CXXPersistLegacyStructScenario` which persists a `bsg_event` struct on disk, then initializes Bugsnag, which converts it to a JSON payload