### PR TITLE
Use marker file to detect launch crashes

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
@@ -224,6 +224,12 @@ internal class ClientInternal constructor(
         if (config.shouldDiscardByReleaseStage()) {
             return
         }
+        // this will be used to determine whether events from the journal should be sent
+        // as a synchronous event
+        val crashedDuringLastLaunch = launchCrashTracker.crashedDuringLastLaunch()
+        logger.d("Temp: crashedDuringLastLaunch=$crashedDuringLastLaunch")
+
+        launchCrashTracker.startAutoTracking(config)
         if (config.enabledErrorTypes.unhandledExceptions) {
             exceptionHandler.install()
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LaunchCrashTracker.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LaunchCrashTracker.kt
@@ -1,43 +1,90 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.internal.ImmutableConfig
+import java.io.File
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Tracks whether the app is currently in its launch period. This creates a timer of
  * configuration.launchDurationMillis, after which which the launch period is considered
  * complete. If this value is zero, then the user must manually call markLaunchCompleted().
+ *
+ * A marker file is also created, which is used to detect whether fatal NDK errors were in the
+ * launch state.
  */
 internal class LaunchCrashTracker @JvmOverloads constructor(
     config: ImmutableConfig,
     private val executor: ScheduledThreadPoolExecutor = ScheduledThreadPoolExecutor(1)
 ) : BaseObservable() {
 
-    private val launching = AtomicBoolean(true)
+    @JvmField
+    @Volatile
+    internal var launching = false
     private val logger = config.logger
+    private val launchPeriodMarkerFile =
+        File(config.persistenceDirectory.value, "launch-crash-marker")
 
-    init {
+    /**
+     * Starts automatically tracking the launch period.
+     */
+    fun startAutoTracking(config: ImmutableConfig) {
         val delay = config.launchDurationMillis
+        markLaunchStarted()
 
         if (delay > 0) {
             executor.executeExistingDelayedTasksAfterShutdownPolicy = false
             try {
                 executor.schedule({ markLaunchCompleted() }, delay, TimeUnit.MILLISECONDS)
             } catch (exc: RejectedExecutionException) {
+                markLaunchCompleted()
                 logger.w("Failed to schedule timer for LaunchCrashTracker", exc)
             }
         }
     }
 
+    /**
+     * Determines whether the application crashed duration the launch period in the last
+     * application process. It is an error to call this after calling [markLaunchStarted].
+     */
+    fun crashedDuringLastLaunch(): Boolean {
+        return runCatching {
+            !isLaunching() && launchPeriodMarkerFile.exists()
+        }.getOrDefault(false)
+    }
+
+    /**
+     * Marks the current launch as started. It is an error to call this more than once,
+     * and this must be called before [markLaunchCompleted].
+     */
+    fun markLaunchStarted() {
+        launching = true
+        runCatching {
+            launchPeriodMarkerFile.createNewFile()
+        }.getOrElse { exc ->
+            logger.w("Failed to create launch marker file", exc)
+        }
+    }
+
+    /**
+     * Marks the current launch as completed. It is an error to call this more than once,
+     * and this must be called after [markLaunchStarted].
+     */
     fun markLaunchCompleted() {
-        executor.shutdown()
-        launching.set(false)
+        launching = false
+        runCatching { executor.shutdown() }
+        runCatching {
+            launchPeriodMarkerFile.delete()
+        }.getOrElse { exc ->
+            logger.w("Failed to delete launch marker file", exc)
+        }
         updateState { StateEvent.UpdateIsLaunching(false) }
         logger.d("App launch period marked as complete")
     }
 
-    fun isLaunching() = launching.get()
+    /**
+     * Determines whether the application is in the launch period.
+     */
+    fun isLaunching() = launching
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashTrackerTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashTrackerTest.kt
@@ -13,29 +13,34 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
+import java.io.File
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 @RunWith(MockitoJUnitRunner::class)
 class LaunchCrashTrackerTest {
 
+    private val cfg = generateImmutableConfig()
+
     @Test
     fun defaultLaunchPeriodManualMark() {
-        val tracker = LaunchCrashTracker(generateImmutableConfig())
+        val tracker = LaunchCrashTracker(cfg)
+        assertFalse(tracker.isLaunching())
+
+        tracker.startAutoTracking(cfg)
         assertTrue(tracker.isLaunching())
+
         tracker.markLaunchCompleted()
         assertFalse(tracker.isLaunching())
     }
 
     @Test
     fun zeroLaunchPeriodManualMark() {
-        val tracker = LaunchCrashTracker(
-            convert(
-                generateConfiguration().apply {
-                    launchDurationMillis = 0
-                }
-            )
-        )
+        val config = convert(generateConfiguration().apply { launchDurationMillis = 0 })
+        val tracker = LaunchCrashTracker(config)
+        assertFalse(tracker.isLaunching())
+
+        tracker.startAutoTracking(config)
         assertTrue(tracker.isLaunching())
 
         java.lang.Thread.sleep(10)
@@ -47,18 +52,55 @@ class LaunchCrashTrackerTest {
     @Test
     fun smallLaunchPeriodAutomatic() {
         val executor = mock(ScheduledThreadPoolExecutor::class.java)
-        LaunchCrashTracker(
-            convert(
-                generateConfiguration().apply {
-                    launchDurationMillis = 1
-                }
-            ),
-            executor
-        )
+        val config = convert(generateConfiguration().apply { launchDurationMillis = 1 })
+        val tracker = LaunchCrashTracker(config, executor)
+        tracker.startAutoTracking(config)
         verify(executor, times(1)).schedule(
             any(Runnable::class.java),
             eq(1L),
             eq(TimeUnit.MILLISECONDS)
         )
+    }
+
+    @Test
+    fun crashedLastLaunchMarkStarted() {
+        with(LaunchCrashTracker(cfg)) {
+            markLaunchStarted()
+            assertFalse(crashedDuringLastLaunch())
+        }
+    }
+
+    @Test
+    fun crashedLastLaunchMarkCompleted() {
+        with(LaunchCrashTracker(cfg)) {
+            markLaunchStarted()
+            markLaunchCompleted()
+            assertFalse(crashedDuringLastLaunch())
+        }
+    }
+
+    @Test
+    fun testCrashedDuringLastLaunch() {
+        val marker = File(cfg.persistenceDirectory.value, "launch-crash-marker")
+        marker.createNewFile()
+
+        val tracker = LaunchCrashTracker(cfg)
+        assertTrue(tracker.crashedDuringLastLaunch())
+
+        marker.delete()
+        assertFalse(tracker.crashedDuringLastLaunch())
+    }
+
+    @Test
+    fun trackerCreatesMarkerFile() {
+        val marker = File(cfg.persistenceDirectory.value, "launch-crash-marker")
+        assertFalse(marker.exists())
+
+        val tracker = LaunchCrashTracker(cfg)
+        tracker.markLaunchStarted()
+        assertTrue(marker.exists())
+
+        tracker.markLaunchCompleted()
+        assertFalse(marker.exists())
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCrashLoopScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCrashLoopScenario.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.log
 
 /**
  * Triggers a crash loop which Bugsnag allows recovery from.
@@ -24,6 +25,7 @@ internal class CXXCrashLoopScenario(
         val lastRunInfo = Bugsnag.getLastRunInfo()
 
         lastRunInfo?.let {
+            log("CXXCrashLoopScenario: loaded LastRunInfo: $it")
             Bugsnag.addMetadata("LastRunInfo", "crashed", it.crashed)
             Bugsnag.addMetadata("LastRunInfo", "crashedDuringLaunch", it.crashedDuringLaunch)
             Bugsnag.addMetadata(
@@ -36,12 +38,16 @@ internal class CXXCrashLoopScenario(
         // the last run info allows the scenario to escape from what would otherwise be
         // a crash loop, by conditionally entering a 'safe mode'.
         if (lastRunInfo?.crashed == true) {
+            log("Confirmed last launch crashed.")
             if (lastRunInfo.consecutiveLaunchCrashes < 2) {
+                log("CXXCrashLoopScenario: <2 previous crashes, crashing again")
                 crash()
             } else {
+                log("CXXCrashLoopScenario: >=2 previous crashes, enabling safe mode")
                 Bugsnag.notify(IllegalArgumentException("Safe mode enabled"))
             }
         } else {
+            log("CXXCrashLoopScenario: no previous crashes, about to crash")
             crash()
         }
     }


### PR DESCRIPTION
## Goal

Uses the presence of a marker file to track the launch period for the last launch. This will be used to determine whether an event generated from the `BugsnagJournal` should be sent synchronously or not.

## Testing

Added unit test coverage and manually verified in the example app that the marker file is created/deleted.