### PR TITLE
NDK Fixes for EventMapper

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -36,6 +36,7 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityReason(@SeverityReason.SeverityReasonType reason: String)</ID>
     <ID>RethrowCaughtException:JsonHelper.kt$JsonHelper.Companion$throw ex</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?> ): DeliveryStatus</ID>
+    <ID>SwallowedException:BugsnagJournalEventMapper.kt$BugsnagJournalEventMapper$catch (pe: IllegalArgumentException) { ndkDateFormatHolder.get()!!.parse(this) ?: throw IllegalArgumentException("cannot parse date $this") }</ID>
     <ID>SwallowedException:ClientInternal.kt$ClientInternal$catch (exc: Throwable) { false }</ID>
     <ID>SwallowedException:ClientInternal.kt$ClientInternal$catch (exception: IllegalArgumentException) { logger.w("Receiver not registered") }</ID>
     <ID>SwallowedException:ConnectivityCompat.kt$ConnectivityLegacy$catch (e: NullPointerException) { // in some rare cases we get a remote NullPointerException via Parcel.readException null }</ID>

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorDeserializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorDeserializationTest.kt
@@ -12,19 +12,22 @@ internal class ErrorDeserializationTest {
     companion object {
         @JvmStatic
         @Parameters
-        fun testCases() = (0..0).map { "event_deserialization_$it.json" }
+        fun testCases() = (0..1).map {
+            "event_deserialization_$it.json" to "event_deserialization_expected_$it.json"
+        }
     }
 
     @Parameter
-    lateinit var resourceName: String
+    lateinit var resource: Pair<String, String>
 
     @Test
     fun testJsonSerialisation() {
-        val jsonContent = JsonParser().read(resourceName)
+        val (inputResource, expectedResource) = resource
+        val jsonContent = JsonParser().read(inputResource)
         val map = JsonHelper.deserialize(jsonContent.toByteArray())
         val eventInternal = BugsnagJournalEventMapper(NoopLogger).convertToEventImpl(map, "api-key")
         val event = Event(eventInternal, NoopLogger)
 
-        verifyJsonMatches(event, resourceName)
+        verifyJsonMatches(event, expectedResource)
     }
 }

--- a/bugsnag-android-core/src/test/resources/event_deserialization_1.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_1.json
@@ -1,0 +1,105 @@
+{
+  "context": "SampleData",
+  "metaData": {
+    "app": {
+      "memoryTrimLevel": "None",
+      "processName": "com.example.bugsnag.android",
+      "activeScreen": "ExampleActivity",
+      "name": "Bugsnag",
+      "memoryLimit": 536870912,
+      "lowMemory": false
+    },
+    "Native": {
+      "field": true
+    },
+    "device": {
+      "locationStatus": "allowed",
+      "emulator": true,
+      "networkAccess": "wifi",
+      "screenDensity": 2.75,
+      "dpi": 440,
+      "screenResolution": "2088x1080",
+      "brand": "google"
+    },
+    "user": {
+      "age": 31
+    }
+  },
+  "severity": "warning",
+  "severityReason": {
+    "type": "handledException",
+    "unhandledOverridden": false
+  },
+  "unhandled": false,
+  "exceptions": [],
+  "user": {},
+  "app": {
+    "version": "1.0",
+    "id": "com.example.bugsnag.android",
+    "type": "android",
+    "releaseStage": "development",
+    "versionCode": 1,
+    "binaryArch": "x86",
+    "duration": 5496998,
+    "durationInForeground": 5490000,
+    "inForeground": true,
+    "isLaunching": true
+  },
+  "device": {
+    "osName": "android",
+    "id": "22943cb8-bd36-457c-b302-4c211d0e1f24",
+    "locale": "en_US",
+    "osVersion": "10",
+    "manufacturer": "Google",
+    "model": "Android SDK built for x86",
+    "orientation": "portrait",
+    "runtimeVersions": {
+      "androidApiLevel": 29,
+      "osBuild": "QSR1.190920.001"
+    },
+    "cpuAbi": [
+      "x86"
+    ],
+    "totalMemory": 2091245568,
+    "jailbroken": false,
+    "time": "1970-01-01T00:00:00Z"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "1970-01-01T00:00:00.000Z",
+      "name": "Connectivity changed",
+      "type": "state",
+      "metaData": {
+        "hasConnection": true,
+        "networkState": "wifi"
+      }
+    },
+    {
+      "timestamp": "1970-01-01T00:00:00.000Z",
+      "name": "Bugsnag loaded",
+      "type": "state"
+    }
+  ],
+  "threads": [
+    {
+      "id": 20948,
+      "name": "bugsnag.android",
+      "type": "c",
+      "state": "running"
+    },
+    {
+      "id": 20954,
+      "name": "Jit thread pool",
+      "type": "c",
+      "state": "sleeping"
+    }
+  ],
+  "session": {
+    "id": "e83a6f98-120c-4a23-940c-abf8cc87",
+    "startedAt": "1970-01-01T00:00:00.000Z",
+    "events": {
+      "handled": 0,
+      "unhandled": 1
+    }
+  }
+}

--- a/bugsnag-android-core/src/test/resources/event_deserialization_expected_0.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_expected_0.json
@@ -1,0 +1,94 @@
+{
+  "metaData": {
+    "example": {
+      "boolean": true,
+      "string": "value",
+      "array": [
+        "a",
+        "b"
+      ],
+      "double": 123.45,
+      "integer": 123,
+      "collection": [
+        "Hello",
+        "World"
+      ],
+      "map": {
+        "key": "value"
+      }
+    }
+  },
+  "severity": "warning",
+  "severityReason": {
+    "type": "handledException",
+    "unhandledOverridden": false
+  },
+  "unhandled": false,
+  "exceptions": [],
+  "projectPackages": [
+    "com.example.foo"
+  ],
+  "user": {},
+  "app": {
+    "type": "android",
+    "versionCode": 0
+  },
+  "device": {
+    "cpuAbi": [],
+    "manufacturer": "samsung",
+    "model": "s7",
+    "osName": "android",
+    "osVersion": "7.1",
+    "runtimeVersions": {
+      "osBuild": "bulldog",
+      "androidApiLevel": 24
+    },
+    "totalMemory": 109230923452,
+    "freeDisk": 22234423124,
+    "freeMemory": 92340255592,
+    "orientation": "portrait",
+    "time": "1970-01-01T00:00:00.000Z"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "1970-01-01T00:00:00.000Z",
+      "name": "helloworld",
+      "type": "manual",
+      "metaData": {}
+    },
+    {
+      "timestamp": "1970-01-01T00:00:00.000Z",
+      "name": "metadata",
+      "type": "process",
+      "metaData": {
+        "foo": true
+      }
+    }
+  ],
+  "threads": [
+    {
+      "id": 24,
+      "name": "main-one",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "run_func",
+          "file": "librunner.so",
+          "lineNumber": 5038
+        },
+        {
+          "method": "Runner.runFunc",
+          "file": "Runner.java",
+          "lineNumber": 14
+        },
+        {
+          "method": "App.launch",
+          "file": "App.java",
+          "lineNumber": 70
+        }
+      ],
+      "errorReportingThread": true
+    }
+  ]
+}

--- a/bugsnag-android-core/src/test/resources/event_deserialization_expected_1.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_expected_1.json
@@ -1,0 +1,108 @@
+{
+  "context": "SampleData",
+  "metaData": {
+    "app": {
+      "memoryTrimLevel": "None",
+      "processName": "com.example.bugsnag.android",
+      "activeScreen": "ExampleActivity",
+      "name": "Bugsnag",
+      "memoryLimit": 536870912,
+      "lowMemory": false
+    },
+    "Native": {
+      "field": true
+    },
+    "device": {
+      "locationStatus": "allowed",
+      "emulator": true,
+      "networkAccess": "wifi",
+      "screenDensity": 2.75,
+      "dpi": 440,
+      "screenResolution": "2088x1080",
+      "brand": "google"
+    },
+    "user": {
+      "age": 31
+    }
+  },
+  "severity": "warning",
+  "severityReason": {
+    "type": "handledException",
+    "unhandledOverridden": false
+  },
+  "unhandled": false,
+  "exceptions": [],
+  "projectPackages":[],
+  "user": {},
+  "app": {
+    "version": "1.0",
+    "id": "com.example.bugsnag.android",
+    "type": "android",
+    "releaseStage": "development",
+    "versionCode": 1,
+    "binaryArch": "x86",
+    "duration": 5496998,
+    "durationInForeground": 5490000,
+    "inForeground": true,
+    "isLaunching": true
+  },
+  "device": {
+    "osName": "android",
+    "id": "22943cb8-bd36-457c-b302-4c211d0e1f24",
+    "locale": "en_US",
+    "osVersion": "10",
+    "manufacturer": "Google",
+    "model": "Android SDK built for x86",
+    "orientation": "portrait",
+    "runtimeVersions": {
+      "androidApiLevel": 29,
+      "osBuild": "QSR1.190920.001"
+    },
+    "cpuAbi": [
+      "x86"
+    ],
+    "totalMemory": 2091245568,
+    "jailbroken": false,
+    "time": "1970-01-01T00:00:00.000Z"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "1970-01-01T00:00:00.000Z",
+      "name": "Connectivity changed",
+      "type": "state",
+      "metaData": {
+        "hasConnection": true,
+        "networkState": "wifi"
+      }
+    },
+    {
+      "timestamp": "1970-01-01T00:00:00.000Z",
+      "name": "Bugsnag loaded",
+      "type": "state"
+    }
+  ],
+  "threads": [
+    {
+      "id": 20948,
+      "name": "bugsnag.android",
+      "type": "c",
+      "state": "running",
+      "stacktrace": []
+    },
+    {
+      "id": 20954,
+      "name": "Jit thread pool",
+      "type": "c",
+      "state": "sleeping",
+      "stacktrace": []
+    }
+  ],
+  "session": {
+    "id": "e83a6f98-120c-4a23-940c-abf8cc87",
+    "startedAt": "1970-01-01T00:00:00.000Z",
+    "events": {
+      "handled": 0,
+      "unhandled": 1
+    }
+  }
+}


### PR DESCRIPTION
## Goal
Handle the NDK date formatting and lack of `projectPackages` so that stores NDK events can be loaded by the `BugsnagJournalEventMapper` for `OnSendCallback`s

## Testing
Added new test fixtures to existing unit tests, based on NDK errors.