### PR TITLE
[Plat-7528] improve performance 3

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -28,6 +28,7 @@
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$299</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$429</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>
+    <ID>MagicNumber:DocumentPath.kt$DocumentPath.Companion$8</ID>
     <ID>MagicNumber:LastRunInfoStore.kt$LastRunInfoStore$3</ID>
     <ID>MaxLineLength:EventSerializationTest.kt$EventSerializationTest.Companion$it.threads.add(Thread(5, "main", ThreadType.ANDROID, true, Thread.State.RUNNABLE, stacktrace, NoopLogger))</ID>
     <ID>MaxLineLength:LastRunInfo.kt$LastRunInfo$return "LastRunInfo(consecutiveLaunchCrashes=$consecutiveLaunchCrashes, crashed=$crashed, crashedDuringLaunch=$crashedDuringLaunch)"</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPath.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/journal/DocumentPath.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.internal.journal
 
 import com.bugsnag.android.internal.bsgToMutableContainersDeep
-import java.util.LinkedList
 
 /**
  * DocumentPath records a path into a hierarchical acyclic document, and can be used to modify
@@ -187,7 +186,11 @@ class DocumentPath(path: String) {
             if (path.isEmpty()) {
                 return emptyList()
             }
-            val directives = LinkedList<DocumentPathDirective<*>>()
+
+            // Choose an initial capacity that is unlikely to be exceeded.
+            // Currently the deepest we go is events.0.exceptions.0.stackTrace.0.xyz
+            val optimalArrayLength = 8
+            val directives = ArrayList<DocumentPathDirective<*>>(optimalArrayLength)
             val buff = StringBuilder(path.length)
             var escapeIsInitiated = false
 


### PR DESCRIPTION
## Design

Allocate a 10-entry array list for document path directives to avoid the overhead of adding to a linked list.
