### PR TITLE
Allow onSend callbacks to run

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -40,6 +40,7 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityReason(@SeverityReason.SeverityReasonType reason: String)</ID>
     <ID>RethrowCaughtException:JsonHelper.kt$JsonHelper.Companion$throw ex</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, streamable: JsonStream.Streamable, headers: Map&lt;String, String?> ): DeliveryStatus</ID>
+    <ID>SwallowedException:BugsnagJournalEventMapper.kt$BugsnagJournalEventMapper$catch (exc: Throwable) { logger.e("Failed to deserialize journal, skipping event") null }</ID>
     <ID>SwallowedException:BugsnagJournalEventMapper.kt$BugsnagJournalEventMapper$catch (pe: IllegalArgumentException) { ndkDateFormatHolder.get()!!.parse(this) ?: throw IllegalArgumentException("cannot parse date $this") }</ID>
     <ID>SwallowedException:ClientInternal.kt$ClientInternal$catch (exc: Throwable) { false }</ID>
     <ID>SwallowedException:ClientInternal.kt$ClientInternal$catch (exception: IllegalArgumentException) { logger.w("Receiver not registered") }</ID>
@@ -54,6 +55,7 @@
     <ID>SwallowedException:JournaledDocument.kt$JournaledDocument.Companion$catch (ex: IOException) { // If we don't even have a base snapshot, we have nothing at all. return null }</ID>
     <ID>SwallowedException:JournaledDocument.kt$JournaledDocument.Companion$catch (ex: IOException) { // mydoc.snapshot.new doesn't exist, or it's corrupt. // Either way, we must fall back to using mydoc.snapshot and mydoc.journal }</ID>
     <ID>SwallowedException:PluginClient.kt$PluginClient$catch (exc: ClassNotFoundException) { logger.d("Plugin '$clz' is not on the classpath - functionality will not be enabled.") null }</ID>
+    <ID>TooManyFunctions:BugsnagJournalEventMapper.kt$BugsnagJournalEventMapper</ID>
     <ID>TooManyFunctions:ClientInternal.kt$ClientInternal : CallbackAwareMetadataAwareUserAware</ID>
     <ID>UnnecessaryAbstractClass:DependencyModule.kt$DependencyModule</ID>
     <ID>UnusedPrivateMember:ThreadStateTest.kt$ThreadStateTest$private val configuration = generateImmutableConfig()</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -211,6 +211,7 @@ class EventStore extends FileStore {
                 return null;
             }
         } catch (Exception ioe) {
+            logger.e("Failed to run onSend callbacks", ioe);
             eventSource.clear();
         }
 

--- a/features/full_tests/onsend_callback.feature
+++ b/features/full_tests/onsend_callback.feature
@@ -1,7 +1,5 @@
 Feature: OnSend Callbacks can alter Events before upload
 
-  # TODO Skip pending PLAT-7586
-  @skip
   Scenario: Handled exception with altered by OnSendCallback
     When I run "OnSendCallbackScenario" and relaunch the app
     And I configure the app to run in the "start-only" state


### PR DESCRIPTION
## Goal

Fixes some bugs in how JVM exceptions were deserialized from disk when running an `OnSend` callback. This is down to `BugsnagJournalEventMapper` converting both an `Event` JSON and journal entries into an `Event`.

## Changeset

- Removed unnecessarily verbose logging around the `BugsnagJournal` which may have confused end-users
- Only loaded the duration from the 'runtime' journal entry if it is present, rather than throwing an exception
- Handling a long/string timestamp for breadcrumbs

This has been tested by uncommenting the E2E scenario and existing unit tests.