### PR TITLE
Remove unnecessary fields from NDK events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   bugsnag-maze-runner!

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
@@ -301,6 +301,10 @@ internal class ClientInternal constructor(
         event.device.freeMemory = null
         event.metadata.clearMetadata("app", "freeMemory")
         event.metadata.clearMetadata("app", "memoryUsage")
+        event.metadata.clearMetadata("app", "networkAccess")
+        event.metadata.clearMetadata("app", "totalMemory")
+        event.metadata.clearMetadata("device", "batteryLevel")
+        event.metadata.clearMetadata("device", "charging")
         event.metadata.clearMetadata("device", "freeMemory")
         event.metadata.clearMetadata("device", "totalMemory")
     }

--- a/features/full_tests/batch_2/native_legacy_struct.feature
+++ b/features/full_tests/batch_2/native_legacy_struct.feature
@@ -42,7 +42,7 @@ Feature: Legacy struct is converted to an error payload
         And the event "device.jailbroken" is true
         And the event "device.time" equals "2017-10-27T13:00:34Z"
         And the event "device.cpuAbi.0" equals "x86"
-        And the event "device.runtimeVersions.androidApiLevel" equals 27
+        And the event "device.runtimeVersions.androidApiLevel" equals "27"
         And the event "device.runtimeVersions.osBuild" equals "custom_build"
 
         # user

--- a/features/full_tests/batch_2/native_on_error.feature
+++ b/features/full_tests/batch_2/native_on_error.feature
@@ -28,7 +28,7 @@ Feature: Native on error callbacks are invoked
         # TODO PLAT-7497
         # And the event "device.totalMemory" equals 99999999
         And the event "device.orientation" equals "custom_orientation"
-        And the event "device.time" equals "1970-01-01T00:00:15.000Z"
+        And the event "device.time" is a timestamp
         And the event "device.osName" equals "custom_os_name"
 
         # user

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -177,8 +177,12 @@ Scenario: Signal raised with overwritten config
     And the event "device.freeMemory" is null
     And the event "metaData.app.freeMemory" is null
     And the event "metaData.app.memoryUsage" is null
+    And the event "metaData.app.networkAccess" is null
+    And the event "metaData.app.totalMemory" is null
     And the event "metaData.device.freeMemory" is null
     And the event "metaData.device.totalMemory" is null
+    And the event "metaData.device.batteryLevel" is null
+    And the event "metaData.device.charging" is null
 
     # Native context override
     And the event "context" equals "Some custom context"


### PR DESCRIPTION
## Goal

The following fields are populated in unhandled NDK events when previously they weren't:

```
app.networkAccess
app.totalMemory
device.batteryLevel
device.charging
```

As these fields don't make sense in the context of an unhandled NDK error because they are not updated throughout the application's lifecycle, they should be omitted for now.