### PR TITLE
Avoid formatting date to improve addBreadcrumb performance

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.DateUtils
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -43,7 +42,7 @@ internal class BreadcrumbState(
             StateEvent.AddBreadcrumb(
                 breadcrumb.impl.message,
                 breadcrumb.impl.type,
-                DateUtils.toIso8601(breadcrumb.impl.timestamp),
+                breadcrumb.impl.timestamp,
                 breadcrumb.impl.metadata ?: mutableMapOf()
             )
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournalEventMapper.kt
@@ -119,7 +119,8 @@ internal class BugsnagJournalEventMapper(
         val type = map[JournalKeys.keyType] as String
         map[JournalKeys.keyType] = BreadcrumbType.valueOf(type.toUpperCase(Locale.US))
 
-        map[JournalKeys.keyTimestamp] = (map[JournalKeys.keyTimestamp] as String).toDate()
+        val time = map[JournalKeys.keyTimestamp] as Long
+        map[JournalKeys.keyTimestamp] = Date(time)
 
         map["metadata"] = map[JournalKeys.keyMetadata]
         map.remove(JournalKeys.keyMetadata)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JournaledStateObserver.kt
@@ -119,7 +119,7 @@ internal class JournaledStateObserver(val client: Client, val journal: BugsnagJo
             mutableMapOf(
                 JournalKeys.keyMetadata to makeMetadataJournalSafe(event.metadata),
                 JournalKeys.keyName to event.message,
-                JournalKeys.keyTimestamp to event.timestamp,
+                JournalKeys.keyTimestamp to event.timestamp.time,
                 JournalKeys.keyType to event.type.toString()
             )
         )

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/StateEvent.kt
@@ -1,5 +1,7 @@
 package com.bugsnag.android
 
+import java.util.Date
+
 sealed class StateEvent { // JvmField allows direct field access optimizations
 
     class Install(
@@ -31,7 +33,7 @@ sealed class StateEvent { // JvmField allows direct field access optimizations
     class AddBreadcrumb(
         @JvmField val message: String,
         @JvmField val type: BreadcrumbType,
-        @JvmField val timestamp: String,
+        @JvmField val timestamp: Date,
         @JvmField val metadata: MutableMap<String, Any?>
     ) : StateEvent()
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagJournalEventMapperTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.math.BigDecimal
+import java.util.Date
 
 class BugsnagJournalEventMapperTest {
 
@@ -38,7 +39,7 @@ class BugsnagJournalEventMapperTest {
                 "metaData" to emptyMap<String, Any?>(),
                 "name" to "Bugsnag loaded",
                 "type" to "state",
-                "timestamp" to "2021-09-28T10:31:09.092Z"
+                "timestamp" to 1636127397411L
             ),
             mapOf(
                 "metaData" to mapOf(
@@ -47,7 +48,7 @@ class BugsnagJournalEventMapperTest {
                 ),
                 "name" to "Connectivity changed",
                 "type" to "request",
-                "timestamp" to "2021-09-28T10:31:10.856Z"
+                "timestamp" to 1636127399625L
             )
         )
         val app = mapOf(
@@ -273,14 +274,14 @@ class BugsnagJournalEventMapperTest {
         with(event.breadcrumbs[0]) {
             assertEquals("Bugsnag loaded", message)
             assertEquals(BreadcrumbType.STATE, type)
-            assertEquals(DateUtils.fromIso8601("2021-09-28T10:31:09.092Z"), timestamp)
+            assertEquals(Date(1636127397411L), timestamp)
             assertEquals(emptyMap<String, Any?>(), metadata)
         }
 
         with(event.breadcrumbs[1]) {
             assertEquals("Connectivity changed", message)
             assertEquals(BreadcrumbType.REQUEST, type)
-            assertEquals(DateUtils.fromIso8601("2021-09-28T10:31:10.856Z"), timestamp)
+            assertEquals(Date(1636127399625L), timestamp)
             val expectedMetadata = mapOf(
                 "hasConnection" to true,
                 "networkState" to "wifi"

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledStateObserverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledStateObserverTest.kt
@@ -14,6 +14,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 import java.io.File
+import java.util.Date
 
 @RunWith(MockitoJUnitRunner::class)
 internal class JournaledStateObserverTest {
@@ -191,7 +192,7 @@ internal class JournaledStateObserverTest {
             StateEvent.AddBreadcrumb(
                 "mymsg",
                 BreadcrumbType.LOG,
-                "mytime",
+                Date(1636127079133),
                 mutableMapOf(
                     "x" to 1,
                     "y" to 2,
@@ -204,7 +205,7 @@ internal class JournaledStateObserverTest {
                 "breadcrumbs" to listOf(
                     mapOf(
                         "name" to "mymsg",
-                        "timestamp" to "mytime",
+                        "timestamp" to 1636127079133L,
                         "type" to "log",
                         "metaData" to mapOf(
                             "x" to 1,

--- a/bugsnag-android-core/src/test/resources/event_deserialization_0.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_0.json
@@ -56,13 +56,13 @@
   },
   "breadcrumbs": [
     {
-      "timestamp": "1970-01-01T00:00:00.000Z",
+      "timestamp": 0,
       "name": "helloworld",
       "type": "manual",
       "metaData": {}
     },
     {
-      "timestamp": "1970-01-01T00:00:00.000Z",
+      "timestamp": 0,
       "name": "metadata",
       "type": "process",
       "metaData": {

--- a/bugsnag-android-core/src/test/resources/event_deserialization_1.json
+++ b/bugsnag-android-core/src/test/resources/event_deserialization_1.json
@@ -71,7 +71,7 @@
   },
   "breadcrumbs": [
     {
-      "timestamp": "1970-01-01T00:00:00.000Z",
+      "timestamp": 0,
       "name": "Connectivity changed",
       "type": "state",
       "metaData": {
@@ -80,7 +80,7 @@
       }
     },
     {
-      "timestamp": "1970-01-01T00:00:00.000Z",
+      "timestamp": 0,
       "name": "Bugsnag loaded",
       "type": "state"
     }

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -97,7 +97,7 @@ class NativeBridge(
             is AddBreadcrumb -> addBreadcrumb(
                 makeSafe(event.message),
                 makeSafe(event.type.toString()),
-                makeSafe(event.timestamp),
+                "", // don't send timestamp to avoid date formatting perf cost
                 event.metadata
             )
             NotifyHandled -> addHandledEvent()


### PR DESCRIPTION
## Goal

Delays the date formatting for breadcrumbs to the point where the event JSON payload is generated, rather than at the point of breadcrumb collection. The journal now stores the breadcrumb timestamp as a `Long`.

Other timestamps are still stored as strings - these can be altered at a future date as they don't impact performance as much as breadcrumb timestamps.

## Testing

When adding 100 breadcrumbs, the previous implementation spent ~100ms on `toIso8601()` when profiled with a full Java method trace:
<img width="822" alt="baseline" src="https://user-images.githubusercontent.com/11800640/140544759-19594697-2701-4d3c-9367-4920eba0e66b.png">

Avoiding date formatting has improved performance by ~13%:

<img width="709" alt="changes" src="https://user-images.githubusercontent.com/11800640/140544751-c1408497-1148-4669-96b9-bd021a3bede9.png">

