### PR TITLE
Fix startup NDK crash

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -26,7 +26,7 @@ final class BugsnagTestUtils {
 
     static {
         runtimeVersions.put("osBuild", "bulldog");
-        runtimeVersions.put("androidApiLevel", 24);
+        runtimeVersions.put("androidApiLevel", "24");
     }
 
     private static String streamableToString(JsonStream.Streamable streamable) throws IOException {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -18,7 +18,7 @@ final class BugsnagTestUtils {
 
     static {
         runtimeVersions.put("osBuild", "bulldog");
-        runtimeVersions.put("androidApiLevel", 24);
+        runtimeVersions.put("androidApiLevel", "24");
     }
 
     static Configuration generateConfiguration() {

--- a/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/EventHooks.java
+++ b/bugsnag-benchmarks/src/androidTest/java/com/bugsnag/android/EventHooks.java
@@ -16,7 +16,7 @@ public class EventHooks {
 
     static {
         runtimeVersions.put("osBuild", "bulldog");
-        runtimeVersions.put("androidApiLevel", 24);
+        runtimeVersions.put("androidApiLevel", "24");
     }
 
     public static EventPayload generateEvent() {

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/StartBugsnagTest.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/StartBugsnagTest.kt
@@ -1,0 +1,34 @@
+package com.bugsnag.android.ndk
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.Delivery
+import com.bugsnag.android.DeliveryParams
+import com.bugsnag.android.DeliveryStatus
+import com.bugsnag.android.EventPayload
+import com.bugsnag.android.Session
+import org.junit.Test
+
+internal class StartBugsnagTest {
+    @Test(timeout = 5_000)
+    fun start() {
+        Bugsnag.start(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            Configuration("5d1ec5bd39a74caa1267142706a7fb21").apply {
+                autoTrackSessions = false
+                delivery = object : Delivery {
+                    override fun deliver(
+                        payload: Session,
+                        deliveryParams: DeliveryParams
+                    ): DeliveryStatus = DeliveryStatus.DELIVERED
+
+                    override fun deliver(
+                        payload: EventPayload,
+                        deliveryParams: DeliveryParams
+                    ): DeliveryStatus = DeliveryStatus.DELIVERED
+                }
+            }
+        )
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -544,8 +544,10 @@ void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                               event->device.os_build,
                               sizeof(event->device.os_build));
 
-    event->device.api_level = bsg_get_map_value_int(
-        env, jni_cache, _runtime_versions, "androidApiLevel");
+    char api_level[8];
+    bsg_copy_map_value_string(env, jni_cache, _runtime_versions,
+                              "androidApiLevel", api_level, sizeof(api_level));
+    event->device.api_level = strtol(api_level, NULL, 10);
     bsg_safe_delete_local_ref(env, _runtime_versions);
   }
   event->device.total_memory =


### PR DESCRIPTION
## Goal
Avoid crashing on startup with:
```
JNI DETECTED ERROR IN APPLICATION: can't call int java.lang.Integer.intValue() on instance of java.lang.String
2021-10-28 13:28:24.720 7696-7696/com.example.bugsnag.android A/bugsnag.androi: java_vm_ext.cc:545]     in call to CallIntMethod
2021-10-28 13:28:24.720 7696-7696/com.example.bugsnag.android A/bugsnag.androi: java_vm_ext.cc:545]     from void com.bugsnag.android.ndk.NativeBridge.install(java.lang.String, java.lang.String, java.lang.String, int, boolean, int, boolean, int)
```

## Changeset
Parse the string `runtimeVersions.androidApiLevel` as an integer using `strtol`, avoiding changing the internal model and requiring an event migration. `strtol` will return `0` if the string cannot be parsed.

## Testing
Manual testing, as end-to-end tests and unit tests did not pick this error up in the first place.