### PR TITLE
Parse Thread for OnSend Callbacks

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
@@ -10,6 +10,20 @@ import java.util.TimeZone
 internal class BugsnagEventMapper(
     private val logger: Logger
 ) {
+
+    @Suppress("UNCHECKED_CAST")
+    internal fun convertThread(thread: Map<String, Any?>): ThreadInternal {
+        return ThreadInternal(
+            (thread["id"] as? Number)?.toLong() ?: 0,
+            thread.readEntry("name"),
+            ThreadType.fromDescriptor(thread.readEntry("type")) ?: ThreadType.ANDROID,
+            thread["errorReportingThread"] == true,
+            thread.readEntry("state"),
+            (thread["stacktrace"] as? List<Map<String, Any?>>)?.let { convertStacktrace(it) }
+                ?: Stacktrace(emptyList())
+        )
+    }
+
     internal fun convertStacktrace(trace: List<Map<String, Any?>>): Stacktrace {
         return Stacktrace(trace.map { convertStackframe(it) })
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -23,7 +23,8 @@ public class Thread implements JsonStream.Streamable {
             @NonNull Thread.State state,
             @NonNull Stacktrace stacktrace,
             @NonNull Logger logger) {
-        this.impl = new ThreadInternal(id, name, type, errorReportingThread, state, stacktrace);
+        this.impl = new ThreadInternal(
+                id, name, type, errorReportingThread, state.getDescriptor(), stacktrace);
         this.logger = logger;
     }
 
@@ -88,7 +89,7 @@ public class Thread implements JsonStream.Streamable {
      */
     public void setState(@NonNull Thread.State threadState) {
         if (threadState != null) {
-            impl.setState(threadState);
+            impl.setState(threadState.getDescriptor());
         } else {
             logNull("state");
         }
@@ -99,7 +100,7 @@ public class Thread implements JsonStream.Streamable {
      */
     @NonNull
     public Thread.State getState() {
-        return impl.getState();
+        return Thread.State.byDescriptor(impl.getState());
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -7,7 +7,7 @@ class ThreadInternal internal constructor(
     var name: String,
     var type: ThreadType,
     val isErrorReportingThread: Boolean,
-    var state: Thread.State,
+    var state: String,
     stacktrace: Stacktrace
 ) : JsonStream.Streamable {
 
@@ -19,7 +19,7 @@ class ThreadInternal internal constructor(
         writer.name("id").value(id)
         writer.name("name").value(name)
         writer.name("type").value(type.desc)
-        writer.name("state").value(state.descriptor)
+        writer.name("state").value(state)
 
         writer.name("stacktrace")
         writer.beginArray()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadType.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadType.kt
@@ -18,5 +18,9 @@ enum class ThreadType(internal val desc: String) {
     /**
      * A thread captured from JavaScript
      */
-    REACTNATIVEJS("reactnativejs")
+    REACTNATIVEJS("reactnativejs");
+
+    internal companion object {
+        internal fun fromDescriptor(desc: String) = ThreadType.values().find { it.desc == desc }
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadSerializationTest.kt
@@ -111,6 +111,14 @@ internal class ThreadSerializationTest {
     @Parameter
     lateinit var testCase: Pair<Thread, String>
 
+    private val eventMapper = BugsnagEventMapper(NoopLogger)
+
     @Test
     fun testJsonSerialisation() = verifyJsonMatches(testCase.first, testCase.second)
+
+    @Test
+    fun testJsonDeserialisation() =
+        verifyJsonParser(testCase.first, testCase.second) {
+            eventMapper.convertThread(it)
+        }
 }


### PR DESCRIPTION
## Goal
Parse threads from stored events into the `Thread` model for processing by `OnSendCallback`s.

## Testing
Updated the `ThreadSerializationTest` to include deserialization of all the existing thread fixtures