### PR TITLE
Unskip tests on Android 10/11

### DIFF
--- a/features/full_tests/batch_1/in_foreground.feature
+++ b/features/full_tests/batch_1/in_foreground.feature
@@ -1,7 +1,5 @@
 Feature: In foreground field populates correctly
 
-# Skip due to an issue on later Android platforms - [PLAT-5464]
-@skip_android_11 @skip_android_10
 Scenario: Test handled exception in background
     When I run "InForegroundScenario"
     And I send the app to the background for 1 seconds

--- a/features/full_tests/batch_2/native_crash_handling.feature
+++ b/features/full_tests/batch_2/native_crash_handling.feature
@@ -59,8 +59,6 @@ Scenario: Dereference a null pointer
         And the event "severity" equals "error"
         And the event "unhandled" is true
 
-    # Skip due to an issue on later Android platforms - [PLAT-5465]
-    @skip_android_10 @skip_android_11
     Scenario: Double free() allocated memory
         When I run "CXXDoubleFreeScenario" and relaunch the app
         And I configure Bugsnag for "CXXDoubleFreeScenario"

--- a/features/full_tests/batch_2/native_event_tracking.feature
+++ b/features/full_tests/batch_2/native_event_tracking.feature
@@ -8,8 +8,6 @@ Feature: Synchronizing app/device metadata in the native layer
         And the event "app.duration" is greater than 0
         And the event "unhandled" is false
 
-    # Skip due to an issue on later Android platforms - [PLAT-5464]
-    @skip_android_10 @skip_android_11
     Scenario: Capture foreground state while in the background
         When I run "CXXBackgroundNotifyScenario"
         And I send the app to the background for 5 seconds
@@ -31,8 +29,6 @@ Feature: Synchronizing app/device metadata in the native layer
         And the event "app.duration" is not null
         And the event "unhandled" is true
 
-    # Skip due to an issue on later Android platforms - [PLAT-5464]
-    @skip_android_10 @skip_android_11
     Scenario: Capture foreground state while in a background crash
         When I run "CXXDelayedCrashScenario"
         And I send the app to the background for 10 seconds

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -39,10 +39,6 @@ Before('@skip_android_10') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version == 10
 end
 
-Before('@skip_android_11') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version == 11
-end
-
 Before('@skip_samsung') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.driver.capabilities['device']&.downcase&.include? 'samsung'
 end


### PR DESCRIPTION
## Goal

Unskip tests on Android 10/11.  These just pass now that an Appium issue has been resolved.

## Testing

Covered by a full CI run.