### PR TITLE
Only remove unquoted whitespace from JSON strings for comparison

### DIFF
--- a/bugsnag-android-core/src/test/resources/app_data_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/app_data_serialization_0.json
@@ -3,7 +3,7 @@
   "codeBundleId": "foo-99",
   "id": "com.example.foo",
   "releaseStage": "test-stage",
-  "type": "ReactNative",
+  "type": "React Native",
   "version": "1.2.3",
   "versionCode": 55
 }

--- a/bugsnag-android-core/src/test/resources/app_data_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/app_data_serialization_1.json
@@ -3,7 +3,7 @@
   "codeBundleId": "foo-99",
   "id": "com.example.foo",
   "releaseStage": "test-stage",
-  "type": "ReactNative",
+  "type": "React Native",
   "version": "1.2.3",
   "versionCode": 55,
   "duration": 0,

--- a/bugsnag-android-core/src/test/resources/breadcrumb_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/breadcrumb_serialization_0.json
@@ -1,6 +1,6 @@
 {
   "timestamp": "1970-01-01T00:00:00.000Z",
-  "name": "helloworld",
+  "name": "hello world",
   "type": "manual",
   "metaData": {}
 }

--- a/bugsnag-android-core/src/test/resources/breadcrumb_state_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/breadcrumb_state_serialization_0.json
@@ -1,7 +1,7 @@
 [
   {
     "timestamp": "1970-01-01T00:00:00.000Z",
-    "name": "helloworld",
+    "name": "hello world",
     "type": "manual",
     "metaData": {
       "direction": "left"

--- a/bugsnag-android-core/src/test/resources/event_serialization_6.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_6.json
@@ -4,7 +4,7 @@
       "foo": 55
     },
     "wham": {
-      "some_key": "Avalue"
+      "some_key": "A value"
     },
     "device": {
       "bar": true
@@ -53,7 +53,7 @@
   "breadcrumbs": [
     {
       "timestamp": "1970-01-01T00:00:00.000Z",
-      "name": "helloworld",
+      "name": "hello world",
       "type": "manual",
       "metaData": {}
     }


### PR DESCRIPTION
## Goal
Only remove unquoted whitespace in JSON strings before comparing them. This retains the correct data for comparison, while avoiding changing the keys or values that we are testing for, and keeping test failure messages helpful.

## Testing
Altered the existing test fixtures to expect whitespace to be transmitted in keys and values.