### PR TITLE
Increase resilience of NDK stackframe method capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Increase resilience of NDK stackframe method capture
+  [#1484](https://github.com/bugsnag/bugsnag-android/pull/1484)
+
 * Avoid reporting false-positive background ANRs with improved foreground detection
   [#1429](https://github.com/bugsnag/bugsnag-android/pull/1429)
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -90,9 +90,8 @@ void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
     // populate method
     jstring method = NULL;
     if (strlen(frame.method) == 0) {
-      size_t frame_len = sizeof(char) * 32;
       char frame_address[32];
-      snprintf(frame_address, frame_len, "0x%lx",
+      snprintf(frame_address, sizeof(frame_address), "0x%lx",
                (unsigned long)frame.frame_address);
       method = bsg_safe_new_string_utf(env, frame_address);
     } else {

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -81,15 +81,25 @@ void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
       goto exit;
     }
 
+    // populate filename
     jstring filename = bsg_safe_new_string_utf(env, frame.filename);
-    jstring method;
+    if (filename == NULL) {
+      goto exit;
+    }
+
+    // populate method
+    jstring method = NULL;
     if (strlen(frame.method) == 0) {
-      char *frame_address = calloc(1, sizeof(char) * 32);
-      sprintf(frame_address, "0x%lx", (unsigned long)frame.frame_address);
+      size_t frame_len = sizeof(char) * 32;
+      char frame_address[32];
+      snprintf(frame_address, frame_len, "0x%lx",
+               (unsigned long)frame.frame_address);
       method = bsg_safe_new_string_utf(env, frame_address);
-      free(frame_address);
     } else {
       method = bsg_safe_new_string_utf(env, frame.method);
+    }
+    if (method == NULL) {
+      goto exit;
     }
 
     // create StackTraceElement object


### PR DESCRIPTION
## Goal

Increases the resilience of the code used to instantiate a `StackTraceElement` object when calling `bugsnag_notify_env`. There were a couple of potential issues with the existing implementation:

- The return values of `filename` and `method` weren't checked for `NULL`, which could lead to exceptions being thrown in `bsg_safe_new_object`
- The return value of `calloc` was not checked for `NULL`, which could lead to a malformed string if `bsg_safe_new_string_utf` failed, resulting in a [SIGABRT](https://cs.android.com/android/platform/superproject/+/master:art/runtime/jni/check_jni.cc;l=1013?q=CheckNonHeapValue)

## Testing

Relied on existing test coverage.