### PR TITLE
Fix journal increment in the crashtime journal

### DIFF
--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledDocumentTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/JournaledDocumentTest.kt
@@ -165,6 +165,166 @@ class JournaledDocumentTest {
             )
         )
     }
+    @Test
+    fun testNonEmptyDocumentIncrement() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = 100L
+        val document = JournaledDocument(
+            baseDocumentPath,
+            standardType,
+            standardVersion,
+            bufferSize,
+            bufferSize,
+            mutableMapOf("x" to 9)
+        )
+        document.addCommand(Journal.Command("x+", 1))
+        // The in-memory document is updated immediately.
+        Assert.assertEquals(10L, document["x"])
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "x" to 10
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            "$standardJournalInfoSerialized{\"x+\":1}\u0000".toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(baseDocumentPath, mutableMapOf("x" to 9))
+
+        // The journal is force-flushed when closed or the app terminates for any reason.
+        document.close()
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "x" to 10
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            standardJournalInfoSerialized.toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(
+            baseDocumentPath,
+            mutableMapOf(
+                "x" to 10
+            )
+        )
+    }
+
+    @Test
+    fun testEmptyDocumentIncrement() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = 100L
+        val document = JournaledDocument(
+            baseDocumentPath,
+            standardType,
+            standardVersion,
+            bufferSize,
+            bufferSize,
+            mutableMapOf()
+        )
+        document.addCommand(Journal.Command("x+", 1))
+        // The in-memory document is updated immediately.
+        Assert.assertEquals(1, document["x"])
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "x" to 1
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            "$standardJournalInfoSerialized{\"x+\":1}\u0000".toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(baseDocumentPath, mutableMapOf())
+
+        // The journal is force-flushed when closed or the app terminates for any reason.
+        document.close()
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "x" to 1
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            standardJournalInfoSerialized.toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(
+            baseDocumentPath,
+            mutableMapOf(
+                "x" to 1
+            )
+        )
+    }
+
+    @Test
+    fun testIncrementDeep() {
+        val baseDocumentPath = folder.newFile("mydocument")
+        val bufferSize = 100L
+        val document = JournaledDocument(
+            baseDocumentPath,
+            standardType,
+            standardVersion,
+            bufferSize,
+            bufferSize,
+            mutableMapOf()
+        )
+        document.addCommand(Journal.Command("a.x+", 1))
+        // The in-memory document is updated immediately.
+        @Suppress("UNCHECKED_CAST")
+        val a = (document["a"] as Map<String, Any>)
+        Assert.assertEquals(1, a["x"])
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "a" to mutableMapOf(
+                    "x" to 1
+                )
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            "$standardJournalInfoSerialized{\"a.x+\":1}\u0000".toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(baseDocumentPath, mutableMapOf())
+
+        // The journal is force-flushed when closed or the app terminates for any reason.
+        document.close()
+
+        assertReloadedDocument(
+            baseDocumentPath,
+            mutableMapOf(
+                "a" to mutableMapOf(
+                    "x" to 1
+                )
+            )
+        )
+        assertJournalContents(
+            baseDocumentPath,
+            bufferSize,
+            standardJournalInfoSerialized.toByteArray(Charsets.UTF_8)
+        )
+        assertSnapshotContents(
+            baseDocumentPath,
+            mutableMapOf(
+                "a" to mutableMapOf(
+                    "x" to 1
+                )
+            )
+        )
+    }
 
     @Test
     fun testOverflow() {

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeCrashTimeJournalTest.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeCrashTimeJournalTest.kt
@@ -442,6 +442,16 @@ class NativeCrashTimeJournalTest {
         }
     }
 
+    // bsg_ctj_set_app_in_foreground
+    private external fun nativeIncrementUnhandled(ctjPath: String): Int
+
+    @Test
+    fun testIncrementUnhandled() {
+        runJournalTest(mutableMapOf(), "testIncrementUnhandled") {
+            nativeIncrementUnhandled(it)
+        }
+    }
+
     // bsg_ctj_store_event
 // TODO PLAT-7589
 //    private external fun nativeStoreEvent(ctjPath: String): Int

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/native_crashtime_journal_test.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/native_crashtime_journal_test.json
@@ -298,5 +298,12 @@
         "type": "c"
       }
     ]
+  },
+  "testIncrementUnhandled": {
+    "session": {
+      "events": {
+        "unhandled": 1
+      }
+    }
   }
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/crashtime_journal.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/crashtime_journal.c
@@ -71,6 +71,7 @@
 #define KEY_TOTAL_MEMORY "totalMemory"
 #define KEY_TYPE "type"
 #define KEY_UNHANDLED "unhandled"
+#define KEY_UNHANDLED_INCREMENT (KEY_UNHANDLED "+")
 #define KEY_UNHANDLED_OVERRIDDEN "unhandledOverridden"
 #define KEY_USER "user"
 #define KEY_VERSION "version"
@@ -158,6 +159,13 @@ static bool add_hex(const char *name, uint64_t value) {
 
 static bool add_double(const char *name, double value) {
   bsg_pb_stack_map_key(name);
+  RETURN_ON_FALSE(bsg_ctj_set_double(bsg_pb_path(), value));
+  bsg_pb_unstack();
+  return true;
+}
+
+static bool add_raw_double(const char *name, double value) {
+  bsg_pb_stack_raw_key(name);
   RETURN_ON_FALSE(bsg_ctj_set_double(bsg_pb_path(), value));
   bsg_pb_unstack();
   return true;
@@ -456,6 +464,21 @@ bool bsg_ctj_set_event_user(const char *id, const char *email,
   RETURN_ON_FALSE(add_string(KEY_ID, id));
   RETURN_ON_FALSE(add_string(KEY_EMAIL, email));
   RETURN_ON_FALSE(add_string(KEY_NAME, name));
+  bsg_pb_reset();
+  return bsg_ctj_flush();
+}
+
+bool bsg_ctj_increment_unhandled_count() {
+  //  "session": {
+  //    "events": {
+  //      "unhandled": 1
+  //    }
+  //  }
+
+  bsg_pb_reset();
+  bsg_pb_stack_map_key(KEY_SESSION);
+  bsg_pb_stack_map_key(KEY_EVENTS);
+  RETURN_ON_FALSE(add_raw_double(KEY_UNHANDLED_INCREMENT, 1));
   bsg_pb_reset();
   return bsg_ctj_flush();
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/crashtime_journal.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/crashtime_journal.h
@@ -97,6 +97,8 @@ bool bsg_ctj_clear_metadata_section(const char *section);
 
 bool bsg_ctj_record_current_time(void);
 
+bool bsg_ctj_increment_unhandled_count(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/path_builder.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/path_builder.c
@@ -64,6 +64,17 @@ static bool contains_special_chars(const char *str, int maxCount) {
   return false;
 }
 
+void bsg_pb_stack_raw_key(const char *key) {
+  char *subpath = subpath_begin();
+  if (subpath == NULL) {
+    return;
+  }
+  int maxCount = available_byte_count(subpath);
+  bsg_strncpy_safe(subpath, key, maxCount);
+  subpath += strlen(subpath);
+  subpath_end(subpath);
+}
+
 void bsg_pb_stack_map_key(const char *key) {
   char *subpath = subpath_begin();
   if (subpath == NULL) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/path_builder.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/path_builder.h
@@ -32,6 +32,15 @@ void bsg_pb_reset(void);
 void bsg_pb_stack_map_key(const char *key);
 
 /**
+ * Stack the raw characters as a key (don't insert escapes).
+ * This is necessary in order to create the special purpose paths that
+ * end in . and +
+ *
+ * @param key The map key for the new path level.
+ */
+void bsg_pb_stack_raw_key(const char *key);
+
+/**
  * Stack an integer (list) level to the current path.
  * Stacking too deep (>100 levels) or building a path that's too long (>500
  * bytes) will cause this function to no-op.

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_ctj.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_ctj.c
@@ -339,3 +339,10 @@ JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_NativeCrashTimeJournalTest_na
     ASSERT_EQ(true, bsg_ctj_store_event(&event));
     PASS();
 }
+
+JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_NativeCrashTimeJournalTest_nativeIncrementUnhandled(
+    JNIEnv *_env, jobject _this, jstring _crashtimeJournalPath) {
+    STOP_ON_FAIL(init_journal_test(_env, _crashtimeJournalPath));
+        ASSERT_EQ(true, bsg_ctj_increment_unhandled_count());
+        PASS();
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_path_builder.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_path_builder.c
@@ -48,6 +48,9 @@ TEST test_general_use(void) {
     ASSERT_STR_EQ("", bsg_pb_path());
     bsg_pb_stack_map_key("bar");
     ASSERT_STR_EQ("bar", bsg_pb_path());
+    bsg_pb_stack_raw_key("x+");
+    ASSERT_STR_EQ("bar.x+", bsg_pb_path());
+    bsg_pb_unstack();
     bsg_pb_unstack();
     ASSERT_STR_EQ("", bsg_pb_path());
     PASS();


### PR DESCRIPTION
## Goal

The crashtime journal needs to support increment operations for an upcoming PR.

## Testing

Added new unit and integration tests.
