### PR TITLE
Copy the initial context to NDK during installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Avoid reporting false-positive background ANRs with improved foreground detection
   [#1429](https://github.com/bugsnag/bugsnag-android/pull/1429)
 
+* Configuration.context is now correctly reported from NDK events
+  [#1437](https://github.com/bugsnag/bugsnag-android/pull/1437)
+
 ## 5.14.0 (2021-09-29)
 
 ### Enhancements 

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
@@ -322,4 +322,10 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXCaptureThreadsNotifyScenario_ac
     (char *)"CXXCaptureThreadStatesNotifyScenario", BSG_SEVERITY_ERR);
 }
 
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXConfiguredContextScenario_crash(JNIEnv *env,
+                                                                                 jobject instance) {
+  abort();
+}
+
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXConfiguredContextScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXConfiguredContextScenario.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+
+internal class CXXConfiguredContextScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+    init {
+        System.loadLibrary("cxx-scenarios-bugsnag")
+        config.context = "CustomConfiguredContext"
+    }
+
+    external fun crash()
+
+    override fun startScenario() {
+        super.startScenario()
+        crash()
+    }
+}

--- a/features/full_tests/batch_2/native_context.feature
+++ b/features/full_tests/batch_2/native_context.feature
@@ -15,3 +15,10 @@ Feature: Native Context API
         And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
         And the exception "message" equals "CXXAutoContextScenario"
         And the event "context" equals "SecondActivity"
+
+    Scenario: Context in Configuration
+        When I run "CXXConfiguredContextScenario"
+        And I wait to receive an error
+
+        Then the error payload contains a completed handled native report
+        And the event "context" equals "CustomConfiguredContext"


### PR DESCRIPTION
## Goal
Ensure that a `context` specified in `Configuration` is copied to NDK during installation.

## Design
If the `currentContext` in the `Install` event and NDK installation.

## Testing
Added a new Mazerunner scenario that sets a custom context in the `Configuration` and then ensures it was reported in a native event.