### PR TITLE
Add complex metadata test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   bugsnag-maze-runner!

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
@@ -301,6 +301,10 @@ internal class ClientInternal constructor(
         event.device.freeMemory = null
         event.metadata.clearMetadata("app", "freeMemory")
         event.metadata.clearMetadata("app", "memoryUsage")
+        event.metadata.clearMetadata("app", "networkAccess")
+        event.metadata.clearMetadata("app", "totalMemory")
+        event.metadata.clearMetadata("device", "batteryLevel")
+        event.metadata.clearMetadata("device", "charging")
         event.metadata.clearMetadata("device", "freeMemory")
         event.metadata.clearMetadata("device", "totalMemory")
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
@@ -9,7 +9,7 @@ internal class ObjectJsonStreamer {
 
     companion object {
         private const val REDACTED_PLACEHOLDER = "[REDACTED]"
-        private const val OBJECT_PLACEHOLDER = "[OBJECT]"
+        internal const val OBJECT_PLACEHOLDER = "[OBJECT]"
     }
 
     var redactedKeys = setOf("password")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DslJsonNormalization.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DslJsonNormalization.kt
@@ -20,11 +20,11 @@ private fun <K, V> normalizedMap(map: Map<K, V>): Map<K, V> {
     val newMap: MutableMap<K, V> = HashMap(map.size)
     map.entries.forEach { entry ->
         var key = entry.key
-        val normalizedKey = normalized(key as Any) as K
+        val normalizedKey = normalized(key as Any?) as K
         if (key != normalizedKey) {
             key = normalizedKey
         }
-        newMap[key] = normalized(entry.value as Any) as V
+        newMap[key] = normalized(entry.value as Any?) as V
     }
     return newMap
 }
@@ -41,7 +41,7 @@ private fun <K, V> normalizedMap(map: Map<K, V>): Map<K, V> {
 </T> */
 @Suppress("UNCHECKED_CAST")
 private fun <T> normalizedList(list: List<T>): List<T> = list.map { entry ->
-    normalized(entry as Any) as T
+    normalized(entry as Any?) as T
 }
 
 /**
@@ -56,7 +56,7 @@ private fun <T> normalizedList(list: List<T>): List<T> = list.map { entry ->
  * @return The normalized object (may be the same object passed in)
  */
 @Suppress("UNCHECKED_CAST")
-fun <T> normalized(obj: Any): T {
+fun <T> normalized(obj: Any?): T {
     return when (obj) {
         is Byte -> obj.toLong()
         is Short -> obj.toLong()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/FallbackWriter.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/FallbackWriter.kt
@@ -1,0 +1,29 @@
+package com.bugsnag.android.internal.journal
+
+import com.bugsnag.android.ObjectJsonStreamer
+import com.dslplatform.json.DslJson
+import java.io.InputStream
+import java.io.OutputStream
+import java.lang.reflect.Type
+
+internal class FallbackWriter : DslJson.Fallback<MutableMap<String, Any>> {
+
+    private val placeholder = "\"${ObjectJsonStreamer.OBJECT_PLACEHOLDER}\"".toByteArray()
+
+    override fun serialize(instance: Any?, stream: OutputStream) {
+        stream.write(placeholder)
+    }
+
+    override fun deserialize(
+        context: MutableMap<String, Any>?,
+        manifest: Type,
+        body: ByteArray,
+        size: Int
+    ): Any = throw UnsupportedOperationException()
+
+    override fun deserialize(
+        context: MutableMap<String, Any>?,
+        manifest: Type,
+        stream: InputStream
+    ): Any = throw UnsupportedOperationException()
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
@@ -131,6 +131,11 @@ class BugsnagJournalEventMapperTest {
                 "type" to "c"
             )
         )
+
+        val metadata = mapOf(
+            "app" to appSection,
+            "foo" to fooSection
+        )
         minimalJournalMap = mapOf(
             "apiKey" to "my-api-key",
             "user" to mapOf(
@@ -138,10 +143,7 @@ class BugsnagJournalEventMapperTest {
                 "name" to "Boog Snoog",
                 "email" to "hello@example.com"
             ),
-            "metaData" to mapOf(
-                "app" to appSection,
-                "foo" to fooSection
-            ),
+            "metaData" to metadata,
             "breadcrumbs" to breadcrumbs,
             "app" to app,
             "device" to device,
@@ -161,6 +163,19 @@ class BugsnagJournalEventMapperTest {
                 "events" to mapOf(
                     "unhandled" to 1,
                     "handled" to 2
+                )
+            ),
+            "metaData" to metadata.plus(
+                "test" to mapOf(
+                    "string" to "foo",
+                    "bool" to true,
+                    "int" to 509,
+                    "long" to 1509234098234L,
+                    "map" to mapOf("a" to "z"),
+                    "list" to listOf("whoops"),
+                    "array" to arrayOf("uh oh"),
+                    "null" to null,
+                    "date" to "2021-09-28T10:31:09.620Z"
                 )
             )
         )
@@ -220,6 +235,18 @@ class BugsnagJournalEventMapperTest {
         assertEquals(DateUtils.fromIso8601("2021-09-28T10:31:09.620Z"), session.startedAt)
         assertEquals(1, session.unhandledCount)
         assertEquals(2, session.handledCount)
+
+        // extra metadata
+        val metadata = checkNotNull(event.getMetadata("test"))
+        assertNull(metadata["null"])
+        assertEquals("foo", metadata["string"])
+        assertTrue(metadata["bool"] as Boolean)
+        assertEquals(1509234098234L, metadata["long"])
+        assertEquals(mapOf("a" to "z"), metadata["map"])
+        assertEquals(listOf("whoops"), metadata["list"])
+        assertArrayEquals(arrayOf("uh oh"), metadata["array"] as Array<*>)
+        assertEquals(509L, metadata["int"])
+        assertEquals("2021-09-28T10:31:09.620Z", metadata["date"])
     }
 
     private fun validateMandatoryEventFields(event: EventInternal) {

--- a/features/fixtures/mazerunner/cxx-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/cxx-scenarios/detekt-baseline.xml
@@ -2,6 +2,14 @@
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
+    <ID>MagicNumber:CXXComplexMetadataScenario.kt$CXXComplexMetadataScenario$1000</ID>
+    <ID>MagicNumber:CXXComplexMetadataScenario.kt$CXXComplexMetadataScenario$1509234098234L</ID>
+    <ID>MagicNumber:CXXComplexMetadataScenario.kt$CXXComplexMetadataScenario$1635770803</ID>
+    <ID>MagicNumber:CXXComplexMetadataScenario.kt$CXXComplexMetadataScenario$19.3f</ID>
+    <ID>MagicNumber:CXXComplexMetadataScenario.kt$CXXComplexMetadataScenario$29</ID>
+    <ID>MagicNumber:CXXComplexMetadataScenario.kt$CXXComplexMetadataScenario$5</ID>
+    <ID>MagicNumber:CXXComplexMetadataScenario.kt$CXXComplexMetadataScenario$5.0f</ID>
+    <ID>MagicNumber:CXXComplexMetadataScenario.kt$CXXComplexMetadataScenario$5.623f</ID>
     <ID>MagicNumber:CXXDelayedCrashScenario.kt$CXXDelayedCrashScenario$405</ID>
     <ID>MagicNumber:CXXLargePayloadScenario.kt$CXXLargePayloadScenario$300</ID>
     <ID>MagicNumber:CXXSessionInfoCrashScenario.kt$CXXSessionInfoCrashScenario$3</ID>

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/cxx-scenarios.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/cxx-scenarios.cpp
@@ -368,4 +368,9 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXLargePayloadScenario_crash(JNIEnv *env) {
   abort();
 }
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXComplexMetadataScenario_crash(JNIEnv *env) {
+  abort();
+}
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXComplexMetadataScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXComplexMetadataScenario.kt
@@ -1,0 +1,55 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.log
+import java.util.Date
+
+/**
+ * Sends a native crash to Bugsnag which has complicated metadata values.
+ */
+internal class CXXComplexMetadataScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    companion object {
+        init {
+            System.loadLibrary("cxx-scenarios")
+        }
+    }
+
+    private external fun crash()
+
+    override fun startScenario() {
+        super.startScenario()
+        val longStr = "Have you tried turning it off and on again and off and on again and off" +
+            " and on again and off and on again and off and on again and off and on again" +
+            " and on again and off and on again and off and on again and off and on again?"
+        val map = mapOf(
+            "int_array" to intArrayOf(-5, 1000, 29, Integer.MAX_VALUE, Integer.MIN_VALUE),
+            "string_array" to arrayOf("a", "b", "c"),
+            "bool_array" to arrayOf(false, true),
+            "large_value" to longStr,
+            "array_with_null" to arrayOf("x", null),
+            "float_array" to arrayOf(5.0f, 19.3f, 5.623f),
+            "long" to 1509234098234L,
+            "null" to null,
+            "date" to Date(1635770803),
+            "unknown_type" to context
+        )
+
+        Bugsnag.addMetadata("individual_values", map)
+        Bugsnag.addMetadata("map_section", "map", map)
+
+        if (Bugsnag.getLastRunInfo() != null) {
+            log("Triggering handled JVM event")
+            Bugsnag.notify(generateException())
+        } else {
+            log("Triggering unhandled NDK event")
+            crash()
+        }
+    }
+}

--- a/features/full_tests/batch_2/native_complex_metadata.feature
+++ b/features/full_tests/batch_2/native_complex_metadata.feature
@@ -1,0 +1,18 @@
+Feature: Bugsnag can deal with complicated metadata values
+
+    Scenario: CXX error handles large breadcrumbs/metadata
+        When I run "CXXComplexMetadataScenario" and relaunch the app
+        When I run "CXXComplexMetadataScenario" and relaunch the app
+        And I wait to receive 2 errors
+
+        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+        And the exception "errorClass" equals "SIGABRT"
+        And the exception "message" equals "Abort program"
+        And the event contains complex metadata
+
+        Then I discard the oldest error
+        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+        And the error payload field "events" is an array with 1 elements
+        And the exception "errorClass" equals "java.lang.RuntimeException"
+        And the exception "message" equals "CXXComplexMetadataScenario"
+        And the event contains complex metadata

--- a/features/full_tests/batch_2/native_legacy_struct.feature
+++ b/features/full_tests/batch_2/native_legacy_struct.feature
@@ -42,7 +42,7 @@ Feature: Legacy struct is converted to an error payload
         And the event "device.jailbroken" is true
         And the event "device.time" equals "2017-10-27T13:00:34Z"
         And the event "device.cpuAbi.0" equals "x86"
-        And the event "device.runtimeVersions.androidApiLevel" equals 27
+        And the event "device.runtimeVersions.androidApiLevel" equals "27"
         And the event "device.runtimeVersions.osBuild" equals "custom_build"
 
         # user

--- a/features/full_tests/batch_2/native_on_error.feature
+++ b/features/full_tests/batch_2/native_on_error.feature
@@ -28,7 +28,7 @@ Feature: Native on error callbacks are invoked
         # TODO PLAT-7497
         # And the event "device.totalMemory" equals 99999999
         And the event "device.orientation" equals "custom_orientation"
-        And the event "device.time" equals "1970-01-01T00:00:15.000Z"
+        And the event "device.time" is a timestamp
         And the event "device.osName" equals "custom_os_name"
 
         # user

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -177,8 +177,12 @@ Scenario: Signal raised with overwritten config
     And the event "device.freeMemory" is null
     And the event "metaData.app.freeMemory" is null
     And the event "metaData.app.memoryUsage" is null
+    And the event "metaData.app.networkAccess" is null
+    And the event "metaData.app.totalMemory" is null
     And the event "metaData.device.freeMemory" is null
     And the event "metaData.device.totalMemory" is null
+    And the event "metaData.device.batteryLevel" is null
+    And the event "metaData.device.charging" is null
 
     # Native context override
     And the event "context" equals "Some custom context"

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -291,6 +291,54 @@ Then('I wait to receive {int} Android startup logs') do |request_count|
   list.sort_by_sent_at! request_count
 end
 
+Then("the event contains complex metadata") do
+
+  # check individual values
+  steps %Q{
+    And the event "metaData.individual_values" contains complex metadata
+    And the event "metaData.map_section.map" contains complex metadata
+  }
+end
+
+Then("the event {string} contains complex metadata") do |path|
+  steps %Q{
+    And the event "#{path}" is not null
+    And the event "#{path}.int_array.0" equals -5
+    And the event "#{path}.int_array.1" equals 1000
+    And the event "#{path}.int_array.2" equals 29
+    And the event "#{path}.int_array.3" equals 2147483647
+    And the event "#{path}.int_array.4" equals -2147483648
+    And the event "#{path}.string_array.0" equals "a"
+    And the event "#{path}.string_array.1" equals "b"
+    And the event "#{path}.string_array.2" equals "c"
+    And the event "#{path}.bool_array.0" is false
+    And the event "#{path}.bool_array.1" is true
+    And the event "#{path}.large_value" equals "Have you tried turning it off and on again and off and on again and off and on again and off and on again and off and on again and off and on again and on again and off and on again and off and on again and off and on again?"
+    And the event "#{path}.null" is null
+    And the event "#{path}.long" equals 1509234098234
+    And the event "#{path}.date" equals "1970-01-19T22:22:50.803Z"
+    And the event "#{path}.array_with_null.0" equals "x"
+    And the event "#{path}.array_with_null.1" is null
+    And the event "#{path}.float_array.0" equals 5.0
+    And the event "#{path}.float_array.1" equals 19.3
+    And the event "#{path}.float_array.2" equals 5.623
+    And the event "#{path}.unknown_type" equals "[OBJECT]"
+  }
+end
+
+Then("the event {string} equals {float}") do |field, value|
+  steps %Q{
+    the "error" payload field "events.0.#{field}" equals #{value}
+  }
+end
+
+Then('the {word} payload field {string} equals {float}') do |request_type, field_path, float_value|
+  puts("Expecting float field to equal #{float_value}")
+  requests = Maze::Server.list_for(request_type)
+  body = Maze::Helper.read_key_path(requests.current[:body])
+  assert_equal(float_value, body, field_path)
+end
+
 def assert_received_startup_logs(request_count, list)
   timeout = Maze.config.receive_requests_wait
   wait = Maze::Wait.new(timeout: timeout)


### PR DESCRIPTION
## Goal

Adds an E2E test which verifies that complex metadata values are serialized correctly. This has required some alterations/bug fixes to the JSON serializer.

## Changeset

Added an E2E test which has various metadata values. Notably the following have been included:

- A large string, to verify that there are no limits in the payload metadata
- A Date, as this was not being serialized correctly by dsl-json
- An unknown type, which has required updates to serialize a placeholder value rather than dsl-json throwing an exception
- Null values, which the `BugsnagJournalEventMapper` could not handle within a Metadata `Map` value
- A nested map

Unit test coverage has also been increased to cover this change.
