### PR TITLE
Avoid reporting false-positive background ANRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Avoid reporting false-positive background ANRs with improved foreground detection
+  [#1429](https://github.com/bugsnag/bugsnag-android/pull/1429)
+
 ## 5.14.0 (2021-09-29)
 
 ### Enhancements 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ForegroundDetector.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ForegroundDetector.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 class ForegroundDetector {
 
+    private static final int IMPORTANCE_FOREGROUND_SERVICE = 125;
+
     @Nullable
     private final ActivityManager activityManager;
 
@@ -36,8 +38,7 @@ class ForegroundDetector {
             ActivityManager.RunningAppProcessInfo info = getProcessInfo();
 
             if (info != null) {
-                return info.importance
-                        <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+                return info.importance <= IMPORTANCE_FOREGROUND_SERVICE;
             } else {
                 return null;
             }


### PR DESCRIPTION
## Goal
Improve foreground detection to stop reporting ANRs as `inForeground=false`, as our ANR detection does not support background ANRs.

## Testing
Relied on existing tests