### PR TITLE
Avoid ClassCastException in JSON serialization

### DIFF
--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/JsonHelperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/journal/JsonHelperTest.kt
@@ -1,0 +1,52 @@
+package com.bugsnag.android.internal.journal
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+
+/**
+ * Serializing mixed type hierarchies should not throw an exception
+ */
+class JsonHelperTest {
+
+    @Test
+    fun testSerializingMixedTypes() {
+        val baos = ByteArrayOutputStream()
+        val mixedTypes: List<Any> = listOf(
+            listOf(1, 2),
+            listOf(true, false),
+            listOf("a", "z")
+        )
+
+        val map: Map<String, Any> = mapOf("list" to mixedTypes)
+        JsonHelper.serialize(map, baos)
+        assertEquals("{\"list\":\"[OBJECT]\"}", String(baos.toByteArray()))
+    }
+
+    @Test
+    fun testSerializingMixedTypesArray() {
+        val baos = ByteArrayOutputStream()
+        val mixedTypes: Array<Any> = arrayOf(
+            arrayOf(1, 2),
+            arrayOf(true, false),
+            arrayOf("a", "z")
+        )
+
+        val map: Map<String, Any> = mapOf("array" to mixedTypes)
+        JsonHelper.serialize(map, baos)
+        assertEquals("{\"array\":\"[OBJECT]\"}", String(baos.toByteArray()))
+    }
+
+    @Test
+    fun testSerializingAnyCollection() {
+        val baos = ByteArrayOutputStream()
+        val mixedTypes: List<Any> = listOf(
+            true,
+            arrayOf(1, 2)
+        )
+
+        val map: Map<String, Any> = mapOf("collection" to mixedTypes)
+        JsonHelper.serialize(map, baos)
+        assertEquals("{\"collection\":[true,\"[OBJECT]\"}", String(baos.toByteArray()))
+    }
+}

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXComplexMetadataScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXComplexMetadataScenario.kt
@@ -43,6 +43,12 @@ internal class CXXComplexMetadataScenario(
 
         Bugsnag.addMetadata("individual_values", map)
         Bugsnag.addMetadata("map_section", "map", map)
+        Bugsnag.addMetadata(
+            "collection_section", "collection",
+            listOf(
+                "a", 5, true
+            )
+        )
 
         if (Bugsnag.getLastRunInfo() != null) {
             log("Triggering handled JVM event")

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -297,6 +297,9 @@ Then("the event contains complex metadata") do
   steps %Q{
     And the event "metaData.individual_values" contains complex metadata
     And the event "metaData.map_section.map" contains complex metadata
+    And the event "metaData.collection_section.collection.0" equals "a"
+    And the event "metaData.collection_section.collection.1" equals 5
+    And the event "metaData.collection_section.collection.2" is true
   }
 end
 


### PR DESCRIPTION
## Goal

Avoids a class cast exception being thrown in a rare edge case by dsl JSON. If dsl-json is provided a list containing a primitive array and some other unrelated type, then it throws an exception.

This changeset updates bugsnag-android to use the fix in [this PR](https://github.com/bugsnag/dsl-json/pull/2). Additionally, it adds some unit test coverage to ensure that an exception is not thrown when serializing JSON with some unusual types.