### PR TITLE
[Plat-7506] journal event timestamp

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -23,6 +23,8 @@
     <ID>LongParameterList:NativeStackframe.kt$NativeStackframe$( /** * The name of the method that was being executed */ var method: String?, /** * The location of the source file */ var file: String?, /** * The line number within the source file this stackframe refers to */ var lineNumber: Number?, /** * The address of the instruction where the event occurred. */ var frameAddress: Long?, /** * The address of the function where the event occurred. */ var symbolAddress: Long?, /** * The address of the library where the event occurred. */ var loadAddress: Long?, /** * Whether this frame identifies the program counter */ var isPC: Boolean?, /** * The type of the error */ var type: ErrorType? = null )</ID>
     <ID>LongParameterList:StateEvent.kt$StateEvent.Install$( @JvmField val apiKey: String, @JvmField val autoDetectNdkCrashes: Boolean, @JvmField val appVersion: String?, @JvmField val buildUuid: String?, @JvmField val releaseStage: String?, @JvmField val lastRunInfoPath: String, @JvmField val consecutiveLaunchCrashes: Int, @JvmField val sendThreads: ThreadSendPolicy )</ID>
     <ID>LongParameterList:ThreadState.kt$ThreadState$( stackTraces: MutableMap&lt;java.lang.Thread, Array&lt;StackTraceElement>>, currentThread: java.lang.Thread, exc: Throwable?, isUnhandled: Boolean, projectPackages: Collection&lt;String>, logger: Logger )</ID>
+    <ID>MagicNumber:BugsnagJournalEventMapper.kt$BugsnagJournalEventMapper$1000</ID>
+    <ID>MagicNumber:BugsnagJournalEventMapper.kt$BugsnagJournalEventMapper$16</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$299</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$429</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
@@ -140,9 +140,17 @@ internal class BugsnagJournalEventMapper(
     }
 
     private fun convertDeviceTime(map: MutableMap<String, Any?>): Date? {
+        val offset0x = 2
+        val base16 = 16
+        val secsToMs = 1000
         return when (val time = map[JournalKeys.keyTime]) {
-            is String -> time.toDate()
-            is Number -> Date(time.toLong())
+            is String -> {
+                if (time.startsWith("0x")) {
+                    Date(time.substring(offset0x).toLong(base16) * secsToMs)
+                } else {
+                    time.toDate()
+                }
+            }
             else -> null
         }
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
@@ -74,7 +74,7 @@ class BugsnagJournalEventMapperTest {
             "osVersion" to "8.0.0",
             "model" to "Android SDK built for x86",
             "id" to "8b105fd3-88bc-4a31-8982-b725d1162d86",
-            "time" to 1509234098592L,
+            "time" to "0x59F515B2",
             "runtimeVersions" to mapOf(
                 "osBuild" to "sdk_gphone_x86-userdebug 8.0.0 OSR1.180418.026 6741039 dev-keys",
                 "androidApiLevel" to 26
@@ -286,7 +286,7 @@ class BugsnagJournalEventMapperTest {
         assertEquals("8.0.0", device.osVersion)
         assertEquals("Android SDK built for x86", device.model)
         assertEquals("8b105fd3-88bc-4a31-8982-b725d1162d86", device.id)
-        assertEquals("2017-10-28T23:41:38.592Z", DateUtils.toIso8601(checkNotNull(device.time)))
+        assertEquals("2017-10-28T23:41:38.000Z", DateUtils.toIso8601(checkNotNull(device.time)))
 
         // projectPackages
         assertEquals(listOf("com.example.bar"), event.projectPackages)

--- a/bugsnag-android-core/src/test/resources/event_deserialization_0.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_0.json
@@ -47,7 +47,7 @@
     "freeDisk": 22234423124,
     "freeMemory": 92340255592,
     "orientation": "portrait",
-    "time": 0
+    "time": "0x0"
   },
   "breadcrumbs": [
     {

--- a/bugsnag-android-core/src/test/resources/event_deserialization_1.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_1.json
@@ -62,7 +62,7 @@
     ],
     "totalMemory": 2091245568,
     "jailbroken": false,
-    "time": 0
+    "time": "0x0"
   },
   "breadcrumbs": [
     {

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/native_crashtime_journal_test.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/native_crashtime_journal_test.json
@@ -109,7 +109,7 @@
   },
   "testSetDeviceTime": {
     "device": {
-      "time": 1000000000
+      "time": "0x3b9aca00"
     }
   },
   "testSetOsName": {
@@ -271,7 +271,7 @@
       }
     },
     "device": {
-      "time": 1500000000
+      "time": "0x59682f00"
     },
     "session": {
       "id": "123",

--- a/bugsnag-plugin-android-ndk/src/main/jni/crashtime_journal.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/crashtime_journal.c
@@ -368,6 +368,15 @@ static bool set_event_subobject_double(const char *event_key,
   return bsg_ctj_flush();
 }
 
+static bool set_event_subobject_hex(const char *event_key,
+                                    const char *object_key, uint64_t value) {
+  bsg_pb_reset();
+  bsg_pb_stack_map_key(event_key);
+  RETURN_ON_FALSE(add_hex(object_key, value));
+  bsg_pb_reset();
+  return bsg_ctj_flush();
+}
+
 static bool set_event_subobject_boolean(const char *event_key,
                                         const char *object_key, bool value) {
   bsg_pb_reset();
@@ -646,7 +655,7 @@ bool bsg_ctj_set_device_time(time_t value) {
 
   // IMPORTANT: This value MUST be converted to an RFC 3339 timestamp and stored
   // under "time" upon reloading the journal!
-  return set_event_subobject_double(KEY_DEVICE, KEY_TIME_UNIX, value);
+  return set_event_subobject_hex(KEY_DEVICE, KEY_TIME_UNIX, value);
 }
 
 bool bsg_ctj_set_device_os_name(const char *value) {


### PR DESCRIPTION
## Goal

Plat-7506: The timestamp was wrong after a native crash.

## Design

Multiply the time value by 1000 because Java expects milliseconds, but the C time() function returns seconds.

Also changed the representation to hex because the float conversion routine has subtle differences from the stdlib that can cause off-by-1 rounding in some edge cases.

## Testing

Updated tests to store seconds in the `device->time` field
