### PR TITLE
Memoize document path directives

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPath.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPath.kt
@@ -146,6 +146,10 @@ class DocumentPath(path: String) {
         private const val PATH_SEPARATOR = '.'
         private const val ADD_OPERATOR = '+'
 
+        // optimization: memoize the results for the path directive
+        @JvmField
+        internal val memo = HashMap<String, List<DocumentPathDirective<Any>>>()
+
         private fun containsEscapeSequence(str: String): Boolean {
             for (c in str) {
                 if (c == ESCAPE_CHAR) {
@@ -183,6 +187,10 @@ class DocumentPath(path: String) {
          * The path cannot have empty components (e.g. "a..b" is invalid).
          */
         internal fun toPathDirectives(path: String): List<DocumentPathDirective<Any>> {
+            return memo.getOrPut(path) { toPathDirectivesImpl(path) }
+        }
+
+        private fun toPathDirectivesImpl(path: String): List<DocumentPathDirective<Any>> {
             if (path.isEmpty()) {
                 return emptyList()
             }


### PR DESCRIPTION
## Goal

Creating a `Journal.Command` object initializes a list of `DocumentPathDirective`. This was relatively expensive to calculate and memoization reduces the amount of time required by an order of magnitude. 

## Testing

Verified that the amount of time dedicated to creating path directives when setting the context drops by an order of magnitude, from ~200ms to ~22ms:

<img width="728" alt="command_init_baseline" src="https://user-images.githubusercontent.com/11800640/140929553-27319e0d-3f91-4fa4-870a-103aae28bd6a.png">
<img width="698" alt="command_init_changes" src="https://user-images.githubusercontent.com/11800640/140929558-2c0adba9-8a58-4ba7-b7ed-a65ff04442e2.png">
