### PR TITLE
Optimize Command.serialize()

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/Journal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/Journal.kt
@@ -97,7 +97,7 @@ class Journal(val type: String, val version: Int) {
          */
         @Throws(IOException::class)
         fun serialize(out: OutputStream) {
-            JsonHelper.serialize(mutableMapOf(path to value), out)
+            JsonHelper.serialize(mapOf(path to value), out)
             out.write(0)
         }
 


### PR DESCRIPTION
## Goal

Optimizes the `serialize()` command to avoid the unnecessary instantiation of a `Pair`, and switches to using the cheaper `HashMap` object.

The rest of the method is dominated by dsl-json which doesn't have any low-hanging fruit for optimization.

## Testing

Verified against a baseline and confirmed that the time taken to instantiate and populate maps reduced from ~55ms to ~25ms.

<img width="650" alt="command_serialize_baseline" src="https://user-images.githubusercontent.com/11800640/140925313-152b8971-b309-4491-a5f0-3a08b083eee7.png">

<img width="710" alt="command_serialize_improvement" src="https://user-images.githubusercontent.com/11800640/140925316-240d36fc-c568-4984-94ed-e00e07a0a0f1.png">


