### PR TITLE
Speed up local builds of test fixtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ endif
 TEST_FIXTURE_NDK_VERSION ?= 16.1.4479499
 test-fixtures:
 	# Build the notifier
-	@./gradlew -PVERSION_NAME=9.9.9 clean assembleRelease publishToMavenLocal
+	@./gradlew -PVERSION_NAME=9.9.9 assembleRelease publishToMavenLocal -x check
 
 	# Build the full test fixture
-	@./gradlew -PTEST_FIXTURE_NDK_VERSION=$(TEST_FIXTURE_NDK_VERSION) -p=features/fixtures/mazerunner/ assembleRelease
+	@./gradlew -PTEST_FIXTURE_NDK_VERSION=$(TEST_FIXTURE_NDK_VERSION) -p=features/fixtures/mazerunner/ assembleRelease -x check
 	@cp features/fixtures/mazerunner/app/build/outputs/apk/release/fixture.apk build/fixture.apk
 
 	# And the minimal (no NDK or ANR plugin) test fixture
-	@./gradlew -PMINIMAL_FIXTURE=true -PTEST_FIXTURE_NAME=fixture-minimal.apk  -p=features/fixtures/mazerunner/ assembleRelease
+	@./gradlew -PMINIMAL_FIXTURE=true -PTEST_FIXTURE_NAME=fixture-minimal.apk  -p=features/fixtures/mazerunner/ assembleRelease -x check
 	@cp features/fixtures/mazerunner/app/build/outputs/apk/release/fixture-minimal.apk build/fixture-minimal.apk
 
 bump:


### PR DESCRIPTION
## Goal

Speeds up local builds of the test fixture, by avoiding execution of the `check` task (which runs static analysis) and the `clean` task, which is unnecessary.

The test fixtures now build in ~30s rather than ~52s with these changes.