### PR TITLE
Introduce SeverityReason.handledError

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SeverityReason.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SeverityReason.java
@@ -11,8 +11,8 @@ import java.lang.annotation.RetentionPolicy;
 final class SeverityReason implements JsonStream.Streamable {
 
     @StringDef({REASON_UNHANDLED_EXCEPTION, REASON_STRICT_MODE, REASON_HANDLED_EXCEPTION,
-        REASON_USER_SPECIFIED, REASON_CALLBACK_SPECIFIED, REASON_PROMISE_REJECTION,
-        REASON_LOG, REASON_SIGNAL, REASON_ANR})
+        REASON_HANDLED_ERROR, REASON_USER_SPECIFIED, REASON_CALLBACK_SPECIFIED,
+        REASON_PROMISE_REJECTION, REASON_LOG, REASON_SIGNAL, REASON_ANR })
     @Retention(RetentionPolicy.SOURCE)
     @interface SeverityReasonType {
     }
@@ -20,6 +20,7 @@ final class SeverityReason implements JsonStream.Streamable {
     static final String REASON_UNHANDLED_EXCEPTION = "unhandledException";
     static final String REASON_STRICT_MODE = "strictMode";
     static final String REASON_HANDLED_EXCEPTION = "handledException";
+    static final String REASON_HANDLED_ERROR = "handledError";
     static final String REASON_USER_SPECIFIED = "userSpecifiedSeverity";
     static final String REASON_CALLBACK_SPECIFIED = "userCallbackSetSeverity";
     static final String REASON_PROMISE_REJECTION = "unhandledPromiseRejection";
@@ -61,6 +62,7 @@ final class SeverityReason implements JsonStream.Streamable {
                 return new SeverityReason(severityReasonType, Severity.ERROR, true, null);
             case REASON_STRICT_MODE:
                 return new SeverityReason(severityReasonType, Severity.WARNING, true, attrVal);
+            case REASON_HANDLED_ERROR:
             case REASON_HANDLED_EXCEPTION:
                 return new SeverityReason(severityReasonType, Severity.WARNING, false, null);
             case REASON_USER_SPECIFIED:

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SeverityReasonSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SeverityReasonSerializationTest.kt
@@ -28,7 +28,8 @@ internal class SeverityReasonSerializationTest {
                 SeverityReason.newInstance(SeverityReason.REASON_PROMISE_REJECTION),
                 SeverityReason.newInstance(SeverityReason.REASON_LOG, Severity.WARNING, "warning"),
                 SeverityReason.newInstance(SeverityReason.REASON_ANR),
-                override
+                override,
+                SeverityReason.newInstance(SeverityReason.REASON_HANDLED_ERROR)
             )
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SeverityReasonTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SeverityReasonTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.SeverityReason.REASON_CALLBACK_SPECIFIED
+import com.bugsnag.android.SeverityReason.REASON_HANDLED_ERROR
 import com.bugsnag.android.SeverityReason.REASON_HANDLED_EXCEPTION
 import com.bugsnag.android.SeverityReason.REASON_LOG
 import com.bugsnag.android.SeverityReason.REASON_PROMISE_REJECTION
@@ -19,6 +20,15 @@ class SeverityReasonTest {
     @Test
     fun testHandled() {
         val handled = newInstance(REASON_HANDLED_EXCEPTION)
+        assertNotNull(handled)
+        assertFalse(handled.unhandled)
+        assertEquals(Severity.WARNING, handled.currentSeverity)
+        assertFalse(handled.unhandledOverridden)
+    }
+
+    @Test
+    fun testHandledError() {
+        val handled = newInstance(REASON_HANDLED_ERROR)
         assertNotNull(handled)
         assertFalse(handled.unhandled)
         assertEquals(Severity.WARNING, handled.currentSeverity)

--- a/bugsnag-android-core/src/test/resources/severity_reason_serialization_9.json
+++ b/bugsnag-android-core/src/test/resources/severity_reason_serialization_9.json
@@ -1,0 +1,4 @@
+{
+  "type": "handledError",
+  "unhandledOverridden": false
+}


### PR DESCRIPTION
## Goal
Added `handledError` as an available `SeverityReason`.

## Testing
Included the new severity reason type in existing unit tests.