### PR TITLE
Use a fork of dsl-json

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "bugsnag-plugin-android-ndk/src/main/jni/external/libunwindstack-ndk"]
 	path = bugsnag-plugin-android-ndk/src/main/jni/external/libunwindstack-ndk
 	url = https://github.com/bugsnag/libunwindstack-ndk
+[submodule "bugsnag-android-core/dsl-json"]
+	path = bugsnag-android-core/dsl-json
+	url = https://github.com/bugsnag/dsl-json

--- a/bugsnag-android-core/build.gradle
+++ b/bugsnag-android-core/build.gradle
@@ -9,10 +9,6 @@ bugsnagBuildOptions {
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.dokka"
 
-dependencies {
-    implementation 'com.dslplatform:dsl-json:1.9.8'
-}
-
 dokkaHtml.configure {
     dokkaSourceSets {
         named("main") {
@@ -22,3 +18,15 @@ dokkaHtml.configure {
 }
 
 apply from: "../gradle/kotlin.gradle"
+
+// pick up dsl-json by adding to the default sourcesets
+android {
+    sourceSets {
+        main {
+            java.srcDirs += ["dsl-json/library/src/main/java"]
+        }
+        test {
+            java.srcDirs += ["dsl-json/library/src/test/java"]
+        }
+    }
+}

--- a/bugsnag-android-core/lint-baseline.xml
+++ b/bugsnag-android-core/lint-baseline.xml
@@ -7,7 +7,7 @@
         errorLine1="  this(new Settings&lt;TContext>()"
         errorLine2="       ^">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="480"
             column="8"/>
     </issue>
@@ -18,7 +18,7 @@
         errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
         errorLine2="                                                                                                                                                  ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="508"
             column="147"/>
     </issue>
@@ -29,7 +29,7 @@
         errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
         errorLine2="                                                                                                                                  ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="508"
             column="131"/>
     </issue>
@@ -40,7 +40,7 @@
         errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
         errorLine2="                                                                                                                                                                                             ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="508"
             column="190"/>
     </issue>
@@ -51,7 +51,7 @@
         errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
         errorLine2="                                                                                                                                                                                                                   ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="508"
             column="212"/>
     </issue>
@@ -62,7 +62,7 @@
         errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
         errorLine2="                                                                                                                                                                        ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="508"
             column="169"/>
     </issue>
@@ -73,7 +73,7 @@
         errorLine1="  this.context = settings.context;"
         errorLine2="                          ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="511"
             column="27"/>
     </issue>
@@ -84,7 +84,7 @@
         errorLine1="  this.fallback = settings.fallback;"
         errorLine2="                           ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="512"
             column="28"/>
     </issue>
@@ -95,7 +95,7 @@
         errorLine1="  this.omitDefaults = settings.omitDefaults;"
         errorLine2="                               ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="513"
             column="32"/>
     </issue>
@@ -106,7 +106,7 @@
         errorLine1="  this.allowArrayFormat = settings.allowArrayFormat;"
         errorLine2="                                   ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="514"
             column="36"/>
     </issue>
@@ -117,7 +117,7 @@
         errorLine1="  this.keyCache = settings.keyCache;"
         errorLine2="                           ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="515"
             column="28"/>
     </issue>
@@ -128,7 +128,7 @@
         errorLine1="  this.valuesCache = settings.valuesCache;"
         errorLine2="                              ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="516"
             column="31"/>
     </issue>
@@ -139,7 +139,7 @@
         errorLine1="  this.unknownNumbers = settings.unknownNumbers;"
         errorLine2="                                 ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="517"
             column="34"/>
     </issue>
@@ -150,7 +150,7 @@
         errorLine1="  this.errorInfo = settings.errorInfo;"
         errorLine2="                            ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="518"
             column="29"/>
     </issue>
@@ -161,7 +161,7 @@
         errorLine1="  this.doublePrecision = settings.doublePrecision;"
         errorLine2="                                  ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="519"
             column="35"/>
     </issue>
@@ -172,7 +172,7 @@
         errorLine1="  this.maxNumberDigits = settings.maxNumberDigits;"
         errorLine2="                                  ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="520"
             column="35"/>
     </issue>
@@ -183,7 +183,7 @@
         errorLine1="  this.maxStringSize = settings.maxStringBuffer;"
         errorLine2="                                ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="521"
             column="33"/>
     </issue>
@@ -194,7 +194,7 @@
         errorLine1="  this.writerFactories.addAll(settings.writerFactories);"
         errorLine2="                                       ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="522"
             column="40"/>
     </issue>
@@ -205,7 +205,7 @@
         errorLine1="  this.settingsWriters = settings.writerFactories.size();"
         errorLine2="                                  ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="523"
             column="35"/>
     </issue>
@@ -216,7 +216,7 @@
         errorLine1="  this.readerFactories.addAll(settings.readerFactories);"
         errorLine2="                                       ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="524"
             column="40"/>
     </issue>
@@ -227,7 +227,7 @@
         errorLine1="  this.settingsReaders = settings.readerFactories.size();"
         errorLine2="                                  ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="525"
             column="35"/>
     </issue>
@@ -238,7 +238,7 @@
         errorLine1="  this.binderFactories.addAll(settings.binderFactories);"
         errorLine2="                                       ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="526"
             column="40"/>
     </issue>
@@ -249,7 +249,7 @@
         errorLine1="  this.settingsBinders = settings.binderFactories.size();"
         errorLine2="                                  ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="527"
             column="35"/>
     </issue>
@@ -260,7 +260,7 @@
         errorLine1="  this.externalConverterAnalyzer = new ExternalConverterAnalyzer(settings.classLoaders);"
         errorLine2="                                                                          ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="528"
             column="75"/>
     </issue>
@@ -271,7 +271,7 @@
         errorLine1="  this.creatorMarkers = new HashMap&lt;Class&lt;? extends Annotation>, Boolean>(settings.creatorMarkers);"
         errorLine2="                                                                                   ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="529"
             column="84"/>
     </issue>
@@ -282,7 +282,7 @@
         errorLine1="  if (settings.javaSpecifics) {"
         errorLine2="               ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="540"
             column="16"/>
     </issue>
@@ -293,7 +293,7 @@
         errorLine1="  for (Configuration serializer : settings.configurations) {"
         errorLine2="                                           ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="610"
             column="44"/>
     </issue>
@@ -304,7 +304,7 @@
         errorLine1="  if (!settings.classLoaders.isEmpty() &amp;&amp; settings.fromServiceLoader == 0) {"
         errorLine2="                ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="613"
             column="17"/>
     </issue>
@@ -315,7 +315,7 @@
         errorLine1="  if (!settings.classLoaders.isEmpty() &amp;&amp; settings.fromServiceLoader == 0) {"
         errorLine2="                                                   ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="613"
             column="52"/>
     </issue>
@@ -326,7 +326,7 @@
         errorLine1="   loadDefaultConverters(this, settings.classLoaders, &quot;dsl_json_Annotation_Processor_External_Serialization&quot;);"
         errorLine2="                                        ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="615"
             column="41"/>
     </issue>
@@ -337,7 +337,7 @@
         errorLine1="   loadDefaultConverters(this, settings.classLoaders, &quot;dsl_json.json.ExternalSerialization&quot;);"
         errorLine2="                                        ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="616"
             column="41"/>
     </issue>
@@ -348,7 +348,7 @@
         errorLine1="   loadDefaultConverters(this, settings.classLoaders, &quot;dsl_json_ExternalSerialization&quot;);"
         errorLine2="                                        ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="617"
             column="41"/>
     </issue>
@@ -359,7 +359,7 @@
         errorLine1="   final DiyFp low = buffer.scaled_boundary_minus;"
         errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="605"
             column="29"/>
     </issue>
@@ -370,7 +370,7 @@
         errorLine1="   final DiyFp w = buffer.scaled_w;"
         errorLine2="                          ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="606"
             column="27"/>
     </issue>
@@ -381,7 +381,7 @@
         errorLine1="   final DiyFp high = buffer.scaled_boundary_plus;"
         errorLine2="                             ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="607"
             column="30"/>
     </issue>
@@ -392,7 +392,7 @@
         errorLine1="   final DiyFp too_low = buffer.too_low;"
         errorLine2="                                ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="621"
             column="33"/>
     </issue>
@@ -403,7 +403,7 @@
         errorLine1="   final DiyFp too_high = buffer.too_high;"
         errorLine2="                                 ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="624"
             column="34"/>
     </issue>
@@ -414,7 +414,7 @@
         errorLine1="   final DiyFp unsafe_interval = buffer.unsafe_interval;"
         errorLine2="                                        ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="629"
             column="41"/>
     </issue>
@@ -425,7 +425,7 @@
         errorLine1="   final DiyFp one = buffer.one;"
         errorLine2="                            ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="640"
             column="29"/>
     </issue>
@@ -436,7 +436,7 @@
         errorLine1="     buffer.point = buffer.end - mk + kappa;"
         errorLine2="                           ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="668"
             column="28"/>
     </issue>
@@ -447,7 +447,7 @@
         errorLine1="     buffer.point = buffer.end - mk + kappa;"
         errorLine2="            ~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="668"
             column="13"/>
     </issue>
@@ -458,7 +458,7 @@
         errorLine1="     final DiyFp minus_round = buffer.minus_round;"
         errorLine2="                                      ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="669"
             column="39"/>
     </issue>
@@ -469,7 +469,7 @@
         errorLine1="     buffer.point = buffer.end - mk + kappa;"
         errorLine2="                           ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="707"
             column="28"/>
     </issue>
@@ -480,7 +480,7 @@
         errorLine1="     buffer.point = buffer.end - mk + kappa;"
         errorLine2="            ~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="707"
             column="13"/>
     </issue>
@@ -491,7 +491,7 @@
         errorLine1="     final DiyFp minus_round = buffer.minus_round;"
         errorLine2="                                      ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Grisu3.java"
             line="708"
             column="39"/>
     </issue>
@@ -502,7 +502,7 @@
         errorLine1=" private static final EOFException eof = new EmptyEOFException();"
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="313"
             column="42"/>
     </issue>
@@ -513,7 +513,7 @@
         errorLine1="    : new ParsingStacklessException(reason);"
         errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="19"
             column="7"/>
     </issue>
@@ -524,7 +524,7 @@
         errorLine1="    : new ParsingStacklessException(reason, cause);"
         errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="26"
             column="7"/>
     </issue>
@@ -535,7 +535,7 @@
         errorLine1="   super(reason);"
         errorLine2="   ~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="32"
             column="4"/>
     </issue>
@@ -546,95 +546,95 @@
         errorLine1="   super(reason, cause);"
         errorLine2="   ~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="36"
             column="4"/>
     </issue>
 
     <issue
         id="LambdaLast"
-        message="Functional interface parameters (such as parameter 1, &quot;converter&quot;, in com.bugsnag.dslplatform.json.DslJson.deserialize) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        message="Functional interface parameters (such as parameter 1, &quot;converter&quot;, in com.bugsnag.android.repackaged.dslplatform.json.DslJson.deserialize) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
         errorLine1="   final JsonReader&lt;TContext> input) throws IOException {"
         errorLine2="   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1522"
             column="4"/>
     </issue>
 
     <issue
         id="LambdaLast"
-        message="Functional interface parameters (such as parameter 1, &quot;binder&quot;, in com.bugsnag.dslplatform.json.JsonReader.next) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        message="Functional interface parameters (such as parameter 1, &quot;binder&quot;, in com.bugsnag.android.repackaged.dslplatform.json.JsonReader.next) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
         errorLine1=" public final &lt;T> T next(final BindObject&lt;T> binder, final T instance) throws IOException {"
         errorLine2="                                                     ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1517"
             column="54"/>
     </issue>
 
     <issue
         id="LambdaLast"
-        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.readArray) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.android.repackaged.dslplatform.json.JsonReader.readArray) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
         errorLine1=" public final &lt;T> T[] readArray(final ReadObject&lt;T> readObject, final T[] emptyArray) throws IOException {"
         errorLine2="                                                                ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1583"
             column="65"/>
     </issue>
 
     <issue
         id="LambdaLast"
-        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.deserializeCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.android.repackaged.dslplatform.json.JsonReader.deserializeCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
         errorLine1=" public final &lt;T, S extends T> void deserializeCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                                          ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1603"
             column="91"/>
     </issue>
 
     <issue
         id="LambdaLast"
-        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.deserializeNullableCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.android.repackaged.dslplatform.json.JsonReader.deserializeNullableCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
         errorLine1=" public final &lt;T, S extends T> void deserializeNullableCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1618"
             column="99"/>
     </issue>
 
     <issue
         id="LambdaLast"
-        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.deserializeCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.android.repackaged.dslplatform.json.JsonReader.deserializeCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
         errorLine1=" public final &lt;T extends JsonObject> void deserializeCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                                                    ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1641"
             column="101"/>
     </issue>
 
     <issue
         id="LambdaLast"
-        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.deserializeNullableCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.android.repackaged.dslplatform.json.JsonReader.deserializeNullableCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
         errorLine1=" public final &lt;T extends JsonObject> void deserializeNullableCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1661"
             column="109"/>
     </issue>
 
     <issue
         id="LambdaLast"
-        message="Functional interface parameters (such as parameter 1, &quot;keyWriter&quot;, in com.bugsnag.dslplatform.json.JsonWriter.writeQuoted) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        message="Functional interface parameters (such as parameter 1, &quot;keyWriter&quot;, in com.bugsnag.android.repackaged.dslplatform.json.JsonWriter.writeQuoted) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
         errorLine1=" public &lt;T> void writeQuoted(final JsonWriter.WriteObject&lt;T> keyWriter, final T key) {"
         errorLine2="                                                                        ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="857"
             column="73"/>
     </issue>
@@ -645,7 +645,7 @@
         errorLine1=" public static void serialize(@Nullable final byte[] value, final JsonWriter sw) {"
         errorLine2="                                                                  ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="26"
             column="67"/>
     </issue>
@@ -656,7 +656,7 @@
         errorLine1=" public static byte[] deserialize(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="36"
             column="16"/>
     </issue>
@@ -667,7 +667,7 @@
         errorLine1=" public static byte[] deserialize(final JsonReader reader) throws IOException {"
         errorLine2="                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="36"
             column="41"/>
     </issue>
@@ -678,7 +678,7 @@
         errorLine1=" public static ArrayList&lt;byte[]&gt; deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="41"
             column="16"/>
     </issue>
@@ -689,7 +689,7 @@
         errorLine1=" public static ArrayList&lt;byte[]&gt; deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="41"
             column="62"/>
     </issue>
@@ -700,7 +700,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;byte[]&gt; res) throws IOException {"
         errorLine2="                                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="45"
             column="49"/>
     </issue>
@@ -711,7 +711,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;byte[]&gt; res) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="45"
             column="74"/>
     </issue>
@@ -722,7 +722,7 @@
         errorLine1=" public static ArrayList&lt;byte[]&gt; deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="50"
             column="16"/>
     </issue>
@@ -733,7 +733,7 @@
         errorLine1=" public static ArrayList&lt;byte[]&gt; deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="50"
             column="70"/>
     </issue>
@@ -744,7 +744,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;byte[]&gt; res) throws IOException {"
         errorLine2="                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="54"
             column="57"/>
     </issue>
@@ -755,7 +755,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;byte[]&gt; res) throws IOException {"
         errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BinaryConverter.java"
             line="54"
             column="82"/>
     </issue>
@@ -766,7 +766,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final Boolean value, final JsonWriter sw) {"
         errorLine2="                                                                           ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="51"
             column="76"/>
     </issue>
@@ -777,7 +777,7 @@
         errorLine1=" public static void serialize(final boolean value, final JsonWriter sw) {"
         errorLine2="                                                         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="61"
             column="58"/>
     </issue>
@@ -788,7 +788,7 @@
         errorLine1=" public static void serialize(@Nullable final boolean[] value, final JsonWriter sw) {"
         errorLine2="                                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="69"
             column="70"/>
     </issue>
@@ -799,7 +799,7 @@
         errorLine1=" public static boolean deserialize(final JsonReader reader) throws IOException {"
         errorLine2="                                         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="84"
             column="42"/>
     </issue>
@@ -810,7 +810,7 @@
         errorLine1=" public static boolean[] deserializeBoolArray(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="93"
             column="16"/>
     </issue>
@@ -821,7 +821,7 @@
         errorLine1=" public static boolean[] deserializeBoolArray(final JsonReader reader) throws IOException {"
         errorLine2="                                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="93"
             column="53"/>
     </issue>
@@ -832,7 +832,7 @@
         errorLine1=" public static ArrayList&lt;Boolean> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="112"
             column="16"/>
     </issue>
@@ -843,7 +843,7 @@
         errorLine1=" public static ArrayList&lt;Boolean> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                              ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="112"
             column="63"/>
     </issue>
@@ -854,7 +854,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Boolean> res) throws IOException {"
         errorLine2="                                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="116"
             column="49"/>
     </issue>
@@ -865,7 +865,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Boolean> res) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="116"
             column="74"/>
     </issue>
@@ -876,7 +876,7 @@
         errorLine1=" public static ArrayList&lt;Boolean> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="121"
             column="16"/>
     </issue>
@@ -887,7 +887,7 @@
         errorLine1=" public static ArrayList&lt;Boolean> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                      ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="121"
             column="71"/>
     </issue>
@@ -898,7 +898,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Boolean> res) throws IOException {"
         errorLine2="                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="125"
             column="57"/>
     </issue>
@@ -909,7 +909,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Boolean> res) throws IOException {"
         errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/BoolConverter.java"
             line="125"
             column="82"/>
     </issue>
@@ -920,7 +920,7 @@
         errorLine1=" void configure(DslJson json);"
         errorLine2="                ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Configuration.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/Configuration.java"
             line="15"
             column="17"/>
     </issue>
@@ -931,7 +931,7 @@
         errorLine1=" public ConfigurationException(String reason) {"
         errorLine2="                               ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ConfigurationException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ConfigurationException.java"
             line="5"
             column="32"/>
     </issue>
@@ -942,7 +942,7 @@
         errorLine1=" public ConfigurationException(Throwable cause) {"
         errorLine2="                               ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ConfigurationException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ConfigurationException.java"
             line="9"
             column="32"/>
     </issue>
@@ -953,7 +953,7 @@
         errorLine1=" public ConfigurationException(String reason, Throwable cause) {"
         errorLine2="                               ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ConfigurationException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ConfigurationException.java"
             line="13"
             column="32"/>
     </issue>
@@ -964,7 +964,7 @@
         errorLine1=" public ConfigurationException(String reason, Throwable cause) {"
         errorLine2="                                              ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ConfigurationException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ConfigurationException.java"
             line="13"
             column="47"/>
     </issue>
@@ -975,7 +975,7 @@
         errorLine1="  void serialize(@Nullable Object instance, OutputStream stream) throws IOException;"
         errorLine2="                                            ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="108"
             column="45"/>
     </issue>
@@ -986,7 +986,7 @@
         errorLine1="  Object deserialize(@Nullable TContext context, Type manifest, byte[] body, int size) throws IOException;"
         errorLine2="                                                 ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="111"
             column="50"/>
     </issue>
@@ -997,7 +997,7 @@
         errorLine1="  Object deserialize(@Nullable TContext context, Type manifest, byte[] body, int size) throws IOException;"
         errorLine2="                                                                ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="111"
             column="65"/>
     </issue>
@@ -1008,7 +1008,7 @@
         errorLine1="  Object deserialize(@Nullable TContext context, Type manifest, InputStream stream) throws IOException;"
         errorLine2="                                                 ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="114"
             column="50"/>
     </issue>
@@ -1019,7 +1019,7 @@
         errorLine1="  Object deserialize(@Nullable TContext context, Type manifest, InputStream stream) throws IOException;"
         errorLine2="                                                                ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="114"
             column="65"/>
     </issue>
@@ -1030,7 +1030,7 @@
         errorLine1="  T tryCreate(Type manifest, DslJson dslJson);"
         errorLine2="              ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="119"
             column="15"/>
     </issue>
@@ -1041,7 +1041,7 @@
         errorLine1="  T tryCreate(Type manifest, DslJson dslJson);"
         errorLine2="                             ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="119"
             column="30"/>
     </issue>
@@ -1052,7 +1052,7 @@
         errorLine1="  public Settings&lt;TContext> withContext(@Nullable TContext context) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="157"
             column="10"/>
     </issue>
@@ -1063,7 +1063,7 @@
         errorLine1="  public Settings&lt;TContext> withJavaConverters(boolean javaSpecifics) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="168"
             column="10"/>
     </issue>
@@ -1074,7 +1074,7 @@
         errorLine1="  public Settings&lt;TContext> fallbackTo(@Nullable Fallback&lt;TContext> fallback) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="181"
             column="10"/>
     </issue>
@@ -1085,7 +1085,7 @@
         errorLine1="  public Settings&lt;TContext> skipDefaultValues(boolean omitDefaults) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="194"
             column="10"/>
     </issue>
@@ -1096,7 +1096,7 @@
         errorLine1="  public Settings&lt;TContext> allowArrayFormat(boolean allowArrayFormat) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="208"
             column="10"/>
     </issue>
@@ -1107,7 +1107,7 @@
         errorLine1="  public Settings&lt;TContext> useKeyCache(@Nullable StringCache keyCache) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="225"
             column="10"/>
     </issue>
@@ -1118,7 +1118,7 @@
         errorLine1="  public Settings&lt;TContext> useStringValuesCache(@Nullable StringCache valuesCache) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="243"
             column="10"/>
     </issue>
@@ -1129,7 +1129,7 @@
         errorLine1="  public Settings&lt;TContext> resolveWriter(ConverterFactory&lt;? extends JsonWriter.WriteObject> writer) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="256"
             column="10"/>
     </issue>
@@ -1140,7 +1140,7 @@
         errorLine1="  public Settings&lt;TContext> resolveWriter(ConverterFactory&lt;? extends JsonWriter.WriteObject> writer) {"
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="256"
             column="43"/>
     </issue>
@@ -1151,7 +1151,7 @@
         errorLine1="  public Settings&lt;TContext> resolveReader(ConverterFactory&lt;? extends JsonReader.ReadObject> reader) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="273"
             column="10"/>
     </issue>
@@ -1162,7 +1162,7 @@
         errorLine1="  public Settings&lt;TContext> resolveReader(ConverterFactory&lt;? extends JsonReader.ReadObject> reader) {"
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="273"
             column="43"/>
     </issue>
@@ -1173,7 +1173,7 @@
         errorLine1="  public Settings&lt;TContext> resolveBinder(ConverterFactory&lt;? extends JsonReader.BindObject> binder) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="290"
             column="10"/>
     </issue>
@@ -1184,7 +1184,7 @@
         errorLine1="  public Settings&lt;TContext> resolveBinder(ConverterFactory&lt;? extends JsonReader.BindObject> binder) {"
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="290"
             column="43"/>
     </issue>
@@ -1195,7 +1195,7 @@
         errorLine1="  public Settings&lt;TContext> includeServiceLoader() {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="309"
             column="10"/>
     </issue>
@@ -1206,7 +1206,7 @@
         errorLine1="  public Settings&lt;TContext> includeServiceLoader(ClassLoader loader) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="324"
             column="10"/>
     </issue>
@@ -1217,7 +1217,7 @@
         errorLine1="  public Settings&lt;TContext> includeServiceLoader(ClassLoader loader) {"
         errorLine2="                                                 ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="324"
             column="50"/>
     </issue>
@@ -1228,7 +1228,7 @@
         errorLine1="  public Settings&lt;TContext> errorInfo(JsonReader.ErrorInfo errorInfo) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="350"
             column="10"/>
     </issue>
@@ -1239,7 +1239,7 @@
         errorLine1="  public Settings&lt;TContext> errorInfo(JsonReader.ErrorInfo errorInfo) {"
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="350"
             column="39"/>
     </issue>
@@ -1250,7 +1250,7 @@
         errorLine1="  public Settings&lt;TContext> doublePrecision(JsonReader.DoublePrecision precision) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="362"
             column="10"/>
     </issue>
@@ -1261,7 +1261,7 @@
         errorLine1="  public Settings&lt;TContext> doublePrecision(JsonReader.DoublePrecision precision) {"
         errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="362"
             column="45"/>
     </issue>
@@ -1272,7 +1272,7 @@
         errorLine1="  public Settings&lt;TContext> unknownNumbers(JsonReader.UnknownNumberParsing unknownNumbers) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="381"
             column="10"/>
     </issue>
@@ -1283,7 +1283,7 @@
         errorLine1="  public Settings&lt;TContext> unknownNumbers(JsonReader.UnknownNumberParsing unknownNumbers) {"
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="381"
             column="44"/>
     </issue>
@@ -1294,7 +1294,7 @@
         errorLine1="  public Settings&lt;TContext> limitDigitsBuffer(int size) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="394"
             column="10"/>
     </issue>
@@ -1305,7 +1305,7 @@
         errorLine1="  public Settings&lt;TContext> limitStringBuffer(int size) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="407"
             column="10"/>
     </issue>
@@ -1316,7 +1316,7 @@
         errorLine1="  public Settings&lt;TContext> creatorMarker(Class&lt;? extends Annotation> marker, boolean expandVisibility) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="421"
             column="10"/>
     </issue>
@@ -1327,7 +1327,7 @@
         errorLine1="  public Settings&lt;TContext> creatorMarker(Class&lt;? extends Annotation> marker, boolean expandVisibility) {"
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="421"
             column="43"/>
     </issue>
@@ -1338,7 +1338,7 @@
         errorLine1="  public Settings&lt;TContext> with(Configuration conf) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="434"
             column="10"/>
     </issue>
@@ -1349,7 +1349,7 @@
         errorLine1="  public Settings&lt;TContext> with(Configuration conf) {"
         errorLine2="                                 ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="434"
             column="34"/>
     </issue>
@@ -1360,7 +1360,7 @@
         errorLine1="   final Iterable&lt;Configuration> serializers) {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="479"
             column="10"/>
     </issue>
@@ -1371,7 +1371,7 @@
         errorLine1=" public DslJson(final Settings&lt;TContext> settings) {"
         errorLine2="                      ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="496"
             column="23"/>
     </issue>
@@ -1382,7 +1382,7 @@
         errorLine1="  public String get(char[] chars, int len) {"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="657"
             column="10"/>
     </issue>
@@ -1393,7 +1393,7 @@
         errorLine1="  public String get(char[] chars, int len) {"
         errorLine2="                    ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="657"
             column="21"/>
     </issue>
@@ -1404,7 +1404,7 @@
         errorLine1=" public JsonWriter newWriter() {"
         errorLine2="        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="688"
             column="9"/>
     </issue>
@@ -1415,7 +1415,7 @@
         errorLine1=" public JsonWriter newWriter(int size) {"
         errorLine2="        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="701"
             column="9"/>
     </issue>
@@ -1426,7 +1426,7 @@
         errorLine1=" public JsonWriter newWriter(byte[] buffer) {"
         errorLine2="        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="714"
             column="9"/>
     </issue>
@@ -1437,7 +1437,7 @@
         errorLine1=" public JsonWriter newWriter(byte[] buffer) {"
         errorLine2="                             ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="714"
             column="30"/>
     </issue>
@@ -1448,7 +1448,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader() {"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="726"
             column="9"/>
     </issue>
@@ -1459,7 +1459,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes) {"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="738"
             column="9"/>
     </issue>
@@ -1470,7 +1470,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes) {"
         errorLine2="                                       ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="738"
             column="40"/>
     </issue>
@@ -1481,7 +1481,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length) {"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="751"
             column="9"/>
     </issue>
@@ -1492,7 +1492,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length) {"
         errorLine2="                                       ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="751"
             column="40"/>
     </issue>
@@ -1503,7 +1503,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length, char[] tmp) {"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="767"
             column="9"/>
     </issue>
@@ -1514,7 +1514,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length, char[] tmp) {"
         errorLine2="                                       ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="767"
             column="40"/>
     </issue>
@@ -1525,7 +1525,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length, char[] tmp) {"
         errorLine2="                                                                 ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="767"
             column="66"/>
     </issue>
@@ -1536,7 +1536,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(InputStream stream, byte[] buffer) throws IOException {"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="782"
             column="9"/>
     </issue>
@@ -1547,7 +1547,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(InputStream stream, byte[] buffer) throws IOException {"
         errorLine2="                                       ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="782"
             column="40"/>
     </issue>
@@ -1558,7 +1558,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(InputStream stream, byte[] buffer) throws IOException {"
         errorLine2="                                                           ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="782"
             column="60"/>
     </issue>
@@ -1569,7 +1569,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(String input) {"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="798"
             column="9"/>
     </issue>
@@ -1580,7 +1580,7 @@
         errorLine1=" public JsonReader&lt;TContext> newReader(String input) {"
         errorLine2="                                       ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="798"
             column="40"/>
     </issue>
@@ -1591,7 +1591,7 @@
         errorLine1=" public &lt;T> void registerDefault(Class&lt;T> manifest, T instance) {"
         errorLine2="                                 ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="822"
             column="34"/>
     </issue>
@@ -1602,7 +1602,7 @@
         errorLine1=" public boolean registerWriterFactory(ConverterFactory&lt;? extends JsonWriter.WriteObject> factory) {"
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="827"
             column="39"/>
     </issue>
@@ -1613,7 +1613,7 @@
         errorLine1=" public boolean registerReaderFactory(ConverterFactory&lt;? extends JsonReader.ReadObject> factory) {"
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="835"
             column="39"/>
     </issue>
@@ -1624,7 +1624,7 @@
         errorLine1=" public boolean registerBinderFactory(ConverterFactory&lt;? extends JsonReader.BindObject> factory) {"
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="843"
             column="39"/>
     </issue>
@@ -1635,7 +1635,7 @@
         errorLine1=" public final Set&lt;Type> getRegisteredDecoders() {"
         errorLine2="              ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="876"
             column="15"/>
     </issue>
@@ -1646,7 +1646,7 @@
         errorLine1=" public final Set&lt;Type> getRegisteredBinders() {"
         errorLine2="              ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="880"
             column="15"/>
     </issue>
@@ -1657,7 +1657,7 @@
         errorLine1=" public final Set&lt;Type> getRegisteredEncoders() {"
         errorLine2="              ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="884"
             column="15"/>
     </issue>
@@ -1668,7 +1668,7 @@
         errorLine1=" public final Map&lt;Class&lt;? extends Annotation>, Boolean> getRegisteredCreatorMarkers() {"
         errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="888"
             column="15"/>
     </issue>
@@ -1679,7 +1679,7 @@
         errorLine1=" public &lt;T, S extends T> void registerReader(final Class&lt;T> manifest, @Nullable final JsonReader.ReadObject&lt;S> reader) {"
         errorLine2="                                                   ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="906"
             column="52"/>
     </issue>
@@ -1690,7 +1690,7 @@
         errorLine1=" public JsonReader.ReadObject registerReader(final Type manifest, @Nullable final JsonReader.ReadObject&lt;?> reader) {"
         errorLine2="                                                   ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="925"
             column="52"/>
     </issue>
@@ -1701,7 +1701,7 @@
         errorLine1=" public &lt;T, S extends T> void registerBinder(final Class&lt;T> manifest, @Nullable final JsonReader.BindObject&lt;S> binder) {"
         errorLine2="                                                   ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="949"
             column="52"/>
     </issue>
@@ -1712,7 +1712,7 @@
         errorLine1=" public void registerBinder(final Type manifest, @Nullable final JsonReader.BindObject&lt;?> binder) {"
         errorLine2="                                  ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="967"
             column="35"/>
     </issue>
@@ -1723,7 +1723,7 @@
         errorLine1=" public &lt;T> void registerWriter(final Class&lt;T> manifest, @Nullable final JsonWriter.WriteObject&lt;T> writer) {"
         errorLine2="                                      ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="985"
             column="39"/>
     </issue>
@@ -1734,7 +1734,7 @@
         errorLine1=" public JsonWriter.WriteObject registerWriter(final Type manifest, @Nullable final JsonWriter.WriteObject&lt;?> writer) {"
         errorLine2="                                                    ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1009"
             column="53"/>
     </issue>
@@ -1745,7 +1745,7 @@
         errorLine1=" public JsonWriter.WriteObject&lt;?> tryFindWriter(final Type manifest) {"
         errorLine2="                                                      ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1031"
             column="55"/>
     </issue>
@@ -1756,7 +1756,7 @@
         errorLine1=" public JsonReader.ReadObject&lt;?> tryFindReader(final Type manifest) {"
         errorLine2="                                                     ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1139"
             column="54"/>
     </issue>
@@ -1767,7 +1767,7 @@
         errorLine1=" public JsonReader.BindObject&lt;?> tryFindBinder(final Type manifest) {"
         errorLine2="                                                     ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1179"
             column="54"/>
     </issue>
@@ -1778,7 +1778,7 @@
         errorLine1=" public &lt;T> JsonWriter.WriteObject&lt;T> tryFindWriter(final Class&lt;T> manifest) {"
         errorLine2="                                                          ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1206"
             column="59"/>
     </issue>
@@ -1789,7 +1789,7 @@
         errorLine1=" public &lt;T> JsonReader.ReadObject&lt;T> tryFindReader(final Class&lt;T> manifest) {"
         errorLine2="                                                         ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1227"
             column="58"/>
     </issue>
@@ -1800,7 +1800,7 @@
         errorLine1=" public &lt;T> JsonReader.BindObject&lt;T> tryFindBinder(final Class&lt;T> manifest) {"
         errorLine2="                                                         ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1248"
             column="58"/>
     </issue>
@@ -1811,7 +1811,7 @@
         errorLine1=" protected final JsonReader.ReadJsonObject&lt;JsonObject> getObjectReader(final Class&lt;?> manifest) {"
         errorLine2="                                                                             ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1290"
             column="78"/>
     </issue>
@@ -1822,7 +1822,7 @@
         errorLine1=" public void serializeMap(final Map&lt;String, Object> value, final JsonWriter sw) throws IOException {"
         errorLine2="                                ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1314"
             column="33"/>
     </issue>
@@ -1833,7 +1833,7 @@
         errorLine1=" public void serializeMap(final Map&lt;String, Object> value, final JsonWriter sw) throws IOException {"
         errorLine2="                                                                 ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1314"
             column="66"/>
     </issue>
@@ -1844,7 +1844,7 @@
         errorLine1=" public static Object deserializeObject(final JsonReader reader) throws IOException {"
         errorLine2="                                              ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1336"
             column="47"/>
     </issue>
@@ -1855,7 +1855,7 @@
         errorLine1=" public static ArrayList&lt;Object> deserializeList(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1347"
             column="16"/>
     </issue>
@@ -1866,7 +1866,7 @@
         errorLine1=" public static ArrayList&lt;Object> deserializeList(final JsonReader reader) throws IOException {"
         errorLine2="                                                       ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1347"
             column="56"/>
     </issue>
@@ -1877,7 +1877,7 @@
         errorLine1=" public static LinkedHashMap&lt;String, Object> deserializeMap(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1358"
             column="16"/>
     </issue>
@@ -1888,7 +1888,7 @@
         errorLine1=" public static LinkedHashMap&lt;String, Object> deserializeMap(final JsonReader reader) throws IOException {"
         errorLine2="                                                                  ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1358"
             column="67"/>
     </issue>
@@ -1899,7 +1899,7 @@
         errorLine1=" public final boolean canSerialize(final Type manifest) {"
         errorLine2="                                         ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1424"
             column="42"/>
     </issue>
@@ -1910,7 +1910,7 @@
         errorLine1=" public final boolean canDeserialize(final Type manifest) {"
         errorLine2="                                           ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1475"
             column="44"/>
     </issue>
@@ -1921,7 +1921,7 @@
         errorLine1="   final JsonReader.ReadObject&lt;T> converter,"
         errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1521"
             column="10"/>
     </issue>
@@ -1932,7 +1932,7 @@
         errorLine1="   final JsonReader&lt;TContext> input) throws IOException {"
         errorLine2="         ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1522"
             column="10"/>
     </issue>
@@ -1943,7 +1943,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1551"
             column="10"/>
     </issue>
@@ -1954,7 +1954,7 @@
         errorLine1="   final byte[] body,"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1552"
             column="10"/>
     </issue>
@@ -1965,7 +1965,7 @@
         errorLine1="   final Type manifest,"
         errorLine2="         ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1605"
             column="10"/>
     </issue>
@@ -1976,7 +1976,7 @@
         errorLine1="   final byte[] body,"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1606"
             column="10"/>
     </issue>
@@ -1987,7 +1987,7 @@
         errorLine1=" protected Object deserializeWith(Type manifest, JsonReader json) throws IOException {"
         errorLine2="                                  ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1634"
             column="35"/>
     </issue>
@@ -1998,7 +1998,7 @@
         errorLine1=" protected Object deserializeWith(Type manifest, JsonReader json) throws IOException {"
         errorLine2="                                                 ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1634"
             column="50"/>
     </issue>
@@ -2009,7 +2009,7 @@
         errorLine1=" protected IOException createErrorMessage(final Class&lt;?> manifest) {"
         errorLine2="           ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1707"
             column="12"/>
     </issue>
@@ -2020,7 +2020,7 @@
         errorLine1=" protected IOException createErrorMessage(final Class&lt;?> manifest) {"
         errorLine2="                                                ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1707"
             column="49"/>
     </issue>
@@ -2031,7 +2031,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1743"
             column="10"/>
     </issue>
@@ -2042,7 +2042,7 @@
         errorLine1="   final byte[] body,"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1744"
             column="10"/>
     </issue>
@@ -2053,7 +2053,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1822"
             column="10"/>
     </issue>
@@ -2064,7 +2064,7 @@
         errorLine1="   final InputStream stream,"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1823"
             column="10"/>
     </issue>
@@ -2075,7 +2075,7 @@
         errorLine1="   final byte[] buffer) throws IOException {"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1824"
             column="10"/>
     </issue>
@@ -2086,7 +2086,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1851"
             column="10"/>
     </issue>
@@ -2097,7 +2097,7 @@
         errorLine1="   final InputStream stream) throws IOException {"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1852"
             column="10"/>
     </issue>
@@ -2108,7 +2108,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1867"
             column="10"/>
     </issue>
@@ -2119,7 +2119,7 @@
         errorLine1="   JsonReader&lt;TContext> json,"
         errorLine2="   ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1868"
             column="4"/>
     </issue>
@@ -2130,7 +2130,7 @@
         errorLine1="   InputStream stream) throws IOException {"
         errorLine2="   ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1869"
             column="4"/>
     </issue>
@@ -2141,7 +2141,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1931"
             column="10"/>
     </issue>
@@ -2152,7 +2152,7 @@
         errorLine1="   final InputStream stream,"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1932"
             column="10"/>
     </issue>
@@ -2163,7 +2163,7 @@
         errorLine1="   final byte[] buffer) throws IOException {"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1933"
             column="10"/>
     </issue>
@@ -2174,7 +2174,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1967"
             column="10"/>
     </issue>
@@ -2185,7 +2185,7 @@
         errorLine1="   final InputStream stream) throws IOException {"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1968"
             column="10"/>
     </issue>
@@ -2196,7 +2196,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1986"
             column="10"/>
     </issue>
@@ -2207,7 +2207,7 @@
         errorLine1="   final JsonReader json,"
         errorLine2="         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1987"
             column="10"/>
     </issue>
@@ -2218,7 +2218,7 @@
         errorLine1="   final InputStream stream) throws IOException {"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="1988"
             column="10"/>
     </issue>
@@ -2229,7 +2229,7 @@
         errorLine1="   final Type manifest,"
         errorLine2="         ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2048"
             column="10"/>
     </issue>
@@ -2240,7 +2240,7 @@
         errorLine1="   final InputStream stream,"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2049"
             column="10"/>
     </issue>
@@ -2251,7 +2251,7 @@
         errorLine1="   final byte[] buffer) throws IOException {"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2050"
             column="10"/>
     </issue>
@@ -2262,7 +2262,7 @@
         errorLine1="   final Type manifest,"
         errorLine2="         ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2092"
             column="10"/>
     </issue>
@@ -2273,7 +2273,7 @@
         errorLine1="   final InputStream stream) throws IOException {"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2093"
             column="10"/>
     </issue>
@@ -2284,7 +2284,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2196"
             column="10"/>
     </issue>
@@ -2295,7 +2295,7 @@
         errorLine1="   final InputStream stream) throws IOException {"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2197"
             column="10"/>
     </issue>
@@ -2306,7 +2306,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2233"
             column="10"/>
     </issue>
@@ -2317,7 +2317,7 @@
         errorLine1="   final InputStream stream,"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2234"
             column="10"/>
     </issue>
@@ -2328,7 +2328,7 @@
         errorLine1="   final byte[] buffer) throws IOException {"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2235"
             column="10"/>
     </issue>
@@ -2339,7 +2339,7 @@
         errorLine1="   final Class&lt;TResult> manifest,"
         errorLine2="         ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2251"
             column="10"/>
     </issue>
@@ -2350,7 +2350,7 @@
         errorLine1="   final JsonReader json,"
         errorLine2="         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2252"
             column="10"/>
     </issue>
@@ -2361,7 +2361,7 @@
         errorLine1="   final InputStream stream) throws IOException {"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2253"
             column="10"/>
     </issue>
@@ -2372,7 +2372,7 @@
         errorLine1="   final Iterator&lt;T> iterator,"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2436"
             column="10"/>
     </issue>
@@ -2383,7 +2383,7 @@
         errorLine1="   final OutputStream stream,"
         errorLine2="         ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2437"
             column="10"/>
     </issue>
@@ -2394,7 +2394,7 @@
         errorLine1="   final Iterator&lt;T> iterator,"
         errorLine2="         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2513"
             column="10"/>
     </issue>
@@ -2405,7 +2405,7 @@
         errorLine1="   final Class&lt;T> manifest,"
         errorLine2="         ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2514"
             column="10"/>
     </issue>
@@ -2416,7 +2416,7 @@
         errorLine1="   final OutputStream stream,"
         errorLine2="         ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2515"
             column="10"/>
     </issue>
@@ -2427,7 +2427,7 @@
         errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, @Nullable final T[] array) {"
         errorLine2="                                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2571"
             column="53"/>
     </issue>
@@ -2438,7 +2438,7 @@
         errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, final T[] array, final int len) {"
         errorLine2="                                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2606"
             column="53"/>
     </issue>
@@ -2449,7 +2449,7 @@
         errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, final T[] array, final int len) {"
         errorLine2="                                                                             ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2606"
             column="78"/>
     </issue>
@@ -2460,7 +2460,7 @@
         errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, @Nullable final List&lt;T> list) {"
         errorLine2="                                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2643"
             column="53"/>
     </issue>
@@ -2471,7 +2471,7 @@
         errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, @Nullable final Collection&lt;T> collection) {"
         errorLine2="                                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2680"
             column="53"/>
     </issue>
@@ -2482,7 +2482,7 @@
         errorLine1=" public boolean serialize(final JsonWriter writer, final Type manifest, @Nullable final Object value) {"
         errorLine2="                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2726"
             column="33"/>
     </issue>
@@ -2493,7 +2493,7 @@
         errorLine1=" public boolean serialize(final JsonWriter writer, final Type manifest, @Nullable final Object value) {"
         errorLine2="                                                         ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2726"
             column="58"/>
     </issue>
@@ -2504,7 +2504,7 @@
         errorLine1=" public final void serialize(@Nullable final Object value, final OutputStream stream) throws IOException {"
         errorLine2="                                                                 ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2851"
             column="66"/>
     </issue>
@@ -2515,7 +2515,7 @@
         errorLine1=" public final void serialize(final JsonWriter writer, @Nullable final Object value) throws IOException {"
         errorLine2="                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/DslJson.java"
             line="2886"
             column="36"/>
     </issue>
@@ -2526,7 +2526,7 @@
         errorLine1=" void serialize(JsonWriter writer, boolean minimal);"
         errorLine2="                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonObject.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonObject.java"
             line="34"
             column="17"/>
     </issue>
@@ -2537,7 +2537,7 @@
         errorLine1=" protected byte[] buffer;"
         errorLine2="           ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="49"
             column="12"/>
     </issue>
@@ -2548,7 +2548,7 @@
         errorLine1=" protected char[] chars;"
         errorLine2="           ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="50"
             column="12"/>
     </issue>
@@ -2559,7 +2559,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, @Nullable final TContext context) {"
         errorLine2="                         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="140"
             column="26"/>
     </issue>
@@ -2570,7 +2570,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, @Nullable final TContext context, @Nullable StringCache keyCache, @Nullable StringCache valuesCache) {"
         errorLine2="                         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="145"
             column="26"/>
     </issue>
@@ -2581,7 +2581,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, final TContext context, final char[] tmp) {"
         errorLine2="                         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="150"
             column="26"/>
     </issue>
@@ -2592,7 +2592,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, final TContext context, final char[] tmp) {"
         errorLine2="                                                                      ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="150"
             column="71"/>
     </issue>
@@ -2603,7 +2603,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, final int length, final TContext context) {"
         errorLine2="                         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="158"
             column="26"/>
     </issue>
@@ -2614,7 +2614,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, final int length, final TContext context, final char[] tmp) {"
         errorLine2="                         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="163"
             column="26"/>
     </issue>
@@ -2625,7 +2625,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, final int length, final TContext context, final char[] tmp) {"
         errorLine2="                                                                                        ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="163"
             column="89"/>
     </issue>
@@ -2636,7 +2636,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, final int length, @Nullable final TContext context, final char[] tmp, @Nullable final StringCache keyCache, @Nullable final StringCache valuesCache) {"
         errorLine2="                         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="168"
             column="26"/>
     </issue>
@@ -2647,7 +2647,7 @@
         errorLine1=" public JsonReader(final byte[] buffer, final int length, @Nullable final TContext context, final char[] tmp, @Nullable final StringCache keyCache, @Nullable final StringCache valuesCache) {"
         errorLine2="                                                                                                  ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="168"
             column="99"/>
     </issue>
@@ -2658,7 +2658,7 @@
         errorLine1=" public final void reset(final InputStream stream) throws IOException {"
         errorLine2="                               ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="211"
             column="32"/>
     </issue>
@@ -2669,7 +2669,7 @@
         errorLine1=" public final JsonReader&lt;TContext> process(@Nullable final InputStream stream) throws IOException {"
         errorLine2="              ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="246"
             column="15"/>
     </issue>
@@ -2680,7 +2680,7 @@
         errorLine1=" public final JsonReader&lt;TContext> process(@Nullable final byte[] newBuffer, final int newLength) {"
         errorLine2="              ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="268"
             column="15"/>
     </issue>
@@ -2691,7 +2691,7 @@
         errorLine1=" public String positionDescription() {"
         errorLine2="        ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="373"
             column="9"/>
     </issue>
@@ -2702,7 +2702,7 @@
         errorLine1=" public String positionDescription(int offset) {"
         errorLine2="        ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="377"
             column="9"/>
     </issue>
@@ -2713,7 +2713,7 @@
         errorLine1=" public final ParsingException newParseError(final String description) {"
         errorLine2="              ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="410"
             column="15"/>
     </issue>
@@ -2724,7 +2724,7 @@
         errorLine1=" public final ParsingException newParseError(final String description) {"
         errorLine2="                                                   ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="410"
             column="52"/>
     </issue>
@@ -2735,7 +2735,7 @@
         errorLine1=" public final ParsingException newParseError(final String description, final int positionOffset) {"
         errorLine2="              ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="414"
             column="15"/>
     </issue>
@@ -2746,7 +2746,7 @@
         errorLine1=" public final ParsingException newParseError(final String description, final int positionOffset) {"
         errorLine2="                                                   ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="414"
             column="52"/>
     </issue>
@@ -2757,7 +2757,7 @@
         errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset) {"
         errorLine2="              ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="426"
             column="15"/>
     </issue>
@@ -2768,7 +2768,7 @@
         errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset) {"
         errorLine2="                                                     ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="426"
             column="54"/>
     </issue>
@@ -2779,7 +2779,7 @@
         errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset, final Exception cause) {"
         errorLine2="              ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="437"
             column="15"/>
     </issue>
@@ -2790,7 +2790,7 @@
         errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset, final Exception cause) {"
         errorLine2="                                                     ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="437"
             column="54"/>
     </issue>
@@ -2801,7 +2801,7 @@
         errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset, final Exception cause) {"
         errorLine2="                                                                                                         ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="437"
             column="106"/>
     </issue>
@@ -2812,7 +2812,7 @@
         errorLine1=" public final ParsingException newParseErrorFormat(final String shortDescription, final int positionOffset, final String longDescriptionFormat, Object... arguments) {"
         errorLine2="              ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="456"
             column="15"/>
     </issue>
@@ -2823,7 +2823,7 @@
         errorLine1=" public final ParsingException newParseErrorFormat(final String shortDescription, final int positionOffset, final String longDescriptionFormat, Object... arguments) {"
         errorLine2="                                                         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="456"
             column="58"/>
     </issue>
@@ -2834,7 +2834,7 @@
         errorLine1=" public final ParsingException newParseErrorFormat(final String shortDescription, final int positionOffset, final String longDescriptionFormat, Object... arguments) {"
         errorLine2="                                                                                                                  ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="456"
             column="115"/>
     </issue>
@@ -2845,7 +2845,7 @@
         errorLine1=" public final ParsingException newParseErrorFormat(final String shortDescription, final int positionOffset, final String longDescriptionFormat, Object... arguments) {"
         errorLine2="                                                                                                                                                ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="456"
             column="145"/>
     </issue>
@@ -2856,7 +2856,7 @@
         errorLine1=" public final ParsingException newParseErrorWith("
         errorLine2="              ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="466"
             column="15"/>
     </issue>
@@ -2867,7 +2867,7 @@
         errorLine1="   final String description, @Nullable Object argument) {"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="467"
             column="10"/>
     </issue>
@@ -2878,7 +2878,7 @@
         errorLine1=" public final ParsingException newParseErrorWith("
         errorLine2="              ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="471"
             column="15"/>
     </issue>
@@ -2889,7 +2889,7 @@
         errorLine1="   final String shortDescription,"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="472"
             column="10"/>
     </issue>
@@ -2900,7 +2900,7 @@
         errorLine1="   final String longDescriptionPrefix,"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="474"
             column="10"/>
     </issue>
@@ -2911,7 +2911,7 @@
         errorLine1="   final String longDescriptionMessage, @Nullable Object argument,"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="475"
             column="10"/>
     </issue>
@@ -2922,7 +2922,7 @@
         errorLine1="   final String longDescriptionSuffix) {"
         errorLine2="         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="476"
             column="10"/>
     </issue>
@@ -2933,7 +2933,7 @@
         errorLine1=" public final char[] readNumber() {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="507"
             column="15"/>
     </issue>
@@ -2944,7 +2944,7 @@
         errorLine1=" public final String readSimpleString() throws ParsingException {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="575"
             column="15"/>
     </issue>
@@ -2955,7 +2955,7 @@
         errorLine1=" public final char[] readSimpleQuote() throws ParsingException {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="600"
             column="15"/>
     </issue>
@@ -2966,7 +2966,7 @@
         errorLine1=" public final String readString() throws IOException {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="626"
             column="15"/>
     </issue>
@@ -2977,7 +2977,7 @@
         errorLine1=" public final StringBuilder appendString(StringBuilder builder) throws IOException {"
         errorLine2="              ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="631"
             column="15"/>
     </issue>
@@ -2988,7 +2988,7 @@
         errorLine1=" public final StringBuilder appendString(StringBuilder builder) throws IOException {"
         errorLine2="                                         ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="631"
             column="42"/>
     </issue>
@@ -2999,7 +2999,7 @@
         errorLine1=" public final StringBuffer appendString(StringBuffer buffer) throws IOException {"
         errorLine2="              ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="637"
             column="15"/>
     </issue>
@@ -3010,7 +3010,7 @@
         errorLine1=" public final StringBuffer appendString(StringBuffer buffer) throws IOException {"
         errorLine2="                                        ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="637"
             column="41"/>
     </issue>
@@ -3021,7 +3021,7 @@
         errorLine1=" public final boolean wasLastName(final String name) {"
         errorLine2="                                        ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1059"
             column="41"/>
     </issue>
@@ -3032,7 +3032,7 @@
         errorLine1=" public final boolean wasLastName(final byte[] name) {"
         errorLine2="                                        ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1083"
             column="41"/>
     </issue>
@@ -3043,7 +3043,7 @@
         errorLine1=" public final String getLastName() throws IOException {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1106"
             column="15"/>
     </issue>
@@ -3054,7 +3054,7 @@
         errorLine1=" public String readNext() throws IOException {"
         errorLine2="        ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1192"
             column="9"/>
     </issue>
@@ -3065,7 +3065,7 @@
         errorLine1=" public final byte[] readBase64() throws IOException {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1198"
             column="15"/>
     </issue>
@@ -3076,7 +3076,7 @@
         errorLine1=" public final String readKey() throws IOException {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1222"
             column="15"/>
     </issue>
@@ -3087,7 +3087,7 @@
         errorLine1="  T read(JsonReader reader) throws IOException;"
         errorLine2="         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1238"
             column="10"/>
     </issue>
@@ -3098,7 +3098,7 @@
         errorLine1="  T bind(JsonReader reader, T instance) throws IOException;"
         errorLine2="         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1248"
             column="10"/>
     </issue>
@@ -3109,7 +3109,7 @@
         errorLine1="  T deserialize(JsonReader reader) throws IOException;"
         errorLine2="                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1253"
             column="17"/>
     </issue>
@@ -3120,7 +3120,7 @@
         errorLine1=" public final void startAttribute(final String name) throws IOException {"
         errorLine2="                                        ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1392"
             column="41"/>
     </issue>
@@ -3131,7 +3131,7 @@
         errorLine1=" public final &lt;T> T next(final Class&lt;T> manifest) throws IOException {"
         errorLine2="                               ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1452"
             column="32"/>
     </issue>
@@ -3142,7 +3142,7 @@
         errorLine1=" public final &lt;T> T next(final ReadObject&lt;T> reader) throws IOException {"
         errorLine2="                               ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1474"
             column="32"/>
     </issue>
@@ -3153,7 +3153,7 @@
         errorLine1=" public final &lt;T> T next(final Class&lt;T> manifest, final T instance) throws IOException {"
         errorLine2="                               ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1494"
             column="32"/>
     </issue>
@@ -3164,7 +3164,7 @@
         errorLine1=" public final &lt;T> T next(final BindObject&lt;T> binder, final T instance) throws IOException {"
         errorLine2="                               ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1517"
             column="32"/>
     </issue>
@@ -3175,7 +3175,7 @@
         errorLine1=" public final &lt;T> ArrayList&lt;T> readCollection(final ReadObject&lt;T> readObject) throws IOException {"
         errorLine2="                                                    ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1528"
             column="53"/>
     </issue>
@@ -3186,7 +3186,7 @@
         errorLine1=" public final &lt;T> LinkedHashSet&lt;T> readSet(final ReadObject&lt;T> readObject) throws IOException {"
         errorLine2="                                                 ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1543"
             column="50"/>
     </issue>
@@ -3197,7 +3197,7 @@
         errorLine1=" public final &lt;K, V> LinkedHashMap&lt;K, V> readMap(final ReadObject&lt;K> readKey, final ReadObject&lt;V> readValue) throws IOException {"
         errorLine2="                                                       ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1558"
             column="56"/>
     </issue>
@@ -3208,7 +3208,7 @@
         errorLine1=" public final &lt;K, V> LinkedHashMap&lt;K, V> readMap(final ReadObject&lt;K> readKey, final ReadObject&lt;V> readValue) throws IOException {"
         errorLine2="                                                                                    ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1558"
             column="85"/>
     </issue>
@@ -3219,7 +3219,7 @@
         errorLine1=" public final &lt;T> T[] readArray(final ReadObject&lt;T> readObject, final T[] emptyArray) throws IOException {"
         errorLine2="                                      ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1583"
             column="39"/>
     </issue>
@@ -3230,7 +3230,7 @@
         errorLine1=" public final &lt;T> T[] readArray(final ReadObject&lt;T> readObject, final T[] emptyArray) throws IOException {"
         errorLine2="                                                                      ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1583"
             column="71"/>
     </issue>
@@ -3241,7 +3241,7 @@
         errorLine1=" public final &lt;T, S extends T> ArrayList&lt;T> deserializeCollection(final ReadObject&lt;S> readObject) throws IOException {"
         errorLine2="                               ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1597"
             column="32"/>
     </issue>
@@ -3252,7 +3252,7 @@
         errorLine1=" public final &lt;T, S extends T> ArrayList&lt;T> deserializeCollection(final ReadObject&lt;S> readObject) throws IOException {"
         errorLine2="                                                                        ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1597"
             column="73"/>
     </issue>
@@ -3263,7 +3263,7 @@
         errorLine1=" public final &lt;T, S extends T> void deserializeCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1603"
             column="65"/>
     </issue>
@@ -3274,7 +3274,7 @@
         errorLine1=" public final &lt;T, S extends T> void deserializeCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                                                ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1603"
             column="97"/>
     </issue>
@@ -3285,7 +3285,7 @@
         errorLine1=" public final &lt;T, S extends T> ArrayList&lt;T> deserializeNullableCollection(final ReadObject&lt;S> readObject) throws IOException {"
         errorLine2="                               ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1612"
             column="32"/>
     </issue>
@@ -3296,7 +3296,7 @@
         errorLine1=" public final &lt;T, S extends T> ArrayList&lt;T> deserializeNullableCollection(final ReadObject&lt;S> readObject) throws IOException {"
         errorLine2="                                                                                ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1612"
             column="81"/>
     </issue>
@@ -3307,7 +3307,7 @@
         errorLine1=" public final &lt;T, S extends T> void deserializeNullableCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                        ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1618"
             column="73"/>
     </issue>
@@ -3318,7 +3318,7 @@
         errorLine1=" public final &lt;T, S extends T> void deserializeNullableCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                                                        ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1618"
             column="105"/>
     </issue>
@@ -3329,7 +3329,7 @@
         errorLine1=" public final &lt;T extends JsonObject> ArrayList&lt;T> deserializeCollection(final ReadJsonObject&lt;T> readObject) throws IOException {"
         errorLine2="                                     ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1635"
             column="38"/>
     </issue>
@@ -3340,7 +3340,7 @@
         errorLine1=" public final &lt;T extends JsonObject> ArrayList&lt;T> deserializeCollection(final ReadJsonObject&lt;T> readObject) throws IOException {"
         errorLine2="                                                                              ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1635"
             column="79"/>
     </issue>
@@ -3351,7 +3351,7 @@
         errorLine1=" public final &lt;T extends JsonObject> void deserializeCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                      ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1641"
             column="71"/>
     </issue>
@@ -3362,7 +3362,7 @@
         errorLine1=" public final &lt;T extends JsonObject> void deserializeCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                                                          ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1641"
             column="107"/>
     </issue>
@@ -3373,7 +3373,7 @@
         errorLine1=" public final &lt;T extends JsonObject> ArrayList&lt;T> deserializeNullableCollection(final ReadJsonObject&lt;T> readObject) throws IOException {"
         errorLine2="                                     ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1655"
             column="38"/>
     </issue>
@@ -3384,7 +3384,7 @@
         errorLine1=" public final &lt;T extends JsonObject> ArrayList&lt;T> deserializeNullableCollection(final ReadJsonObject&lt;T> readObject) throws IOException {"
         errorLine2="                                                                                      ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1655"
             column="87"/>
     </issue>
@@ -3395,7 +3395,7 @@
         errorLine1=" public final &lt;T extends JsonObject> void deserializeNullableCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                              ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1661"
             column="79"/>
     </issue>
@@ -3406,7 +3406,7 @@
         errorLine1=" public final &lt;T extends JsonObject> void deserializeNullableCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
         errorLine2="                                                                                                                  ~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1661"
             column="115"/>
     </issue>
@@ -3417,7 +3417,7 @@
         errorLine1=" public final &lt;T> Iterator&lt;T> iterateOver(final JsonReader.ReadObject&lt;T> reader) {"
         errorLine2="                  ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1679"
             column="19"/>
     </issue>
@@ -3428,7 +3428,7 @@
         errorLine1=" public final &lt;T> Iterator&lt;T> iterateOver(final JsonReader.ReadObject&lt;T> reader) {"
         errorLine2="                                                ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1679"
             column="49"/>
     </issue>
@@ -3439,7 +3439,7 @@
         errorLine1=" public final &lt;T extends JsonObject> Iterator&lt;T> iterateOver(final JsonReader.ReadJsonObject&lt;T> reader) {"
         errorLine2="                                     ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1683"
             column="38"/>
     </issue>
@@ -3450,7 +3450,7 @@
         errorLine1=" public final &lt;T extends JsonObject> Iterator&lt;T> iterateOver(final JsonReader.ReadJsonObject&lt;T> reader) {"
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonReader.java"
             line="1683"
             column="68"/>
     </issue>
@@ -3461,7 +3461,7 @@
         errorLine1=" public final void writeString(final String value) {"
         errorLine2="                                     ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="159"
             column="38"/>
     </issue>
@@ -3472,7 +3472,7 @@
         errorLine1=" public final void writeString(final CharSequence value) {"
         errorLine2="                                     ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="186"
             column="38"/>
     </issue>
@@ -3483,7 +3483,7 @@
         errorLine1=" public final void writeAscii(final String value) {"
         errorLine2="                                    ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="387"
             column="37"/>
     </issue>
@@ -3494,7 +3494,7 @@
         errorLine1=" public final void writeAscii(final String value, final int len) {"
         errorLine2="                                    ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="404"
             column="37"/>
     </issue>
@@ -3505,7 +3505,7 @@
         errorLine1=" public final void writeAscii(final byte[] buf) {"
         errorLine2="                                    ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="418"
             column="37"/>
     </issue>
@@ -3516,7 +3516,7 @@
         errorLine1=" public final void writeAscii(final byte[] buf, final int len) {"
         errorLine2="                                    ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="438"
             column="37"/>
     </issue>
@@ -3527,7 +3527,7 @@
         errorLine1=" public final void writeRaw(final byte[] buf, final int offset, final int len) {"
         errorLine2="                                  ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="458"
             column="35"/>
     </issue>
@@ -3538,7 +3538,7 @@
         errorLine1=" public final void writeBinary(final byte[] value) {"
         errorLine2="                                     ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="472"
             column="38"/>
     </issue>
@@ -3549,7 +3549,7 @@
         errorLine1=" public final byte[] toByteArray() {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="516"
             column="15"/>
     </issue>
@@ -3560,7 +3560,7 @@
         errorLine1=" public final void toStream(final OutputStream stream) throws IOException {"
         errorLine2="                                  ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="530"
             column="35"/>
     </issue>
@@ -3571,7 +3571,7 @@
         errorLine1=" public final byte[] getByteBuffer() {"
         errorLine2="              ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="545"
             column="15"/>
     </issue>
@@ -3582,7 +3582,7 @@
         errorLine1="  void write(JsonWriter writer, @Nullable T value);"
         errorLine2="             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="628"
             column="14"/>
     </issue>
@@ -3593,7 +3593,7 @@
         errorLine1=" public &lt;T extends JsonObject> void serialize(final T[] array) {"
         errorLine2="                                                    ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="638"
             column="53"/>
     </issue>
@@ -3604,7 +3604,7 @@
         errorLine1=" public &lt;T extends JsonObject> void serialize(final T[] array, final int len) {"
         errorLine2="                                                    ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="659"
             column="53"/>
     </issue>
@@ -3615,7 +3615,7 @@
         errorLine1=" public &lt;T extends JsonObject> void serialize(final List&lt;T> list) {"
         errorLine2="                                                    ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="681"
             column="53"/>
     </issue>
@@ -3626,7 +3626,7 @@
         errorLine1=" public &lt;T> void serialize(@Nullable final T[] array, final WriteObject&lt;T> encoder) {"
         errorLine2="                                                            ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="702"
             column="61"/>
     </issue>
@@ -3637,7 +3637,7 @@
         errorLine1=" public &lt;T> void serialize(@Nullable final List&lt;T> list, final WriteObject&lt;T> encoder) {"
         errorLine2="                                                               ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="740"
             column="64"/>
     </issue>
@@ -3648,7 +3648,7 @@
         errorLine1=" public void serializeRaw(@Nullable final List list, final WriteObject encoder) {"
         errorLine2="                                                           ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="785"
             column="60"/>
     </issue>
@@ -3659,7 +3659,7 @@
         errorLine1=" public &lt;T> void serialize(@Nullable final Collection&lt;T> collection, final WriteObject&lt;T> encoder) {"
         errorLine2="                                                                           ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="798"
             column="76"/>
     </issue>
@@ -3670,7 +3670,7 @@
         errorLine1=" public void serializeRaw(@Nullable final Collection collection, final WriteObject encoder) {"
         errorLine2="                                                                       ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="825"
             column="72"/>
     </issue>
@@ -3681,7 +3681,7 @@
         errorLine1=" public &lt;K, V> void serialize(@Nullable final Map&lt;K, V> map, final WriteObject&lt;K> keyEncoder, final WriteObject&lt;V> valueEncoder) {"
         errorLine2="                                                                   ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="829"
             column="68"/>
     </issue>
@@ -3692,7 +3692,7 @@
         errorLine1=" public &lt;K, V> void serialize(@Nullable final Map&lt;K, V> map, final WriteObject&lt;K> keyEncoder, final WriteObject&lt;V> valueEncoder) {"
         errorLine2="                                                                                                    ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="829"
             column="101"/>
     </issue>
@@ -3703,7 +3703,7 @@
         errorLine1=" public void serializeRaw(@Nullable final Map map, final WriteObject keyEncoder, final WriteObject valueEncoder) {"
         errorLine2="                                                         ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="853"
             column="58"/>
     </issue>
@@ -3714,7 +3714,7 @@
         errorLine1=" public void serializeRaw(@Nullable final Map map, final WriteObject keyEncoder, final WriteObject valueEncoder) {"
         errorLine2="                                                                                       ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="853"
             column="88"/>
     </issue>
@@ -3725,7 +3725,7 @@
         errorLine1=" public &lt;T> void writeQuoted(final JsonWriter.WriteObject&lt;T> keyWriter, final T key) {"
         errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/JsonWriter.java"
             line="857"
             column="36"/>
     </issue>
@@ -3736,7 +3736,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final Map&lt;String, String> value, final JsonWriter sw) {"
         errorLine2="                                                                                       ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="19"
             column="88"/>
     </issue>
@@ -3747,7 +3747,7 @@
         errorLine1=" public static void serialize(final Map&lt;String, String> value, final JsonWriter sw) {"
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="27"
             column="37"/>
     </issue>
@@ -3758,7 +3758,7 @@
         errorLine1=" public static void serialize(final Map&lt;String, String> value, final JsonWriter sw) {"
         errorLine2="                                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="27"
             column="70"/>
     </issue>
@@ -3769,7 +3769,7 @@
         errorLine1=" public static Map&lt;String, String> deserialize(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="47"
             column="16"/>
     </issue>
@@ -3780,7 +3780,7 @@
         errorLine1=" public static Map&lt;String, String> deserialize(final JsonReader reader) throws IOException {"
         errorLine2="                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="47"
             column="54"/>
     </issue>
@@ -3791,7 +3791,7 @@
         errorLine1=" public static ArrayList&lt;Map&lt;String, String>> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="72"
             column="16"/>
     </issue>
@@ -3802,7 +3802,7 @@
         errorLine1=" public static ArrayList&lt;Map&lt;String, String>> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                          ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="72"
             column="75"/>
     </issue>
@@ -3813,7 +3813,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Map&lt;String, String>> res) throws IOException {"
         errorLine2="                                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="76"
             column="49"/>
     </issue>
@@ -3824,7 +3824,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Map&lt;String, String>> res) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="76"
             column="74"/>
     </issue>
@@ -3835,7 +3835,7 @@
         errorLine1=" public static ArrayList&lt;Map&lt;String, String>> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="81"
             column="16"/>
     </issue>
@@ -3846,7 +3846,7 @@
         errorLine1=" public static ArrayList&lt;Map&lt;String, String>> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                                  ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="81"
             column="83"/>
     </issue>
@@ -3857,7 +3857,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Map&lt;String, String>> res) throws IOException {"
         errorLine2="                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="85"
             column="57"/>
     </issue>
@@ -3868,7 +3868,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Map&lt;String, String>> res) throws IOException {"
         errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/MapConverter.java"
             line="85"
             column="82"/>
     </issue>
@@ -3879,7 +3879,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final URI value, final JsonWriter sw) {"
         errorLine2="                                                                       ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="41"
             column="72"/>
     </issue>
@@ -3890,7 +3890,7 @@
         errorLine1=" public static void serialize(final URI value, final JsonWriter sw) {"
         errorLine2="                                    ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="49"
             column="37"/>
     </issue>
@@ -3901,7 +3901,7 @@
         errorLine1=" public static void serialize(final URI value, final JsonWriter sw) {"
         errorLine2="                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="49"
             column="54"/>
     </issue>
@@ -3912,7 +3912,7 @@
         errorLine1=" public static URI deserializeUri(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="53"
             column="16"/>
     </issue>
@@ -3923,7 +3923,7 @@
         errorLine1=" public static URI deserializeUri(final JsonReader reader) throws IOException {"
         errorLine2="                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="53"
             column="41"/>
     </issue>
@@ -3934,7 +3934,7 @@
         errorLine1=" public static ArrayList&lt;URI> deserializeUriCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="58"
             column="16"/>
     </issue>
@@ -3945,7 +3945,7 @@
         errorLine1=" public static ArrayList&lt;URI> deserializeUriCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="58"
             column="62"/>
     </issue>
@@ -3956,7 +3956,7 @@
         errorLine1=" public static void deserializeUriCollection(final JsonReader reader, final Collection&lt;URI> res) throws IOException {"
         errorLine2="                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="62"
             column="52"/>
     </issue>
@@ -3967,7 +3967,7 @@
         errorLine1=" public static void deserializeUriCollection(final JsonReader reader, final Collection&lt;URI> res) throws IOException {"
         errorLine2="                                                                            ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="62"
             column="77"/>
     </issue>
@@ -3978,7 +3978,7 @@
         errorLine1=" public static ArrayList&lt;URI> deserializeUriNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="67"
             column="16"/>
     </issue>
@@ -3989,7 +3989,7 @@
         errorLine1=" public static ArrayList&lt;URI> deserializeUriNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="67"
             column="70"/>
     </issue>
@@ -4000,7 +4000,7 @@
         errorLine1=" public static void deserializeUriNullableCollection(final JsonReader reader, final Collection&lt;URI> res) throws IOException {"
         errorLine2="                                                           ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="71"
             column="60"/>
     </issue>
@@ -4011,7 +4011,7 @@
         errorLine1=" public static void deserializeUriNullableCollection(final JsonReader reader, final Collection&lt;URI> res) throws IOException {"
         errorLine2="                                                                                    ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="71"
             column="85"/>
     </issue>
@@ -4022,7 +4022,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final InetAddress value, final JsonWriter sw) {"
         errorLine2="                                                                               ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="75"
             column="80"/>
     </issue>
@@ -4033,7 +4033,7 @@
         errorLine1=" public static void serialize(final InetAddress value, final JsonWriter sw) {"
         errorLine2="                                    ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="83"
             column="37"/>
     </issue>
@@ -4044,7 +4044,7 @@
         errorLine1=" public static void serialize(final InetAddress value, final JsonWriter sw) {"
         errorLine2="                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="83"
             column="62"/>
     </issue>
@@ -4055,7 +4055,7 @@
         errorLine1=" public static InetAddress deserializeIp(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="89"
             column="16"/>
     </issue>
@@ -4066,7 +4066,7 @@
         errorLine1=" public static InetAddress deserializeIp(final JsonReader reader) throws IOException {"
         errorLine2="                                               ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="89"
             column="48"/>
     </issue>
@@ -4077,7 +4077,7 @@
         errorLine1=" public static ArrayList&lt;InetAddress> deserializeIpCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="94"
             column="16"/>
     </issue>
@@ -4088,7 +4088,7 @@
         errorLine1=" public static ArrayList&lt;InetAddress> deserializeIpCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="94"
             column="69"/>
     </issue>
@@ -4099,7 +4099,7 @@
         errorLine1=" public static void deserializeIpCollection(final JsonReader reader, final Collection&lt;InetAddress> res) throws IOException {"
         errorLine2="                                                  ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="98"
             column="51"/>
     </issue>
@@ -4110,7 +4110,7 @@
         errorLine1=" public static void deserializeIpCollection(final JsonReader reader, final Collection&lt;InetAddress> res) throws IOException {"
         errorLine2="                                                                           ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="98"
             column="76"/>
     </issue>
@@ -4121,7 +4121,7 @@
         errorLine1=" public static ArrayList&lt;InetAddress> deserializeIpNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="103"
             column="16"/>
     </issue>
@@ -4132,7 +4132,7 @@
         errorLine1=" public static ArrayList&lt;InetAddress> deserializeIpNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                            ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="103"
             column="77"/>
     </issue>
@@ -4143,7 +4143,7 @@
         errorLine1=" public static void deserializeIpNullableCollection(final JsonReader reader, final Collection&lt;InetAddress> res) throws IOException {"
         errorLine2="                                                          ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="107"
             column="59"/>
     </issue>
@@ -4154,7 +4154,7 @@
         errorLine1=" public static void deserializeIpNullableCollection(final JsonReader reader, final Collection&lt;InetAddress> res) throws IOException {"
         errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NetConverter.java"
             line="107"
             column="84"/>
     </issue>
@@ -4165,7 +4165,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final Double value, final JsonWriter sw) {"
         errorLine2="                                                                          ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="303"
             column="75"/>
     </issue>
@@ -4176,7 +4176,7 @@
         errorLine1=" public static void serialize(final double value, final JsonWriter sw) {"
         errorLine2="                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="330"
             column="57"/>
     </issue>
@@ -4187,7 +4187,7 @@
         errorLine1=" public static void serialize(@Nullable final double[] value, final JsonWriter sw) {"
         errorLine2="                                                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="334"
             column="69"/>
     </issue>
@@ -4198,7 +4198,7 @@
         errorLine1=" public static double deserializeDouble(final JsonReader reader) throws IOException {"
         errorLine2="                                              ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="380"
             column="47"/>
     </issue>
@@ -4209,7 +4209,7 @@
         errorLine1=" public static ArrayList&lt;Double> deserializeDoubleCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="572"
             column="16"/>
     </issue>
@@ -4220,7 +4220,7 @@
         errorLine1=" public static ArrayList&lt;Double> deserializeDoubleCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="572"
             column="68"/>
     </issue>
@@ -4231,7 +4231,7 @@
         errorLine1=" public static void deserializeDoubleCollection(final JsonReader reader, final Collection&lt;Double> res) throws IOException {"
         errorLine2="                                                      ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="576"
             column="55"/>
     </issue>
@@ -4242,7 +4242,7 @@
         errorLine1=" public static void deserializeDoubleCollection(final JsonReader reader, final Collection&lt;Double> res) throws IOException {"
         errorLine2="                                                                               ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="576"
             column="80"/>
     </issue>
@@ -4253,7 +4253,7 @@
         errorLine1=" public static ArrayList&lt;Double> deserializeDoubleNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="581"
             column="16"/>
     </issue>
@@ -4264,7 +4264,7 @@
         errorLine1=" public static ArrayList&lt;Double> deserializeDoubleNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                           ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="581"
             column="76"/>
     </issue>
@@ -4275,7 +4275,7 @@
         errorLine1=" public static void deserializeDoubleNullableCollection(final JsonReader reader, final Collection&lt;Double> res) throws IOException {"
         errorLine2="                                                              ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="585"
             column="63"/>
     </issue>
@@ -4286,7 +4286,7 @@
         errorLine1=" public static void deserializeDoubleNullableCollection(final JsonReader reader, final Collection&lt;Double> res) throws IOException {"
         errorLine2="                                                                                       ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="585"
             column="88"/>
     </issue>
@@ -4297,7 +4297,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final Float value, final JsonWriter sw) {"
         errorLine2="                                                                         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="589"
             column="74"/>
     </issue>
@@ -4308,7 +4308,7 @@
         errorLine1=" public static void serialize(final float value, final JsonWriter sw) {"
         errorLine2="                                                       ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="597"
             column="56"/>
     </issue>
@@ -4319,7 +4319,7 @@
         errorLine1=" public static void serialize(@Nullable final float[] value, final JsonWriter sw) {"
         errorLine2="                                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="609"
             column="68"/>
     </issue>
@@ -4330,7 +4330,7 @@
         errorLine1=" public static float deserializeFloat(final JsonReader reader) throws IOException {"
         errorLine2="                                            ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="625"
             column="45"/>
     </issue>
@@ -4341,7 +4341,7 @@
         errorLine1=" public static ArrayList&lt;Float> deserializeFloatCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="774"
             column="16"/>
     </issue>
@@ -4352,7 +4352,7 @@
         errorLine1=" public static ArrayList&lt;Float> deserializeFloatCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                 ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="774"
             column="66"/>
     </issue>
@@ -4363,7 +4363,7 @@
         errorLine1=" public static void deserializeFloatCollection(final JsonReader reader, Collection&lt;Float> res) throws IOException {"
         errorLine2="                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="778"
             column="54"/>
     </issue>
@@ -4374,7 +4374,7 @@
         errorLine1=" public static void deserializeFloatCollection(final JsonReader reader, Collection&lt;Float> res) throws IOException {"
         errorLine2="                                                                        ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="778"
             column="73"/>
     </issue>
@@ -4385,7 +4385,7 @@
         errorLine1=" public static ArrayList&lt;Float> deserializeFloatNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="783"
             column="16"/>
     </issue>
@@ -4396,7 +4396,7 @@
         errorLine1=" public static ArrayList&lt;Float> deserializeFloatNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="783"
             column="74"/>
     </issue>
@@ -4407,7 +4407,7 @@
         errorLine1=" public static void deserializeFloatNullableCollection(final JsonReader reader, final Collection&lt;Float> res) throws IOException {"
         errorLine2="                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="787"
             column="62"/>
     </issue>
@@ -4418,7 +4418,7 @@
         errorLine1=" public static void deserializeFloatNullableCollection(final JsonReader reader, final Collection&lt;Float> res) throws IOException {"
         errorLine2="                                                                                      ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="787"
             column="87"/>
     </issue>
@@ -4429,7 +4429,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final Integer value, final JsonWriter sw) {"
         errorLine2="                                                                           ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="791"
             column="76"/>
     </issue>
@@ -4440,7 +4440,7 @@
         errorLine1=" public static void serialize(final int value, final JsonWriter sw) {"
         errorLine2="                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="802"
             column="54"/>
     </issue>
@@ -4451,7 +4451,7 @@
         errorLine1=" public static void serialize(@Nullable final int[] values, final JsonWriter sw) {"
         errorLine2="                                                                  ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="854"
             column="67"/>
     </issue>
@@ -4462,7 +4462,7 @@
         errorLine1=" public static void serialize(@Nullable final short[] value, final JsonWriter sw) {"
         errorLine2="                                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="873"
             column="68"/>
     </issue>
@@ -4473,7 +4473,7 @@
         errorLine1=" public static short deserializeShort(final JsonReader reader) throws IOException {"
         errorLine2="                                            ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="889"
             column="45"/>
     </issue>
@@ -4484,7 +4484,7 @@
         errorLine1=" public static int deserializeInt(final JsonReader reader) throws IOException {"
         errorLine2="                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="912"
             column="41"/>
     </issue>
@@ -4495,7 +4495,7 @@
         errorLine1=" public static ArrayList&lt;Integer> deserializeIntCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="983"
             column="16"/>
     </issue>
@@ -4506,7 +4506,7 @@
         errorLine1=" public static ArrayList&lt;Integer> deserializeIntCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                 ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="983"
             column="66"/>
     </issue>
@@ -4517,7 +4517,7 @@
         errorLine1=" public static int[] deserializeIntArray(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="987"
             column="16"/>
     </issue>
@@ -4528,7 +4528,7 @@
         errorLine1=" public static int[] deserializeIntArray(final JsonReader reader) throws IOException {"
         errorLine2="                                               ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="987"
             column="48"/>
     </issue>
@@ -4539,7 +4539,7 @@
         errorLine1=" public static short[] deserializeShortArray(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1005"
             column="16"/>
     </issue>
@@ -4550,7 +4550,7 @@
         errorLine1=" public static short[] deserializeShortArray(final JsonReader reader) throws IOException {"
         errorLine2="                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1005"
             column="52"/>
     </issue>
@@ -4561,7 +4561,7 @@
         errorLine1=" public static long[] deserializeLongArray(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1023"
             column="16"/>
     </issue>
@@ -4572,7 +4572,7 @@
         errorLine1=" public static long[] deserializeLongArray(final JsonReader reader) throws IOException {"
         errorLine2="                                                 ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1023"
             column="50"/>
     </issue>
@@ -4583,7 +4583,7 @@
         errorLine1=" public static float[] deserializeFloatArray(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1041"
             column="16"/>
     </issue>
@@ -4594,7 +4594,7 @@
         errorLine1=" public static float[] deserializeFloatArray(final JsonReader reader) throws IOException {"
         errorLine2="                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1041"
             column="52"/>
     </issue>
@@ -4605,7 +4605,7 @@
         errorLine1=" public static double[] deserializeDoubleArray(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1059"
             column="16"/>
     </issue>
@@ -4616,7 +4616,7 @@
         errorLine1=" public static double[] deserializeDoubleArray(final JsonReader reader) throws IOException {"
         errorLine2="                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1059"
             column="54"/>
     </issue>
@@ -4627,7 +4627,7 @@
         errorLine1=" public static void deserializeShortCollection(final JsonReader reader, final Collection&lt;Short> res) throws IOException {"
         errorLine2="                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1077"
             column="54"/>
     </issue>
@@ -4638,7 +4638,7 @@
         errorLine1=" public static void deserializeShortCollection(final JsonReader reader, final Collection&lt;Short> res) throws IOException {"
         errorLine2="                                                                              ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1077"
             column="79"/>
     </issue>
@@ -4649,7 +4649,7 @@
         errorLine1=" public static ArrayList&lt;Short> deserializeShortNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1082"
             column="16"/>
     </issue>
@@ -4660,7 +4660,7 @@
         errorLine1=" public static ArrayList&lt;Short> deserializeShortNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1082"
             column="74"/>
     </issue>
@@ -4671,7 +4671,7 @@
         errorLine1=" public static void deserializeShortNullableCollection(final JsonReader reader, final Collection&lt;Short> res) throws IOException {"
         errorLine2="                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1086"
             column="62"/>
     </issue>
@@ -4682,7 +4682,7 @@
         errorLine1=" public static void deserializeShortNullableCollection(final JsonReader reader, final Collection&lt;Short> res) throws IOException {"
         errorLine2="                                                                                      ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1086"
             column="87"/>
     </issue>
@@ -4693,7 +4693,7 @@
         errorLine1=" public static void deserializeIntCollection(final JsonReader reader, final Collection&lt;Integer> res) throws IOException {"
         errorLine2="                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1090"
             column="52"/>
     </issue>
@@ -4704,7 +4704,7 @@
         errorLine1=" public static void deserializeIntCollection(final JsonReader reader, final Collection&lt;Integer> res) throws IOException {"
         errorLine2="                                                                            ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1090"
             column="77"/>
     </issue>
@@ -4715,7 +4715,7 @@
         errorLine1=" public static ArrayList&lt;Integer> deserializeIntNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1095"
             column="16"/>
     </issue>
@@ -4726,7 +4726,7 @@
         errorLine1=" public static ArrayList&lt;Integer> deserializeIntNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1095"
             column="74"/>
     </issue>
@@ -4737,7 +4737,7 @@
         errorLine1=" public static void deserializeIntNullableCollection(final JsonReader reader, final Collection&lt;Integer> res) throws IOException {"
         errorLine2="                                                           ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1099"
             column="60"/>
     </issue>
@@ -4748,7 +4748,7 @@
         errorLine1=" public static void deserializeIntNullableCollection(final JsonReader reader, final Collection&lt;Integer> res) throws IOException {"
         errorLine2="                                                                                    ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1099"
             column="85"/>
     </issue>
@@ -4759,7 +4759,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final Long value, final JsonWriter sw) {"
         errorLine2="                                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1103"
             column="73"/>
     </issue>
@@ -4770,7 +4770,7 @@
         errorLine1=" public static void serialize(final long value, final JsonWriter sw) {"
         errorLine2="                                                      ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1131"
             column="55"/>
     </issue>
@@ -4781,7 +4781,7 @@
         errorLine1=" public static void serialize(@Nullable final long[] values, final JsonWriter sw) {"
         errorLine2="                                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1228"
             column="68"/>
     </issue>
@@ -4792,7 +4792,7 @@
         errorLine1=" public static long deserializeLong(final JsonReader reader) throws IOException {"
         errorLine2="                                          ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1247"
             column="43"/>
     </issue>
@@ -4803,7 +4803,7 @@
         errorLine1=" public static ArrayList&lt;Long> deserializeLongCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1319"
             column="16"/>
     </issue>
@@ -4814,7 +4814,7 @@
         errorLine1=" public static ArrayList&lt;Long> deserializeLongCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                               ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1319"
             column="64"/>
     </issue>
@@ -4825,7 +4825,7 @@
         errorLine1=" public static void deserializeLongCollection(final JsonReader reader, final Collection&lt;Long> res) throws IOException {"
         errorLine2="                                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1323"
             column="53"/>
     </issue>
@@ -4836,7 +4836,7 @@
         errorLine1=" public static void deserializeLongCollection(final JsonReader reader, final Collection&lt;Long> res) throws IOException {"
         errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1323"
             column="78"/>
     </issue>
@@ -4847,7 +4847,7 @@
         errorLine1=" public static ArrayList&lt;Long> deserializeLongNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1328"
             column="16"/>
     </issue>
@@ -4858,7 +4858,7 @@
         errorLine1=" public static ArrayList&lt;Long> deserializeLongNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                       ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1328"
             column="72"/>
     </issue>
@@ -4869,7 +4869,7 @@
         errorLine1=" public static void deserializeLongNullableCollection(final JsonReader reader, final Collection&lt;Long> res) throws IOException {"
         errorLine2="                                                            ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1332"
             column="61"/>
     </issue>
@@ -4880,7 +4880,7 @@
         errorLine1=" public static void deserializeLongNullableCollection(final JsonReader reader, final Collection&lt;Long> res) throws IOException {"
         errorLine2="                                                                                     ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1332"
             column="86"/>
     </issue>
@@ -4891,7 +4891,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final BigDecimal value, final JsonWriter sw) {"
         errorLine2="                                                                              ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1336"
             column="79"/>
     </issue>
@@ -4902,7 +4902,7 @@
         errorLine1=" public static void serialize(final BigDecimal value, final JsonWriter sw) {"
         errorLine2="                                    ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1344"
             column="37"/>
     </issue>
@@ -4913,7 +4913,7 @@
         errorLine1=" public static void serialize(final BigDecimal value, final JsonWriter sw) {"
         errorLine2="                                                            ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1344"
             column="61"/>
     </issue>
@@ -4924,7 +4924,7 @@
         errorLine1=" public static BigDecimal deserializeDecimal(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1348"
             column="16"/>
     </issue>
@@ -4935,7 +4935,7 @@
         errorLine1=" public static BigDecimal deserializeDecimal(final JsonReader reader) throws IOException {"
         errorLine2="                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1348"
             column="52"/>
     </issue>
@@ -4946,7 +4946,7 @@
         errorLine1=" public static Number deserializeNumber(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1528"
             column="16"/>
     </issue>
@@ -4957,7 +4957,7 @@
         errorLine1=" public static Number deserializeNumber(final JsonReader reader) throws IOException {"
         errorLine2="                                              ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1528"
             column="47"/>
     </issue>
@@ -4968,7 +4968,7 @@
         errorLine1=" public static ArrayList&lt;BigDecimal> deserializeDecimalCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1684"
             column="16"/>
     </issue>
@@ -4979,7 +4979,7 @@
         errorLine1=" public static ArrayList&lt;BigDecimal> deserializeDecimalCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1684"
             column="73"/>
     </issue>
@@ -4990,7 +4990,7 @@
         errorLine1=" public static void deserializeDecimalCollection(final JsonReader reader, final Collection&lt;BigDecimal> res) throws IOException {"
         errorLine2="                                                       ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1688"
             column="56"/>
     </issue>
@@ -5001,7 +5001,7 @@
         errorLine1=" public static void deserializeDecimalCollection(final JsonReader reader, final Collection&lt;BigDecimal> res) throws IOException {"
         errorLine2="                                                                                ~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1688"
             column="81"/>
     </issue>
@@ -5012,7 +5012,7 @@
         errorLine1=" public static ArrayList&lt;BigDecimal> deserializeDecimalNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1693"
             column="16"/>
     </issue>
@@ -5023,7 +5023,7 @@
         errorLine1=" public static ArrayList&lt;BigDecimal> deserializeDecimalNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1693"
             column="81"/>
     </issue>
@@ -5034,7 +5034,7 @@
         errorLine1=" public static void deserializeDecimalNullableCollection(final JsonReader reader, final Collection&lt;BigDecimal> res) throws IOException {"
         errorLine2="                                                               ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1697"
             column="64"/>
     </issue>
@@ -5045,7 +5045,7 @@
         errorLine1=" public static void deserializeDecimalNullableCollection(final JsonReader reader, final Collection&lt;BigDecimal> res) throws IOException {"
         errorLine2="                                                                                        ~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/NumberConverter.java"
             line="1697"
             column="89"/>
     </issue>
@@ -5056,7 +5056,7 @@
         errorLine1=" public static void serializeNullableMap(@Nullable final Map&lt;String, Object> value, final JsonWriter sw) {"
         errorLine2="                                                                                          ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="27"
             column="91"/>
     </issue>
@@ -5067,7 +5067,7 @@
         errorLine1=" public static void serializeMap(final Map&lt;String, Object> value, final JsonWriter sw) {"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="35"
             column="40"/>
     </issue>
@@ -5078,7 +5078,7 @@
         errorLine1=" public static void serializeMap(final Map&lt;String, Object> value, final JsonWriter sw) {"
         errorLine2="                                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="35"
             column="73"/>
     </issue>
@@ -5089,7 +5089,7 @@
         errorLine1=" public static void serializeObject(@Nullable final Object value, final JsonWriter sw) throws IOException {"
         errorLine2="                                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="55"
             column="73"/>
     </issue>
@@ -5100,7 +5100,7 @@
         errorLine1=" public static Object deserializeObject(final JsonReader reader) throws IOException {"
         errorLine2="                                              ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="60"
             column="47"/>
     </issue>
@@ -5111,7 +5111,7 @@
         errorLine1=" public static ArrayList&lt;Object> deserializeList(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="88"
             column="16"/>
     </issue>
@@ -5122,7 +5122,7 @@
         errorLine1=" public static ArrayList&lt;Object> deserializeList(final JsonReader reader) throws IOException {"
         errorLine2="                                                       ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="88"
             column="56"/>
     </issue>
@@ -5133,7 +5133,7 @@
         errorLine1=" public static LinkedHashMap&lt;String, Object> deserializeMap(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="102"
             column="16"/>
     </issue>
@@ -5144,7 +5144,7 @@
         errorLine1=" public static LinkedHashMap&lt;String, Object> deserializeMap(final JsonReader reader) throws IOException {"
         errorLine2="                                                                  ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="102"
             column="67"/>
     </issue>
@@ -5155,7 +5155,7 @@
         errorLine1=" public static ArrayList&lt;Map&lt;String, Object>> deserializeMapCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="119"
             column="16"/>
     </issue>
@@ -5166,7 +5166,7 @@
         errorLine1=" public static ArrayList&lt;Map&lt;String, Object>> deserializeMapCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="119"
             column="78"/>
     </issue>
@@ -5177,7 +5177,7 @@
         errorLine1=" public static void deserializeMapCollection(final JsonReader reader, final Collection&lt;Map&lt;String, Object>> res) throws IOException {"
         errorLine2="                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="123"
             column="52"/>
     </issue>
@@ -5188,7 +5188,7 @@
         errorLine1=" public static void deserializeMapCollection(final JsonReader reader, final Collection&lt;Map&lt;String, Object>> res) throws IOException {"
         errorLine2="                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="123"
             column="77"/>
     </issue>
@@ -5199,7 +5199,7 @@
         errorLine1=" public static ArrayList&lt;Map&lt;String, Object>> deserializeNullableMapCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="128"
             column="16"/>
     </issue>
@@ -5210,7 +5210,7 @@
         errorLine1=" public static ArrayList&lt;Map&lt;String, Object>> deserializeNullableMapCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="128"
             column="86"/>
     </issue>
@@ -5221,7 +5221,7 @@
         errorLine1=" public static void deserializeNullableMapCollection(final JsonReader reader, final Collection&lt;Map&lt;String, Object>> res) throws IOException {"
         errorLine2="                                                           ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="132"
             column="60"/>
     </issue>
@@ -5232,7 +5232,7 @@
         errorLine1=" public static void deserializeNullableMapCollection(final JsonReader reader, final Collection&lt;Map&lt;String, Object>> res) throws IOException {"
         errorLine2="                                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ObjectConverter.java"
             line="132"
             column="85"/>
     </issue>
@@ -5243,7 +5243,7 @@
         errorLine1=" public static ParsingException create(String reason, boolean withStackTrace) {"
         errorLine2="               ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="16"
             column="16"/>
     </issue>
@@ -5254,7 +5254,7 @@
         errorLine1=" public static ParsingException create(String reason, boolean withStackTrace) {"
         errorLine2="                                       ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="16"
             column="40"/>
     </issue>
@@ -5265,7 +5265,7 @@
         errorLine1=" public static ParsingException create(String reason, Throwable cause, boolean withStackTrace) {"
         errorLine2="               ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="23"
             column="16"/>
     </issue>
@@ -5276,7 +5276,7 @@
         errorLine1=" public static ParsingException create(String reason, Throwable cause, boolean withStackTrace) {"
         errorLine2="                                       ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="23"
             column="40"/>
     </issue>
@@ -5287,7 +5287,7 @@
         errorLine1=" public static ParsingException create(String reason, Throwable cause, boolean withStackTrace) {"
         errorLine2="                                                      ~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/ParsingException.java"
             line="23"
             column="55"/>
     </issue>
@@ -5298,7 +5298,7 @@
         errorLine1=" String get(char[] chars, int len);"
         errorLine2=" ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringCache.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringCache.java"
             line="4"
             column="2"/>
     </issue>
@@ -5309,7 +5309,7 @@
         errorLine1=" String get(char[] chars, int len);"
         errorLine2="            ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringCache.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringCache.java"
             line="4"
             column="13"/>
     </issue>
@@ -5320,7 +5320,7 @@
         errorLine1=" public static void serializeShortNullable(@Nullable final String value, final JsonWriter sw) {"
         errorLine2="                                                                               ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="53"
             column="80"/>
     </issue>
@@ -5331,7 +5331,7 @@
         errorLine1=" public static void serializeShort(final String value, final JsonWriter sw) {"
         errorLine2="                                         ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="61"
             column="42"/>
     </issue>
@@ -5342,7 +5342,7 @@
         errorLine1=" public static void serializeShort(final String value, final JsonWriter sw) {"
         errorLine2="                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="61"
             column="62"/>
     </issue>
@@ -5353,7 +5353,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final String value, final JsonWriter sw) {"
         errorLine2="                                                                          ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="65"
             column="75"/>
     </issue>
@@ -5364,7 +5364,7 @@
         errorLine1=" public static void serialize(final String value, final JsonWriter sw) {"
         errorLine2="                                    ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="73"
             column="37"/>
     </issue>
@@ -5375,7 +5375,7 @@
         errorLine1=" public static void serialize(final String value, final JsonWriter sw) {"
         errorLine2="                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="73"
             column="57"/>
     </issue>
@@ -5386,7 +5386,7 @@
         errorLine1=" public static String deserialize(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="77"
             column="16"/>
     </issue>
@@ -5397,7 +5397,7 @@
         errorLine1=" public static String deserialize(final JsonReader reader) throws IOException {"
         errorLine2="                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="77"
             column="41"/>
     </issue>
@@ -5408,7 +5408,7 @@
         errorLine1=" public static String deserializeNullable(final JsonReader reader) throws IOException {"
         errorLine2="                                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="82"
             column="49"/>
     </issue>
@@ -5419,7 +5419,7 @@
         errorLine1=" public static ArrayList&lt;String> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="91"
             column="16"/>
     </issue>
@@ -5430,7 +5430,7 @@
         errorLine1=" public static ArrayList&lt;String> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="91"
             column="62"/>
     </issue>
@@ -5441,7 +5441,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;String> res) throws IOException {"
         errorLine2="                                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="95"
             column="49"/>
     </issue>
@@ -5452,7 +5452,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;String> res) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="95"
             column="74"/>
     </issue>
@@ -5463,7 +5463,7 @@
         errorLine1=" public static ArrayList&lt;String> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="100"
             column="16"/>
     </issue>
@@ -5474,7 +5474,7 @@
         errorLine1=" public static ArrayList&lt;String> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                     ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="100"
             column="70"/>
     </issue>
@@ -5485,7 +5485,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;String> res) throws IOException {"
         errorLine2="                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="104"
             column="57"/>
     </issue>
@@ -5496,7 +5496,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;String> res) throws IOException {"
         errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="104"
             column="82"/>
     </issue>
@@ -5507,7 +5507,7 @@
         errorLine1=" public static void serialize(final List&lt;String> list, final JsonWriter writer) {"
         errorLine2="                                    ~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="108"
             column="37"/>
     </issue>
@@ -5518,7 +5518,7 @@
         errorLine1=" public static void serialize(final List&lt;String> list, final JsonWriter writer) {"
         errorLine2="                                                             ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/StringConverter.java"
             line="108"
             column="62"/>
     </issue>
@@ -5529,7 +5529,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final UUID value, final JsonWriter sw) {"
         errorLine2="                                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="51"
             column="73"/>
     </issue>
@@ -5540,7 +5540,7 @@
         errorLine1=" public static void serialize(final UUID value, final JsonWriter sw) {"
         errorLine2="                                    ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="59"
             column="37"/>
     </issue>
@@ -5551,7 +5551,7 @@
         errorLine1=" public static void serialize(final UUID value, final JsonWriter sw) {"
         errorLine2="                                                      ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="59"
             column="55"/>
     </issue>
@@ -5562,7 +5562,7 @@
         errorLine1=" public static void serialize(final long hi, final long lo, final JsonWriter sw) {"
         errorLine2="                                                                  ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="63"
             column="67"/>
     </issue>
@@ -5573,7 +5573,7 @@
         errorLine1=" public static UUID deserialize(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="143"
             column="16"/>
     </issue>
@@ -5584,7 +5584,7 @@
         errorLine1=" public static UUID deserialize(final JsonReader reader) throws IOException {"
         errorLine2="                                      ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="143"
             column="39"/>
     </issue>
@@ -5595,7 +5595,7 @@
         errorLine1=" public static ArrayList&lt;UUID> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="182"
             column="16"/>
     </issue>
@@ -5606,7 +5606,7 @@
         errorLine1=" public static ArrayList&lt;UUID> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                           ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="182"
             column="60"/>
     </issue>
@@ -5617,7 +5617,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;UUID> res) throws IOException {"
         errorLine2="                                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="186"
             column="49"/>
     </issue>
@@ -5628,7 +5628,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;UUID> res) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="186"
             column="74"/>
     </issue>
@@ -5639,7 +5639,7 @@
         errorLine1=" public static ArrayList&lt;UUID> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="191"
             column="16"/>
     </issue>
@@ -5650,7 +5650,7 @@
         errorLine1=" public static ArrayList&lt;UUID> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                   ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="191"
             column="68"/>
     </issue>
@@ -5661,7 +5661,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;UUID> res) throws IOException {"
         errorLine2="                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="195"
             column="57"/>
     </issue>
@@ -5672,7 +5672,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;UUID> res) throws IOException {"
         errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/UUIDConverter.java"
             line="195"
             column="82"/>
     </issue>
@@ -5683,7 +5683,7 @@
         errorLine1=" public static void serializeNullable(@Nullable final Element value, final JsonWriter sw) {"
         errorLine2="                                                                           ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="48"
             column="76"/>
     </issue>
@@ -5694,7 +5694,7 @@
         errorLine1=" public static void serialize(final Element value, final JsonWriter sw) {"
         errorLine2="                                    ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="55"
             column="37"/>
     </issue>
@@ -5705,7 +5705,7 @@
         errorLine1=" public static void serialize(final Element value, final JsonWriter sw) {"
         errorLine2="                                                         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="55"
             column="58"/>
     </issue>
@@ -5716,7 +5716,7 @@
         errorLine1=" public static Element deserialize(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="67"
             column="16"/>
     </issue>
@@ -5727,7 +5727,7 @@
         errorLine1=" public static Element deserialize(final JsonReader reader) throws IOException {"
         errorLine2="                                         ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="67"
             column="42"/>
     </issue>
@@ -5738,7 +5738,7 @@
         errorLine1=" public static Element mapToXml(final Map&lt;String, Object> map) throws IOException {"
         errorLine2="               ~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="81"
             column="16"/>
     </issue>
@@ -5749,7 +5749,7 @@
         errorLine1=" public static Element mapToXml(final Map&lt;String, Object> map) throws IOException {"
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="81"
             column="39"/>
     </issue>
@@ -5760,7 +5760,7 @@
         errorLine1=" public static ArrayList&lt;Element> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="201"
             column="16"/>
     </issue>
@@ -5771,7 +5771,7 @@
         errorLine1=" public static ArrayList&lt;Element> deserializeCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                              ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="201"
             column="63"/>
     </issue>
@@ -5782,7 +5782,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Element> res) throws IOException {"
         errorLine2="                                                ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="205"
             column="49"/>
     </issue>
@@ -5793,7 +5793,7 @@
         errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Element> res) throws IOException {"
         errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="205"
             column="74"/>
     </issue>
@@ -5804,7 +5804,7 @@
         errorLine1=" public static ArrayList&lt;Element> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="               ~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="210"
             column="16"/>
     </issue>
@@ -5815,7 +5815,7 @@
         errorLine1=" public static ArrayList&lt;Element> deserializeNullableCollection(final JsonReader reader) throws IOException {"
         errorLine2="                                                                      ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="210"
             column="71"/>
     </issue>
@@ -5826,7 +5826,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Element> res) throws IOException {"
         errorLine2="                                                        ~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="214"
             column="57"/>
     </issue>
@@ -5837,7 +5837,7 @@
         errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Element> res) throws IOException {"
         errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            file="dsl-json/library/src/main/java/com/bugsnag/android/repackaged/dslplatform/json/XmlConverter.java"
             line="214"
             column="82"/>
     </issue>

--- a/bugsnag-android-core/lint-baseline.xml
+++ b/bugsnag-android-core/lint-baseline.xml
@@ -2,31 +2,5844 @@
 <issues format="6" by="lint 7.0.2" type="baseline" client="gradle" name="AGP (7.0.2)" variant="all" version="7.0.2">
 
     <issue
-        id="InvalidPackage"
-        message="Invalid package reference in com.dslplatform:dsl-json; not included in Android: `java.awt.geom`. Referenced from `com.dslplatform.json.DslJson`.">
+        id="SyntheticAccessor"
+        message="Access to `private` method `with` of class `Settings` requires synthetic accessor"
+        errorLine1="  this(new Settings&lt;TContext>()"
+        errorLine2="       ^">
         <location
-            file="../../../.gradle/caches/modules-2/files-2.1/com.dslplatform/dsl-json/1.9.8/33d30c7b113651e1b0d060f3f0af35fbf43f1403/dsl-json-1.9.8.jar"/>
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="480"
+            column="8"/>
     </issue>
 
     <issue
-        id="InvalidPackage"
-        message="Invalid package reference in com.dslplatform:dsl-json; not included in Android: `java.awt.image`. Referenced from `com.dslplatform.json.DslJson`.">
+        id="SyntheticAccessor"
+        message="Access to `private` field `doublePrecision` of class `DslJson` requires synthetic accessor"
+        errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
+        errorLine2="                                                                                                                                                  ~~~~~~~~~~~~~~~">
         <location
-            file="../../../.gradle/caches/modules-2/files-2.1/com.dslplatform/dsl-json/1.9.8/33d30c7b113651e1b0d060f3f0af35fbf43f1403/dsl-json-1.9.8.jar"/>
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="508"
+            column="147"/>
     </issue>
 
     <issue
-        id="InvalidPackage"
-        message="Invalid package reference in com.dslplatform:dsl-json; not included in Android: `java.awt`. Referenced from `com.dslplatform.json.DslJson`.">
+        id="SyntheticAccessor"
+        message="Access to `private` field `errorInfo` of class `DslJson` requires synthetic accessor"
+        errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
+        errorLine2="                                                                                                                                  ~~~~~~~~~">
         <location
-            file="../../../.gradle/caches/modules-2/files-2.1/com.dslplatform/dsl-json/1.9.8/33d30c7b113651e1b0d060f3f0af35fbf43f1403/dsl-json-1.9.8.jar"/>
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="508"
+            column="131"/>
     </issue>
 
     <issue
-        id="InvalidPackage"
-        message="Invalid package reference in com.dslplatform:dsl-json; not included in Android: `javax.imageio`. Referenced from `com.dslplatform.json.JavaGeomConverter`.">
+        id="SyntheticAccessor"
+        message="Access to `private` field `maxNumberDigits` of class `DslJson` requires synthetic accessor"
+        errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
+        errorLine2="                                                                                                                                                                                             ~~~~~~~~~~~~~~~">
         <location
-            file="../../../.gradle/caches/modules-2/files-2.1/com.dslplatform/dsl-json/1.9.8/33d30c7b113651e1b0d060f3f0af35fbf43f1403/dsl-json-1.9.8.jar"/>
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="508"
+            column="190"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `maxStringSize` of class `DslJson` requires synthetic accessor"
+        errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
+        errorLine2="                                                                                                                                                                                                                   ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="508"
+            column="212"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `unknownNumbers` of class `DslJson` requires synthetic accessor"
+        errorLine1="    return new JsonReader&lt;TContext>(new byte[4096], 4096, self.context, new char[64], self.keyCache, self.valuesCache, self, self.errorInfo, self.doublePrecision, self.unknownNumbers, self.maxNumberDigits, self.maxStringSize);"
+        errorLine2="                                                                                                                                                                        ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="508"
+            column="169"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `context` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.context = settings.context;"
+        errorLine2="                          ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="511"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `fallback` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.fallback = settings.fallback;"
+        errorLine2="                           ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="512"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `omitDefaults` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.omitDefaults = settings.omitDefaults;"
+        errorLine2="                               ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="513"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `allowArrayFormat` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.allowArrayFormat = settings.allowArrayFormat;"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="514"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `keyCache` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.keyCache = settings.keyCache;"
+        errorLine2="                           ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="515"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `valuesCache` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.valuesCache = settings.valuesCache;"
+        errorLine2="                              ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="516"
+            column="31"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `unknownNumbers` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.unknownNumbers = settings.unknownNumbers;"
+        errorLine2="                                 ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="517"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `errorInfo` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.errorInfo = settings.errorInfo;"
+        errorLine2="                            ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="518"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `doublePrecision` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.doublePrecision = settings.doublePrecision;"
+        errorLine2="                                  ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="519"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `maxNumberDigits` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.maxNumberDigits = settings.maxNumberDigits;"
+        errorLine2="                                  ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="520"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `maxStringBuffer` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.maxStringSize = settings.maxStringBuffer;"
+        errorLine2="                                ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="521"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `writerFactories` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.writerFactories.addAll(settings.writerFactories);"
+        errorLine2="                                       ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="522"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `writerFactories` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.settingsWriters = settings.writerFactories.size();"
+        errorLine2="                                  ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="523"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `readerFactories` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.readerFactories.addAll(settings.readerFactories);"
+        errorLine2="                                       ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="524"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `readerFactories` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.settingsReaders = settings.readerFactories.size();"
+        errorLine2="                                  ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="525"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `binderFactories` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.binderFactories.addAll(settings.binderFactories);"
+        errorLine2="                                       ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="526"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `binderFactories` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.settingsBinders = settings.binderFactories.size();"
+        errorLine2="                                  ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="527"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `classLoaders` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.externalConverterAnalyzer = new ExternalConverterAnalyzer(settings.classLoaders);"
+        errorLine2="                                                                          ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="528"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `creatorMarkers` of class `Settings` requires synthetic accessor"
+        errorLine1="  this.creatorMarkers = new HashMap&lt;Class&lt;? extends Annotation>, Boolean>(settings.creatorMarkers);"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="529"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `javaSpecifics` of class `Settings` requires synthetic accessor"
+        errorLine1="  if (settings.javaSpecifics) {"
+        errorLine2="               ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="540"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `configurations` of class `Settings` requires synthetic accessor"
+        errorLine1="  for (Configuration serializer : settings.configurations) {"
+        errorLine2="                                           ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="610"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `classLoaders` of class `Settings` requires synthetic accessor"
+        errorLine1="  if (!settings.classLoaders.isEmpty() &amp;&amp; settings.fromServiceLoader == 0) {"
+        errorLine2="                ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="613"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `fromServiceLoader` of class `Settings` requires synthetic accessor"
+        errorLine1="  if (!settings.classLoaders.isEmpty() &amp;&amp; settings.fromServiceLoader == 0) {"
+        errorLine2="                                                   ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="613"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `classLoaders` of class `Settings` requires synthetic accessor"
+        errorLine1="   loadDefaultConverters(this, settings.classLoaders, &quot;dsl_json_Annotation_Processor_External_Serialization&quot;);"
+        errorLine2="                                        ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="615"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `classLoaders` of class `Settings` requires synthetic accessor"
+        errorLine1="   loadDefaultConverters(this, settings.classLoaders, &quot;dsl_json.json.ExternalSerialization&quot;);"
+        errorLine2="                                        ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="616"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `classLoaders` of class `Settings` requires synthetic accessor"
+        errorLine1="   loadDefaultConverters(this, settings.classLoaders, &quot;dsl_json_ExternalSerialization&quot;);"
+        errorLine2="                                        ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="617"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `scaled_boundary_minus` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="   final DiyFp low = buffer.scaled_boundary_minus;"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="605"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `scaled_w` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="   final DiyFp w = buffer.scaled_w;"
+        errorLine2="                          ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="606"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `scaled_boundary_plus` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="   final DiyFp high = buffer.scaled_boundary_plus;"
+        errorLine2="                             ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="607"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `too_low` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="   final DiyFp too_low = buffer.too_low;"
+        errorLine2="                                ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="621"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `too_high` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="   final DiyFp too_high = buffer.too_high;"
+        errorLine2="                                 ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="624"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `unsafe_interval` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="   final DiyFp unsafe_interval = buffer.unsafe_interval;"
+        errorLine2="                                        ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="629"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `one` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="   final DiyFp one = buffer.one;"
+        errorLine2="                            ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="640"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `end` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="     buffer.point = buffer.end - mk + kappa;"
+        errorLine2="                           ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="668"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `point` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="     buffer.point = buffer.end - mk + kappa;"
+        errorLine2="            ~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="668"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `minus_round` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="     final DiyFp minus_round = buffer.minus_round;"
+        errorLine2="                                      ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="669"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `end` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="     buffer.point = buffer.end - mk + kappa;"
+        errorLine2="                           ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="707"
+            column="28"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `point` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="     buffer.point = buffer.end - mk + kappa;"
+        errorLine2="            ~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="707"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` field `minus_round` of class `FastDtoaBuilder` requires synthetic accessor"
+        errorLine1="     final DiyFp minus_round = buffer.minus_round;"
+        errorLine2="                                      ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Grisu3.java"
+            line="708"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` member of class `EmptyEOFException` requires synthetic accessor"
+        errorLine1=" private static final EOFException eof = new EmptyEOFException();"
+        errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="313"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` constructor of class `ParsingStacklessException` requires synthetic accessor"
+        errorLine1="    : new ParsingStacklessException(reason);"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="19"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` constructor of class `ParsingStacklessException` requires synthetic accessor"
+        errorLine1="    : new ParsingStacklessException(reason, cause);"
+        errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="26"
+            column="7"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` constructor of class `ParsingException` requires synthetic accessor"
+        errorLine1="   super(reason);"
+        errorLine2="   ~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="32"
+            column="4"/>
+    </issue>
+
+    <issue
+        id="SyntheticAccessor"
+        message="Access to `private` constructor of class `ParsingException` requires synthetic accessor"
+        errorLine1="   super(reason, cause);"
+        errorLine2="   ~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="36"
+            column="4"/>
+    </issue>
+
+    <issue
+        id="LambdaLast"
+        message="Functional interface parameters (such as parameter 1, &quot;converter&quot;, in com.bugsnag.dslplatform.json.DslJson.deserialize) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        errorLine1="   final JsonReader&lt;TContext> input) throws IOException {"
+        errorLine2="   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1522"
+            column="4"/>
+    </issue>
+
+    <issue
+        id="LambdaLast"
+        message="Functional interface parameters (such as parameter 1, &quot;binder&quot;, in com.bugsnag.dslplatform.json.JsonReader.next) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        errorLine1=" public final &lt;T> T next(final BindObject&lt;T> binder, final T instance) throws IOException {"
+        errorLine2="                                                     ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1517"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="LambdaLast"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.readArray) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        errorLine1=" public final &lt;T> T[] readArray(final ReadObject&lt;T> readObject, final T[] emptyArray) throws IOException {"
+        errorLine2="                                                                ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1583"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="LambdaLast"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.deserializeCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        errorLine1=" public final &lt;T, S extends T> void deserializeCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                                          ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1603"
+            column="91"/>
+    </issue>
+
+    <issue
+        id="LambdaLast"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.deserializeNullableCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        errorLine1=" public final &lt;T, S extends T> void deserializeNullableCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1618"
+            column="99"/>
+    </issue>
+
+    <issue
+        id="LambdaLast"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.deserializeCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        errorLine1=" public final &lt;T extends JsonObject> void deserializeCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                                                    ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1641"
+            column="101"/>
+    </issue>
+
+    <issue
+        id="LambdaLast"
+        message="Functional interface parameters (such as parameter 1, &quot;readObject&quot;, in com.bugsnag.dslplatform.json.JsonReader.deserializeNullableCollection) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        errorLine1=" public final &lt;T extends JsonObject> void deserializeNullableCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1661"
+            column="109"/>
+    </issue>
+
+    <issue
+        id="LambdaLast"
+        message="Functional interface parameters (such as parameter 1, &quot;keyWriter&quot;, in com.bugsnag.dslplatform.json.JsonWriter.writeQuoted) should be last to improve Kotlin interoperability; see https://kotlinlang.org/docs/reference/java-interop.html#sam-conversions"
+        errorLine1=" public &lt;T> void writeQuoted(final JsonWriter.WriteObject&lt;T> keyWriter, final T key) {"
+        errorLine2="                                                                        ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="857"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(@Nullable final byte[] value, final JsonWriter sw) {"
+        errorLine2="                                                                  ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="26"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static byte[] deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="36"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static byte[] deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="36"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;byte[]&gt; deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="41"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;byte[]&gt; deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="41"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;byte[]&gt; res) throws IOException {"
+        errorLine2="                                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="45"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;byte[]&gt; res) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="45"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;byte[]&gt; deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="50"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;byte[]&gt; deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="50"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;byte[]&gt; res) throws IOException {"
+        errorLine2="                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="54"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;byte[]&gt; res) throws IOException {"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BinaryConverter.java"
+            line="54"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final Boolean value, final JsonWriter sw) {"
+        errorLine2="                                                                           ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="51"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final boolean value, final JsonWriter sw) {"
+        errorLine2="                                                         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="61"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(@Nullable final boolean[] value, final JsonWriter sw) {"
+        errorLine2="                                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="69"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static boolean deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="                                         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="84"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static boolean[] deserializeBoolArray(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="93"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static boolean[] deserializeBoolArray(final JsonReader reader) throws IOException {"
+        errorLine2="                                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="93"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Boolean> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="112"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Boolean> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                              ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="112"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Boolean> res) throws IOException {"
+        errorLine2="                                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="116"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Boolean> res) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="116"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Boolean> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="121"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Boolean> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                      ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="121"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Boolean> res) throws IOException {"
+        errorLine2="                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="125"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Boolean> res) throws IOException {"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/BoolConverter.java"
+            line="125"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" void configure(DslJson json);"
+        errorLine2="                ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/Configuration.java"
+            line="15"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public ConfigurationException(String reason) {"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ConfigurationException.java"
+            line="5"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public ConfigurationException(Throwable cause) {"
+        errorLine2="                               ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ConfigurationException.java"
+            line="9"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public ConfigurationException(String reason, Throwable cause) {"
+        errorLine2="                               ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ConfigurationException.java"
+            line="13"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public ConfigurationException(String reason, Throwable cause) {"
+        errorLine2="                                              ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ConfigurationException.java"
+            line="13"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  void serialize(@Nullable Object instance, OutputStream stream) throws IOException;"
+        errorLine2="                                            ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="108"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  Object deserialize(@Nullable TContext context, Type manifest, byte[] body, int size) throws IOException;"
+        errorLine2="                                                 ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="111"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  Object deserialize(@Nullable TContext context, Type manifest, byte[] body, int size) throws IOException;"
+        errorLine2="                                                                ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="111"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  Object deserialize(@Nullable TContext context, Type manifest, InputStream stream) throws IOException;"
+        errorLine2="                                                 ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="114"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  Object deserialize(@Nullable TContext context, Type manifest, InputStream stream) throws IOException;"
+        errorLine2="                                                                ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="114"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  T tryCreate(Type manifest, DslJson dslJson);"
+        errorLine2="              ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="119"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  T tryCreate(Type manifest, DslJson dslJson);"
+        errorLine2="                             ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="119"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> withContext(@Nullable TContext context) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="157"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> withJavaConverters(boolean javaSpecifics) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="168"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> fallbackTo(@Nullable Fallback&lt;TContext> fallback) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="181"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> skipDefaultValues(boolean omitDefaults) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="194"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> allowArrayFormat(boolean allowArrayFormat) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="208"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> useKeyCache(@Nullable StringCache keyCache) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="225"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> useStringValuesCache(@Nullable StringCache valuesCache) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="243"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> resolveWriter(ConverterFactory&lt;? extends JsonWriter.WriteObject> writer) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="256"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> resolveWriter(ConverterFactory&lt;? extends JsonWriter.WriteObject> writer) {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="256"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> resolveReader(ConverterFactory&lt;? extends JsonReader.ReadObject> reader) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="273"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> resolveReader(ConverterFactory&lt;? extends JsonReader.ReadObject> reader) {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="273"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> resolveBinder(ConverterFactory&lt;? extends JsonReader.BindObject> binder) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="290"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> resolveBinder(ConverterFactory&lt;? extends JsonReader.BindObject> binder) {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="290"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> includeServiceLoader() {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="309"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> includeServiceLoader(ClassLoader loader) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="324"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> includeServiceLoader(ClassLoader loader) {"
+        errorLine2="                                                 ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="324"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> errorInfo(JsonReader.ErrorInfo errorInfo) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="350"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> errorInfo(JsonReader.ErrorInfo errorInfo) {"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="350"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> doublePrecision(JsonReader.DoublePrecision precision) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="362"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> doublePrecision(JsonReader.DoublePrecision precision) {"
+        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="362"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> unknownNumbers(JsonReader.UnknownNumberParsing unknownNumbers) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="381"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> unknownNumbers(JsonReader.UnknownNumberParsing unknownNumbers) {"
+        errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="381"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> limitDigitsBuffer(int size) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="394"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> limitStringBuffer(int size) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="407"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> creatorMarker(Class&lt;? extends Annotation> marker, boolean expandVisibility) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="421"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> creatorMarker(Class&lt;? extends Annotation> marker, boolean expandVisibility) {"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="421"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> with(Configuration conf) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="434"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public Settings&lt;TContext> with(Configuration conf) {"
+        errorLine2="                                 ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="434"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Iterable&lt;Configuration> serializers) {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="479"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public DslJson(final Settings&lt;TContext> settings) {"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="496"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public String get(char[] chars, int len) {"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="657"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  public String get(char[] chars, int len) {"
+        errorLine2="                    ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="657"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonWriter newWriter() {"
+        errorLine2="        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="688"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonWriter newWriter(int size) {"
+        errorLine2="        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="701"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonWriter newWriter(byte[] buffer) {"
+        errorLine2="        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="714"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonWriter newWriter(byte[] buffer) {"
+        errorLine2="                             ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="714"
+            column="30"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader() {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="726"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="738"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="738"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="751"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="751"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length, char[] tmp) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="767"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length, char[] tmp) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="767"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(byte[] bytes, int length, char[] tmp) {"
+        errorLine2="                                                                 ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="767"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(InputStream stream, byte[] buffer) throws IOException {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="782"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(InputStream stream, byte[] buffer) throws IOException {"
+        errorLine2="                                       ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="782"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(InputStream stream, byte[] buffer) throws IOException {"
+        errorLine2="                                                           ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="782"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(String input) {"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="798"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader&lt;TContext> newReader(String input) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="798"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> void registerDefault(Class&lt;T> manifest, T instance) {"
+        errorLine2="                                 ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="822"
+            column="34"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public boolean registerWriterFactory(ConverterFactory&lt;? extends JsonWriter.WriteObject> factory) {"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="827"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public boolean registerReaderFactory(ConverterFactory&lt;? extends JsonReader.ReadObject> factory) {"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="835"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public boolean registerBinderFactory(ConverterFactory&lt;? extends JsonReader.BindObject> factory) {"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="843"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final Set&lt;Type> getRegisteredDecoders() {"
+        errorLine2="              ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="876"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final Set&lt;Type> getRegisteredBinders() {"
+        errorLine2="              ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="880"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final Set&lt;Type> getRegisteredEncoders() {"
+        errorLine2="              ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="884"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final Map&lt;Class&lt;? extends Annotation>, Boolean> getRegisteredCreatorMarkers() {"
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="888"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T, S extends T> void registerReader(final Class&lt;T> manifest, @Nullable final JsonReader.ReadObject&lt;S> reader) {"
+        errorLine2="                                                   ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="906"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader.ReadObject registerReader(final Type manifest, @Nullable final JsonReader.ReadObject&lt;?> reader) {"
+        errorLine2="                                                   ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="925"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T, S extends T> void registerBinder(final Class&lt;T> manifest, @Nullable final JsonReader.BindObject&lt;S> binder) {"
+        errorLine2="                                                   ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="949"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public void registerBinder(final Type manifest, @Nullable final JsonReader.BindObject&lt;?> binder) {"
+        errorLine2="                                  ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="967"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> void registerWriter(final Class&lt;T> manifest, @Nullable final JsonWriter.WriteObject&lt;T> writer) {"
+        errorLine2="                                      ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="985"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonWriter.WriteObject registerWriter(final Type manifest, @Nullable final JsonWriter.WriteObject&lt;?> writer) {"
+        errorLine2="                                                    ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1009"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonWriter.WriteObject&lt;?> tryFindWriter(final Type manifest) {"
+        errorLine2="                                                      ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1031"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader.ReadObject&lt;?> tryFindReader(final Type manifest) {"
+        errorLine2="                                                     ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1139"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader.BindObject&lt;?> tryFindBinder(final Type manifest) {"
+        errorLine2="                                                     ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1179"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> JsonWriter.WriteObject&lt;T> tryFindWriter(final Class&lt;T> manifest) {"
+        errorLine2="                                                          ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1206"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> JsonReader.ReadObject&lt;T> tryFindReader(final Class&lt;T> manifest) {"
+        errorLine2="                                                         ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1227"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> JsonReader.BindObject&lt;T> tryFindBinder(final Class&lt;T> manifest) {"
+        errorLine2="                                                         ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1248"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" protected final JsonReader.ReadJsonObject&lt;JsonObject> getObjectReader(final Class&lt;?> manifest) {"
+        errorLine2="                                                                             ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1290"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public void serializeMap(final Map&lt;String, Object> value, final JsonWriter sw) throws IOException {"
+        errorLine2="                                ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1314"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public void serializeMap(final Map&lt;String, Object> value, final JsonWriter sw) throws IOException {"
+        errorLine2="                                                                 ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1314"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Object deserializeObject(final JsonReader reader) throws IOException {"
+        errorLine2="                                              ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1336"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Object> deserializeList(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1347"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Object> deserializeList(final JsonReader reader) throws IOException {"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1347"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static LinkedHashMap&lt;String, Object> deserializeMap(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1358"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static LinkedHashMap&lt;String, Object> deserializeMap(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                  ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1358"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final boolean canSerialize(final Type manifest) {"
+        errorLine2="                                         ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1424"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final boolean canDeserialize(final Type manifest) {"
+        errorLine2="                                           ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1475"
+            column="44"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final JsonReader.ReadObject&lt;T> converter,"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1521"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final JsonReader&lt;TContext> input) throws IOException {"
+        errorLine2="         ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1522"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1551"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final byte[] body,"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1552"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Type manifest,"
+        errorLine2="         ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1605"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final byte[] body,"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1606"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" protected Object deserializeWith(Type manifest, JsonReader json) throws IOException {"
+        errorLine2="                                  ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1634"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" protected Object deserializeWith(Type manifest, JsonReader json) throws IOException {"
+        errorLine2="                                                 ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1634"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" protected IOException createErrorMessage(final Class&lt;?> manifest) {"
+        errorLine2="           ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1707"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" protected IOException createErrorMessage(final Class&lt;?> manifest) {"
+        errorLine2="                                                ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1707"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1743"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final byte[] body,"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1744"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1822"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream,"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1823"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final byte[] buffer) throws IOException {"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1824"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1851"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream) throws IOException {"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1852"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1867"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   JsonReader&lt;TContext> json,"
+        errorLine2="   ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1868"
+            column="4"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   InputStream stream) throws IOException {"
+        errorLine2="   ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1869"
+            column="4"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1931"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream,"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1932"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final byte[] buffer) throws IOException {"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1933"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1967"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream) throws IOException {"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1968"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1986"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final JsonReader json,"
+        errorLine2="         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1987"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream) throws IOException {"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="1988"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Type manifest,"
+        errorLine2="         ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2048"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream,"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2049"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final byte[] buffer) throws IOException {"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2050"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Type manifest,"
+        errorLine2="         ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2092"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream) throws IOException {"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2093"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2196"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream) throws IOException {"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2197"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2233"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream,"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2234"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final byte[] buffer) throws IOException {"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2235"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;TResult> manifest,"
+        errorLine2="         ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2251"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final JsonReader json,"
+        errorLine2="         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2252"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final InputStream stream) throws IOException {"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2253"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Iterator&lt;T> iterator,"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2436"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final OutputStream stream,"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2437"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Iterator&lt;T> iterator,"
+        errorLine2="         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2513"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final Class&lt;T> manifest,"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2514"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final OutputStream stream,"
+        errorLine2="         ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2515"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, @Nullable final T[] array) {"
+        errorLine2="                                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2571"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, final T[] array, final int len) {"
+        errorLine2="                                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2606"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, final T[] array, final int len) {"
+        errorLine2="                                                                             ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2606"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, @Nullable final List&lt;T> list) {"
+        errorLine2="                                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2643"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T extends JsonObject> void serialize(final JsonWriter writer, @Nullable final Collection&lt;T> collection) {"
+        errorLine2="                                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2680"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public boolean serialize(final JsonWriter writer, final Type manifest, @Nullable final Object value) {"
+        errorLine2="                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2726"
+            column="33"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public boolean serialize(final JsonWriter writer, final Type manifest, @Nullable final Object value) {"
+        errorLine2="                                                         ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2726"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void serialize(@Nullable final Object value, final OutputStream stream) throws IOException {"
+        errorLine2="                                                                 ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2851"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void serialize(final JsonWriter writer, @Nullable final Object value) throws IOException {"
+        errorLine2="                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/DslJson.java"
+            line="2886"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" void serialize(JsonWriter writer, boolean minimal);"
+        errorLine2="                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonObject.java"
+            line="34"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" protected byte[] buffer;"
+        errorLine2="           ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="49"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" protected char[] chars;"
+        errorLine2="           ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="50"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, @Nullable final TContext context) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="140"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, @Nullable final TContext context, @Nullable StringCache keyCache, @Nullable StringCache valuesCache) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="145"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, final TContext context, final char[] tmp) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="150"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, final TContext context, final char[] tmp) {"
+        errorLine2="                                                                      ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="150"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, final int length, final TContext context) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="158"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, final int length, final TContext context, final char[] tmp) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="163"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, final int length, final TContext context, final char[] tmp) {"
+        errorLine2="                                                                                        ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="163"
+            column="89"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, final int length, @Nullable final TContext context, final char[] tmp, @Nullable final StringCache keyCache, @Nullable final StringCache valuesCache) {"
+        errorLine2="                         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="168"
+            column="26"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public JsonReader(final byte[] buffer, final int length, @Nullable final TContext context, final char[] tmp, @Nullable final StringCache keyCache, @Nullable final StringCache valuesCache) {"
+        errorLine2="                                                                                                  ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="168"
+            column="99"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void reset(final InputStream stream) throws IOException {"
+        errorLine2="                               ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="211"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final JsonReader&lt;TContext> process(@Nullable final InputStream stream) throws IOException {"
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="246"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final JsonReader&lt;TContext> process(@Nullable final byte[] newBuffer, final int newLength) {"
+        errorLine2="              ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="268"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public String positionDescription() {"
+        errorLine2="        ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="373"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public String positionDescription(int offset) {"
+        errorLine2="        ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="377"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseError(final String description) {"
+        errorLine2="              ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="410"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseError(final String description) {"
+        errorLine2="                                                   ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="410"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseError(final String description, final int positionOffset) {"
+        errorLine2="              ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="414"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseError(final String description, final int positionOffset) {"
+        errorLine2="                                                   ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="414"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset) {"
+        errorLine2="              ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="426"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset) {"
+        errorLine2="                                                     ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="426"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset, final Exception cause) {"
+        errorLine2="              ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="437"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset, final Exception cause) {"
+        errorLine2="                                                     ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="437"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorAt(final String description, final int positionOffset, final Exception cause) {"
+        errorLine2="                                                                                                         ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="437"
+            column="106"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorFormat(final String shortDescription, final int positionOffset, final String longDescriptionFormat, Object... arguments) {"
+        errorLine2="              ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="456"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorFormat(final String shortDescription, final int positionOffset, final String longDescriptionFormat, Object... arguments) {"
+        errorLine2="                                                         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="456"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorFormat(final String shortDescription, final int positionOffset, final String longDescriptionFormat, Object... arguments) {"
+        errorLine2="                                                                                                                  ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="456"
+            column="115"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorFormat(final String shortDescription, final int positionOffset, final String longDescriptionFormat, Object... arguments) {"
+        errorLine2="                                                                                                                                                ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="456"
+            column="145"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorWith("
+        errorLine2="              ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="466"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final String description, @Nullable Object argument) {"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="467"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final ParsingException newParseErrorWith("
+        errorLine2="              ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="471"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final String shortDescription,"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="472"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final String longDescriptionPrefix,"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="474"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final String longDescriptionMessage, @Nullable Object argument,"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="475"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="   final String longDescriptionSuffix) {"
+        errorLine2="         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="476"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final char[] readNumber() {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="507"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final String readSimpleString() throws ParsingException {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="575"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final char[] readSimpleQuote() throws ParsingException {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="600"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final String readString() throws IOException {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="626"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final StringBuilder appendString(StringBuilder builder) throws IOException {"
+        errorLine2="              ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="631"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final StringBuilder appendString(StringBuilder builder) throws IOException {"
+        errorLine2="                                         ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="631"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final StringBuffer appendString(StringBuffer buffer) throws IOException {"
+        errorLine2="              ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="637"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final StringBuffer appendString(StringBuffer buffer) throws IOException {"
+        errorLine2="                                        ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="637"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final boolean wasLastName(final String name) {"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1059"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final boolean wasLastName(final byte[] name) {"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1083"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final String getLastName() throws IOException {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1106"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public String readNext() throws IOException {"
+        errorLine2="        ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1192"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final byte[] readBase64() throws IOException {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1198"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final String readKey() throws IOException {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1222"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  T read(JsonReader reader) throws IOException;"
+        errorLine2="         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1238"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  T bind(JsonReader reader, T instance) throws IOException;"
+        errorLine2="         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1248"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  T deserialize(JsonReader reader) throws IOException;"
+        errorLine2="                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1253"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void startAttribute(final String name) throws IOException {"
+        errorLine2="                                        ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1392"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> T next(final Class&lt;T> manifest) throws IOException {"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1452"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> T next(final ReadObject&lt;T> reader) throws IOException {"
+        errorLine2="                               ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1474"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> T next(final Class&lt;T> manifest, final T instance) throws IOException {"
+        errorLine2="                               ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1494"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> T next(final BindObject&lt;T> binder, final T instance) throws IOException {"
+        errorLine2="                               ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1517"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> ArrayList&lt;T> readCollection(final ReadObject&lt;T> readObject) throws IOException {"
+        errorLine2="                                                    ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1528"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> LinkedHashSet&lt;T> readSet(final ReadObject&lt;T> readObject) throws IOException {"
+        errorLine2="                                                 ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1543"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;K, V> LinkedHashMap&lt;K, V> readMap(final ReadObject&lt;K> readKey, final ReadObject&lt;V> readValue) throws IOException {"
+        errorLine2="                                                       ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1558"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;K, V> LinkedHashMap&lt;K, V> readMap(final ReadObject&lt;K> readKey, final ReadObject&lt;V> readValue) throws IOException {"
+        errorLine2="                                                                                    ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1558"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> T[] readArray(final ReadObject&lt;T> readObject, final T[] emptyArray) throws IOException {"
+        errorLine2="                                      ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1583"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> T[] readArray(final ReadObject&lt;T> readObject, final T[] emptyArray) throws IOException {"
+        errorLine2="                                                                      ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1583"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T, S extends T> ArrayList&lt;T> deserializeCollection(final ReadObject&lt;S> readObject) throws IOException {"
+        errorLine2="                               ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1597"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T, S extends T> ArrayList&lt;T> deserializeCollection(final ReadObject&lt;S> readObject) throws IOException {"
+        errorLine2="                                                                        ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1597"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T, S extends T> void deserializeCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1603"
+            column="65"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T, S extends T> void deserializeCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                                                ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1603"
+            column="97"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T, S extends T> ArrayList&lt;T> deserializeNullableCollection(final ReadObject&lt;S> readObject) throws IOException {"
+        errorLine2="                               ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1612"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T, S extends T> ArrayList&lt;T> deserializeNullableCollection(final ReadObject&lt;S> readObject) throws IOException {"
+        errorLine2="                                                                                ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1612"
+            column="81"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T, S extends T> void deserializeNullableCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                        ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1618"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T, S extends T> void deserializeNullableCollection(final ReadObject&lt;S> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                                                        ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1618"
+            column="105"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> ArrayList&lt;T> deserializeCollection(final ReadJsonObject&lt;T> readObject) throws IOException {"
+        errorLine2="                                     ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1635"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> ArrayList&lt;T> deserializeCollection(final ReadJsonObject&lt;T> readObject) throws IOException {"
+        errorLine2="                                                                              ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1635"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> void deserializeCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1641"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> void deserializeCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                                                          ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1641"
+            column="107"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> ArrayList&lt;T> deserializeNullableCollection(final ReadJsonObject&lt;T> readObject) throws IOException {"
+        errorLine2="                                     ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1655"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> ArrayList&lt;T> deserializeNullableCollection(final ReadJsonObject&lt;T> readObject) throws IOException {"
+        errorLine2="                                                                                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1655"
+            column="87"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> void deserializeNullableCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                              ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1661"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> void deserializeNullableCollection(final ReadJsonObject&lt;T> readObject, final Collection&lt;T> res) throws IOException {"
+        errorLine2="                                                                                                                  ~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1661"
+            column="115"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> Iterator&lt;T> iterateOver(final JsonReader.ReadObject&lt;T> reader) {"
+        errorLine2="                  ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1679"
+            column="19"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T> Iterator&lt;T> iterateOver(final JsonReader.ReadObject&lt;T> reader) {"
+        errorLine2="                                                ~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1679"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> Iterator&lt;T> iterateOver(final JsonReader.ReadJsonObject&lt;T> reader) {"
+        errorLine2="                                     ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1683"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final &lt;T extends JsonObject> Iterator&lt;T> iterateOver(final JsonReader.ReadJsonObject&lt;T> reader) {"
+        errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonReader.java"
+            line="1683"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void writeString(final String value) {"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="159"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void writeString(final CharSequence value) {"
+        errorLine2="                                     ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="186"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void writeAscii(final String value) {"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="387"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void writeAscii(final String value, final int len) {"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="404"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void writeAscii(final byte[] buf) {"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="418"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void writeAscii(final byte[] buf, final int len) {"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="438"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void writeRaw(final byte[] buf, final int offset, final int len) {"
+        errorLine2="                                  ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="458"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void writeBinary(final byte[] value) {"
+        errorLine2="                                     ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="472"
+            column="38"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final byte[] toByteArray() {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="516"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final void toStream(final OutputStream stream) throws IOException {"
+        errorLine2="                                  ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="530"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public final byte[] getByteBuffer() {"
+        errorLine2="              ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="545"
+            column="15"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1="  void write(JsonWriter writer, @Nullable T value);"
+        errorLine2="             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="628"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T extends JsonObject> void serialize(final T[] array) {"
+        errorLine2="                                                    ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="638"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T extends JsonObject> void serialize(final T[] array, final int len) {"
+        errorLine2="                                                    ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="659"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T extends JsonObject> void serialize(final List&lt;T> list) {"
+        errorLine2="                                                    ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="681"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> void serialize(@Nullable final T[] array, final WriteObject&lt;T> encoder) {"
+        errorLine2="                                                            ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="702"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> void serialize(@Nullable final List&lt;T> list, final WriteObject&lt;T> encoder) {"
+        errorLine2="                                                               ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="740"
+            column="64"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public void serializeRaw(@Nullable final List list, final WriteObject encoder) {"
+        errorLine2="                                                           ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="785"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> void serialize(@Nullable final Collection&lt;T> collection, final WriteObject&lt;T> encoder) {"
+        errorLine2="                                                                           ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="798"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public void serializeRaw(@Nullable final Collection collection, final WriteObject encoder) {"
+        errorLine2="                                                                       ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="825"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;K, V> void serialize(@Nullable final Map&lt;K, V> map, final WriteObject&lt;K> keyEncoder, final WriteObject&lt;V> valueEncoder) {"
+        errorLine2="                                                                   ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="829"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;K, V> void serialize(@Nullable final Map&lt;K, V> map, final WriteObject&lt;K> keyEncoder, final WriteObject&lt;V> valueEncoder) {"
+        errorLine2="                                                                                                    ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="829"
+            column="101"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public void serializeRaw(@Nullable final Map map, final WriteObject keyEncoder, final WriteObject valueEncoder) {"
+        errorLine2="                                                         ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="853"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public void serializeRaw(@Nullable final Map map, final WriteObject keyEncoder, final WriteObject valueEncoder) {"
+        errorLine2="                                                                                       ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="853"
+            column="88"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public &lt;T> void writeQuoted(final JsonWriter.WriteObject&lt;T> keyWriter, final T key) {"
+        errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/JsonWriter.java"
+            line="857"
+            column="36"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final Map&lt;String, String> value, final JsonWriter sw) {"
+        errorLine2="                                                                                       ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="19"
+            column="88"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final Map&lt;String, String> value, final JsonWriter sw) {"
+        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="27"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final Map&lt;String, String> value, final JsonWriter sw) {"
+        errorLine2="                                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="27"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Map&lt;String, String> deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="47"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Map&lt;String, String> deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="47"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Map&lt;String, String>> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="72"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Map&lt;String, String>> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                          ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="72"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Map&lt;String, String>> res) throws IOException {"
+        errorLine2="                                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="76"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Map&lt;String, String>> res) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="76"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Map&lt;String, String>> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="81"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Map&lt;String, String>> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                                  ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="81"
+            column="83"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Map&lt;String, String>> res) throws IOException {"
+        errorLine2="                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="85"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Map&lt;String, String>> res) throws IOException {"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/MapConverter.java"
+            line="85"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final URI value, final JsonWriter sw) {"
+        errorLine2="                                                                       ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="41"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final URI value, final JsonWriter sw) {"
+        errorLine2="                                    ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="49"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final URI value, final JsonWriter sw) {"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="49"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static URI deserializeUri(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="53"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static URI deserializeUri(final JsonReader reader) throws IOException {"
+        errorLine2="                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="53"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;URI> deserializeUriCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="58"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;URI> deserializeUriCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="58"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeUriCollection(final JsonReader reader, final Collection&lt;URI> res) throws IOException {"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="62"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeUriCollection(final JsonReader reader, final Collection&lt;URI> res) throws IOException {"
+        errorLine2="                                                                            ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="62"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;URI> deserializeUriNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="67"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;URI> deserializeUriNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="67"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeUriNullableCollection(final JsonReader reader, final Collection&lt;URI> res) throws IOException {"
+        errorLine2="                                                           ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="71"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeUriNullableCollection(final JsonReader reader, final Collection&lt;URI> res) throws IOException {"
+        errorLine2="                                                                                    ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="71"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final InetAddress value, final JsonWriter sw) {"
+        errorLine2="                                                                               ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="75"
+            column="80"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final InetAddress value, final JsonWriter sw) {"
+        errorLine2="                                    ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="83"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final InetAddress value, final JsonWriter sw) {"
+        errorLine2="                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="83"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static InetAddress deserializeIp(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="89"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static InetAddress deserializeIp(final JsonReader reader) throws IOException {"
+        errorLine2="                                               ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="89"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;InetAddress> deserializeIpCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="94"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;InetAddress> deserializeIpCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="94"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeIpCollection(final JsonReader reader, final Collection&lt;InetAddress> res) throws IOException {"
+        errorLine2="                                                  ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="98"
+            column="51"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeIpCollection(final JsonReader reader, final Collection&lt;InetAddress> res) throws IOException {"
+        errorLine2="                                                                           ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="98"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;InetAddress> deserializeIpNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="103"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;InetAddress> deserializeIpNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                            ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="103"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeIpNullableCollection(final JsonReader reader, final Collection&lt;InetAddress> res) throws IOException {"
+        errorLine2="                                                          ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="107"
+            column="59"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeIpNullableCollection(final JsonReader reader, final Collection&lt;InetAddress> res) throws IOException {"
+        errorLine2="                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NetConverter.java"
+            line="107"
+            column="84"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final Double value, final JsonWriter sw) {"
+        errorLine2="                                                                          ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="303"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final double value, final JsonWriter sw) {"
+        errorLine2="                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="330"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(@Nullable final double[] value, final JsonWriter sw) {"
+        errorLine2="                                                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="334"
+            column="69"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static double deserializeDouble(final JsonReader reader) throws IOException {"
+        errorLine2="                                              ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="380"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Double> deserializeDoubleCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="572"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Double> deserializeDoubleCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="572"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeDoubleCollection(final JsonReader reader, final Collection&lt;Double> res) throws IOException {"
+        errorLine2="                                                      ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="576"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeDoubleCollection(final JsonReader reader, final Collection&lt;Double> res) throws IOException {"
+        errorLine2="                                                                               ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="576"
+            column="80"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Double> deserializeDoubleNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="581"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Double> deserializeDoubleNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                           ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="581"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeDoubleNullableCollection(final JsonReader reader, final Collection&lt;Double> res) throws IOException {"
+        errorLine2="                                                              ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="585"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeDoubleNullableCollection(final JsonReader reader, final Collection&lt;Double> res) throws IOException {"
+        errorLine2="                                                                                       ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="585"
+            column="88"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final Float value, final JsonWriter sw) {"
+        errorLine2="                                                                         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="589"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final float value, final JsonWriter sw) {"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="597"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(@Nullable final float[] value, final JsonWriter sw) {"
+        errorLine2="                                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="609"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static float deserializeFloat(final JsonReader reader) throws IOException {"
+        errorLine2="                                            ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="625"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Float> deserializeFloatCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="774"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Float> deserializeFloatCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                 ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="774"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeFloatCollection(final JsonReader reader, Collection&lt;Float> res) throws IOException {"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="778"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeFloatCollection(final JsonReader reader, Collection&lt;Float> res) throws IOException {"
+        errorLine2="                                                                        ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="778"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Float> deserializeFloatNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="783"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Float> deserializeFloatNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="783"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeFloatNullableCollection(final JsonReader reader, final Collection&lt;Float> res) throws IOException {"
+        errorLine2="                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="787"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeFloatNullableCollection(final JsonReader reader, final Collection&lt;Float> res) throws IOException {"
+        errorLine2="                                                                                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="787"
+            column="87"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final Integer value, final JsonWriter sw) {"
+        errorLine2="                                                                           ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="791"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final int value, final JsonWriter sw) {"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="802"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(@Nullable final int[] values, final JsonWriter sw) {"
+        errorLine2="                                                                  ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="854"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(@Nullable final short[] value, final JsonWriter sw) {"
+        errorLine2="                                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="873"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static short deserializeShort(final JsonReader reader) throws IOException {"
+        errorLine2="                                            ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="889"
+            column="45"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static int deserializeInt(final JsonReader reader) throws IOException {"
+        errorLine2="                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="912"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Integer> deserializeIntCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="983"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Integer> deserializeIntCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                 ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="983"
+            column="66"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static int[] deserializeIntArray(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="987"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static int[] deserializeIntArray(final JsonReader reader) throws IOException {"
+        errorLine2="                                               ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="987"
+            column="48"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static short[] deserializeShortArray(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1005"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static short[] deserializeShortArray(final JsonReader reader) throws IOException {"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1005"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static long[] deserializeLongArray(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1023"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static long[] deserializeLongArray(final JsonReader reader) throws IOException {"
+        errorLine2="                                                 ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1023"
+            column="50"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static float[] deserializeFloatArray(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1041"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static float[] deserializeFloatArray(final JsonReader reader) throws IOException {"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1041"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static double[] deserializeDoubleArray(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1059"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static double[] deserializeDoubleArray(final JsonReader reader) throws IOException {"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1059"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeShortCollection(final JsonReader reader, final Collection&lt;Short> res) throws IOException {"
+        errorLine2="                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1077"
+            column="54"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeShortCollection(final JsonReader reader, final Collection&lt;Short> res) throws IOException {"
+        errorLine2="                                                                              ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1077"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Short> deserializeShortNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1082"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Short> deserializeShortNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1082"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeShortNullableCollection(final JsonReader reader, final Collection&lt;Short> res) throws IOException {"
+        errorLine2="                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1086"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeShortNullableCollection(final JsonReader reader, final Collection&lt;Short> res) throws IOException {"
+        errorLine2="                                                                                      ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1086"
+            column="87"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeIntCollection(final JsonReader reader, final Collection&lt;Integer> res) throws IOException {"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1090"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeIntCollection(final JsonReader reader, final Collection&lt;Integer> res) throws IOException {"
+        errorLine2="                                                                            ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1090"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Integer> deserializeIntNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1095"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Integer> deserializeIntNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1095"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeIntNullableCollection(final JsonReader reader, final Collection&lt;Integer> res) throws IOException {"
+        errorLine2="                                                           ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1099"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeIntNullableCollection(final JsonReader reader, final Collection&lt;Integer> res) throws IOException {"
+        errorLine2="                                                                                    ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1099"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final Long value, final JsonWriter sw) {"
+        errorLine2="                                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1103"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final long value, final JsonWriter sw) {"
+        errorLine2="                                                      ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1131"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(@Nullable final long[] values, final JsonWriter sw) {"
+        errorLine2="                                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1228"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static long deserializeLong(final JsonReader reader) throws IOException {"
+        errorLine2="                                          ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1247"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Long> deserializeLongCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1319"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Long> deserializeLongCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                               ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1319"
+            column="64"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeLongCollection(final JsonReader reader, final Collection&lt;Long> res) throws IOException {"
+        errorLine2="                                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1323"
+            column="53"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeLongCollection(final JsonReader reader, final Collection&lt;Long> res) throws IOException {"
+        errorLine2="                                                                             ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1323"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Long> deserializeLongNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1328"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Long> deserializeLongNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                       ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1328"
+            column="72"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeLongNullableCollection(final JsonReader reader, final Collection&lt;Long> res) throws IOException {"
+        errorLine2="                                                            ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1332"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeLongNullableCollection(final JsonReader reader, final Collection&lt;Long> res) throws IOException {"
+        errorLine2="                                                                                     ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1332"
+            column="86"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final BigDecimal value, final JsonWriter sw) {"
+        errorLine2="                                                                              ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1336"
+            column="79"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final BigDecimal value, final JsonWriter sw) {"
+        errorLine2="                                    ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1344"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final BigDecimal value, final JsonWriter sw) {"
+        errorLine2="                                                            ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1344"
+            column="61"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static BigDecimal deserializeDecimal(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1348"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static BigDecimal deserializeDecimal(final JsonReader reader) throws IOException {"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1348"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Number deserializeNumber(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1528"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Number deserializeNumber(final JsonReader reader) throws IOException {"
+        errorLine2="                                              ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1528"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;BigDecimal> deserializeDecimalCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1684"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;BigDecimal> deserializeDecimalCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1684"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeDecimalCollection(final JsonReader reader, final Collection&lt;BigDecimal> res) throws IOException {"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1688"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeDecimalCollection(final JsonReader reader, final Collection&lt;BigDecimal> res) throws IOException {"
+        errorLine2="                                                                                ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1688"
+            column="81"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;BigDecimal> deserializeDecimalNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1693"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;BigDecimal> deserializeDecimalNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1693"
+            column="81"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeDecimalNullableCollection(final JsonReader reader, final Collection&lt;BigDecimal> res) throws IOException {"
+        errorLine2="                                                               ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1697"
+            column="64"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeDecimalNullableCollection(final JsonReader reader, final Collection&lt;BigDecimal> res) throws IOException {"
+        errorLine2="                                                                                        ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/NumberConverter.java"
+            line="1697"
+            column="89"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullableMap(@Nullable final Map&lt;String, Object> value, final JsonWriter sw) {"
+        errorLine2="                                                                                          ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="27"
+            column="91"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeMap(final Map&lt;String, Object> value, final JsonWriter sw) {"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="35"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeMap(final Map&lt;String, Object> value, final JsonWriter sw) {"
+        errorLine2="                                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="35"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeObject(@Nullable final Object value, final JsonWriter sw) throws IOException {"
+        errorLine2="                                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="55"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Object deserializeObject(final JsonReader reader) throws IOException {"
+        errorLine2="                                              ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="60"
+            column="47"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Object> deserializeList(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="88"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Object> deserializeList(final JsonReader reader) throws IOException {"
+        errorLine2="                                                       ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="88"
+            column="56"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static LinkedHashMap&lt;String, Object> deserializeMap(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="102"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static LinkedHashMap&lt;String, Object> deserializeMap(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                  ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="102"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Map&lt;String, Object>> deserializeMapCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="119"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Map&lt;String, Object>> deserializeMapCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="119"
+            column="78"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeMapCollection(final JsonReader reader, final Collection&lt;Map&lt;String, Object>> res) throws IOException {"
+        errorLine2="                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="123"
+            column="52"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeMapCollection(final JsonReader reader, final Collection&lt;Map&lt;String, Object>> res) throws IOException {"
+        errorLine2="                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="123"
+            column="77"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Map&lt;String, Object>> deserializeNullableMapCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="128"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Map&lt;String, Object>> deserializeNullableMapCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="128"
+            column="86"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableMapCollection(final JsonReader reader, final Collection&lt;Map&lt;String, Object>> res) throws IOException {"
+        errorLine2="                                                           ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="132"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableMapCollection(final JsonReader reader, final Collection&lt;Map&lt;String, Object>> res) throws IOException {"
+        errorLine2="                                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ObjectConverter.java"
+            line="132"
+            column="85"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ParsingException create(String reason, boolean withStackTrace) {"
+        errorLine2="               ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="16"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ParsingException create(String reason, boolean withStackTrace) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="16"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ParsingException create(String reason, Throwable cause, boolean withStackTrace) {"
+        errorLine2="               ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="23"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ParsingException create(String reason, Throwable cause, boolean withStackTrace) {"
+        errorLine2="                                       ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="23"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ParsingException create(String reason, Throwable cause, boolean withStackTrace) {"
+        errorLine2="                                                      ~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/ParsingException.java"
+            line="23"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" String get(char[] chars, int len);"
+        errorLine2=" ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringCache.java"
+            line="4"
+            column="2"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" String get(char[] chars, int len);"
+        errorLine2="            ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringCache.java"
+            line="4"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeShortNullable(@Nullable final String value, final JsonWriter sw) {"
+        errorLine2="                                                                               ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="53"
+            column="80"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeShort(final String value, final JsonWriter sw) {"
+        errorLine2="                                         ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="61"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeShort(final String value, final JsonWriter sw) {"
+        errorLine2="                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="61"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final String value, final JsonWriter sw) {"
+        errorLine2="                                                                          ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="65"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final String value, final JsonWriter sw) {"
+        errorLine2="                                    ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="73"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final String value, final JsonWriter sw) {"
+        errorLine2="                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="73"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static String deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="77"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static String deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="77"
+            column="41"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static String deserializeNullable(final JsonReader reader) throws IOException {"
+        errorLine2="                                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="82"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;String> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="91"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;String> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="91"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;String> res) throws IOException {"
+        errorLine2="                                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="95"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;String> res) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="95"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;String> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="100"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;String> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                     ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="100"
+            column="70"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;String> res) throws IOException {"
+        errorLine2="                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="104"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;String> res) throws IOException {"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="104"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final List&lt;String> list, final JsonWriter writer) {"
+        errorLine2="                                    ~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="108"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final List&lt;String> list, final JsonWriter writer) {"
+        errorLine2="                                                             ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/StringConverter.java"
+            line="108"
+            column="62"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final UUID value, final JsonWriter sw) {"
+        errorLine2="                                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="51"
+            column="73"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final UUID value, final JsonWriter sw) {"
+        errorLine2="                                    ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="59"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final UUID value, final JsonWriter sw) {"
+        errorLine2="                                                      ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="59"
+            column="55"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final long hi, final long lo, final JsonWriter sw) {"
+        errorLine2="                                                                  ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="63"
+            column="67"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static UUID deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="143"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static UUID deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="                                      ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="143"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;UUID> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="182"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;UUID> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                           ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="182"
+            column="60"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;UUID> res) throws IOException {"
+        errorLine2="                                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="186"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;UUID> res) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="186"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;UUID> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="191"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;UUID> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                   ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="191"
+            column="68"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;UUID> res) throws IOException {"
+        errorLine2="                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="195"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;UUID> res) throws IOException {"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/UUIDConverter.java"
+            line="195"
+            column="82"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serializeNullable(@Nullable final Element value, final JsonWriter sw) {"
+        errorLine2="                                                                           ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="48"
+            column="76"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final Element value, final JsonWriter sw) {"
+        errorLine2="                                    ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="55"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void serialize(final Element value, final JsonWriter sw) {"
+        errorLine2="                                                         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="55"
+            column="58"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Element deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="67"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Element deserialize(final JsonReader reader) throws IOException {"
+        errorLine2="                                         ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="67"
+            column="42"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Element mapToXml(final Map&lt;String, Object> map) throws IOException {"
+        errorLine2="               ~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="81"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static Element mapToXml(final Map&lt;String, Object> map) throws IOException {"
+        errorLine2="                                      ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="81"
+            column="39"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Element> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="201"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Element> deserializeCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                              ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="201"
+            column="63"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Element> res) throws IOException {"
+        errorLine2="                                                ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="205"
+            column="49"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeCollection(final JsonReader reader, final Collection&lt;Element> res) throws IOException {"
+        errorLine2="                                                                         ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="205"
+            column="74"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Element> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="210"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static ArrayList&lt;Element> deserializeNullableCollection(final JsonReader reader) throws IOException {"
+        errorLine2="                                                                      ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="210"
+            column="71"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Element> res) throws IOException {"
+        errorLine2="                                                        ~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="214"
+            column="57"/>
+    </issue>
+
+    <issue
+        id="UnknownNullness"
+        message="Unknown nullability; explicitly declare as `@Nullable` or `@NonNull` to improve Kotlin interoperability; see https://android.github.io/kotlin-guides/interop.html#nullability-annotations"
+        errorLine1=" public static void deserializeNullableCollection(final JsonReader reader, final Collection&lt;Element> res) throws IOException {"
+        errorLine2="                                                                                 ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="dsl-json/library/src/main/java/com/bugsnag/dslplatform/json/XmlConverter.java"
+            line="214"
+            column="82"/>
     </issue>
 
 </issues>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/FallbackWriter.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/FallbackWriter.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.internal.journal
 
 import com.bugsnag.android.ObjectJsonStreamer
-import com.bugsnag.dslplatform.json.DslJson
+import com.bugsnag.android.repackaged.dslplatform.json.DslJson
 import java.io.InputStream
 import java.io.OutputStream
 import java.lang.reflect.Type

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/FallbackWriter.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/FallbackWriter.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.internal.journal
 
 import com.bugsnag.android.ObjectJsonStreamer
-import com.dslplatform.json.DslJson
+import com.bugsnag.dslplatform.json.DslJson
 import java.io.InputStream
 import java.io.OutputStream
 import java.lang.reflect.Type

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JsonHelper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JsonHelper.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android.internal.journal
 
 import com.bugsnag.android.internal.DateUtils
-import com.dslplatform.json.DslJson
-import com.dslplatform.json.JsonWriter
+import com.bugsnag.dslplatform.json.DslJson
+import com.bugsnag.dslplatform.json.JsonWriter
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
@@ -25,7 +25,12 @@ class JsonHelper private constructor() {
         private val dslJson = DslJson(settings)
 
         init {
-            dslJson.registerWriter(Date::class.java, ::serializeDate)
+            dslJson.registerWriter(Date::class.java) { writer: JsonWriter, value: Date? ->
+                value?.let {
+                    val timestamp = DateUtils.toIso8601(it)
+                    writer.writeString(timestamp)
+                }
+            }
         }
 
         fun serialize(value: Any, stream: OutputStream) {
@@ -71,13 +76,6 @@ class JsonHelper private constructor() {
                 throw ex
             } catch (ex: IOException) {
                 throw IOException("Could not deserialize from $file", ex)
-            }
-        }
-
-        private fun serializeDate(writer: JsonWriter, value: Date?) {
-            value?.let {
-                val timestamp = DateUtils.toIso8601(value)
-                writer.writeString(timestamp)
             }
         }
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JsonHelper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JsonHelper.kt
@@ -1,8 +1,8 @@
 package com.bugsnag.android.internal.journal
 
 import com.bugsnag.android.internal.DateUtils
-import com.bugsnag.dslplatform.json.DslJson
-import com.bugsnag.dslplatform.json.JsonWriter
+import com.bugsnag.android.repackaged.dslplatform.json.DslJson
+import com.bugsnag.android.repackaged.dslplatform.json.JsonWriter
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException


### PR DESCRIPTION
## Goal

Updates bugsnag-android to use a forked version of dsl-json. 

The primary concern against using the dsl-json supplied artefacts is that `DslJson` currently uses `java.awt.*` imports. This results in an Android lint warning that could break the build of end-users of bugsnag-android, necessitating this fork.

Forking the library will also allow us to customize the implementation as needed, and also remove code which isn't used by our project.

## Changeset

- Added dsl-json as a git submodule
- Added dsl-json submodule to the `bugsnag-android-core` sourcesets
- Updated existing code to use forked dsl-json package name
- Suppressed existing lint warnings in dsl-json with a baseline file

## Testing

Relied on existing test coverage.