### PR TITLE
Attempt to recreate journal when an I/O error is encountered

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -48,7 +48,7 @@
     <ID>SwallowedException:DeviceIdStore.kt$DeviceIdStore$catch (exc: OverlappingFileLockException) { Thread.sleep(FILE_LOCK_WAIT_MS) }</ID>
     <ID>SwallowedException:JournaledDocument.kt$JournaledDocument$catch (ex: BufferOverflowException) { snapshot() command.serialize(journalStream) }</ID>
     <ID>SwallowedException:JournaledDocument.kt$JournaledDocument.Companion$catch (ex: Exception) { // The journal file is missing or corrupt, so we won't use it return document }</ID>
-    <ID>SwallowedException:JournaledDocument.kt$JournaledDocument.Companion$catch (ex: FileNotFoundException) { // If we don't even have a base snapshot, we have nothing at all. return null }</ID>
+    <ID>SwallowedException:JournaledDocument.kt$JournaledDocument.Companion$catch (ex: IOException) { // If we don't even have a base snapshot, we have nothing at all. return null }</ID>
     <ID>SwallowedException:JournaledDocument.kt$JournaledDocument.Companion$catch (ex: IOException) { // mydoc.snapshot.new doesn't exist, or it's corrupt. // Either way, we must fall back to using mydoc.snapshot and mydoc.journal }</ID>
     <ID>SwallowedException:PluginClient.kt$PluginClient$catch (exc: ClassNotFoundException) { logger.d("Plugin '$clz' is not on the classpath - functionality will not be enabled.") null }</ID>
     <ID>TooManyFunctions:ClientInternal.kt$ClientInternal : CallbackAwareMetadataAwareUserAware</ID>

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagJournalFailedCreationTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagJournalFailedCreationTest.kt
@@ -1,0 +1,115 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.internal.journal.JournaledDocument
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class BugsnagJournalFailedCreationTest {
+
+    @Rule
+    @JvmField
+    val folder: TemporaryFolder = TemporaryFolder()
+
+    lateinit var baseDocumentPath: File
+    lateinit var logger: InterceptingLogger
+
+    @Before
+    fun setUp() {
+        baseDocumentPath = File(folder.root, "journal")
+        logger = InterceptingLogger()
+    }
+
+    /**
+     * Simulate an I/O error by making the journal files non-writable. The journal should log
+     * failure in this case.
+     */
+    @Test
+    fun testFailedJournalCreation() {
+        alterJournalFiles(baseDocumentPath, false)
+
+        // attempt to create the journal
+        val journalPath = baseDocumentPath
+        val journal = BugsnagJournal(logger, journalPath, mapOf())
+        assertEquals("Failed to create journal", logger.msg)
+
+        // attempt to add a command
+        journal.addCommand("x", 100)
+
+        // attempt to add multiple commands
+        journal.addCommands(
+            Pair("y", "hello"),
+            Pair("z", true)
+        )
+
+        // attempt to snapshot the journal
+        journal.snapshot()
+
+        // check the journal map is empty
+        assertNull(BugsnagJournal.loadPreviousDocument(journalPath))
+    }
+
+    /**
+     * Simulate an I/O error by making the journal files non-writable. The journal should attempt
+     * to recover from this by recreating the stream - using a rate-limit.
+     */
+    @Test
+    fun attemptToRecreateJournal() {
+        alterJournalFiles(baseDocumentPath, false)
+
+        // attempt to create the journal
+        val journalPath = baseDocumentPath
+        val journal = BugsnagJournal(logger, journalPath, mapOf(), 0)
+        assertEquals("Failed to create journal", logger.msg)
+
+        // remove the I/O error
+        alterJournalFiles(baseDocumentPath, true)
+
+        // attempt to add a command again
+        journal.addCommand("x", 100)
+
+        // attempt to add multiple commands
+        journal.addCommands(
+            Pair("y", "hello"),
+            Pair("z", true)
+        )
+
+        // attempt to snapshot the journal
+        journal.snapshot()
+
+        // check the journal map is empty
+        val observed = checkNotNull(BugsnagJournal.loadPreviousDocument(journalPath))
+        val expectedDocument = BugsnagJournal.withInitialDocumentContents(
+            mapOf(
+                "x" to 100L,
+                "y" to "hello",
+                "z" to true
+            )
+        )
+        assertEquals(expectedDocument["x"], observed["x"])
+        assertEquals(expectedDocument["y"], observed["y"])
+        assertEquals(expectedDocument["z"], observed["z"])
+    }
+
+    private fun alterJournalFiles(baseDocumentPath: File, enabled: Boolean) {
+        checkNotNull(baseDocumentPath.parentFile).mkdirs()
+        val journalFiles = listOf(
+            JournaledDocument.getSnapshotPath(baseDocumentPath),
+            JournaledDocument.getRuntimeJournalPath(baseDocumentPath),
+            JournaledDocument.getCrashtimeJournalPath(baseDocumentPath)
+        )
+        journalFiles.forEach { file ->
+            file.apply {
+                delete()
+                createNewFile()
+                setWritable(enabled)
+                setReadable(enabled)
+            }
+        }
+        folder.root.setWritable(enabled)
+    }
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/InterceptingLogger.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/InterceptingLogger.kt
@@ -1,0 +1,22 @@
+package com.bugsnag.android
+
+class InterceptingLogger : Logger {
+
+    var msg: String? = null
+
+    override fun w(msg: String) {
+        this.msg = msg
+    }
+
+    override fun w(msg: String, throwable: Throwable) {
+        this.msg = msg
+    }
+
+    override fun e(msg: String) {
+        this.msg = msg
+    }
+
+    override fun e(msg: String, throwable: Throwable) {
+        this.msg = msg
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
@@ -6,7 +6,6 @@ import com.bugsnag.android.internal.MemoryMappedOutputStream
 import com.bugsnag.android.internal.asConcurrent
 import java.io.Closeable
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.BufferOverflowException
 import java.util.function.BiConsumer
@@ -45,6 +44,7 @@ constructor(
     private val highWater: Long,
     initialDocument: Map<String, Any>
 ) : Map<String, Any>, Closeable {
+
     private val journalPath = getRuntimeJournalPath(baseDocumentPath)
     private val snapshotPath = getSnapshotPath(baseDocumentPath)
     private val newSnapshotPath = getNewSnapshotPath(baseDocumentPath)
@@ -259,7 +259,7 @@ constructor(
 
             val document = try {
                 JsonHelper.deserialize(snapshotPath)
-            } catch (ex: FileNotFoundException) {
+            } catch (ex: IOException) {
                 // If we don't even have a base snapshot, we have nothing at all.
                 return null
             }

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/BugsnagBuildPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/BugsnagBuildPlugin.kt
@@ -1,8 +1,12 @@
 package com.bugsnag.android
 
 import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.UnitTestOptions
+import org.gradle.kotlin.dsl.delegateClosureOf
+import org.gradle.kotlin.dsl.KotlinClosure1
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.dependencies
 import java.io.File
@@ -42,7 +46,7 @@ class BugsnagBuildPlugin : Plugin<Project> {
         android.apply {
             configureDefaults()
             configureAndroidLint(project)
-            configureTests()
+            project.apply(from = project.file("../gradle/tests.gradle"))
             configureAndroidPackagingOptions()
 
             if (bugsnag.usesNdk) {
@@ -113,17 +117,6 @@ class BugsnagBuildPlugin : Plugin<Project> {
             isCheckAllWarnings = true
             baseline(File(project.projectDir, "lint-baseline.xml"))
             disable("GradleDependency", "NewerVersionAvailable")
-        }
-    }
-
-    /**
-     * Configures options for how the unit test target behaves.
-     */
-    private fun BaseExtension.configureTests() {
-        testOptions {
-            unitTests {
-                isReturnDefaultValues = true
-            }
         }
     }
 

--- a/gradle/tests.gradle
+++ b/gradle/tests.gradle
@@ -1,0 +1,17 @@
+
+android {
+    testOptions {
+        unitTests {
+            returnDefaultValues = true
+
+            all {
+                testLogging {
+                    events "failed", "standardError"
+                    showStackTraces = true
+                    showCauses = true
+                    exceptionFormat = "full"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Attempts to recreate the journal when an I/O error is encountered. This should improve Bugsnag's chances of recovering from transient I/O issues - such as when the disk is full.

This additionally alters the unit test output so that more information about the exceptions are logged out on CI.

## Testing

Adde test coverage where the journal files are not writable, which results in an `IOException` being thrown. Ran the new instrumentation tests locally.