### PR TITLE
test(feature flags): mazerunner feature to test feature flags

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -447,7 +446,7 @@ public final class Bugsnag {
      * @param name the name of the feature flag to remove
      */
     public static void clearFeatureFlag(@NonNull String name) {
-        getClient().clearMetadata(name);
+        getClient().clearFeatureFlag(name);
     }
 
     /**

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXFeatureFlagNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXFeatureFlagNativeCrashScenario.java
@@ -2,11 +2,14 @@ package com.bugsnag.android.mazerunner.scenarios;
 
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
+import com.bugsnag.android.FeatureFlag;
 
 import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.Arrays;
 
 public class CXXFeatureFlagNativeCrashScenario extends Scenario {
     static {
@@ -24,8 +27,26 @@ public class CXXFeatureFlagNativeCrashScenario extends Scenario {
     @Override
     public void startScenario() {
         super.startScenario();
+
+        Bugsnag.addFeatureFlag("demo_mode");
+
+        Bugsnag.addFeatureFlags(Arrays.asList(
+                new FeatureFlag("should_not_be_reported_1"),
+                new FeatureFlag("should_not_be_reported_2"),
+                new FeatureFlag("should_not_be_reported_3")
+        ));
+
+        Bugsnag.clearFeatureFlag("should_not_be_reported_3");
+        Bugsnag.clearFeatureFlag("should_not_be_reported_2");
+        Bugsnag.clearFeatureFlag("should_not_be_reported_1");
+
         Bugsnag.addFeatureFlag("demo_mode");
         Bugsnag.addFeatureFlag("sample_group", "a");
+
+        if (getEventMetadata() != null && getEventMetadata().contains("cleared")) {
+            Bugsnag.clearFeatureFlags();
+        }
+
         crash();
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -23,6 +23,7 @@
     <ID>TooGenericExceptionThrown:CrashHandlerScenario.kt$CrashHandlerScenario$throw RuntimeException("CrashHandlerScenario")</ID>
     <ID>TooGenericExceptionThrown:CustomHttpClientFlushScenario.kt$CustomHttpClientFlushScenario$throw RuntimeException("ReportCacheScenario")</ID>
     <ID>TooGenericExceptionThrown:DisableAutoDetectErrorsScenario.kt$DisableAutoDetectErrorsScenario$throw RuntimeException("Should never appear")</ID>
+    <ID>TooGenericExceptionThrown:FeatureFlagScenario.kt$FeatureFlagScenario$throw RuntimeException("FeatureFlagScenario unhandled")</ID>
     <ID>TooGenericExceptionThrown:ReportCacheScenario.kt$ReportCacheScenario$throw RuntimeException("ReportCacheScenario")</ID>
     <ID>TooGenericExceptionThrown:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$throw RuntimeException("Regular crash")</ID>
     <ID>TooGenericExceptionThrown:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$throw RuntimeException("Startup crash")</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/FeatureFlagScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/FeatureFlagScenario.kt
@@ -1,0 +1,47 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.FeatureFlag
+
+class FeatureFlagScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+    override fun startScenario() {
+        super.startScenario()
+
+        Bugsnag.addFeatureFlag("demo_mode")
+
+        Bugsnag.addFeatureFlags(
+            listOf(
+                FeatureFlag("should_not_be_reported_1"),
+                FeatureFlag("should_not_be_reported_2"),
+                FeatureFlag("should_not_be_reported_3")
+            )
+        )
+
+        Bugsnag.clearFeatureFlag("should_not_be_reported_3")
+        Bugsnag.clearFeatureFlag("should_not_be_reported_2")
+        Bugsnag.clearFeatureFlag("should_not_be_reported_1")
+
+        if (eventMetadata?.contains("callback") == true) {
+            Bugsnag.addOnError { error ->
+                error.addFeatureFlag("sample_group", "a")
+                return@addOnError true
+            }
+        }
+
+        if (eventMetadata?.contains("cleared") == true) {
+            Bugsnag.clearFeatureFlags()
+        }
+
+        if (eventMetadata?.contains("unhandled") == true) {
+            throw RuntimeException("FeatureFlagScenario unhandled")
+        } else {
+            Bugsnag.notify(RuntimeException("FeatureFlagScenario handled"))
+        }
+    }
+}

--- a/features/full_tests/feature_flags.feature
+++ b/features/full_tests/feature_flags.feature
@@ -6,7 +6,9 @@ Scenario: Sends handled exception which includes feature flags
   And the exception "errorClass" equals "java.lang.RuntimeException"
   And the event "unhandled" is false
   And event 0 contains the feature flag "demo_mode" with no variant
-  And event 0 does not contain the feature flag "demo_mode" with no variant
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"
 
 Scenario: Sends handled exception which includes feature flags added in the notify callback
   When I configure the app to run in the "callback" state
@@ -16,6 +18,9 @@ Scenario: Sends handled exception which includes feature flags added in the noti
   And the event "unhandled" is false
   And event 0 contains the feature flag "demo_mode" with no variant
   And event 0 contains the feature flag "sample_group" with variant "a"
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"
 
 Scenario: Sends unhandled exception which includes feature flags added in the notify callback
   When I configure the app to run in the "unhandled callback" state
@@ -26,3 +31,14 @@ Scenario: Sends unhandled exception which includes feature flags added in the no
   And the event "unhandled" is true
   And event 0 contains the feature flag "demo_mode" with no variant
   And event 0 contains the feature flag "sample_group" with variant "a"
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"
+
+Scenario: Sends no feature flags after clearFeatureFlags()
+  When I configure the app to run in the "cleared" state
+  And I run "FeatureFlagScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "java.lang.RuntimeException"
+  And the event "unhandled" is false
+  And event 0 has no feature flags

--- a/features/full_tests/native_feature_flags.feature
+++ b/features/full_tests/native_feature_flags.feature
@@ -8,3 +8,15 @@ Feature: Synchronizing feature flags to the native layer
     And the exception "errorClass" equals "SIGILL"
     And event 0 contains the feature flag "demo_mode" with no variant
     And event 0 contains the feature flag "sample_group" with variant "a"
+    And event 0 does not contain the feature flag "should_not_be_reported_1"
+    And event 0 does not contain the feature flag "should_not_be_reported_2"
+    And event 0 does not contain the feature flag "should_not_be_reported_3"
+
+  Scenario: clearFeatureFlags() is synchronized to the native layer
+    When I configure the app to run in the "cleared" state
+    And I run "CXXFeatureFlagNativeCrashScenario"
+    And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGILL"
+    And event 0 has no feature flags


### PR DESCRIPTION
## Goal
Mazerunner test feature covering the new feature flags logic. This covers feature flags added globally (using `Bugsnag.addFeatureFlag`) and directly to an `Event` via an `OnErrorCallback`.

Tests include checking for:
* A feature flag with a name only
* A feature flags with names and variants
* Adding a feature flag with a null name (should be ignored and not sent)
