### PR TITLE
Resolve flaky E2E scenario

### DIFF
--- a/features/full_tests/batch_2/override_unhandled.feature
+++ b/features/full_tests/batch_2/override_unhandled.feature
@@ -33,7 +33,6 @@ Scenario: CXX error overridden to handled
     When I run "CXXHandledOverrideScenario" and relaunch the app
     And I configure Bugsnag for "CXXHandledOverrideScenario"
     And I wait to receive an error
-    And I wait to receive a session
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "SIGABRT"
     And the exception "message" equals "Abort program"


### PR DESCRIPTION
## Goal

Ports a fix to a test flake from the integration branch: https://github.com/bugsnag/bugsnag-android/pull/1439/files#diff-d458b8b32c79a65bc9aa14a62febddd0320710bb45a3890ba49e3481835c83f2L36

The scenario flakes because there was a race between a fatal NDK error and a session being delivered/persisted to disk. The solution is not to bother asserting the session request was received.