### PR TITLE
Read additional fields from journal entries

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.internal.DateUtils
+import com.bugsnag.android.internal.journal.JournalKeys
 import java.io.File
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -39,97 +40,109 @@ internal class BugsnagJournalEventMapper(
     @Suppress("UNCHECKED_CAST")
     internal fun convertToEventImpl(
         map: Map<in String, Any?>,
-        apiKey: String = map.readEntry("apiKey")
+        apiKey: String = map.readEntry(JournalKeys.pathApiKey)
     ): EventInternal {
         logger.d("Read previous journal, contents=$map")
         val event = EventInternal(apiKey)
 
         // populate user
-        val userMap: Map<String, String> = map.readEntry("user")
+        val userMap: Map<String, String> = map.readEntry(JournalKeys.pathUser)
         event.userImpl = User(userMap)
 
         // populate metadata
-        val metadataMap: Map<String, Map<String, Any?>> = map.readEntry("metaData")
+        val metadataMap: Map<String, Map<String, Any?>> = map.readEntry(JournalKeys.pathMetadata)
         metadataMap.forEach { (key, value) ->
             event.addMetadata(key, value)
         }
 
         // populate breadcrumbs
-        val breadcrumbList: List<MutableMap<String, Any?>> = map.readEntry("breadcrumbs")
+        val breadcrumbList: List<MutableMap<String, Any?>> =
+            map.readEntry(JournalKeys.pathBreadcrumbs)
         val crumbs = breadcrumbList
             .map(this::sanitizeBreadcrumbMap)
             .map { Breadcrumb(BreadcrumbInternal(it), logger) }
         event.breadcrumbs.addAll(crumbs)
 
         // populate context
-        event.context = map["context"] as? String
+        event.context = map[JournalKeys.pathContext] as? String
+
+        // populate groupingHash
+        event.groupingHash = map[JournalKeys.pathGroupingHash] as? String
 
         // populate app
-        val appMap: MutableMap<String, Any?> = map.readEntry("app")
-        event.app = AppWithState(appMap)
+        val appMap: MutableMap<String, Any?> = map.readEntry(JournalKeys.pathApp)
+        event.app = convertAppWithState(appMap)
+
         // populate device
-        val deviceMap: MutableMap<String, Any?> = map.readEntry("device")
+        val deviceMap: MutableMap<String, Any?> = map.readEntry(JournalKeys.pathDevice)
         event.device = convertDeviceWithState(deviceMap)
 
         // populate session
-        val sessionMap = map["session"] as? Map<String, Any?>
+        val sessionMap = map[JournalKeys.pathSession] as? Map<String, Any?>
         sessionMap?.let {
             event.session = Session(it, logger)
         }
 
-        val threads = map["threads"] as? List<Map<String, Any?>>
+        val threads = map[JournalKeys.pathThreads] as? List<Map<String, Any?>>
         threads?.mapTo(event.threads) { Thread(convertThreadInternal(it), logger) }
 
         // populate projectPackages
-        val projectPackages = map["projectPackages"] as? List<String>
+        val projectPackages = map[JournalKeys.pathProjectPackages] as? List<String>
         projectPackages?.let {
             event.projectPackages = projectPackages
         }
 
         // populate exceptions
-        val exceptions: List<MutableMap<String, Any?>> = map.readEntry("exceptions")
+        val exceptions: List<MutableMap<String, Any?>> = map.readEntry(JournalKeys.pathExceptions)
         exceptions.mapTo(event.errors) { Error(convertErrorInternal(it), this.logger) }
         return event
     }
 
     private fun sanitizeBreadcrumbMap(src: Map<String, Any?>): MutableMap<String, Any?> {
         val map = src.toMutableMap()
-        map["message"] = map["name"]
-        map.remove("name")
+        map["message"] = map[JournalKeys.keyName]
+        map.remove(JournalKeys.keyName)
 
-        val type = map["type"] as String
-        map["type"] = BreadcrumbType.valueOf(type.toUpperCase(Locale.US))
+        val type = map[JournalKeys.keyType] as String
+        map[JournalKeys.keyType] = BreadcrumbType.valueOf(type.toUpperCase(Locale.US))
 
-        map["timestamp"] = (map["timestamp"] as String).toDate()
+        map[JournalKeys.keyTimestamp] = (map[JournalKeys.keyTimestamp] as String).toDate()
 
-        map["metadata"] = map["metaData"]
-        map.remove("metaData")
+        map["metadata"] = map[JournalKeys.keyMetadata]
+        map.remove(JournalKeys.keyMetadata)
         return map
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun convertAppWithState(src: Map<String, Any?>): AppWithState {
+        val map = src.toMutableMap()
+        map["buildUuid"] = map[JournalKeys.keyBuildUUID] as? String
+        return AppWithState(map)
     }
 
     @Suppress("UNCHECKED_CAST")
     private fun convertDeviceWithState(src: Map<String, Any?>): DeviceWithState {
         val map = src.toMutableMap()
-        map["cpuAbi"] = (map["cpuAbi"] as? List<String>)?.toTypedArray()
-        map["time"] = (map["time"] as? String)?.toDate()
+        map[JournalKeys.keyCpuAbi] = (map[JournalKeys.keyCpuAbi] as? List<String>)?.toTypedArray()
+        map[JournalKeys.keyTime] = (map[JournalKeys.keyTime] as? String)?.toDate()
         return DeviceWithState(map)
     }
 
     @Suppress("UNCHECKED_CAST")
     private fun convertThreadInternal(src: Map<String, Any?>): ThreadInternal {
         val stacktrace = Stacktrace(
-            (src["stacktrace"] as? List<Map<String, Any?>>)?.map { Stackframe(it) }
+            (src[JournalKeys.keyStackTrace] as? List<Map<String, Any?>>)?.map { Stackframe(it) }
                 ?: emptyList()
         )
 
         return ThreadInternal(
-            src.readEntry("id"),
-            src.readEntry("name"),
-            src.readEntry<String>("type")
+            src.readEntry(JournalKeys.keyId),
+            src.readEntry(JournalKeys.keyName),
+            src.readEntry<String>(JournalKeys.keyType)
                 .let { type -> ThreadType.values().find { it.desc == type } }
                 ?: ThreadType.ANDROID,
-            src["errorReportingThread"] == true,
-            src.readEntry("state"),
+            src[JournalKeys.keyErrorReportingThread] == true,
+            src.readEntry(JournalKeys.keyState),
             stacktrace
         )
     }
@@ -137,22 +150,26 @@ internal class BugsnagJournalEventMapper(
     @Suppress("UNCHECKED_CAST")
     private fun convertErrorInternal(src: Map<String, Any?>): ErrorInternal {
         val map = src.toMutableMap()
-        map["stacktrace"] =
-            (src["stacktrace"] as List<Map<String, Any>>).map(this::convertStacktraceInternal)
+        map[JournalKeys.keyStackTrace] =
+            (src[JournalKeys.keyStackTrace] as List<Map<String, Any>>).map(this::convertStacktraceInternal)
         return ErrorInternal(map)
     }
 
     private fun convertStacktraceInternal(frame: Map<String, Any>): MutableMap<String, Any?> {
         val copy: MutableMap<String, Any?> = frame.toMutableMap()
-        val lineNumber = frame["lineNumber"] as? Number
-        copy["lineNumber"] = lineNumber?.toLong()
+        val lineNumber = frame[JournalKeys.keyLineNumber] as? Number
+        copy[JournalKeys.keyLineNumber] = lineNumber?.toLong()
 
-        (frame["frameAddress"] as? String)?.let {
-            copy["frameAddress"] = java.lang.Long.decode(it)
+        (frame[JournalKeys.keyFrameAddress] as? String)?.let {
+            copy[JournalKeys.keyFrameAddress] = java.lang.Long.decode(it)
         }
 
-        (frame["symbolAddress"] as? String)?.let {
-            copy["symbolAddress"] = java.lang.Long.decode(it)
+        (frame[JournalKeys.keySymbolAddress] as? String)?.let {
+            copy[JournalKeys.keySymbolAddress] = java.lang.Long.decode(it)
+        }
+
+        (frame[JournalKeys.keyLoadAddress] as? String)?.let {
+            copy[JournalKeys.keyLoadAddress] = java.lang.Long.decode(it)
         }
         return copy
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournalKeys.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournalKeys.kt
@@ -59,8 +59,12 @@ internal object JournalKeys {
     internal const val pathBreadcrumbs = "breadcrumbs"
     internal const val pathContext = "context"
     internal const val pathDevice = keyDevice
+    internal const val pathExceptions = "exceptions"
+    internal const val pathGroupingHash = "groupingHash"
     internal const val pathMetadata = keyMetadata
     internal const val pathSession = "session"
+    internal const val pathSeverity = "severity"
+    internal const val pathThreads = "threads"
     internal const val pathUser = "user"
     internal const val pathNotifier = "notifier"
     internal const val pathProjectPackages = "projectPackages"

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
@@ -61,7 +61,7 @@ class BugsnagJournalEventMapperTest {
             "type" to "android",
             "version" to "1.0",
             "versionCode" to 1,
-            "buildUuid" to "123",
+            "buildUUID" to "123",
             "codeBundleId" to "456"
         )
         val device = mapOf(
@@ -84,6 +84,7 @@ class BugsnagJournalEventMapperTest {
             mapOf(
                 "frameAddress" to "0x82545948",
                 "symbolAddress" to "0x82545000",
+                "loadAddress" to "0x90000000",
                 "lineNumber" to BigDecimal.valueOf(273),
                 "isPC" to true,
                 "file" to "/data/app/com.example.bugsnag.android-EPFji4GE4IHgwGM2GoOXvQ==/lib/x86/libentrypoint.so",
@@ -92,6 +93,7 @@ class BugsnagJournalEventMapperTest {
             mapOf(
                 "frameAddress" to "0x900040923",
                 "symbolAddress" to "0x900010000",
+                "loadAddress" to "0x00001000",
                 "lineNumber" to BigDecimal.valueOf(509),
                 "file" to "/data/app/com.example.bugsnag.android-EPFji4GE4IHgwGM2GoOXvQ==/oat/x86/base.odex",
                 "method" to "Java_com_example_bugsnag_android_BaseCrashyActivity_crashFromCXX"
@@ -122,6 +124,7 @@ class BugsnagJournalEventMapperTest {
         )
         journalMap = minimalJournalMap + mapOf(
             "context" to "ExampleActivity",
+            "groupingHash" to "hash-123",
             "session" to mapOf(
                 "startedAt" to "2021-09-28T10:31:09.620Z",
                 "id" to "b4a03b1b-e0dc-4bed-81e8-cb9e9f2ed825",
@@ -153,6 +156,7 @@ class BugsnagJournalEventMapperTest {
         // context/session
         assertNull(event.context)
         assertNull(event.session)
+        assertNull(event.groupingHash)
     }
 
     /**
@@ -168,6 +172,7 @@ class BugsnagJournalEventMapperTest {
 
         // context
         assertEquals("ExampleActivity", event.context)
+        assertEquals("hash-123", event.groupingHash)
 
         // session
         val session = checkNotNull(event.session)
@@ -259,6 +264,7 @@ class BugsnagJournalEventMapperTest {
         assertEquals(273L, firstFrame["lineNumber"])
         assertEquals(0x82545948, firstFrame["frameAddress"])
         assertEquals(0x82545000, firstFrame["symbolAddress"])
+        assertEquals(0x90000000, firstFrame["loadAddress"])
         assertEquals(
             "/data/app/com.example.bugsnag.android-" +
                 "EPFji4GE4IHgwGM2GoOXvQ==/lib/x86/libentrypoint.so",
@@ -271,6 +277,7 @@ class BugsnagJournalEventMapperTest {
         assertEquals(509L, secondFrame["lineNumber"])
         assertEquals(0x900040923, secondFrame["frameAddress"])
         assertEquals(0x900010000, secondFrame["symbolAddress"])
+        assertEquals(0x00001000L, secondFrame["loadAddress"])
         assertEquals(
             "/data/app/com.example.bugsnag.android-" +
                 "EPFji4GE4IHgwGM2GoOXvQ==/oat/x86/base.odex",


### PR DESCRIPTION
## Goal

Reads some additional fields from journal entries which were not being mapped onto the event, specifically:

- `buildUUID`
- `groupingHash`
- `loadAddress`

This also updates the `BugsnagJournalEventMapper` to use the constants in `JournalKeys` to avoid null values being passed in future.

## Testing

Added unit tests to cover the change.