### PR TITLE
Build example app for Espresso tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -69,9 +69,6 @@ steps:
       TEST_APK_LOCATION: 'bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk'
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # TODO remove when PLAT-7453 is complete
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 5 NDK r16 end-to-end tests - batch 1'
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -169,9 +169,6 @@ steps:
       TEST_APK_LOCATION: 'bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk'
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # TODO remove when PLAT-7453 is complete
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: NDK Instrumentation tests'
     key: 'ndk-instrumentation-tests'
@@ -188,9 +185,6 @@ steps:
       TEST_APK_LOCATION: 'bugsnag-plugin-android-ndk/build/outputs/apk/androidTest/debug/bugsnag-plugin-android-ndk-debug-androidTest.apk'
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # TODO remove when PLAT-7453 is complete
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Performance benchmarks'
     key: 'perf-benchmarks'
@@ -207,9 +201,6 @@ steps:
       TEST_APK_LOCATION: 'bugsnag-benchmarks/build/outputs/apk/androidTest/release/bugsnag-benchmarks-release-androidTest.apk'
     concurrency: 9
     concurrency_group: 'browserstack-app'
-    # TODO remove when PLAT-7453 is complete
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':android: Android 4.4 NDK r16 smoke tests'
     key: 'android-4-4-smoke'

--- a/scripts/build-instrumentation-tests.sh
+++ b/scripts/build-instrumentation-tests.sh
@@ -1,2 +1,7 @@
-# Build the Espresso Test App
+  # Build the example app as the Espresso "target" (which is not actually used)
+pushd examples/sdk-app-example
+  ./gradlew clean assembleRelease
+popd
+
+# Build the test app
 ./gradlew assembleAndroidTest --stacktrace


### PR DESCRIPTION
## Goal

Ensure example app is built for the instrumentation tests.  Also reenable the steps in the pipeline, as Espresso tests now seem to be working on BrowserStack.

## Testing

Covered by CI, although I would await confirmation of the Espresso test fix from BrowserStack before merging.