### PR TITLE
Alter serialization of crashtime journal entries

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
@@ -30,10 +30,7 @@ internal class BugsnagJournalEventMapper(
 
     fun convertToEvent(map: Map<in String, Any?>): EventInternal? {
         return try {
-            when {
-                map[JournalKeys.pathExceptions] != null -> convertToEventImpl(map)
-                else -> null
-            }
+            convertToEventImpl(map)
         } catch (exc: Throwable) {
             logger.e("Failed to deserialize journal, skipping event", exc)
             null
@@ -135,7 +132,8 @@ internal class BugsnagJournalEventMapper(
     private fun convertDeviceWithState(src: Map<String, Any?>): DeviceWithState {
         val map = src.toMutableMap()
         map[JournalKeys.keyCpuAbi] = (map[JournalKeys.keyCpuAbi] as? List<String>)?.toTypedArray()
-        map[JournalKeys.keyTime] = (map[JournalKeys.keyTime] as? String)?.toDate()
+        val number: Number = map.readEntry(JournalKeys.keyTime)
+        map[JournalKeys.keyTime] = Date(number.toLong())
         return DeviceWithState(map)
     }
 
@@ -161,8 +159,8 @@ internal class BugsnagJournalEventMapper(
     @Suppress("UNCHECKED_CAST")
     private fun convertErrorInternal(src: Map<String, Any?>): ErrorInternal {
         val map = src.toMutableMap()
-        map[JournalKeys.keyStackTrace] =
-            (src[JournalKeys.keyStackTrace] as List<Map<String, Any>>).map(this::convertStacktraceInternal)
+        val list: List<Map<String, Any>> = src.readEntry(JournalKeys.keyStackTrace)
+        map[JournalKeys.keyStackTrace] = list.map(this::convertStacktraceInternal)
         return ErrorInternal(map)
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
@@ -74,7 +74,7 @@ class BugsnagJournalEventMapperTest {
             "osVersion" to "8.0.0",
             "model" to "Android SDK built for x86",
             "id" to "8b105fd3-88bc-4a31-8982-b725d1162d86",
-            "time" to "2011-05-29T05:20:51Z",
+            "time" to 1509234098592L,
             "runtimeVersions" to mapOf(
                 "osBuild" to "sdk_gphone_x86-userdebug 8.0.0 OSR1.180418.026 6741039 dev-keys",
                 "androidApiLevel" to 26
@@ -285,6 +285,7 @@ class BugsnagJournalEventMapperTest {
         assertEquals("8.0.0", device.osVersion)
         assertEquals("Android SDK built for x86", device.model)
         assertEquals("8b105fd3-88bc-4a31-8982-b725d1162d86", device.id)
+        assertEquals("2017-10-28T23:41:38.592Z", DateUtils.toIso8601(checkNotNull(device.time)))
 
         // projectPackages
         assertEquals(listOf("com.example.bar"), event.projectPackages)

--- a/bugsnag-android-core/src/test/resources/event_deserialization_0.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_0.json
@@ -47,7 +47,7 @@
     "freeDisk": 22234423124,
     "freeMemory": 92340255592,
     "orientation": "portrait",
-    "time": "1970-01-01T00:00:00.000Z"
+    "time": 0
   },
   "breadcrumbs": [
     {

--- a/bugsnag-android-core/src/test/resources/event_deserialization_1.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_1.json
@@ -62,7 +62,7 @@
     ],
     "totalMemory": 2091245568,
     "jailbroken": false,
-    "time": "1970-01-01T00:00:00Z"
+    "time": 0
   },
   "breadcrumbs": [
     {

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/native_crashtime_journal_test.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/native_crashtime_journal_test.json
@@ -1,422 +1,278 @@
 {
-	"testSetApiKey": {
-		"apiKey": "my-key"
-	},
-	"testSetContext": {
-		"events": [
-			{
-				"context": "my-context"
-			}
-		]
-	},
-	"testSetUser": {
-		"events": [
-			{
-				"user": {
-					"name": "my-name",
-					"id": "my-id",
-					"email": "my-user@nowhere.com"
-				}
-			}
-		]
-	},
-	"testSetBinaryArch": {
-		"events": [
-			{
-				"app": {
-					"binaryArch": "my-arch"
-				}
-			}
-		]
-	},
-	"testSetBuildUuid": {
-		"events": [
-			{
-				"app": {
-					"buildUUID": "123e4567-e89b-12d3-a456-426614174000"
-				}
-			}
-		]
-	},
-	"testSetAppId": {
-		"events": [
-			{
-				"app": {
-					"id": "my-id"
-				}
-			}
-		]
-	},
-	"testSetAppReleaseStage": {
-		"events": [
-			{
-				"app": {
-					"releaseStage": "my-stage"
-				}
-			}
-		]
-	},
-	"testSetAppType": {
-		"events": [
-			{
-				"app": {
-					"type": "my-type"
-				}
-			}
-		]
-	},
-	"testSetAppVersion": {
-		"events": [
-			{
-				"app": {
-					"version": "my-version"
-				}
-			}
-		]
-	},
-	"testSetAppVersionCode": {
-		"events": [
-			{
-				"app": {
-					"versionCode": 100
-				}
-			}
-		]
-	},
-	"testSetAppDuration": {
-		"events": [
-			{
-				"app": {
-					"duration": 100
-				}
-			}
-		]
-	},
-	"testSetAppDurationInForeground": {
-		"events": [
-			{
-				"app": {
-					"durationInForeground": 100
-				}
-			}
-		]
-	},
-	"testSetAppInForeground": {
-		"events": [
-			{
-				"app": {
-					"inForeground": true
-				}
-			}
-		]
-	},
-	"testSetAppIsLaunching": {
-		"events": [
-			{
-				"app": {
-					"isLaunching": true
-				}
-			}
-		]
-	},
-	"testSetJailbroken": {
-		"events": [
-			{
-				"device": {
-					"jailbroken": false
-				}
-			}
-		]
-	},
-	"testSetDeviceId": {
-		"events": [
-			{
-				"device": {
-					"id": "my-id"
-				}
-			}
-		]
-	},
-	"testSetLocale": {
-		"events": [
-			{
-				"device": {
-					"locale": "my-locale"
-				}
-			}
-		]
-	},
-	"testSetManufacturer": {
-		"events": [
-			{
-				"device": {
-					"manufacturer": "my-manufacturer"
-				}
-			}
-		]
-	},
-	"testSetDeviceModel": {
-		"events": [
-			{
-				"device": {
-					"model": "my-model"
-				}
-			}
-		]
-	},
-	"testSetOsVersion": {
-		"events": [
-			{
-				"device": {
-					"osVersion": "my-version"
-				}
-			}
-		]
-	},
-	"testSetTotalMemory": {
-		"events": [
-			{
-				"device": {
-					"totalMemory": 1000000000
-				}
-			}
-		]
-	},
-	"testSetOrientation": {
-		"events": [
-			{
-				"device": {
-					"orientation": "my-orientation"
-				}
-			}
-		]
-	},
-	"testSetDeviceTime": {
-		"events": [
-			{
-				"device": {
-					"timeUnixTimestamp": 1000000000
-				}
-			}
-		]
-	},
-	"testSetOsName": {
-		"events": [
-			{
-				"device": {
-					"osName": "my-name"
-				}
-			}
-		]
-	},
-	"testSetErrorClass": {
-		"events": [
-			{
-				"exceptions": [
-					{
-						"errorClass": "my-class"
-					}
-				]
-			}
-		]
-	},
-	"testSetErrorMessage": {
-		"events": [
-			{
-				"exceptions": [
-					{
-						"message": "my-message"
-					}
-				]
-			}
-		]
-	},
-	"testSetErrorType": {
-		"events": [
-			{
-				"exceptions": [
-					{
-						"type": "my-type"
-					}
-				]
-			}
-		]
-	},
-	"testSetEventSeverity": {
-		"events": [
-			{
-				"severity": "warning"
-			}
-		]
-	},
-	"testSetEventUnhandled": {
-		"events": [
-			{
-				"unhandled": true
-			}
-		]
-	},
-	"testSetGroupingHash": {
-		"events": [
-			{
-				"groupingHash": "my-hash"
-			}
-		]
-	},
-	"testAddMetadataDouble": {
-		"events": [
-			{
-				"metaData": {
-					"my-section": {
-						"my-name": 1.5
-					}
-				}
-			}
-		]
-	},
-	"testAddMetadataBool": {
-		"events": [
-			{
-				"metaData": {
-					"my-section": {
-						"my-name": true
-					}
-				}
-			}
-		]
-	},
-	"testAddMetadataString": {
-		"events": [
-			{
-				"metaData": {
-					"my-section": {
-						"my-name": "my-value"
-					}
-				}
-			}
-		]
-	},
-	"testClearMetadataInitial": {
-		"events": [
-			{
-				"metaData": {
-					"my-section": {
-						"my-name": true,
-						"my-other-name": 100
-					},
-					"my-other-section": {
-						"a": true,
-						"b": 100
-					}
-				}
-			}
-		]
-	},
-	"testClearMetadataFinal": {
-		"events": [
-			{
-				"metaData": {
-					"my-section": {
-						"my-other-name": 100
-					},
-					"my-other-section": {
-						"a": true,
-						"b": 100
-					}
-				}
-			}
-		]
-	},
-	"testClearMetadataSectionInitial": {
-		"events": [
-			{
-				"metaData": {
-					"my-section": {
-						"my-name": true,
-						"my-other-name": 100
-					},
-					"my-other-section": {
-						"a": true,
-						"b": 100
-					}
-				}
-			}
-		]
-	},
-	"testClearMetadataSectionFinal": {
-		"events": [
-			{
-				"metaData": {
-					"my-other-section": {
-						"a": true,
-						"b": 100
-					}
-				}
-			}
-		]
-	},
-	"testStoreEvent": {
-		"events": [
-			{
-				"exceptions": [
-					{
-						"message": "test message",
-						"type": "c",
-						"errorClass": "SIGSEGV",
-						"stackTrace": [
-							{
-								"frameAddress": "0x0",
-								"loadAddress": "0x1000",
-								"symbolAddress": "0x2000",
-								"file": "file_0.c",
-								"method": "method_0",
-								"lineNumber": 100,
-								"isPC": true
-							},
-							{
-								"frameAddress": "0x1",
-								"loadAddress": "0x1001",
-								"symbolAddress": "0x2001",
-								"file": "file_1.c",
-								"method": "method_1",
-								"lineNumber": 101
-							}
-						]
-					}
-				],
-				"unhandled": true,
-				"severity": "error",
-				"severityReason": {
-					"unhandledOverridden": false,
-					"type": "signal",
-					"attributes": {
-						"signalType": "SIGSEGV"
-					}
-				},
-				"device": {
-					"timeUnixTimestamp": 1500000000
-				},
-				"session": {
-					"events": {
-						"handled": 5,
-						"unhandled": 1
-					}
-				},
-				"threads": [
-					{
-						"id": 29695,
-						"name": "ConnectivityThr",
-						"state": "running",
-						"type": "c"
-					},
-					{
-						"id": 29698,
-						"name": "Binder:29227_3",
-						"state": "sleeping",
-						"type": "c"
-					}
-				]
-			}
-		]
-	}
+  "testSetApiKey": {
+    "apiKey": "my-key"
+  },
+  "testSetContext": {
+    "context": "my-context"
+  },
+  "testSetUser": {
+    "user": {
+      "name": "my-name",
+      "id": "my-id",
+      "email": "my-user@nowhere.com"
+    }
+  },
+  "testSetBinaryArch": {
+    "app": {
+      "binaryArch": "my-arch"
+    }
+  },
+  "testSetBuildUuid": {
+    "app": {
+      "buildUUID": "123e4567-e89b-12d3-a456-426614174000"
+    }
+  },
+  "testSetAppId": {
+    "app": {
+      "id": "my-id"
+    }
+  },
+  "testSetAppReleaseStage": {
+    "app": {
+      "releaseStage": "my-stage"
+    }
+  },
+  "testSetAppType": {
+    "app": {
+      "type": "my-type"
+    }
+  },
+  "testSetAppVersion": {
+    "app": {
+      "version": "my-version"
+    }
+  },
+  "testSetAppVersionCode": {
+    "app": {
+      "versionCode": 100
+    }
+  },
+  "testSetAppDuration": {
+    "app": {
+      "duration": 100
+    }
+  },
+  "testSetAppDurationInForeground": {
+    "app": {
+      "durationInForeground": 100
+    }
+  },
+  "testSetAppInForeground": {
+    "app": {
+      "inForeground": true
+    }
+  },
+  "testSetAppIsLaunching": {
+    "app": {
+      "isLaunching": true
+    }
+  },
+  "testSetJailbroken": {
+    "device": {
+      "jailbroken": false
+    }
+  },
+  "testSetDeviceId": {
+    "device": {
+      "id": "my-id"
+    }
+  },
+  "testSetLocale": {
+    "device": {
+      "locale": "my-locale"
+    }
+  },
+  "testSetManufacturer": {
+    "device": {
+      "manufacturer": "my-manufacturer"
+    }
+  },
+  "testSetDeviceModel": {
+    "device": {
+      "model": "my-model"
+    }
+  },
+  "testSetOsVersion": {
+    "device": {
+      "osVersion": "my-version"
+    }
+  },
+  "testSetTotalMemory": {
+    "device": {
+      "totalMemory": 1000000000
+    }
+  },
+  "testSetOrientation": {
+    "device": {
+      "orientation": "my-orientation"
+    }
+  },
+  "testSetDeviceTime": {
+    "device": {
+      "time": 1000000000
+    }
+  },
+  "testSetOsName": {
+    "device": {
+      "osName": "my-name"
+    }
+  },
+  "testSetErrorClass": {
+    "exceptions": [
+      {
+        "errorClass": "my-class"
+      }
+    ]
+  },
+  "testSetErrorMessage": {
+    "exceptions": [
+      {
+        "message": "my-message"
+      }
+    ]
+  },
+  "testSetErrorType": {
+    "exceptions": [
+      {
+        "type": "my-type"
+      }
+    ]
+  },
+  "testSetEventSeverity": {
+    "severity": "warning"
+  },
+  "testSetEventUnhandled": {
+    "unhandled": true
+  },
+  "testSetGroupingHash": {
+    "groupingHash": "my-hash"
+  },
+  "testAddMetadataDouble": {
+    "metaData": {
+      "my-section": {
+        "my-name": 1.5
+      }
+    }
+  },
+  "testAddMetadataBool": {
+    "metaData": {
+      "my-section": {
+        "my-name": true
+      }
+    }
+  },
+  "testAddMetadataString": {
+    "metaData": {
+      "my-section": {
+        "my-name": "my-value"
+      }
+    }
+  },
+  "testClearMetadataInitial": {
+    "metaData": {
+      "my-section": {
+        "my-name": true,
+        "my-other-name": 100
+      },
+      "my-other-section": {
+        "a": true,
+        "b": 100
+      }
+    }
+  },
+  "testClearMetadataFinal": {
+    "metaData": {
+      "my-section": {
+        "my-other-name": 100
+      },
+      "my-other-section": {
+        "a": true,
+        "b": 100
+      }
+    }
+  },
+  "testClearMetadataSectionInitial": {
+    "metaData": {
+      "my-section": {
+        "my-name": true,
+        "my-other-name": 100
+      },
+      "my-other-section": {
+        "a": true,
+        "b": 100
+      }
+    }
+  },
+  "testClearMetadataSectionFinal": {
+    "metaData": {
+      "my-other-section": {
+        "a": true,
+        "b": 100
+      }
+    }
+  },
+  "testStoreEvent": {
+    "exceptions": [
+      {
+        "message": "test message",
+        "type": "c",
+        "errorClass": "SIGSEGV",
+        "stacktrace": [
+          {
+            "frameAddress": "0x0",
+            "loadAddress": "0x1000",
+            "symbolAddress": "0x2000",
+            "file": "file_0.c",
+            "method": "method_0",
+            "lineNumber": 100,
+            "isPC": true,
+            "type": "c"
+          },
+          {
+            "frameAddress": "0x1",
+            "loadAddress": "0x1001",
+            "symbolAddress": "0x2001",
+            "file": "file_1.c",
+            "method": "method_1",
+            "lineNumber": 101,
+            "type": "c"
+          }
+        ]
+      }
+    ],
+    "unhandled": true,
+    "severity": "error",
+    "severityReason": {
+      "unhandledOverridden": false,
+      "type": "signal",
+      "attributes": {
+        "signalType": "SIGSEGV"
+      }
+    },
+    "device": {
+      "time": 1500000000
+    },
+    "session": {
+      "id": "123",
+      "startedAt": "2018-08-07T10:16:34.564Z",
+      "events": {
+        "handled": 5,
+        "unhandled": 1
+      }
+    },
+    "threads": [
+      {
+        "id": 29695,
+        "name": "ConnectivityThr",
+        "state": "running",
+        "type": "c"
+      },
+      {
+        "id": 29698,
+        "name": "Binder:29227_3",
+        "state": "sleeping",
+        "type": "c"
+      }
+    ]
+  }
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_ctj.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_ctj.c
@@ -307,6 +307,8 @@ JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_NativeCrashTimeJournalTest_na
     event.unhandled = true;
     event.unhandled_events = 1;
     event.handled_events = 5;
+    strcpy(event.session_id, "123");
+    strcpy(event.session_start, "2018-08-07T10:16:34.564Z");
     event.device.time = 1500000000;
 
     // error


### PR DESCRIPTION
## Goal

Alters how the crashtime journal is serialized as there were some discrepancies in path values compared to JVM entries, leading to `Event` fields not being populated correctly. This changeset includes the following fixes:

- Alters `events.exceptions` to `exceptions`, to stay consistent with how the JVM journal works
- Alters `stackTrace` to `stacktrace`
- Handle deserialization of unix timestamp ms
- Ensures that the session ID + startedAt are recorded correctly and not overwritten at crashtime
- Moved check for whether the event contains a stacktrace further down into `convertEventImpl`

## Testing

Added unit test coverage and tested manually on #1439.