### PR TITLE
Fix override handled / unhandled test scenarios

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXHandledOverrideScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXHandledOverrideScenario.kt
@@ -12,7 +12,6 @@ internal class CXXHandledOverrideScenario(
 
     init {
         System.loadLibrary("cxx-scenarios-bugsnag")
-        disableSessionDelivery(config)
     }
 
     external fun activate()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToHandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToHandledExceptionScenario.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.OnErrorCallback
-import com.bugsnag.android.OnSessionCallback
 
 /**
  * Generates an unhandled exception that is overridden so that unhandled is false.
@@ -22,7 +21,6 @@ internal class OverrideToHandledExceptionScenario(
                 true
             }
         )
-        config.addOnSession(OnSessionCallback { false })
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToUnhandledExceptionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OverrideToUnhandledExceptionScenario.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.OnSessionCallback
 
 /**
  * Generates a handled exception that is overridden so that unhandled is true.
@@ -13,10 +12,6 @@ internal class OverrideToUnhandledExceptionScenario(
     context: Context,
     eventMetadata: String?
 ) : Scenario(config, context, eventMetadata) {
-
-    init {
-        config.addOnSession(OnSessionCallback { false })
-    }
 
     override fun startScenario() {
         super.startScenario()

--- a/features/full_tests/batch_2/override_unhandled.feature
+++ b/features/full_tests/batch_2/override_unhandled.feature
@@ -3,6 +3,7 @@ Feature: Overriding unhandled state
 Scenario: Non-fatal exception overridden to unhandled
     When I run "OverrideToUnhandledExceptionScenario"
     Then I wait to receive an error
+    And I wait to receive a session
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "OverrideToUnhandledExceptionScenario"
@@ -17,6 +18,7 @@ Scenario: Fatal exception overridden to handled
     When I run "OverrideToHandledExceptionScenario" and relaunch the app
     And I configure Bugsnag for "OverrideToHandledExceptionScenario"
     And I wait to receive an error
+    And I wait to receive a session
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "OverrideToHandledExceptionScenario"
@@ -31,6 +33,7 @@ Scenario: CXX error overridden to handled
     When I run "CXXHandledOverrideScenario" and relaunch the app
     And I configure Bugsnag for "CXXHandledOverrideScenario"
     And I wait to receive an error
+    And I wait to receive a session
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "SIGABRT"
     And the exception "message" equals "Abort program"


### PR DESCRIPTION
## Goal
Allow the Sessions to be tracked as-expected in the handled/unhandled override test scenarios
