### PR TITLE
Mitigate test flake caused by markLaunchCompleted() race

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCrashLoopScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCrashLoopScenario.kt
@@ -20,6 +20,11 @@ internal class CXXCrashLoopScenario(
 
     external fun crash()
 
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
+        config.launchDurationMillis = 0
+        super.startBugsnag(startBugsnagOnly)
+    }
+
     override fun startScenario() {
         super.startScenario()
         val lastRunInfo = Bugsnag.getLastRunInfo()

--- a/features/full_tests/batch_1/identify_crashes_on_launch.feature
+++ b/features/full_tests/batch_1/identify_crashes_on_launch.feature
@@ -75,7 +75,7 @@ Feature: Identifying crashes on launch
         And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
         And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 2
 
-    # TODO PLAT-7501
+    # TODO PLAT-7537
     @skip_android_6
     Scenario: Escaping from a crash loop by reading LastRunInfo in an NDK error
         When I run "CXXCrashLoopScenario" and relaunch the app

--- a/features/full_tests/batch_1/multi_process.feature
+++ b/features/full_tests/batch_1/multi_process.feature
@@ -79,7 +79,7 @@ Scenario: Handled NDK error
     And the error payload field "events.0.device.id" equals the stored value "first_device_id"
     And the error payload field "events.0.user.id" equals the stored value "first_device_id"
 
-# TODO PLAT-7501
+# TODO PLAT-7537
 @skip_android_6
 Scenario: Unhandled NDK error
     And I configure the app to run in the "main-activity" state


### PR DESCRIPTION
## Goal

Resolves a flake in `CXXCrashLoopScenario` where if Bugsnag takes a long time to initialize, `markLaunchCompleted()` will be called before the crashy scenario code. This invalidates an assumption of the scenario that a crash loop is occurring, meaning no requests are received by Mazerunner.

The fix is to set launchDurationMillis to 0, as this avoids any race condition.

It's worth noting that there is a separate issue with the resilience of Appium on Android 6 which prevents dialogs clearing/buttons pressing before an app can be terminated. Therefore the two affected tests are skipped on Android 6 for now until this ticket is addressed.