### PR TITLE
[Plat-7528] improve journal performance

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagJournal.kt
@@ -194,9 +194,19 @@ internal class BugsnagJournal @JvmOverloads internal constructor(
          * - All occurrences of special characters (+ . \)
          */
         fun unspecialMapPath(pathComponent: String): String {
-            val index = pathComponent.toIntOrNull()
-            if (index != null) {
-                return "\\" + pathComponent
+            if (pathComponent.length == 0) {
+                return pathComponent
+            }
+            val firstChar = pathComponent[0]
+            if (firstChar == '-' || (firstChar >= '0' && firstChar <= '9')) {
+                val index = pathComponent.toIntOrNull()
+                if (index != null) {
+                    return "\\" + pathComponent
+                }
+            }
+
+            if (pathComponent.indexOfFirst { it == '.' || it == '+' || it == '\\' } < 0) {
+                return pathComponent
             }
             return pathComponent.replace(specialCharsRegex, specialCharsReplacement)
         }


### PR DESCRIPTION
## Goal

`unspecialMapPath` is a guard against special characters in a path component, but this is the exception, not the norm. Optimize for the happy path.
