### PR TITLE
Fix plugins for metadata sections populated using a `Map`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Prevent events being attached to phantom sessions when they are blocked by an `OnSessionCallback`
   [#1434](https://github.com/bugsnag/bugsnag-android/pull/1434)
 
+* Plugins will correctly mirror metadata added using `addMetadata(String, Map)`
+  [#1454](https://github.com/bugsnag/bugsnag-android/pull/1454)
+
 ## 5.14.0 (2021-09-29)
 
 ### Enhancements 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MetadataState.kt
@@ -61,7 +61,7 @@ internal data class MetadataState(val metadata: Metadata = Metadata()) :
 
     private fun notifyMetadataAdded(section: String, value: Map<String, Any?>) {
         value.entries.forEach {
-            updateState { AddMetadata(section, it.key, metadata.getMetadata(it.key)) }
+            updateState { AddMetadata(section, it.key, metadata.getMetadata(section, it.key)) }
         }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MetadataStateTest.kt
@@ -87,4 +87,19 @@ internal class MetadataStateTest {
         assertEquals(setOf("foo"), sections)
         assertEquals(setOf("key1", "key2", "key3"), keys)
     }
+
+    @Test
+    fun observableMessageWithMap() {
+        val events = mutableListOf<StateEvent.AddMetadata>()
+        state.addObserver(
+            StateObserver {
+                events.add(it as StateEvent.AddMetadata)
+            }
+        )
+
+        state.addMetadata("fruit", mapOf<String, Any?>("apple" to "gala"))
+        assertEquals("fruit", events[0].section)
+        assertEquals("apple", events[0].key)
+        assertEquals("gala", events[0].value)
+    }
 }


### PR DESCRIPTION
## Goal
Ensure that metadata added using `addMetadata(String, Map)` is correctly sent to all of the plugins.

## Testing
Additional unit test for the expected behaviour.