### PR TITLE
Don't update currentSession when the Session isn't tracked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Avoid reporting false-positive background ANRs with improved foreground detection
   [#1429](https://github.com/bugsnag/bugsnag-android/pull/1429)
 
+* Prevent events being attached to phantom sessions when they are blocked by an `OnSessionCallback`
+  [#1434](https://github.com/bugsnag/bugsnag-android/pull/1434)
+
 ## 5.14.0 (2021-09-29)
 
 ### Enhancements 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -38,7 +38,7 @@ class SessionTracker extends BaseObservable {
 
     // The first Activity in this 'session' was started at this time.
     private final AtomicLong lastEnteredForegroundMs = new AtomicLong(0);
-    private final AtomicReference<Session> currentSession = new AtomicReference<>();
+    private volatile Session currentSession = null;
     private final ForegroundDetector foregroundDetector;
     final BackgroundTaskService backgroundTaskService;
     final Logger logger;
@@ -89,9 +89,11 @@ class SessionTracker extends BaseObservable {
         }
         String id = UUID.randomUUID().toString();
         Session session = new Session(id, date, user, autoCaptured, client.getNotifier(), logger);
-        currentSession.set(session);
-        trackSessionIfNeeded(session);
-        return session;
+        if (trackSessionIfNeeded(session)) {
+            return session;
+        } else {
+            return null;
+        }
     }
 
     Session startSession(boolean autoCaptured) {
@@ -102,7 +104,7 @@ class SessionTracker extends BaseObservable {
     }
 
     void pauseSession() {
-        Session session = currentSession.get();
+        Session session = currentSession;
 
         if (session != null) {
             session.isPaused.set(true);
@@ -111,7 +113,7 @@ class SessionTracker extends BaseObservable {
     }
 
     boolean resumeSession() {
-        Session session = currentSession.get();
+        Session session = currentSession;
         boolean resumed;
 
         if (session == null) {
@@ -159,7 +161,7 @@ class SessionTracker extends BaseObservable {
         } else {
             updateState(StateEvent.PauseSession.INSTANCE);
         }
-        currentSession.set(session);
+        currentSession = session;
         return session;
     }
 
@@ -168,23 +170,29 @@ class SessionTracker extends BaseObservable {
      * stored and sent to the Bugsnag API, otherwise no action will occur in this method.
      *
      * @param session the session
+     * @return true if the Session should be tracked
      */
-    private void trackSessionIfNeeded(final Session session) {
+    private boolean trackSessionIfNeeded(final Session session) {
         logger.d("SessionTracker#trackSessionIfNeeded() - session captured by Client");
         session.setApp(client.getAppDataCollector().generateApp());
         session.setDevice(client.getDeviceDataCollector().generateDevice());
         boolean deliverSession = callbackState.runOnSessionTasks(session, logger);
 
         if (deliverSession && session.isTracked().compareAndSet(false, true)) {
+            currentSession = session;
             notifySessionStartObserver(session);
             flushAsync();
             flushInMemorySession(session);
+
+            return true;
         }
+
+        return false;
     }
 
     @Nullable
     Session getCurrentSession() {
-        Session session = currentSession.get();
+        Session session = currentSession;
 
         if (session != null && !session.isPaused.get()) {
             return session;

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
@@ -12,6 +12,8 @@ import com.bugsnag.android.internal.ImmutableConfig;
 import android.app.ActivityManager;
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -220,5 +222,20 @@ public class SessionTrackerTest {
         assertNull(sessionTracker.getCurrentSession());
         sessionTracker.startNewSession(new Date(), user, false);
         assertNotNull(sessionTracker.getCurrentSession());
+    }
+
+    @Test
+    public void blockSessionInCallback() {
+        CallbackState callbackState = configuration.impl.callbackState;
+        callbackState.addOnSession(new OnSessionCallback() {
+            @Override
+            public boolean onSession(@NonNull Session session) {
+                return false;
+            }
+        });
+
+        Date date = new Date();
+        sessionTracker.startNewSession(date, user, false);
+        assertNull(sessionTracker.getCurrentSession());
     }
 }


### PR DESCRIPTION
## Goal
Don't associate Events with Sessions that were blocked by an `OnSessionCallback`.

## Changeset
When a `Session` is not tracked, we discard the `Session` completely to avoid associating any `Event`s with it.

## Testing
Added a new unit test to the existing `SessionTrackerTest`.