### PR TITLE
Deserialize thread states from journal entries

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
@@ -83,6 +83,7 @@ internal class BugsnagJournalEventMapper(
             event.session = Session(it, logger)
         }
 
+        // populate threads
         val threads = map[JournalKeys.pathThreads] as? List<Map<String, Any?>>
         threads?.mapTo(event.threads) { Thread(convertThreadInternal(it), logger) }
 
@@ -143,7 +144,7 @@ internal class BugsnagJournalEventMapper(
         )
 
         return ThreadInternal(
-            src.readEntry(JournalKeys.keyId),
+            src.readEntry<Number>(JournalKeys.keyId).toLong(),
             src.readEntry(JournalKeys.keyName),
             src.readEntry<String>(JournalKeys.keyType)
                 .let { type -> ThreadType.values().find { it.desc == type } }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
@@ -113,6 +113,23 @@ class BugsnagJournalEventMapperTest {
                 "signalType" to "SIGSEGV"
             )
         )
+
+        // threads
+        val threads = listOf(
+            mapOf(
+                "id" to BigDecimal.valueOf(29695),
+                "name" to "ConnectivityThr",
+                "state" to "running",
+                "type" to "c"
+
+            ),
+            mapOf(
+                "id" to BigDecimal.valueOf(29698),
+                "name" to "Binder:29227_3",
+                "state" to "sleeping",
+                "type" to "c"
+            )
+        )
         minimalJournalMap = mapOf(
             "apiKey" to "my-api-key",
             "user" to mapOf(
@@ -131,7 +148,8 @@ class BugsnagJournalEventMapperTest {
             "exceptions" to listOf(exception),
             "unhandled" to true,
             "severity" to "error",
-            "severityReason" to severityReason
+            "severityReason" to severityReason,
+            "threads" to threads
         )
         journalMap = minimalJournalMap + mapOf(
             "context" to "ExampleActivity",
@@ -296,7 +314,10 @@ class BugsnagJournalEventMapperTest {
                 "EPFji4GE4IHgwGM2GoOXvQ==/oat/x86/base.odex",
             secondFrame["file"]
         )
-        assertEquals("Java_com_example_bugsnag_android_BaseCrashyActivity_crashFromCXX", secondFrame["method"])
+        assertEquals(
+            "Java_com_example_bugsnag_android_BaseCrashyActivity_crashFromCXX",
+            secondFrame["method"]
+        )
 
         // severity/handledness
         assertEquals(Severity.ERROR, event.severity)
@@ -308,6 +329,21 @@ class BugsnagJournalEventMapperTest {
             assertEquals(Severity.ERROR, currentSeverity)
             assertEquals("signal", severityReasonType)
             assertEquals("SIGSEGV", attributeValue)
+        }
+
+        // threads
+        assertEquals(2, event.threads.size)
+        with(event.threads[0]) {
+            assertEquals(29695L, id)
+            assertEquals("ConnectivityThr", name)
+            assertEquals("running", impl.state)
+            assertEquals(ThreadType.C, type)
+        }
+        with(event.threads[1]) {
+            assertEquals(29698, id)
+            assertEquals("Binder:29227_3", name)
+            assertEquals("sleeping", impl.state)
+            assertEquals(ThreadType.C, type)
         }
     }
 }

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeJournalSaveEventTest.java
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeJournalSaveEventTest.java
@@ -11,6 +11,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -110,6 +111,19 @@ public class NativeJournalSaveEventTest {
         root.put("session", sessionMap);
         sessionMap.put("events", eventsMap);
         eventsMap.put("unhandled", 1);
+
+        // threads
+        Map<String, Object> firstThread = new HashMap<>();
+        firstThread.put("id", BigDecimal.valueOf(29695));
+        firstThread.put("name", "ConnectivityThr");
+        firstThread.put("state", "running");
+        firstThread.put("type", "c");
+        Map<String, Object> secondThread = new HashMap<>();
+        secondThread.put("id", BigDecimal.valueOf(29698));
+        secondThread.put("name", "Binder:29227_3");
+        secondThread.put("state", "sleeping");
+        secondThread.put("type", "c");
+        root.put("threads", Arrays.asList(firstThread, secondThread));
         return root;
     }
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_journal_save_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_journal_save_event.c
@@ -28,6 +28,7 @@ TEST test_write_event(void) {
     strcpy(error->errorClass, "SIGSEGV");
     strcpy(error->type, "c");
     error->frame_count = 2;
+
     for (int i = 0; i < error->frame_count; i++) {
         bugsnag_stackframe *frame = &error->stacktrace[i];
         frame->frame_address = 0x0000 + i;
@@ -37,6 +38,15 @@ TEST test_write_event(void) {
         sprintf(frame->filename, "file_%d.c", i);
         sprintf(frame->method, "method_%d", i);
     }
+
+    // threads
+    event.thread_count = 2;
+    strcpy(event.threads[0].name, "ConnectivityThr");
+    event.threads[0].id = 29695;
+    strcpy(event.threads[0].state, "running");
+    strcpy(event.threads[1].name, "Binder:29227_3");
+    event.threads[1].id = 29698;
+    strcpy(event.threads[1].state, "sleeping");
     bsg_crashtime_journal_store_event(&event);
     PASS();
 }


### PR DESCRIPTION
## Goal

Deserializes thread states by adding entries in the crashtime journal. This passes the `native_threads.feature` scenario when sending an `Event` payload generated from a journal.

## Testing

Added new unit tests to cover the functionality.