### PR TITLE
Resolve test scenario flake with app.isLaunching

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmDelayedErrorScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmDelayedErrorScenario.kt
@@ -16,7 +16,8 @@ internal class JvmDelayedErrorScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     companion object {
-        private const val CRASH_DELAY_MS = 250L
+        private const val CRASH_DELAY_MS = 2000L
+        private const val NOTIFY_DELAY_MS = CRASH_DELAY_MS * 2
     }
 
     init {
@@ -33,7 +34,7 @@ internal class JvmDelayedErrorScenario(
             {
                 Bugsnag.notify(generateException())
             },
-            CRASH_DELAY_MS * 2
+            NOTIFY_DELAY_MS
         )
     }
 }


### PR DESCRIPTION
## Goal

Resolves a flake in `JvmDelayedErrorScenario`. Currently this scenario asserts that the first exception captured has `app.isLaunching == true`, and the second exception has `app.isLaunching == false`.

This was achieved by setting the `launchDurationMillis` to 250ms and then calling `Bugsnag.notify()`. However, if Bugsnag takes longer than 250ms to notify (as seen on older Android 6 devices), then `app.isLaunching` will be false, failing the test.

These changes increase the timeout so that Bugsnag will definitely have initialized in this time period, avoiding the race.
