### PR TITLE
Increase journal buffer size

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
@@ -156,11 +156,11 @@ internal class BugsnagJournal @JvmOverloads internal constructor(
         internal const val journalVersion = 1
 
         // Size of the on-disk memory-mapped buffer in bytes.
-        private const val mmapBufferSize = 100000L
+        private const val mmapBufferSize = 1000000L
 
         // If the memory-mapped buffer fills beyond this many bytes, it gets auto-snapshotted.
         // Note: The size of mmapBufferSize and highWater have no effect on snapshot runtime cost.
-        private const val highWater = 50000L
+        private const val highWater = 500000L
 
         // Polling interval in milliseconds for the high water check thread.
         private const val highWaterPollingIntervalMS = 200L


### PR DESCRIPTION
## Goal

Increases the buffer size used by the journal. This should increase performance when adding large amounts of information in a very short amount of time, by reducing the number of times the buffer needs to flush. This was tested by adding complex breadcrumbs 1000 times, which improved performance by ~10% in manual profiling.