### PR TITLE
Add BugsnagJournalStore class

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
@@ -45,6 +45,7 @@ internal class BugsnagJournal @JvmOverloads internal constructor(
         initialDocument: Map<String, Any>
     ): JournaledDocument? {
         return try {
+            baseDocumentPath.parentFile?.mkdirs()
             JournaledDocument(
                 baseDocumentPath,
                 journalType,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
@@ -30,7 +30,10 @@ internal class BugsnagJournalEventMapper(
 
     fun convertToEvent(map: Map<in String, Any?>): EventInternal? {
         return try {
-            convertToEventImpl(map)
+            when {
+                map[JournalKeys.pathExceptions] != null -> convertToEventImpl(map)
+                else -> null
+            }
         } catch (exc: Throwable) {
             logger.e("Failed to deserialize journal, skipping event", exc)
             null

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -659,6 +660,10 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
     BreadcrumbState getBreadcrumbState() {
         return impl.getBreadcrumbState();
+    }
+
+    File getCrashtimeJournalPath() {
+        return impl.getCrashtimeJournalPath();
     }
 
     void setAutoNotify(boolean autoNotify) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/BugsnagJournalStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/BugsnagJournalStore.kt
@@ -1,0 +1,93 @@
+package com.bugsnag.android.internal.journal
+
+import androidx.annotation.VisibleForTesting
+import com.bugsnag.android.BugsnagJournal
+import com.bugsnag.android.BugsnagJournalEventMapper
+import com.bugsnag.android.EventInternal
+import com.bugsnag.android.Logger
+import java.io.File
+import java.io.IOException
+
+internal class BugsnagJournalStore(
+    private val storageDir: File,
+    private val logger: Logger,
+    timeProvider: () -> Long = { System.currentTimeMillis() }
+) {
+
+    internal val currentBasePath = File(storageDir, "journal_${timeProvider()}")
+    private val eventMapper = BugsnagJournalEventMapper(logger)
+
+    /**
+     * Creates a new journal which will be used by the current process to record entries.
+     */
+    fun createNewJournal(): BugsnagJournal {
+        return BugsnagJournal(logger, currentBasePath)
+    }
+
+    /**
+     * Processes any previous journals which are stored on disk, excluding the one that is used
+     * by the current process. The [action] parameter will be invoked if a File can be converted
+     * into an [EventInternal]. A file will always be deleted immediately after it has been
+     * processed.
+     */
+    fun processPreviousJournals(action: (EventInternal) -> Unit) {
+        findOldJournalFiles().forEach { file ->
+            processJournalFile(file, action)
+        }
+
+        // remove any leftover files
+        findAnyJournalFiles().forEach(this::deleteFile)
+    }
+
+    /**
+     * Processes the most recent journal which is stored on disk, excluding the one that is used
+     * by the current process. The [action] parameter will be invoked if a File can be converted
+     * into an [EventInternal]. A file will always be deleted immediately after it has been
+     * processed.
+     */
+    fun processMostRecentJournal(action: (EventInternal) -> Unit) {
+        findOldJournalFiles().firstOrNull()?.let {
+            processJournalFile(it, action)
+        }
+    }
+
+    private fun processJournalFile(file: File, action: (EventInternal) -> Unit) {
+        val baseDocumentPath = JournaledDocument.getBaseDocumentPath(file)
+        val event = eventMapper.convertToEvent(baseDocumentPath)
+
+        if (event != null) {
+            action(event)
+        }
+        deleteFile(file)
+    }
+
+    /**
+     * Finds .journal files from previous processes which are stored on disk.
+     */
+    @VisibleForTesting
+    internal fun findOldJournalFiles() = findAnyJournalFiles().filter {
+        it.extension == "journal"
+    }
+
+    /**
+     * Finds any files related to journalling from previous processes which are stored on disk.
+     * This does not filter based on file extension.
+     */
+    @VisibleForTesting
+    internal fun findAnyJournalFiles(): List<File> {
+        val files = storageDir.listFiles() ?: emptyArray()
+        return files.filter { file: File ->
+            !file.name.startsWith(currentBasePath.name)
+        }.sortedByDescending { it.name }
+    }
+
+    private fun deleteFile(file: File) {
+        try {
+            if (!file.delete()) {
+                file.deleteOnExit()
+            }
+        } catch (exc: IOException) {
+            logger.w("Failed to delete old journal file", exc)
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
@@ -209,6 +209,10 @@ constructor(
             return File(basePath.path + ".journal.crashtime")
         }
 
+        internal fun getBaseDocumentPath(runtimeJournalPath: File): File {
+            return File(runtimeJournalPath.parentFile, runtimeJournalPath.nameWithoutExtension)
+        }
+
         /**
          * Check if a journal-backed document exists at this base path.
          *

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
@@ -172,6 +172,16 @@ class BugsnagJournalEventMapperTest {
     }
 
     /**
+     * Validates that an event without a stacktrace is ignored.
+     */
+    @Test
+    fun eventWithoutExceptionsIgnored() {
+        val mapper = BugsnagJournalEventMapper(NoopLogger)
+        val event = mapper.convertToEvent(minimalJournalMap.minus("exceptions"))
+        assertNull(event)
+    }
+
+    /**
      * Validates that an event that omits non-mandatory fields such as
      * context/session is deserialized.
      */

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalStoreTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/BugsnagJournalStoreTest.kt
@@ -1,0 +1,168 @@
+package com.bugsnag.android.internal.journal
+
+import com.bugsnag.android.NoopLogger
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+private const val FIRST_MOCK_MS = 12345670000L
+
+class BugsnagJournalStoreTest {
+
+    @Rule
+    @JvmField
+    val folder: TemporaryFolder = TemporaryFolder()
+
+    lateinit var storageDir: File
+
+    @Before
+    fun setUp() {
+        storageDir = File(folder.root, "bugsnag-dir")
+        storageDir.mkdirs()
+    }
+
+    /**
+     * Creating a new journal creates the necessary files on disk.
+     */
+    @Test
+    fun createNewJournal() {
+        val store = BugsnagJournalStore(storageDir, NoopLogger) { FIRST_MOCK_MS }
+        assertArrayEquals(emptyArray<File>(), storageDir.listFiles())
+        store.createNewJournal()
+        assertCurrentJournalFilesPresent()
+    }
+
+    /**
+     * findOldJournalFiles() handles an empty list.
+     */
+    @Test
+    fun testFindOldFilesEmpty() {
+        val store = BugsnagJournalStore(storageDir, NoopLogger) { FIRST_MOCK_MS }
+        assertTrue(store.findOldJournalFiles().isEmpty())
+    }
+
+    /**
+     * findOldJournalFiles() sorts and filters for .journal files specifically.
+     */
+    @Test
+    fun testFindOldFiles() {
+        listOf(
+            "journal_150000000.journal",
+            "journal_190000100.journal",
+            "journal_190000201.snapshot",
+            "journal_170000000.journal.crashtime",
+            "journal_180002000.journal",
+            "journal_160005000.journal",
+            "journal_170003000.journal",
+            "journal_190000201.snapshot.new"
+        ).forEach {
+            File(storageDir, it).createNewFile()
+        }
+
+        val store = BugsnagJournalStore(storageDir, NoopLogger) { FIRST_MOCK_MS }
+        val observed = store.findOldJournalFiles().map { it.name }
+        assertEquals(5, observed.size)
+        val expected = listOf(
+            "journal_190000100.journal",
+            "journal_180002000.journal",
+            "journal_170003000.journal",
+            "journal_160005000.journal",
+            "journal_150000000.journal"
+        )
+        assertEquals(expected, observed)
+    }
+
+    /**
+     * Checks that the action is not invoked for invalid files, as an Event cannot be generated
+     * from these.
+     */
+    @Test
+    fun testProcessInvalidFiles() {
+        listOf(
+            "journal_150000000.journal",
+            "journal_190000201.journal",
+            "journal_190000201.snapshot",
+            "journal_190000201.journal.crashtime",
+            "journal_180002000.journal",
+            "journal_160005000.journal",
+            "journal_170003000.journal",
+            "journal_190000201.snapshot.new"
+        ).forEach {
+            File(storageDir, it).createNewFile()
+        }
+
+        val store = BugsnagJournalStore(storageDir, NoopLogger) { FIRST_MOCK_MS }.apply {
+            createNewJournal()
+        }
+
+        var invoked = false
+        store.processPreviousJournals {
+            invoked = true
+        }
+
+        // check that 0 valid events were generated
+        assertFalse(invoked)
+
+        // check that only the current journal is present
+        assertCurrentJournalFilesPresent()
+    }
+
+    /**
+     * Checks that the action is only invoked for the most recent journal.
+     */
+    @Test
+    fun testProcessMostRecentJournal() {
+        val initialFiles = listOf(
+            "journal_150000000.journal",
+            "journal_190000201.journal",
+            "journal_190000201.snapshot",
+            "journal_190000201.journal.crashtime",
+            "journal_180002000.journal",
+            "journal_160005000.journal",
+            "journal_200003000.journal",
+            "journal_190000201.snapshot.new"
+        )
+        initialFiles.forEach {
+            File(storageDir, it).createNewFile()
+        }
+
+        BugsnagJournalStore(storageDir, NoopLogger) { FIRST_MOCK_MS }.apply {
+            createNewJournal()
+            processMostRecentJournal { }
+        }
+
+        // check that only the most recent journal was processed
+        val expected = initialFiles.minus("journal_200003000.journal").plus(
+            listOf("journal_12345670000.journal", "journal_12345670000.snapshot")
+        ).sorted()
+        val observed = checkNotNull(storageDir.listFiles()).map { it.name }.sorted().toList()
+        assertEquals(expected, observed)
+    }
+
+    /**
+     * The current journal is not deleted when previous journals are processed
+     */
+    @Test
+    fun currentJournalNotDeleted() {
+        // create 2 bugsnag journals, one after another
+        BugsnagJournalStore(storageDir, NoopLogger) { FIRST_MOCK_MS }.apply {
+            createNewJournal()
+            processPreviousJournals { }
+        }
+
+        // assert that a journal was created for each
+        assertCurrentJournalFilesPresent()
+    }
+
+    private fun assertCurrentJournalFilesPresent() {
+        val observed = checkNotNull(storageDir.listFiles()).sorted().map { it.name }
+        val expected = listOf("journal_$FIRST_MOCK_MS.journal", "journal_$FIRST_MOCK_MS.snapshot")
+        assertEquals(expected, observed)
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.ndk.NativeBridge
-import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class NdkPlugin : Plugin {
@@ -23,7 +22,7 @@ internal class NdkPlugin : Plugin {
     private var client: Client? = null
 
     private fun initNativeBridge(client: Client): NativeBridge {
-        val crashtimeJournalPath = File(client.config.journalBasePath.absolutePath + ".journal.crashtime")
+        val crashtimeJournalPath = client.crashtimeJournalPath
         val nativeBridge = NativeBridge(crashtimeJournalPath)
         client.addObserver(nativeBridge)
         client.setupNdkPlugin()


### PR DESCRIPTION
## Goal

Adds a `BugsnagJournalStore` class which is responsible for creating a new `BugsnagJournal` for each application launch. This also contains methods to process (and delete) old journals so that they are converted into events.

## Changeset

- Altered `BugsnagJournalEventMapper` so that it returns `null` if an event does not contain a stacktrace
- Reorganized `ClientInternal` constructor so that bugsnag journals are created + processed at the appropriate time
- Created `BugsnagJournalStore`. This contains methods for creating a new journal, processing the most recent one (intended for use in launch crashes), and batch processing events.

## Testing

Added unit test coverage and tested manually to confirm an event is generated in the lambda parameter.