### PR TITLE
Resolve incorrect assertion in E2E scenarios

### DIFF
--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -43,7 +43,7 @@ Scenario: Notify caught Java exception with default configuration
     And the event "app.isLaunching" is true
     And the error payload field "events.0.metaData.app.memoryUsage" is greater than 0
     And the error payload field "events.0.metaData.app.totalMemory" is greater than 0
-    And the error payload field "events.0.metaData.app.freeMemory" is greater than 0
+    And the error payload field "events.0.metaData.app.freeMemory" is an integer
     And the error payload field "events.0.metaData.app.memoryLimit" is greater than 0
     And the event "metaData.app.name" equals "MazeRunner"
     And the event "metaData.app.lowMemory" is false

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -44,7 +44,7 @@ Scenario: Unhandled Java Exception with loaded configuration
     And the event "app.isLaunching" is true
     And the error payload field "events.0.metaData.app.memoryUsage" is greater than 0
     And the error payload field "events.0.metaData.app.totalMemory" is greater than 0
-    And the error payload field "events.0.metaData.app.freeMemory" is greater than 0
+    And the error payload field "events.0.metaData.app.freeMemory" is an integer
     And the error payload field "events.0.metaData.app.memoryLimit" is greater than 0
 
     # Metadata


### PR DESCRIPTION
## Goal

Reduces the specificity of assertions around `metaData.app.freeMemory`, as checking for a value greater than zero was causing test flakes.

I confirmed with a local test run that `Runtime.freeMemory()` does sometimes return 0 on Android 9/10, meaning that this is a valid value that presumably is only returned earlier on during app initialization.

