### PR TITLE
[PLAT-7581] Use mutable maps for anything that can be put in the journal

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
@@ -20,7 +20,7 @@ import kotlin.concurrent.thread
 internal class BugsnagJournal @JvmOverloads internal constructor(
     private val logger: Logger,
     private val baseDocumentPath: File,
-    private val initialDocument: Map<String, Any> = mapOf(),
+    private val initialDocument: Map<String, Any> = mutableMapOf(),
     private val retryIntervalMs: Long = DEFAULT_RETRY_INTERVAL_MS
 ) : Closeable {
 
@@ -178,7 +178,7 @@ internal class BugsnagJournal @JvmOverloads internal constructor(
         // Internal to keep it accessible to unit tests
         internal fun withInitialDocumentContents(document: Map<String, Any>): Map<String, Any> {
             val docWithVersionInfo = document.toMutableMap()
-            docWithVersionInfo[JournalKeys.keyVersionInfo] = mapOf(
+            docWithVersionInfo[JournalKeys.keyVersionInfo] = mutableMapOf(
                 JournalKeys.keyType to journalType,
                 JournalKeys.keyVersion to journalVersion
             )

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientInternal.kt
@@ -316,7 +316,7 @@ internal class ClientInternal constructor(
     private fun onConnectivityChange(hasConnection: Boolean, networkState: String?) {
         leaveAutoBreadcrumb(
             "Connectivity changed", BreadcrumbType.STATE,
-            mapOf(
+            mutableMapOf(
                 "hasConnection" to hasConnection,
                 "networkState" to networkState
             )
@@ -377,7 +377,7 @@ internal class ClientInternal constructor(
                 { oldOrientation: String?, newOrientation: String? ->
                     leaveAutoBreadcrumb(
                         "Orientation changed", BreadcrumbType.STATE,
-                        mapOf(
+                        mutableMapOf(
                             "from" to oldOrientation,
                             "to" to newOrientation
                         )
@@ -390,7 +390,7 @@ internal class ClientInternal constructor(
                     leaveAutoBreadcrumb(
                         "Trim Memory",
                         BreadcrumbType.STATE,
-                        mapOf("trimLevel" to memoryTrimState.trimLevelDescription)
+                        mutableMapOf("trimLevel" to memoryTrimState.trimLevelDescription)
                     )
                 }
                 memoryTrimState.emitObservableEvent()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceWithState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceWithState.kt
@@ -65,7 +65,7 @@ class DeviceWithState internal constructor(
     var freeDisk: Long? by map
 
     override fun toJournalSection(): Map<String, Any?> = super.toJournalSection().plus(
-        mapOf(
+        mutableMapOf(
             JournalKeys.keyFreeDisk to freeDisk,
             JournalKeys.keyFreeMemory to freeMemory,
             JournalKeys.keyOrientation to orientation,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
@@ -2,7 +2,6 @@
 
 package com.bugsnag.android
 
-import com.bugsnag.android.internal.journal.Journalable
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 
@@ -14,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 internal data class Metadata @JvmOverloads constructor(
     internal val store: MutableMap<String, MutableMap<String, Any>> = ConcurrentHashMap()
-) : JsonStream.Streamable, MetadataAware, Journalable {
+) : JsonStream.Streamable, MetadataAware {
 
     val jsonStreamer: ObjectJsonStreamer = ObjectJsonStreamer()
 
@@ -26,10 +25,8 @@ internal data class Metadata @JvmOverloads constructor(
 
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {
-        jsonStreamer.objectToStream(toJournalSection(), writer, true)
+        jsonStreamer.objectToStream(store, writer, true)
     }
-
-    override fun toJournalSection(): Map<String, Any?> = store.toMap()
 
     override fun addMetadata(section: String, value: Map<String, Any?>) {
         value.entries.forEach {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -19,7 +19,7 @@ class Notifier @JvmOverloads constructor(
     override fun toStream(writer: JsonStream) = writer.value(toJournalSection())
 
     override fun toJournalSection(): Map<String, Any?> {
-        val data = mapOf(
+        val data = mutableMapOf(
             JournalKeys.keyName to name,
             JournalKeys.keyVersion to version,
             JournalKeys.keyUrl to url

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
@@ -122,7 +122,7 @@ class Stackframe : JsonStream.Streamable, Journalable {
     override fun toStream(writer: JsonStream) = writer.value(toJournalSection())
 
     override fun toJournalSection(): Map<String, Any?> = nativeFrame?.toJournalSection()
-        ?: mapOf(
+        ?: mutableMapOf(
             JournalKeys.keyMethod to method,
             JournalKeys.keyFile to file,
             JournalKeys.keyLineNumber to lineNumber,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/User.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/User.kt
@@ -9,7 +9,7 @@ import java.io.IOException
  * Information about the current user of your application.
  */
 class User internal constructor(
-    data: Map<String, String?> = mapOf()
+    data: Map<String, String?> = mutableMapOf()
 ) : JsonStream.Streamable, Journalable {
 
     private val map: Map<String, String?> = data.withDefault { null }
@@ -30,7 +30,7 @@ class User internal constructor(
     val name: String? by map
 
     internal constructor(id: String?, email: String?, name: String?) : this(
-        mapOf(
+        mutableMapOf(
             JournalKeys.keyId to id,
             JournalKeys.keyEmail to email,
             JournalKeys.keyName to name

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPathDirective.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPathDirective.kt
@@ -1,8 +1,6 @@
 package com.bugsnag.android.internal.journal
 
 import com.bugsnag.android.internal.bsgToMutableContainersDeep
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * A directive determines how document path commands are interpreted. Making a container,
@@ -55,7 +53,7 @@ internal interface DocumentPathDirective<C> {
     open class MapKeyDirective(private val key: String) :
         DocumentPathDirective<MutableMap<String, in Any>> {
         override fun newContainer(): MutableMap<String, in Any> {
-            return ConcurrentHashMap()
+            return mutableMapOf()
         }
 
         override fun getFromContainer(container: MutableMap<String, in Any>): Any? {
@@ -100,7 +98,7 @@ internal interface DocumentPathDirective<C> {
     open class ListIndexDirective(private val index: Int) :
         DocumentPathDirective<MutableList<in Any>> {
         override fun newContainer(): MutableList<in Any> {
-            return CopyOnWriteArrayList()
+            return mutableListOf()
         }
 
         override fun getFromContainer(container: MutableList<in Any>): Any? {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/JournaledDocument.kt
@@ -15,10 +15,6 @@ import java.util.function.BiConsumer
  * Document snapshots are persisted to files, and journal entries are persisted to a memory-mapped
  * file.
  *
- * This document will always be internally composed of ConcurrentHashMap and CopyOnWriteArrayList.
- * Thus, the document and its children will have the same concurrency protections and requirements
- * of those classes.
- *
  * Changes to the document must me made only via journal commands. Do not modify the document or any
  * of its sub-components directly!
  */

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativeBridge.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativeBridge.kt
@@ -27,7 +27,7 @@ internal class BugsnagReactNativeBridge(
             is UpdateUser -> {
                 MessageEvent(
                     "UserUpdate",
-                    mapOf(
+                    mutableMapOf(
                         Pair("id", event.user.id),
                         Pair("email", event.user.email),
                         Pair("name", event.user.name)


### PR DESCRIPTION
## Goal

The journal requires mutable containers and auto-converts anything non-conformant. Make sure anything we pass in is already mutable.

## Testing

Re-ran all automated tests.
