### PR TITLE
[PLAT-7419] numeric journal path keys

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
@@ -184,5 +184,22 @@ internal class BugsnagJournal @JvmOverloads internal constructor(
             )
             return docWithVersionInfo
         }
+
+        private val specialCharsRegex = """([.+\\])""".toRegex()
+        private const val specialCharsReplacement = """\\$1"""
+
+        /**
+         * Force a path component to be interpreted as a map key that's not special in any
+         * way by escaping:
+         * - The first char if the path component can be converted to an integer
+         * - All occurrences of special characters (+ . \)
+         */
+        fun unspecialMapPath(pathComponent: String): String {
+            val index = pathComponent.toIntOrNull()
+            if (index != null) {
+                return "\\" + pathComponent
+            }
+            return pathComponent.replace(specialCharsRegex, specialCharsReplacement)
+        }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalTest.kt
@@ -184,4 +184,34 @@ class BugsnagJournalTest {
             BugsnagTestUtils.normalized(observedDocument)
         )
     }
+
+    @Test
+    fun testUnspecialMapPath() {
+        Assert.assertEquals("""""", BugsnagJournal.unspecialMapPath(""""""))
+        Assert.assertEquals("""a""", BugsnagJournal.unspecialMapPath("""a"""))
+        Assert.assertEquals("""\0""", BugsnagJournal.unspecialMapPath("""0"""))
+        Assert.assertEquals("""\1234""", BugsnagJournal.unspecialMapPath("""1234"""))
+        Assert.assertEquals("""a\\\.\+""", BugsnagJournal.unspecialMapPath("""a\.+"""))
+    }
+
+    @Test
+    fun testJournalEntryUnspecialMapPath() {
+        val journalPath = newBaseDocumentPath()
+        val journal = BugsnagJournal(NoopLogger, journalPath, mapOf())
+        journal.addCommand(BugsnagJournal.unspecialMapPath("""a\.+"""), 100)
+        journal.snapshot()
+
+        val observedDocument = BugsnagJournal.loadPreviousDocument(journalPath)
+        val expectedDocument = HashMap(BugsnagJournal.withInitialDocumentContents(mapOf()))
+        expectedDocument["""a\.+"""] = 100
+
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(observedDocument)
+        )
+        Assert.assertEquals(
+            BugsnagTestUtils.normalized(expectedDocument),
+            BugsnagTestUtils.normalized(journal.document)
+        )
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DocumentPathTest.kt
@@ -317,6 +317,28 @@ class DocumentPathTest {
         BugsnagTestUtils.assertNormalizedEquals(expected, observed)
     }
 
+    @Test
+    fun testEscapedNumerals() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("\\0.\\-1")
+        val value = 1
+        val expected = mapOf<String, Any>("0" to mapOf("-1" to 1))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
+    @Test
+    fun testEscapedSpecials() {
+        val document = mutableMapOf<String, Any>()
+        val docpath = DocumentPath("""x.a\\\.\+""")
+        val value = 1
+        val expected = mapOf<String, Any>("x" to mapOf("""a\.+""" to 1))
+
+        val observed = docpath.modifyDocument(document, value)
+        BugsnagTestUtils.assertNormalizedEquals(expected, observed)
+    }
+
     @Test(expected = IllegalArgumentException::class)
     fun testLastDotNull() {
         val document = mutableMapOf<String, Any>()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledStateObserverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledStateObserverTest.kt
@@ -134,6 +134,56 @@ internal class JournaledStateObserverTest {
     }
 
     @Test
+    fun testMetadataNumeric() {
+        val journal = emptyJournal()
+        val observer = JournaledStateObserver(client, journal)
+        observer.onStateChange(StateEvent.AddMetadata("0", "-1", "myvalue"))
+        var expected = BugsnagJournal.withInitialDocumentContents(
+            mapOf(
+                "metaData" to mapOf(
+                    "0" to mapOf(
+                        "-1" to "myvalue"
+                    )
+                )
+            )
+        )
+        BugsnagTestUtils.assertNormalizedEquals(expected, journal.document)
+
+        observer.onStateChange(StateEvent.ClearMetadataSection("0"))
+        expected = BugsnagJournal.withInitialDocumentContents(
+            mapOf(
+                "metaData" to mapOf<String, Any>()
+            )
+        )
+        BugsnagTestUtils.assertNormalizedEquals(expected, journal.document)
+    }
+
+    @Test
+    fun testMetadataSpecialChars() {
+        val journal = emptyJournal()
+        val observer = JournaledStateObserver(client, journal)
+        observer.onStateChange(StateEvent.AddMetadata("0\\1.4", "a+", "myvalue"))
+        var expected = BugsnagJournal.withInitialDocumentContents(
+            mapOf(
+                "metaData" to mapOf(
+                    "0\\1.4" to mapOf(
+                        "a+" to "myvalue"
+                    )
+                )
+            )
+        )
+        BugsnagTestUtils.assertNormalizedEquals(expected, journal.document)
+
+        observer.onStateChange(StateEvent.ClearMetadataSection("0\\1.4"))
+        expected = BugsnagJournal.withInitialDocumentContents(
+            mapOf(
+                "metaData" to mapOf<String, Any>()
+            )
+        )
+        BugsnagTestUtils.assertNormalizedEquals(expected, journal.document)
+    }
+
+    @Test
     fun testBreadcrumbs() {
         val journal = emptyJournal()
         val observer = JournaledStateObserver(client, journal)

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeCrashTimeJournalTest.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeCrashTimeJournalTest.kt
@@ -372,6 +372,9 @@ class NativeCrashTimeJournalTest {
         runJournalTest(mapOf(), "testAddMetadataDouble") {
             nativeAddMetadataDouble(it, "my-section", "my-name", 1.5)
         }
+        runJournalTest(mapOf(), "testAddMetadataDigitsDouble") {
+            nativeAddMetadataDouble(it, "-1", "0\\.+", 1.5)
+        }
     }
 
     // bsg_ctj_set_metadata_bool
@@ -382,6 +385,9 @@ class NativeCrashTimeJournalTest {
         runJournalTest(mapOf(), "testAddMetadataBool") {
             nativeAddMetadataBool(it, "my-section", "my-name", true)
         }
+        runJournalTest(mapOf(), "testAddMetadataDigitsBool") {
+            nativeAddMetadataBool(it, "1000", "3456\\.+", false)
+        }
     }
 
     // bsg_ctj_set_metadata_string
@@ -391,6 +397,9 @@ class NativeCrashTimeJournalTest {
     fun testAddMetadataString() {
         runJournalTest(mapOf(), "testAddMetadataString") {
             nativeAddMetadataString(it, "my-section", "my-name", "my-value")
+        }
+        runJournalTest(mapOf(), "testAddMetadataDigitsString") {
+            nativeAddMetadataString(it, "9", "9\\.+", "my-value")
         }
     }
 

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/native_crashtime_journal_test.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/native_crashtime_journal_test.json
@@ -154,6 +154,13 @@
       }
     }
   },
+  "testAddMetadataDigitsDouble": {
+    "metaData": {
+      "-1": {
+        "0\\.+": 1.5
+      }
+    }
+  },
   "testAddMetadataBool": {
     "metaData": {
       "my-section": {
@@ -161,10 +168,24 @@
       }
     }
   },
+  "testAddMetadataDigitsBool": {
+    "metaData": {
+      "1000": {
+        "3456\\.+": false
+      }
+    }
+  },
   "testAddMetadataString": {
     "metaData": {
       "my-section": {
         "my-name": "my-value"
+      }
+    }
+  },
+  "testAddMetadataDigitsString": {
+    "metaData": {
+      "9": {
+        "9\\.+": "my-value"
       }
     }
   },

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/path_builder.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/path_builder.c
@@ -5,6 +5,7 @@
 #include "path_builder.h"
 #include "number_to_string.h"
 #include "string.h"
+#include <stdbool.h>
 #include <string.h>
 
 #define MAX_SUBPATHS 100
@@ -52,12 +53,49 @@ void bsg_pb_reset() {
   g_path.subpath_level = 0;
 }
 
+static bool contains_special_chars(const char *str, int maxCount) {
+  const char *ptr = str;
+  for (int i = 0; i < maxCount && *ptr != 0; i++) {
+    if (*ptr == '.' || *ptr == '+' || *ptr == '\\') {
+      return true;
+    }
+    ptr++;
+  }
+  return false;
+}
+
 void bsg_pb_stack_map_key(const char *key) {
   char *subpath = subpath_begin();
   if (subpath == NULL) {
     return;
   }
-  bsg_strncpy_safe(subpath, key, available_byte_count(subpath));
+  int maxCount = available_byte_count(subpath);
+
+  if (contains_special_chars(key, maxCount)) {
+    const char *pSrc = key;
+    char *pDst = subpath;
+
+    while (pDst - subpath < maxCount) {
+      char ch = *pSrc++;
+      switch (ch) {
+      case '.':
+      case '+':
+      case '\\':
+        *pDst++ = '\\';
+      }
+      *pDst++ = ch;
+    }
+    subpath_end(pDst);
+    return;
+  }
+
+  if ((*key >= '0' && *key <= '9') || *key == '-') {
+    // To be absolutely sure this doesn't get interpreted as a list entry,
+    // insert an escape.
+    *subpath++ = '\\';
+    maxCount--;
+  }
+  bsg_strncpy_safe(subpath, key, maxCount);
   subpath += strlen(subpath);
   subpath_end(subpath);
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_path_builder.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_path_builder.c
@@ -53,6 +53,15 @@ TEST test_general_use(void) {
     PASS();
 }
 
+TEST test_auto_escape(void) {
+    bsg_pb_reset();
+    ASSERT_STR_EQ("", bsg_pb_path());
+    bsg_pb_stack_map_key("foo");
+    ASSERT_STR_EQ("foo", bsg_pb_path());
+    bsg_pb_stack_map_key("0");
+    ASSERT_STR_EQ("foo.\\0", bsg_pb_path());
+}
+
 TEST test_unstack_too_far(void) {
     bsg_pb_reset();
     ASSERT_STR_EQ("", bsg_pb_path());
@@ -101,6 +110,7 @@ TEST test_path_too_long(void) {
 SUITE(suite_path_builder) {
     RUN_TEST(test_reset);
     RUN_TEST(test_general_use);
+    RUN_TEST(test_auto_escape);
     RUN_TEST(test_unstack_too_far);
     RUN_TEST(test_stack_too_far);
     RUN_TEST(test_path_too_long);


### PR DESCRIPTION
## Goal

The existing journal specification (PLAT-6353) didn't allow for map keys consisting of only numeric digits ("5", "-1", etc). I've updated the specification to always interpret a journal path as a map key when there are escape sequences present. This gives us a mechanism to ensure that the user-facing metadata API is safe even if the user defines things like "1000" or other such "numeric" section or value keys.

## Design

* Updated the journal path mechanism to the updated journal spec so that it interprets path components made up of numerals as if they were map keys instead of list indices (when escapes are present).
* Updated the user-facing metadata API to defensively handle metadata sections and keys made up of only numerals or containing special characters.
* Updated journal path code to check for and escape special characters.

## Testing

Added new tests to cover these cases.
