### PR TITLE
Buildkite - eager concurrency

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -47,6 +47,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android size reporting'
     depends_on: "android-ci"
@@ -69,6 +70,7 @@ steps:
       TEST_APK_LOCATION: 'bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk'
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 5 NDK r16 end-to-end tests - batch 1'
     depends_on:
@@ -90,6 +92,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
     soft_fail:
       - exit_status: "*"
 
@@ -113,6 +116,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
     soft_fail:
       - exit_status: "*"
 
@@ -136,6 +140,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 6 NDK r16 end-to-end tests - batch 2'
     depends_on:
@@ -157,6 +162,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 7 NDK r19 end-to-end tests - batch 1'
     depends_on:
@@ -178,6 +184,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 7 NDK r19 end-to-end tests - batch 2'
     depends_on:
@@ -199,6 +206,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 8.1 NDK r19 end-to-end tests - batch 1'
     depends_on:
@@ -220,6 +228,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 8.1 NDK r19 end-to-end tests - batch 2'
     depends_on:
@@ -241,6 +250,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 10 NDK r21 end-to-end tests - batch 1'
     depends_on:
@@ -262,6 +272,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 10 NDK r21 end-to-end tests - batch 2'
     depends_on:
@@ -283,6 +294,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory to
   # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
@@ -308,6 +320,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 11 NDK r21 end-to-end tests - batch 2'
     depends_on:
@@ -329,6 +342,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   # If there is a tag present activate a manual publishing step
 

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -18,6 +18,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
     soft_fail:
       - exit_status: "*"
 
@@ -40,6 +41,7 @@ steps:
         - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 7 NDK r19 smoke tests'
     key: 'android-7-smoke'
@@ -60,6 +62,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 8.1 NDK r19 smoke tests'
     key: 'android-8-1-smoke'
@@ -80,6 +83,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 9 NDK r21 smoke tests'
     key: 'android-9-smoke'
@@ -100,6 +104,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 9 NDK r21 end-to-end tests - batch 1'
     depends_on:
@@ -120,6 +125,7 @@ steps:
           - "--device=ANDROID_9_0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 9 NDK r21 end-to-end tests - batch 2'
     depends_on:
@@ -140,6 +146,7 @@ steps:
           - "--device=ANDROID_9_0"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 10 NDK r21 smoke tests'
     key: 'android-10-smoke'
@@ -160,3 +167,4 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -169,6 +169,7 @@ steps:
       TEST_APK_LOCATION: 'bugsnag-android-core/build/outputs/apk/androidTest/debug/bugsnag-android-core-debug-androidTest.apk'
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: NDK Instrumentation tests'
     key: 'ndk-instrumentation-tests'
@@ -185,6 +186,7 @@ steps:
       TEST_APK_LOCATION: 'bugsnag-plugin-android-ndk/build/outputs/apk/androidTest/debug/bugsnag-plugin-android-ndk-debug-androidTest.apk'
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Performance benchmarks'
     key: 'perf-benchmarks'
@@ -201,6 +203,7 @@ steps:
       TEST_APK_LOCATION: 'bugsnag-benchmarks/build/outputs/apk/androidTest/release/bugsnag-benchmarks-release-androidTest.apk'
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: ':android: Android 4.4 NDK r16 smoke tests'
     key: 'android-4-4-smoke'
@@ -221,6 +224,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory to
   # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
@@ -247,6 +251,7 @@ steps:
           - "--fail-fast"
     concurrency: 9
     concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
   - label: 'Conditionally trigger full set of tests'
     command: sh -c .buildkite/pipeline_trigger.sh


### PR DESCRIPTION
## Goal

Implement eager concurrency for the CI browserstack-app concurrency group.

## Design

By default, Buildkite processes jobs in the order in which they were created, which is often very inefficient for our needs.  Jobs that are ready to be processed can be held behind those that are still waiting for other steps to complete.  

## Changeset

Setting `concurrency_method` to `eager` is Buildkite's mechanism to avoid this situation and is perfect for our needs.

## Testing

Covered by CI.