### PR TITLE
feat(feature flags): added FeatureFlags to `Event`

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -681,7 +681,9 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
             }
             SeverityReason severityReason = SeverityReason.newInstance(REASON_HANDLED_EXCEPTION);
             Metadata metadata = metadataState.getMetadata();
-            Event event = new Event(exc, immutableConfig, severityReason, metadata, logger);
+            FeatureFlags featureFlags = featureFlagState.getFeatureFlags();
+            Event event = new Event(exc, immutableConfig, severityReason, metadata, featureFlags,
+                    logger);
             populateAndNotifyAndroidEvent(event, onError);
         } else {
             logNull("notify");
@@ -699,7 +701,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         SeverityReason handledState
                 = SeverityReason.newInstance(severityReason, Severity.ERROR, attributeValue);
         Metadata data = Metadata.Companion.merge(metadataState.getMetadata(), metadata);
-        Event event = new Event(exc, immutableConfig, handledState, data, logger);
+        Event event = new Event(exc, immutableConfig, handledState,
+                data, featureFlagState.getFeatureFlags(), logger);
         populateAndNotifyAndroidEvent(event, null);
 
         // persist LastRunInfo so that on relaunch users can check the app crashed
@@ -1097,6 +1100,10 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
 
     MetadataState getMetadataState() {
         return metadataState;
+    }
+
+    FeatureFlagState getFeatureFlagState() {
+        return featureFlagState;
     }
 
     ContextState getContextState() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * sent to Bugsnag's API.
  */
 @SuppressWarnings("ConstantConditions")
-public class Event implements JsonStream.Streamable, MetadataAware, UserAware {
+public class Event implements JsonStream.Streamable, MetadataAware, UserAware, FeatureFlagAware {
 
     private final EventInternal impl;
     private final Logger logger;
@@ -24,15 +24,17 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware {
           @NonNull ImmutableConfig config,
           @NonNull SeverityReason severityReason,
           @NonNull Logger logger) {
-        this(originalError, config, severityReason, new Metadata(), logger);
+        this(originalError, config, severityReason, new Metadata(), new FeatureFlags(), logger);
     }
 
     Event(@Nullable Throwable originalError,
           @NonNull ImmutableConfig config,
           @NonNull SeverityReason severityReason,
           @NonNull Metadata metadata,
+          @NonNull FeatureFlags featureFlags,
           @NonNull Logger logger) {
-        this(new EventInternal(originalError, config, severityReason, metadata), logger);
+        this(new EventInternal(originalError, config, severityReason, metadata, featureFlags),
+                logger);
     }
 
     Event(@NonNull EventInternal impl, @NonNull Logger logger) {
@@ -281,6 +283,62 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware {
             logNull("getMetadata");
             return null;
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addFeatureFlag(@NonNull String name) {
+        if (name != null) {
+            impl.addFeatureFlag(name);
+        } else {
+            logNull("addFeatureFlag");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addFeatureFlag(@NonNull String name, @Nullable String variant) {
+        if (name != null) {
+            impl.addFeatureFlag(name, variant);
+        } else {
+            logNull("addFeatureFlag");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addFeatureFlags(@NonNull Iterable<FeatureFlag> featureFlags) {
+        if (featureFlags != null) {
+            impl.addFeatureFlags(featureFlags);
+        } else {
+            logNull("addFeatureFlags");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearFeatureFlag(@NonNull String name) {
+        if (name != null) {
+            impl.clearFeatureFlag(name);
+        } else {
+            logNull("clearFeatureFlag");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearFeatureFlags() {
+        impl.clearFeatureFlags();
     }
 
     @Override

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -7,10 +7,12 @@ internal class EventInternal @JvmOverloads internal constructor(
     val originalError: Throwable? = null,
     config: ImmutableConfig,
     private var severityReason: SeverityReason,
-    data: Metadata = Metadata()
-) : JsonStream.Streamable, MetadataAware, UserAware {
+    data: Metadata = Metadata(),
+    featureFlags: FeatureFlags = FeatureFlags()
+) : JsonStream.Streamable, MetadataAware, UserAware, FeatureFlagAware {
 
     val metadata: Metadata = data.copy()
+    val featureFlags: FeatureFlags = featureFlags.copy()
     private val discardClasses: Set<String> = config.discardClasses.toSet()
     private val projectPackages = config.projectPackages
 
@@ -106,6 +108,8 @@ internal class EventInternal @JvmOverloads internal constructor(
         threads.forEach { writer.value(it) }
         writer.endArray()
 
+        writer.name("featureFlags").value(featureFlags)
+
         if (session != null) {
             val copy = Session.copySession(session)
             writer.name("session").beginObject()
@@ -167,4 +171,15 @@ internal class EventInternal @JvmOverloads internal constructor(
     override fun getMetadata(section: String) = metadata.getMetadata(section)
 
     override fun getMetadata(section: String, key: String) = metadata.getMetadata(section, key)
+
+    override fun addFeatureFlag(name: String) = featureFlags.addFeatureFlag(name)
+
+    override fun addFeatureFlag(name: String, variant: String?) = featureFlags.addFeatureFlag(name, variant)
+
+    override fun addFeatureFlags(featureFlags: MutableIterable<FeatureFlag>) =
+        this.featureFlags.addFeatureFlags(featureFlags)
+
+    override fun clearFeatureFlag(name: String) = featureFlags.clearFeatureFlag(name)
+
+    override fun clearFeatureFlags() = featureFlags.clearFeatureFlags()
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FeatureFlagState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FeatureFlagState.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android
 
 internal data class FeatureFlagState(
-    private val featureFlags: FeatureFlags = FeatureFlags()
+    val featureFlags: FeatureFlags = FeatureFlags()
 ) : BaseObservable(), FeatureFlagAware {
     override fun addFeatureFlag(name: String) {
         this.featureFlags.addFeatureFlag(name)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -397,12 +397,22 @@ public class NativeInterface {
         });
     }
 
+    /**
+     * Create an {@code Event} object
+     *
+     * @param exc the Throwable object that caused the event
+     * @param client the Client object that the event is associated with
+     * @param severityReason the severity of the Event
+     * @return a new {@code Event} object
+     */
     @NonNull
     public static Event createEvent(@Nullable Throwable exc,
                                     @NonNull Client client,
                                     @NonNull SeverityReason severityReason) {
         Metadata metadata = client.getMetadataState().getMetadata();
-        return new Event(exc, client.getConfig(), severityReason, metadata, client.logger);
+        FeatureFlags featureFlags = client.getFeatureFlagState().getFeatureFlags();
+        return new Event(exc, client.getConfig(), severityReason, metadata, featureFlags,
+                client.logger);
     }
 
     @NonNull

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -131,6 +131,7 @@ public class ClientFacadeTest {
 
         // required fields for generating an event
         when(metadataState.getMetadata()).thenReturn(new Metadata());
+        when(featureFlagState.getFeatureFlags()).thenReturn(new FeatureFlags());
         when(immutableConfig.getLogger()).thenReturn(logger);
         when(immutableConfig.getSendThreads()).thenReturn(ThreadSendPolicy.ALWAYS);
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventApiTest.kt
@@ -64,4 +64,41 @@ internal class EventApiTest {
         event.clearMetadata("foo", "wham")
         assertNull(event.impl.metadata.getMetadata("foo", "wham"))
     }
+
+    @Test
+    fun addFeatureFlagWithoutVariant() {
+        event.addFeatureFlag("demo_mode")
+        assertEquals(
+            listOf(FeatureFlag("demo_mode")),
+            event.impl.featureFlags.toList()
+        )
+    }
+
+    @Test
+    fun addFeatureFlag() {
+        event.addFeatureFlag("sample_group", "a")
+        assertEquals(
+            listOf(FeatureFlag("sample_group", "a")),
+            event.impl.featureFlags.toList()
+        )
+    }
+
+    @Test
+    fun clearFeatureFlag() {
+        event.addFeatureFlag("demo_group")
+        event.addFeatureFlag("sample_group", "a")
+        event.clearFeatureFlag("demo_group")
+        assertEquals(
+            listOf(FeatureFlag("sample_group", "a")),
+            event.impl.featureFlags.toList()
+        )
+    }
+
+    @Test
+    fun clearFeatureFlags() {
+        event.addFeatureFlag("demo_group")
+        event.addFeatureFlag("sample_group", "a")
+        event.clearFeatureFlags()
+        assertEquals(emptyList<FeatureFlag>(), event.impl.featureFlags.toList())
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFeatureFlagsCloneTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFeatureFlagsCloneTest.kt
@@ -1,0 +1,43 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+
+class EventFeatureFlagsCloneTest {
+
+    @Test
+    fun testFeatureFlagsClone() {
+        val featureFlags = FeatureFlags()
+        featureFlags.addFeatureFlag("sample_group", "123")
+
+        val handledState = SeverityReason.newInstance(
+            SeverityReason.REASON_HANDLED_EXCEPTION
+        )
+        val config = BugsnagTestUtils.generateImmutableConfig()
+        val event = Event(
+            RuntimeException(),
+            config,
+            handledState,
+            Metadata(),
+            featureFlags,
+            NoopLogger
+        )
+
+        event.addFeatureFlag("demo_mode")
+
+        // featureFlags objects should be deep copied
+        assertNotSame(featureFlags, event.impl.featureFlags)
+
+        // validate origin featureFlags
+        val origExpected = listOf(FeatureFlag("sample_group", "123"))
+        assertEquals(origExpected, featureFlags.toList())
+
+        // validate event featureFlags
+        val eventExpected = listOf(
+            FeatureFlag("sample_group", "123"),
+            FeatureFlag("demo_mode")
+        )
+        assertEquals(eventExpected, event.impl.featureFlags.toList())
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventMetadataCloneTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventMetadataCloneTest.kt
@@ -15,7 +15,15 @@ class EventMetadataCloneTest {
             SeverityReason.REASON_HANDLED_EXCEPTION
         )
         val config = BugsnagTestUtils.generateImmutableConfig()
-        val event = Event(RuntimeException(), config, handledState, data, NoopLogger)
+        val event = Event(
+            RuntimeException(),
+            config,
+            handledState,
+            data,
+            FeatureFlags(),
+            NoopLogger
+        )
+
         event.addMetadata("test_section", "second", "another value")
 
         // metadata object should be deep copied

--- a/bugsnag-android-core/src/test/resources/event_redaction.json
+++ b/bugsnag-android-core/src/test/resources/event_redaction.json
@@ -51,5 +51,6 @@
       }
     }
   ],
-  "threads": []
+  "threads": [],
+  "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_0.json
@@ -32,5 +32,6 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
-  "threads": []
+  "threads": [],
+  "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_1.json
@@ -33,5 +33,6 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
-  "threads": []
+  "threads": [],
+  "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_2.json
@@ -33,5 +33,6 @@
   },
   "breadcrumbs": [],
   "groupingHash": "herpderp",
-  "threads": []
+  "threads": [],
+  "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_3.json
@@ -32,5 +32,6 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
-  "threads": []
+  "threads": [],
+  "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_4.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_4.json
@@ -33,6 +33,7 @@
   },
   "breadcrumbs": [],
   "threads": [],
+  "featureFlags": [],
   "session": {
     "id": "123",
     "startedAt": "1970-01-01T00:00:00.000Z",

--- a/bugsnag-android-core/src/test/resources/event_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_5.json
@@ -41,5 +41,6 @@
       "stacktrace": [],
       "errorReportingThread": true
     }
-  ]
+  ],
+  "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_6.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_6.json
@@ -58,5 +58,6 @@
       "metaData": {}
     }
   ],
-  "threads": []
+  "threads": [],
+  "featureFlags": []
 }

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/AnrDetailsCollectorTest.kt
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/AnrDetailsCollectorTest.kt
@@ -65,6 +65,7 @@ class AnrDetailsCollectorTest {
     fun anrDetailsAltered() {
         Mockito.`when`(client.config).thenReturn(BugsnagTestUtils.generateImmutableConfig())
         Mockito.`when`(client.getMetadataState()).thenReturn(BugsnagTestUtils.generateMetadataState())
+        Mockito.`when`(client.getFeatureFlagState()).thenReturn(BugsnagTestUtils.generateFeatureFlagState())
         val event = NativeInterface.createEvent(
             RuntimeException("whoops"),
             client,

--- a/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-plugin-android-anr/src/test/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -35,6 +35,10 @@ final class BugsnagTestUtils {
         return new MetadataState();
     }
 
+    static FeatureFlagState generateFeatureFlagState() {
+        return new FeatureFlagState();
+    }
+
     static ImmutableConfig convert(Configuration config) {
         return ImmutableConfigKt.convertToImmutableConfig(config, null);
     }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -43,6 +43,7 @@ class EventDeserializerTest {
         `when`(client.config).thenReturn(TestData.generateConfig())
         `when`(client.getLogger()).thenReturn(object : Logger {})
         `when`(client.getMetadataState()).thenReturn(TestHooks.generateMetadataState())
+        `when`(client.getFeatureFlagState()).thenReturn(TestHooks.generateFeatureFlagsState())
     }
 
     private fun breadcrumbMap() = hashMapOf(

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestHooks.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestHooks.java
@@ -8,4 +8,8 @@ class TestHooks {
     static MetadataState generateMetadataState() {
         return new MetadataState();
     }
+
+    static FeatureFlagState generateFeatureFlagsState() {
+        return new FeatureFlagState();
+    }
 }


### PR DESCRIPTION
## Goal
Expose `FeatureFlags` on the `Event` object so that they can be altered by crash-time callbacks before being uploaded. The `FeatureFlags` are copied from the client state when the `Event` is created, and can then be altered on a per-event basis before being sent.

## Testing
A new unit test covers the `FeatureFlags` deep-copy behaviour and per-event changes in the same way as we test per-event `Metadata`