### PR TITLE
Don't serialise an empty stack trace

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
@@ -170,7 +170,9 @@ internal class BugsnagJournalEventMapper(
     private fun convertErrorInternal(src: Map<String, Any?>): ErrorInternal {
         val map = src.toMutableMap()
         val list: List<Map<String, Any>> = src.readEntry(JournalKeys.keyStackTrace)
-        map[JournalKeys.keyStackTrace] = list.map(this::convertStacktraceInternal)
+        if (list.isNotEmpty()) {
+            map[JournalKeys.keyStackTrace] = list.map(this::convertStacktraceInternal)
+        }
         return ErrorInternal(map)
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -19,19 +19,20 @@ class ThreadInternal internal constructor(
     override fun toStream(writer: JsonStream) = writer.value(toJournalSection())
 
     override fun toJournalSection(): Map<String, Any?> {
-        val data = mapOf(
+        val data = mutableMapOf(
             JournalKeys.keyId to id,
             JournalKeys.keyName to name,
             JournalKeys.keyType to type.desc,
-            JournalKeys.keyState to state,
-            JournalKeys.keyStackTrace to stacktrace.map { it.toJournalSection() }
+            JournalKeys.keyState to state
         )
 
-        return when {
-            isErrorReportingThread -> data.plus(
-                Pair(JournalKeys.keyErrorReportingThread, isErrorReportingThread)
-            )
-            else -> data
+        if (stacktrace.isNotEmpty()) {
+            data[JournalKeys.keyStackTrace] = stacktrace.map { it.toJournalSection() }
         }
+        if (isErrorReportingThread) {
+            data[JournalKeys.keyErrorReportingThread] = isErrorReportingThread
+        }
+
+        return data
     }
 }

--- a/bugsnag-android-core/src/test/resources/event_deserialization_expected_1.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_expected_1.json
@@ -86,15 +86,13 @@
       "id": 20948,
       "name": "bugsnag.android",
       "type": "c",
-      "state": "running",
-      "stacktrace": []
+      "state": "running"
     },
     {
       "id": 20954,
       "name": "Jit thread pool",
       "type": "c",
-      "state": "sleeping",
-      "stacktrace": []
+      "state": "sleeping"
     }
   ],
   "session": {

--- a/bugsnag-android-core/src/test/resources/event_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_5.json
@@ -38,7 +38,6 @@
       "name": "main",
       "type": "android",
       "state": "RUNNABLE",
-      "stacktrace": [],
       "errorReportingThread": true
     }
   ]


### PR DESCRIPTION
## Goal

PLAT-7507

## Testing

Manual testing with the example app because everything will have a stack trace unless an error prevents the library from capturing one.
