### PR TITLE
Remove concurrent containers requirement for performance reasons

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPath.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPath.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.internal.journal
 
-import com.bugsnag.android.internal.asConcurrent
 import java.util.LinkedList
 
 /**
@@ -75,10 +74,9 @@ class DocumentPath(path: String) {
         value: Any?
     ): MutableMap<String, Any> {
         if (directives.isEmpty()) {
-            val concurrentValue = value.asConcurrent()
-            require(concurrentValue is MutableMap<*, *>) { "Value replacing document must be a map" }
+            require(value is Map<*, *>) { "Value replacing document must be a map" }
             @Suppress("UNCHECKED_CAST")
-            return concurrentValue as MutableMap<String, Any>
+            return (value as Map<String, Any>).toMutableMap()
         }
         val filledInDocument = fillInMissingContainers(document, 0)
         require(filledInDocument is MutableMap<*, *>) { "Document path must result in a top level map" }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPathDirective.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPathDirective.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.internal.journal
 
-import com.bugsnag.android.internal.asConcurrent
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -63,11 +62,10 @@ internal interface DocumentPathDirective<C> {
         }
 
         override fun setInContainer(container: MutableMap<String, in Any>, value: Any?) {
-            val concurrentValue = value.asConcurrent()
-            if (concurrentValue == null) {
+            if (value == null) {
                 container.remove(key)
             } else {
-                container[key] = concurrentValue
+                container[key] = value
             }
         }
 
@@ -108,10 +106,9 @@ internal interface DocumentPathDirective<C> {
         }
 
         override fun setInContainer(container: MutableList<in Any>, value: Any?) {
-            val concurrentValue = value.asConcurrent()
             container.removeAt(index)
-            if (concurrentValue != null) {
-                container.add(index, concurrentValue)
+            if (value != null) {
+                container.add(index, value)
             }
         }
 
@@ -148,12 +145,11 @@ internal interface DocumentPathDirective<C> {
         }
 
         override fun setInContainer(container: MutableList<in Any>, value: Any?) {
-            val concurrentValue = value.asConcurrent()
             if (container.isNotEmpty()) {
                 container.removeAt(container.lastIndex)
             }
-            if (concurrentValue != null) {
-                container.add(concurrentValue)
+            if (value != null) {
+                container.add(value)
             }
         }
 
@@ -200,9 +196,8 @@ internal interface DocumentPathDirective<C> {
         }
 
         override fun setInContainer(container: MutableList<in Any>, value: Any?) {
-            val concurrentValue = value.asConcurrent()
-            requireNotNull(concurrentValue) { "Cannot use null for last path insert value" }
-            container.add(concurrentValue)
+            requireNotNull(value) { "Cannot use null for last path insert value" }
+            container.add(value)
         }
 
         override fun toString(): String {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android.internal.journal
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.bugsnag.android.internal.MemoryMappedOutputStream
-import com.bugsnag.android.internal.asConcurrent
 import java.io.Closeable
 import java.io.File
 import java.io.IOException
@@ -49,7 +48,7 @@ constructor(
     private val snapshotPath = getSnapshotPath(baseDocumentPath)
     private val newSnapshotPath = getNewSnapshotPath(baseDocumentPath)
 
-    private var document = convertDocumentToConcurrent(initialDocument)
+    private var document = initialDocument.toMutableMap()
     private val journal = Journal(journalType, version)
     private val journalStream = MemoryMappedOutputStream(journalPath, bufferSize, clearedByteValue)
     private var isOpen = true
@@ -282,11 +281,6 @@ constructor(
             }
 
             return journal.applyTo(document)
-        }
-
-        internal fun convertDocumentToConcurrent(document: Map<String, Any>): MutableMap<String, Any> {
-            @Suppress("UNCHECKED_CAST")
-            return document.asConcurrent() as MutableMap<String, Any>
         }
     }
 }


### PR DESCRIPTION
## Goal

PLAT-7528

Concurrent containers were severely slowing performance for a feature we're not even using (concurrent journal access). We can deal with that issue if and when we actually need it.

## Testing

Did manual performance testing to verify the improvement.
