### PR TITLE
Ensure bugsnag journal setup occurs at correct time

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
@@ -218,7 +218,9 @@ internal class ClientInternal constructor(
      * Populates the Bugsnag Journal with some initial state.
      */
     private fun addInitialJournalEntries() {
-        addObserver(JournaledStateObserver(client, journal.value))
+        val observer = JournaledStateObserver(client, journal.value)
+        observer.onStateChange(StateEvent.JournalSetup(config.apiKey))
+        addObserver(observer)
         syncInitialState()
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
@@ -7,8 +7,8 @@ import java.util.Date
 internal class JournaledStateObserver(val client: Client, val journal: BugsnagJournal) : StateObserver {
     override fun onStateChange(event: StateEvent) {
         when (event) {
-            is StateEvent.Install -> {
-                handleInstallEvent(event)
+            is StateEvent.JournalSetup -> {
+                handleJournalSetup(event)
             }
             StateEvent.DeliverPending -> {
                 // Nothing for us to do
@@ -96,10 +96,10 @@ internal class JournaledStateObserver(val client: Client, val journal: BugsnagJo
         )
     }
 
-    private fun handleInstallEvent(event: StateEvent.Install) {
-        val appDataCollector = client.getAppDataCollector()
+    private fun handleJournalSetup(event: StateEvent.JournalSetup) {
+        val appDataCollector = client.appDataCollector
         val appData = appDataCollector.generateAppWithState()
-        val deviceDataCollector = client.getDeviceDataCollector()
+        val deviceDataCollector = client.deviceDataCollector
         val deviceData = deviceDataCollector.generateDeviceWithState(Date().time)
         val device = deviceData.toJournalSection().filter { it.key != "time" }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
@@ -70,4 +70,6 @@ sealed class StateEvent { // JvmField allows direct field access optimizations
         @JvmField val memoryTrimLevel: Int? = null,
         @JvmField val memoryTrimLevelDescription: String = "None"
     ) : StateEvent()
+
+    class JournalSetup(@JvmField val apiKey: String) : StateEvent()
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledStateObserverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledStateObserverTest.kt
@@ -78,7 +78,7 @@ internal class JournaledStateObserverTest {
 
         val journal = emptyJournal()
         val observer = JournaledStateObserver(client, journal)
-        observer.onStateChange(StateEvent.Install("myapikey", true, "myversion", "myuuid", "myrelease", "/somepath", 0, ThreadSendPolicy.ALWAYS))
+        observer.onStateChange(StateEvent.JournalSetup("myapikey"))
 
         val doc = journal.document
         assertNotNull(doc["app"])


### PR DESCRIPTION
## Goal

The `JournaledStateObserver` relied on the NDK's `Install` event to populate the journal with initial entries. This was bad for several reasons:

- The observer doesn't use most of the NDK-related information
- The `Install` message only fires if the NDK is installed
- The `Install` message needs to be sent before the `JournaledStateObserver` is created

This changeset creates a separate `JournalSetup` event which can be fired at the appropriate time, and populates the journal with the correct information.

## Testing

Relied on existing test coverage, and ran the example app with a debugger to confirm an event was deserialized.