### PR TITLE
Add a new debug-build test fixture and build step

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -12,6 +12,7 @@ steps:
       MINIMAL_FIXTURE: true
       TEST_FIXTURE_NDK_VERSION: "17.2.4988734"
       TEST_FIXTURE_NAME: "fixture-minimal.apk"
+      BUILD_TASK: "assembleRelease"
 
   - label: ':android: Build Example App'
     depends_on: "android-ci"
@@ -20,6 +21,21 @@ steps:
     plugins:
       docker-compose#v3.7.0:
         run: android-ci
+
+  - label: ':android: Build debug fixture APK'
+    key: "fixture-debug"
+    depends_on: "android-ci"
+    timeout_in_minutes: 30
+    artifact_paths: build/debug/fixture-debug.apk
+    plugins:
+      - docker-compose#v3.7.0:
+          run: android-builder
+    env:
+      MAVEN_VERSION: "3.6.1"
+      MINIMAL_FIXTURE: false
+      TEST_FIXTURE_NDK_VERSION: "17.2.4988734"
+      TEST_FIXTURE_NAME: "fixture-debug.apk"
+      BUILD_TASK: "assembleDebug"
 
   - label: ':android: Build Scan'
     depends_on: "android-ci"
@@ -42,6 +58,27 @@ steps:
         command:
           - "features/minimal"
           - "--app=/app/build/release/fixture-minimal.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_9_0"
+          - "--fail-fast"
+    concurrency: 9
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: ':android: Debug fixture smoke tests'
+    depends_on: "fixture-debug"
+    timeout_in_minutes: 30
+    plugins:
+      artifacts#v1.2.0:
+        download: "build/debug/fixture-debug.apk"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: android-maze-runner
+        run: android-maze-runner
+        command:
+          - "features/smoke_tests"
+          - "--tags=debug-safe"
+          - "--app=/app/build/debug/fixture-debug.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "--fail-fast"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,6 +63,7 @@ steps:
       TEST_FIXTURE_NDK_VERSION: "17.2.4988734"
       TEST_FIXTURE_NAME: "fixture-r16.apk"
       USE_LEGACY_OKHTTP: "true"
+      BUILD_TASK: "assembleRelease"
 
   - label: ':android: Build fixture APK r19'
     key: "fixture-r19"
@@ -76,6 +77,7 @@ steps:
       MAVEN_VERSION: "3.6.1"
       TEST_FIXTURE_NDK_VERSION: "19.2.5345600"
       TEST_FIXTURE_NAME: "fixture-r19.apk"
+      BUILD_TASK: "assembleRelease"
 
   - label: ':android: Build fixture APK r21'
     key: "fixture-r21"
@@ -89,6 +91,7 @@ steps:
       MAVEN_VERSION: "3.6.1"
       TEST_FIXTURE_NDK_VERSION: "21.3.6528147"
       TEST_FIXTURE_NAME: "fixture-r21.apk"
+      BUILD_TASK: "assembleRelease"
 
   - label: ':android: Lint'
     depends_on: "android-ci"

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ test-fixtures:
 	@./gradlew -PMINIMAL_FIXTURE=true -PTEST_FIXTURE_NAME=fixture-minimal.apk  -p=features/fixtures/mazerunner/ assembleRelease -x check
 	@cp features/fixtures/mazerunner/app/build/outputs/apk/release/fixture-minimal.apk build/fixture-minimal.apk
 
+	# And the debug test fixture (full fixture - but a debug build)
+	@./gradlew -PTEST_FIXTURE_NDK_VERSION=$(TEST_FIXTURE_NDK_VERSION) -p=features/fixtures/mazerunner/ assembleDebug -x check
+	@cp features/fixtures/mazerunner/app/build/outputs/apk/debug/fixture.apk build/fixture-debug.apk
+
 bump:
 ifneq ($(shell git diff --staged),)
 	@git diff --staged

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       TEST_FIXTURE_NDK_VERSION:
       TEST_FIXTURE_NAME:
       USE_LEGACY_OKHTTP:
+      BUILD_TASK:
     volumes:
       - ./build:/app/build
 

--- a/dockerfiles/Dockerfile.android-builder
+++ b/dockerfiles/Dockerfile.android-builder
@@ -6,9 +6,9 @@ ENV FIXTURE_PROJECT=/app/features/fixtures/mazerunner
 
 COPY features/ /app/features
 
-CMD ./gradlew -p=${FIXTURE_PROJECT} assembleRelease \
+CMD ./gradlew -p=${FIXTURE_PROJECT} ${BUILD_TASK} \
   -PUSE_LEGACY_OKHTTP=${USE_LEGACY_OKHTTP} \
   -PMINIMAL_FIXTURE=${MINIMAL_FIXTURE} \
   -PTEST_FIXTURE_NDK_VERSION=${TEST_FIXTURE_NDK_VERSION} \
   -PTEST_FIXTURE_NAME=${TEST_FIXTURE_NAME} \
-  && cp -R ${FIXTURE_PROJECT}/app/build/outputs/apk/release /app/build
+  && cp -R ${FIXTURE_PROJECT}/app/build/outputs/apk/* /app/build

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -165,6 +165,7 @@ Scenario: Notify Kotlin exception with overwritten configuration
     And the event "threads.0.stacktrace.0.file" is not null
     And the event "threads.0.stacktrace.0.lineNumber" is not null
 
+@debug-safe
 Scenario: Handled C functionality
     When I run "CXXNotifySmokeScenario"
     And I wait to receive an error

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -1,5 +1,6 @@
 Feature: Session functionality smoke tests
 
+@debug-safe
 Scenario: Automated sessions send
     When I run "AutoSessionSmokeScenario"
     And I wait to receive a session
@@ -51,6 +52,7 @@ Scenario: Automated sessions send
     And the event "session.events.unhandled" equals 0
     And the event "severityReason.unhandledOverridden" is false
 
+@debug-safe
 Scenario: Manual session control works
     When I run "ManualSessionSmokeScenario" and relaunch the app
     And I configure Bugsnag for "ManualSessionSmokeScenario"

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -181,6 +181,7 @@ Scenario: Signal raised with overwritten config
     And the event "metaData.fruit.ripe" is true
     And the event "metaData.fruit.counters" equals 47
 
+@debug-safe
 Scenario: C++ exception thrown with overwritten config
     When I run "CXXExceptionSmokeScenario" and relaunch the app
     And I configure Bugsnag for "CXXExceptionSmokeScenario"


### PR DESCRIPTION
## Goal
Introduce a debug variant of the Mazerunner test fixture, and run some of the test features against it to.

## Changeset
Modified the `android-builder` job to allow the Gradle task to be specified externally (`assembleRelease` / `assembleDebug`) and to copy *all* generated APK artifacts out, allowing access `debug/fixture.apk`or `release/fixture.apk`.

## Testing
A full CI test run was used as part of this PR.