### PR TITLE
Store Feature Flags for NDK

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -428,6 +428,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         contextState.emitObservableEvent();
         userState.emitObservableEvent();
         memoryTrimState.emitObservableEvent();
+        featureFlagState.emitObservableEvent();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FeatureFlagState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FeatureFlagState.kt
@@ -37,6 +37,14 @@ internal data class FeatureFlagState(
         }
     }
 
+    fun emitObservableEvent() {
+        val flags = toList()
+
+        flags.forEach { (name, variant) ->
+            updateState { StateEvent.AddFeatureFlag(name, variant) }
+        }
+    }
+
     fun toList(): List<FeatureFlag> = featureFlags.toList()
     fun copy() = FeatureFlagState(featureFlags.copy())
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/FeatureFlagStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/FeatureFlagStateTest.kt
@@ -93,4 +93,32 @@ internal class FeatureFlagStateTest {
 
         assertNotNull(events.find { it is StateEvent.ClearFeatureFlags })
     }
+
+    @Test
+    fun emitObservableEvent() {
+        state.addFeatureFlag("sample_group", "4321")
+        state.addFeatureFlag("listing_view", "legacy")
+        state.addFeatureFlag("demo_mode")
+
+        // clear the events
+        events.clear()
+
+        state.emitObservableEvent()
+        assertEquals(3, events.size)
+        val addSampleGroup = events
+            .filterIsInstance<StateEvent.AddFeatureFlag>()
+            .find { it.name == "sample_group" }
+        assertEquals("4321", addSampleGroup?.variant)
+
+        val addListingView = events
+            .filterIsInstance<StateEvent.AddFeatureFlag>()
+            .find { it.name == "listing_view" }
+        assertEquals("legacy", addListingView?.variant)
+
+        val addDemoMode = events
+            .filterIsInstance<StateEvent.AddFeatureFlag>()
+            .find { it.name == "demo_mode" }
+        assertNotNull(addDemoMode)
+        assertNull(addDemoMode!!.variant)
+    }
 }

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeFeatureFlagsTest.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/NativeFeatureFlagsTest.kt
@@ -1,0 +1,19 @@
+package com.bugsnag.android.ndk
+
+import org.junit.Test
+
+class NativeFeatureFlagsTest {
+    companion object {
+        init {
+            System.loadLibrary("bugsnag-ndk")
+            System.loadLibrary("bugsnag-ndk-test")
+        }
+    }
+
+    external fun run(): Int
+
+    @Test
+    fun testPassesNativeSuite() {
+        verifyNativeRun(run())
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library( # Specifies the name of the library.
     jni/metadata.c
     jni/safejni.c
     jni/event.c
+    jni/featureflags.c
     jni/handlers/signal_handler.c
     jni/handlers/cpp_handler.cpp
     jni/utils/crash_info.c

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library( # Specifies the name of the library.
     jni/utils/serializer.c
     jni/utils/string.c
     jni/utils/threads.c
+    jni/utils/buffered_writer.c
     jni/deps/parson/parson.c
              )
 

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -78,6 +78,9 @@ class NativeBridge : StateObserver {
     external fun updateUserName(newValue: String)
     external fun getUnwindStackFunction(): Long
     external fun updateLowMemory(newValue: Boolean, memoryTrimLevelDescription: String)
+    external fun addFeatureFlag(name: String, variant: String?)
+    external fun clearFeatureFlag(name: String)
+    external fun clearFeatureFlags()
 
     override fun onStateChange(event: StateEvent) {
         if (isInvalidMessage(event)) return
@@ -120,6 +123,12 @@ class NativeBridge : StateObserver {
                 updateUserEmail(makeSafe(event.user.email ?: ""))
             }
             is StateEvent.UpdateMemoryTrimEvent -> updateLowMemory(event.isLowMemory, event.memoryTrimLevelDescription)
+            is StateEvent.AddFeatureFlag -> addFeatureFlag(
+                makeSafe(event.name),
+                event.variant?.let { makeSafe(it) }
+            )
+            is StateEvent.ClearFeatureFlag -> clearFeatureFlag(makeSafe(event.name))
+            is StateEvent.ClearFeatureFlags -> clearFeatureFlags()
         }
     }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include "event.h"
+#include "featureflags.h"
 #include "handlers/cpp_handler.h"
 #include "handlers/signal_handler.h"
 #include "metadata.h"
@@ -190,6 +191,10 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
                      sizeof(bugsnag_env->next_event.api_key));
     bsg_safe_release_string_utf_chars(env, _api_key, api_key);
   }
+
+  // clear the feature flag fields
+  bugsnag_env->next_event.feature_flag_count = 0;
+  bugsnag_env->next_event.feature_flags = NULL;
 
   bsg_global_env = bugsnag_env;
   bsg_update_next_run_info(bsg_global_env);
@@ -706,6 +711,58 @@ JNIEXPORT jlong JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_getUnwindStackFunction(JNIEnv *env,
                                                                  jobject thiz) {
   return (jlong)bsg_unwind_stack_default;
+}
+
+JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addFeatureFlag(
+    JNIEnv *env, jobject thiz, jstring name_, jstring variant_) {
+
+  if (bsg_global_env == NULL) {
+    return;
+  }
+
+  char *name = (char *)bsg_safe_get_string_utf_chars(env, name_);
+  char *variant = (char *)bsg_safe_get_string_utf_chars(env, variant_);
+
+  if (name != NULL) {
+    bsg_request_env_write_lock();
+    bsg_set_feature_flag(&bsg_global_env->next_event, name, variant);
+    bsg_release_env_write_lock();
+  }
+
+  bsg_safe_release_string_utf_chars(env, name_, name);
+  bsg_safe_release_string_utf_chars(env, variant_, variant);
+}
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_ndk_NativeBridge_clearFeatureFlag(JNIEnv *env,
+                                                           jobject thiz,
+                                                           jstring name_) {
+
+  if (bsg_global_env == NULL) {
+    return;
+  }
+
+  char *name = (char *)bsg_safe_get_string_utf_chars(env, name_);
+
+  if (name != NULL) {
+    bsg_request_env_write_lock();
+    bsg_clear_feature_flag(&bsg_global_env->next_event, name);
+    bsg_release_env_write_lock();
+  }
+
+  bsg_safe_release_string_utf_chars(env, name_, name);
+}
+
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_ndk_NativeBridge_clearFeatureFlags(JNIEnv *env,
+                                                            jobject thiz) {
+  if (bsg_global_env == NULL) {
+    return;
+  }
+
+  bsg_request_env_write_lock();
+  bsg_free_feature_flags(&bsg_global_env->next_event);
+  bsg_release_env_write_lock();
 }
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -271,6 +271,7 @@ exit:
   if (event != NULL) {
     bsg_safe_release_byte_array_elements(env, jstage,
                                          (jbyte *)event->app.release_stage);
+    bsg_free_feature_flags(event);
     free(event);
   }
   if (payload != NULL) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -79,6 +79,16 @@ typedef struct {
    * at the time of an error.
    */
   bsg_thread_send_policy send_threads;
+
+  /**
+   * The number of feature flags currently specified.
+   */
+  size_t feature_flag_count;
+
+  /**
+   * Pointer to the current feature flags.
+   */
+  bsg_feature_flag *feature_flags;
 } bsg_environment;
 
 bsg_unwinder bsg_configured_unwind_style();

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -79,16 +79,6 @@ typedef struct {
    * at the time of an error.
    */
   bsg_thread_send_policy send_threads;
-
-  /**
-   * The number of feature flags currently specified.
-   */
-  size_t feature_flag_count;
-
-  /**
-   * Pointer to the current feature flags.
-   */
-  bsg_feature_flag *feature_flags;
 } bsg_environment;
 
 bsg_unwinder bsg_configured_unwind_style();

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -34,7 +34,7 @@
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
-#define BUGSNAG_EVENT_VERSION 7
+#define BUGSNAG_EVENT_VERSION 8
 
 #ifdef __cplusplus
 extern "C" {

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -198,6 +198,11 @@ typedef enum {
 } bsg_thread_send_policy;
 
 typedef struct {
+  char *name;
+  char *variant;
+} bsg_feature_flag;
+
+typedef struct {
   bsg_notifier notifier;
   bsg_app_info app;
   bsg_device_info device;
@@ -224,6 +229,17 @@ typedef struct {
 
   int thread_count;
   bsg_thread threads[BUGSNAG_THREADS_MAX];
+
+  /**
+   * The number of feature flags currently specified.
+   */
+  size_t feature_flag_count;
+
+  /**
+   * Pointer to the current feature flags. This is dynamically allocated and
+   * serialized/deserialized separately to the rest of the struct.
+   */
+  bsg_feature_flag *feature_flags;
 } bugsnag_event;
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,

--- a/bugsnag-plugin-android-ndk/src/main/jni/featureflags.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/featureflags.c
@@ -1,0 +1,141 @@
+#include <string.h>
+
+#include "bugsnag_ndk.h"
+#include "featureflags.h"
+#include "utils/string.h"
+
+/*
+ * Implementation notes:
+ *
+ * We store Feature Flags in a dynamically allocated array, sorted by the
+ * feature flag 'name' string, allowing us to binary-search the array for
+ * duplicates.
+ *
+ * This provides a reasonable compromise between speed and size, since the array
+ * is no larger than the number of feature flags (not counting malloc padding)
+ * and is unlikely to be modified often. It also keeps testing simple, as the
+ * keys will always be in a known order.
+ *
+ * We resize the array using 'realloc' and 'memmove' to try and keep the
+ * overhead reasonable.
+ */
+
+static int feature_flag_index(const bugsnag_event *env, const char *name) {
+  // simple binary search for a feature-flag by name
+  int low = 0;
+  int high = env->feature_flag_count - 1;
+
+  while (low <= high) {
+    int mid = (low + high) >> 1;
+    int cmp = strcmp(env->feature_flags[mid].name, name);
+
+    if (cmp < 0) {
+      low = mid + 1;
+    } else if (cmp > 0) {
+      high = mid - 1;
+    } else {
+      return mid; // found it
+    }
+  }
+
+  return -(low + 1);
+}
+
+static void *grow_array_for_index(void *array, const size_t element_count,
+                                  const size_t element_size,
+                                  const unsigned int index) {
+  void *new_array = realloc(array, (element_count + 1) * element_size);
+
+  if (!new_array) {
+    return NULL;
+  }
+
+  // if we need to: shift the "end" of the array by 1 element so 'index' has a
+  // space
+  memmove(new_array + ((index + 1) * element_size),
+          new_array + (index * element_size),
+          (element_count - index) * element_size);
+
+  return new_array;
+}
+
+void bsg_set_feature_flag(bugsnag_event *env, const char *name,
+                          const char *variant) {
+  int expected_index = feature_flag_index(env, name);
+
+  if (expected_index >= 0) {
+    // feature flag already exists, so we overwrite the variant
+    bsg_feature_flag *flag = &env->feature_flags[expected_index];
+
+    // make sure we release the existing variant, if one exists
+    free(flag->variant);
+
+    if (variant) {
+      // make a copy of the variant, so that the JVM can have it's memory back
+      flag->variant = strdup(variant);
+    } else {
+      flag->variant = NULL;
+    }
+  } else {
+    int new_flag_index = -expected_index - 1;
+
+    // this is a new feature flag, we need to insert it - which means we also
+    // need a new array
+    bsg_feature_flag *new_flags =
+        grow_array_for_index(env->feature_flags, env->feature_flag_count,
+                             sizeof(bsg_feature_flag), new_flag_index);
+
+    // we cannot grow the feature flag array, so we return
+    if (!new_flags) {
+      return;
+    }
+
+    new_flags[new_flag_index].name = strdup(name);
+
+    if (variant) {
+      new_flags[new_flag_index].variant = strdup(variant);
+    } else {
+      new_flags[new_flag_index].variant = NULL;
+    }
+
+    env->feature_flags = new_flags;
+    env->feature_flag_count = env->feature_flag_count + 1;
+  }
+}
+
+void bsg_clear_feature_flag(bugsnag_event *env, const char *name) {
+  int flag_index = feature_flag_index(env, name);
+
+  if (flag_index < 0) {
+    // no such feature flag - early exit
+    return;
+  }
+
+  bsg_feature_flag *flag = &env->feature_flags[flag_index];
+
+  // release the memory held for name and possibly the variant
+  free(flag->name);
+  free(flag->variant);
+
+  // pack the array elements down to fill in the "gap"
+  // we don't resize the array down by one, that gets handled when elements are
+  // added
+  memmove(&env->feature_flags[flag_index], &env->feature_flags[flag_index + 1],
+          (env->feature_flag_count - flag_index - 1) *
+              sizeof(bsg_feature_flag));
+
+  // mark the array as having one-less flag
+  env->feature_flag_count = env->feature_flag_count - 1;
+}
+
+void bsg_free_feature_flags(bugsnag_event *env) {
+  for (int index = 0; index < env->feature_flag_count; index++) {
+    free(env->feature_flags[index].name);
+    free(env->feature_flags[index].variant);
+  }
+
+  free(env->feature_flags);
+
+  env->feature_flags = NULL;
+  env->feature_flag_count = 0;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/featureflags.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/featureflags.c
@@ -4,6 +4,10 @@
 #include "featureflags.h"
 #include "utils/string.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Implementation notes:
  *
@@ -139,3 +143,7 @@ void bsg_free_feature_flags(bugsnag_event *env) {
   env->feature_flags = NULL;
   env->feature_flag_count = 0;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/featureflags.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/featureflags.h
@@ -1,0 +1,40 @@
+#ifndef BUGSNAG_ANDROID_FEATUREFLAGS_H
+#define BUGSNAG_ANDROID_FEATUREFLAGS_H
+
+#include "bugsnag_ndk.h"
+
+/**
+ * Set a feature flag in the given `bugsnag_event` with an optional variant.
+ * This function will overwrite any existing feature flag with the specified
+ * name. Setting a `variant` to NULL is *not* the same as clearing the feature
+ * flag, which must be done with `bsg_clear_feature_flag`.
+ *
+ * @param env the environment to populate with the given feature flag
+ * @param name the name of the feature flag (may not be NULL)
+ * @param variant if non-NULL: the variant to set the feature flag to
+ */
+void bsg_set_feature_flag(bugsnag_event *env, const char *name,
+                          const char *variant);
+
+/**
+ * Release a specified feature flag from the given `bugsnag_event` if it
+ * exists. If the flag does not exist this is a no-op and the `bugsnag_event`
+ * will remain untouched. Any dynamic memory associated with the cleared feature
+ * flag is correctly released.
+ *
+ * @param env the environment to clear the given feature flag in
+ * @param name the name of the feature flag to clear
+ */
+void bsg_clear_feature_flag(bugsnag_event *env, const char *name);
+
+/**
+ * Release all of the memory for all of the feature flags stored in the given
+ * `bugsnag_event`. This also zeroes the `bugsnag_event->feature_flag_count`
+ * and cleans up the array pointers, effectively clearing all of the feature
+ * flags.
+ *
+ * @param env the environment to remove all the feature flags from
+ */
+void bsg_free_feature_flags(bugsnag_event *env);
+
+#endif // BUGSNAG_ANDROID_FEATUREFLAGS_H

--- a/bugsnag-plugin-android-ndk/src/main/jni/featureflags.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/featureflags.h
@@ -9,11 +9,11 @@
  * name. Setting a `variant` to NULL is *not* the same as clearing the feature
  * flag, which must be done with `bsg_clear_feature_flag`.
  *
- * @param env the environment to populate with the given feature flag
+ * @param event the environment to populate with the given feature flag
  * @param name the name of the feature flag (may not be NULL)
  * @param variant if non-NULL: the variant to set the feature flag to
  */
-void bsg_set_feature_flag(bugsnag_event *env, const char *name,
+void bsg_set_feature_flag(bugsnag_event *event, const char *name,
                           const char *variant);
 
 /**
@@ -22,10 +22,10 @@ void bsg_set_feature_flag(bugsnag_event *env, const char *name,
  * will remain untouched. Any dynamic memory associated with the cleared feature
  * flag is correctly released.
  *
- * @param env the environment to clear the given feature flag in
+ * @param event the environment to clear the given feature flag in
  * @param name the name of the feature flag to clear
  */
-void bsg_clear_feature_flag(bugsnag_event *env, const char *name);
+void bsg_clear_feature_flag(bugsnag_event *event, const char *name);
 
 /**
  * Release all of the memory for all of the feature flags stored in the given
@@ -33,8 +33,8 @@ void bsg_clear_feature_flag(bugsnag_event *env, const char *name);
  * and cleans up the array pointers, effectively clearing all of the feature
  * flags.
  *
- * @param env the environment to remove all the feature flags from
+ * @param event the environment to remove all the feature flags from
  */
-void bsg_free_feature_flags(bugsnag_event *env);
+void bsg_free_feature_flags(bugsnag_event *event);
 
 #endif // BUGSNAG_ANDROID_FEATUREFLAGS_H

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.c
@@ -1,0 +1,114 @@
+//
+// Created by Jason Morris on 19/11/2021.
+//
+
+#include "buffered_writer.h"
+#include "bugsnag_ndk.h"
+#include <fcntl.h>
+#include <inttypes.h>
+#include <malloc.h>
+#include <memory.h>
+#include <unistd.h>
+
+static bool bsg_flush_impl(const int fd, const char *buff,
+                           size_t bytes_to_write) {
+  if (bytes_to_write == 0) {
+    return true;
+  }
+
+  // Try a few times, then give up.
+  // write() will write less bytes on signal interruption, disk full, or
+  // resource limit.
+  for (int i = 0; i < 10; i++) {
+    ssize_t written_count = write(fd, buff, bytes_to_write);
+    if (written_count == bytes_to_write) {
+      return true;
+    }
+    if (written_count < 0) {
+      return false;
+    }
+    buff += written_count;
+    bytes_to_write -= written_count;
+  }
+
+  return false;
+}
+
+static bool bsg_buffered_writer_flush(struct bsg_buffered_writer *writer) {
+  if (bsg_flush_impl(writer->fd, writer->buffer, writer->pos)) {
+    writer->pos = 0;
+    return true;
+  }
+
+  return false;
+}
+
+// The compiler keeps changing sizeof(size_t) on different platforms, which
+// breaks printf().
+#if __SIZEOF_SIZE_T__ == 8
+#define PRIsize_t PRIu64
+#else
+#define PRIsize_t PRIu32
+#endif
+
+static bool bsg_buffered_writer_write(struct bsg_buffered_writer *writer,
+                                      const void *data, size_t length) {
+
+  if (length > BSG_BUFFER_SIZE) {
+    // this data won't fit in the buffer, so we first flush anything already in
+    // the buffer
+    if (!writer->flush(writer)) {
+      return false;
+    }
+
+    // then we flush the data we're needing to write
+    if (!bsg_flush_impl(writer->fd, data, length)) {
+      return false;
+    }
+
+    // then we return
+    return true;
+  }
+
+  // the data will fit into the buffer, but the data doesn't have the space
+  if (length > BSG_BUFFER_SIZE - writer->pos) {
+    // so we flush the buffer first
+    if (!writer->flush(writer)) {
+      return false;
+    }
+  }
+
+  memcpy(writer->buffer + writer->pos, data, length);
+  writer->pos += length;
+  return true;
+}
+
+static bool bsg_buffered_writer_close(bsg_buffered_writer *writer) {
+  writer->flush(writer);
+  if (close(writer->fd) < 0) {
+    return false;
+  }
+  return true;
+}
+
+bool bsg_buffered_writer_open(struct bsg_buffered_writer *writer,
+                              const char *path) {
+  int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY, 0600);
+  if (fd < 0) {
+    goto fail;
+  }
+
+  writer->fd = fd;
+  writer->pos = 0;
+  writer->write = bsg_buffered_writer_write;
+  writer->flush = bsg_buffered_writer_flush;
+  writer->dispose = bsg_buffered_writer_close;
+
+  return true;
+
+fail:
+  if (fd > 0) {
+    close(fd);
+  }
+  return false;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
@@ -32,6 +32,26 @@ typedef struct bsg_buffered_writer {
                 size_t length);
 
   /**
+   * Write a single byte-value to this writer.
+   *
+   * @param writer This writer
+   * @param byte the single byte to be written
+   * @return True on success. Check errno on error.
+   */
+  bool (*write_byte)(struct bsg_buffered_writer *writer, const uint8_t byte);
+
+  /**
+   * Write a length-prefixed string to this writer. This will first write 4
+   * bytes for the length of the string, and then the string itself (without
+   * it's null-terminator character).
+   *
+   * @param writer This writer
+   * @param string the string to write, may not be NULL
+   * @return True on success. Check errno on error.
+   */
+  bool (*write_string)(struct bsg_buffered_writer *writer, const char *string);
+
+  /**
    * Force a flush to file.
    *
    * Note: This method is async-safe.
@@ -45,7 +65,7 @@ typedef struct bsg_buffered_writer {
    * Dispose of this writer, closing and freeing all resources. The pointer to
    * writer will be invalid after this call.
    *
-   * Note: This method is NOT async-safe!
+   * Note: This method is async-safe!
    *
    * @param writer This writer.
    * @return True on success. Check errno on error.

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
@@ -1,0 +1,66 @@
+/**
+ * Async-safe buffered writer.
+ *
+ * This writer buffers up data and flushes to disk as needed, using primitive
+ * async-safe functions open(), close(), and write() under the hood.
+ */
+#ifndef BUGSNAG_BUFFERED_WRITER_H
+#define BUGSNAG_BUFFERED_WRITER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define BSG_BUFFER_SIZE 128
+
+typedef struct bsg_buffered_writer {
+  int fd;
+  size_t pos;
+  char buffer[BSG_BUFFER_SIZE];
+
+  /**
+   * Write to this writer. If the internal buffer size is exceeded, it will
+   * automatically flush to file.
+   *
+   * Note: This method is async-safe.
+   *
+   * @param writer This writer.
+   * @param data The data to write.
+   * @param length The length of the data to write.
+   * @return True on success. Check errno on error.
+   */
+  bool (*write)(struct bsg_buffered_writer *writer, const void *data,
+                size_t length);
+
+  /**
+   * Force a flush to file.
+   *
+   * Note: This method is async-safe.
+   *
+   * @param writer This writer.
+   * @return True on success. Check errno on error.
+   */
+  bool (*flush)(struct bsg_buffered_writer *writer);
+
+  /**
+   * Dispose of this writer, closing and freeing all resources. The pointer to
+   * writer will be invalid after this call.
+   *
+   * Note: This method is NOT async-safe!
+   *
+   * @param writer This writer.
+   * @return True on success. Check errno on error.
+   */
+  bool (*dispose)(struct bsg_buffered_writer *writer);
+} bsg_buffered_writer;
+
+/**
+ * Create a new buffered writer.
+ *
+ * @param buffer_size The size of the buffer to use.
+ * @param path The path of the file to write to.
+ * @return A buffered writer, or NULL on error. Check errno on error.
+ */
+bool bsg_buffered_writer_open(struct bsg_buffered_writer *writer,
+                              const char *path);
+
+#endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -279,6 +279,35 @@ typedef struct {
   char api_key[64];
 } bugsnag_report_v6;
 
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
+
+  int thread_count;
+  bsg_thread threads[BUGSNAG_THREADS_MAX];
+} bugsnag_report_v7;
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -22,12 +22,16 @@ bool bsg_event_write(struct bsg_buffered_writer *writer,
 
 bugsnag_event *bsg_event_read(int fd);
 bsg_report_header *bsg_report_header_read(int fd);
+bugsnag_event *bsg_map_v7_to_report(bugsnag_report_v7 *report_v7);
 bugsnag_event *bsg_map_v6_to_report(bugsnag_report_v6 *report_v6);
 bugsnag_event *bsg_map_v5_to_report(bugsnag_report_v5 *report_v5);
 bugsnag_event *bsg_map_v4_to_report(bugsnag_report_v4 *report_v4);
 bugsnag_event *bsg_map_v3_to_report(bugsnag_report_v3 *report_v3);
 bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2);
 bugsnag_event *bsg_map_v1_to_report(bugsnag_report_v1 *report_v1);
+
+void bsg_read_feature_flags(int fd, bsg_feature_flag **out_feature_flags,
+                            size_t *out_feature_flag_count);
 
 void migrate_app_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event);
 void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event);
@@ -66,10 +70,11 @@ bool bsg_serialize_event_to_file(bsg_environment *env) {
     goto fail;
   }
 
-  if (!bsg_write_feature_flags(env, &writer)) {
+  if (!bsg_write_feature_flags(&env->next_event, &writer)) {
     goto fail;
   }
 
+  writer.dispose(&writer);
   return true;
 
 fail:
@@ -158,7 +163,52 @@ bugsnag_report_v6 *bsg_report_v6_read(int fd) {
   return event;
 }
 
-bugsnag_event *bsg_report_v7_read(int fd) {
+bugsnag_report_v7 *bsg_report_v7_read(int fd) {
+  size_t event_size = sizeof(bugsnag_report_v7);
+  bugsnag_report_v7 *event = calloc(1, event_size);
+
+  ssize_t len = read(fd, event, event_size);
+  if (len != event_size) {
+    free(event);
+    return NULL;
+  }
+  return event;
+}
+
+static char *read_string(int fd) {
+  ssize_t len;
+  uint32_t string_length;
+  len = read(fd, &string_length, sizeof(string_length));
+
+  if (len != sizeof(string_length)) {
+    return NULL;
+  }
+
+  // allocate enough space, zero filler, and with a trailing '\0' terminator
+  char *string_buffer = calloc(1, (string_length + 1));
+  if (!string_buffer) {
+    return NULL;
+  }
+
+  len = read(fd, string_buffer, string_length);
+  if (len != string_length) {
+    free(string_buffer);
+    return NULL;
+  }
+
+  return string_buffer;
+}
+
+int read_byte(int fd) {
+  char value;
+  if (read(fd, &value, 1) != 1) {
+    return -1;
+  }
+
+  return value;
+}
+
+bugsnag_event *bsg_report_v8_read(int fd) {
   size_t event_size = sizeof(bugsnag_event);
   bugsnag_event *event = calloc(1, event_size);
 
@@ -167,6 +217,10 @@ bugsnag_event *bsg_report_v7_read(int fd) {
     free(event);
     return NULL;
   }
+
+  // read the feature flags, if possible
+  bsg_read_feature_flags(fd, &event->feature_flags, &event->feature_flag_count);
+
   return event;
 }
 
@@ -209,7 +263,10 @@ bugsnag_event *bsg_event_read(int fd) {
     bugsnag_report_v6 *report_v6 = bsg_report_v6_read(fd);
     event = bsg_map_v6_to_report(report_v6);
   } else if (event_version == 7) {
-    event = bsg_report_v7_read(fd);
+    bugsnag_report_v7 *report_v7 = bsg_report_v7_read(fd);
+    event = bsg_map_v7_to_report(report_v7);
+  } else if (event_version == 8) {
+    event = bsg_report_v8_read(fd);
   }
   return event;
 }
@@ -223,6 +280,19 @@ bugsnag_event *bsg_map_v6_to_report(bugsnag_report_v6 *report_v6) {
   if (event != NULL) {
     memcpy(event, report_v6, sizeof(bugsnag_report_v6));
     free(report_v6);
+  }
+  return event;
+}
+
+bugsnag_event *bsg_map_v7_to_report(bugsnag_report_v7 *report_v7) {
+  if (report_v7 == NULL) {
+    return NULL;
+  }
+  bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+
+  if (event != NULL) {
+    memcpy(event, report_v7, sizeof(bugsnag_report_v7));
+    free(report_v7);
   }
   return event;
 }
@@ -885,6 +955,26 @@ void bsg_serialize_threads(const bugsnag_event *event, JSON_Array *threads) {
   }
 }
 
+void bsg_serialize_feature_flags(const bugsnag_event *event,
+                                 JSON_Array *feature_flags) {
+  if (event->feature_flag_count <= 0) {
+    return;
+  }
+
+  for (int index = 0; index < event->feature_flag_count; index++) {
+    JSON_Value *feature_flag_val = json_value_init_object();
+    JSON_Object *feature_flag = json_value_get_object(feature_flag_val);
+    json_array_append_value(feature_flags, feature_flag_val);
+
+    const bsg_feature_flag *flag = &event->feature_flags[index];
+    json_object_set_string(feature_flag, "featureFlag", flag->name);
+
+    if (flag->variant) {
+      json_object_set_string(feature_flag, "variant", flag->variant);
+    }
+  }
+}
+
 char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   JSON_Value *event_val = json_value_init_object();
   JSON_Object *event_obj = json_value_get_object(event_val);
@@ -898,10 +988,13 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   JSON_Array *threads = json_value_get_array(threads_val);
   JSON_Value *stack_val = json_value_init_array();
   JSON_Array *stacktrace = json_value_get_array(stack_val);
+  JSON_Value *feature_flags_val = json_value_init_object();
+  JSON_Array *feature_flags = json_value_get_array(feature_flags_val);
   json_object_set_value(event_obj, "exceptions", exceptions_val);
   json_object_set_value(event_obj, "breadcrumbs", crumbs_val);
   json_object_set_value(event_obj, "threads", threads_val);
   json_object_set_value(exception, "stacktrace", stack_val);
+  json_object_set_value(event_obj, "featureFlags", feature_flags_val);
   json_array_append_value(exceptions, ex_val);
   char *serialized_string = NULL;
   {
@@ -918,6 +1011,7 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
     bsg_serialize_error(event->error, exception, stacktrace);
     bsg_serialize_breadcrumbs(event, crumbs);
     bsg_serialize_threads(event, threads);
+    bsg_serialize_feature_flags(event, feature_flags);
 
     serialized_string = json_serialize_to_string(event_val);
     json_value_free(event_val);
@@ -925,41 +1019,22 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   return serialized_string;
 }
 
-static bool write_string(bsg_buffered_writer *writer, const char *s) {
-  // prefix with the string length uint32
-  const uint32_t length = bsg_strlen(s);
-  if (!writer->write(writer, &length, sizeof(length))) {
-    return false;
-  }
-
-  // then write the string data without trailing '\0'
-  if (!writer->write(writer, s, length)) {
-    return false;
-  }
-
-  return true;
-}
-
-static bool write_byte(bsg_buffered_writer *writer, const char value) {
-  return writer->write(writer, &value, 1);
-}
-
 static bool write_feature_flag(bsg_buffered_writer *writer,
                                bsg_feature_flag *flag) {
-  if (!write_string(writer, flag->name)) {
+  if (!writer->write_string(writer, flag->name)) {
     return false;
   }
 
   if (flag->variant) {
-    if (!write_byte(writer, 1)) {
+    if (!writer->write_byte(writer, 1)) {
       return false;
     }
 
-    if (!write_string(writer, flag->variant)) {
+    if (!writer->write_string(writer, flag->variant)) {
       return false;
     }
   } else {
-    if (!write_byte(writer, 0)) {
+    if (!writer->write_byte(writer, 0)) {
       return false;
     }
   }
@@ -967,18 +1042,77 @@ static bool write_feature_flag(bsg_buffered_writer *writer,
   return true;
 }
 
-bool bsg_write_feature_flags(bsg_environment *env,
+bool bsg_write_feature_flags(bugsnag_event *event,
                              bsg_buffered_writer *writer) {
-  const uint32_t feature_flag_count = env->feature_flag_count;
+  const uint32_t feature_flag_count = event->feature_flag_count;
   if (!writer->write(writer, &feature_flag_count, sizeof(feature_flag_count))) {
     return false;
   }
 
   for (uint32_t index = 0; index < feature_flag_count; index++) {
-    if (!write_feature_flag(writer, &env->feature_flags[index])) {
+    if (!write_feature_flag(writer, &event->feature_flags[index])) {
       return false;
     }
   }
 
   return true;
+}
+
+void bsg_read_feature_flags(int fd, bsg_feature_flag **out_feature_flags,
+                            size_t *out_feature_flag_count) {
+
+  ssize_t len;
+  uint32_t feature_flag_count = 0;
+  len = read(fd, &feature_flag_count, sizeof(feature_flag_count));
+  if (len != sizeof(feature_flag_count)) {
+    goto feature_flags_error;
+  }
+
+  bsg_feature_flag *flags =
+      calloc(feature_flag_count, sizeof(bsg_feature_flag));
+  for (uint32_t index = 0; index < feature_flag_count; index++) {
+    char *name = read_string(fd);
+    if (!name) {
+      goto feature_flags_error;
+    }
+
+    int variant_exists = read_byte(fd);
+    if (variant_exists < 0) {
+      goto feature_flags_error;
+    }
+
+    char *variant = NULL;
+    if (variant_exists) {
+      variant = read_string(fd);
+      if (!variant) {
+        goto feature_flags_error;
+      }
+    }
+
+    flags[index].name = name;
+    flags[index].variant = variant;
+  }
+
+  *out_feature_flag_count = feature_flag_count;
+  *out_feature_flags = flags;
+
+  return;
+
+feature_flags_error:
+  // something wrong - we release all allocated memory
+  for (uint32_t index = 0; index < feature_flag_count; index++) {
+    if (flags[index].name) {
+      free(flags[index].name);
+    }
+
+    if (flags[index].variant) {
+      free(flags[index].variant);
+    }
+  }
+
+  free(flags);
+
+  // clear the out fields to indicate no feature-flags are availables
+  *out_feature_flag_count = 0;
+  *out_feature_flags = NULL;
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -1,4 +1,5 @@
 #include "../bugsnag_ndk.h"
+#include "buffered_writer.h"
 #include "build.h"
 #include <fcntl.h>
 #include <parson/parson.h>
@@ -49,6 +50,8 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 int bsg_calculate_total_crumbs(int old_count);
 int bsg_calculate_v1_start_index(int old_count);
 int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index);
+
+bool bsg_write_feature_flags(bsg_environment *env, bsg_buffered_writer *writer);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -45,13 +45,15 @@ void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
                          JSON_Array *stacktrace);
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
 void bsg_serialize_threads(const bugsnag_event *event, JSON_Array *threads);
+void bsg_serialize_feature_flags(const bugsnag_event *event,
+                                 JSON_Array *feature_flags);
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 
 int bsg_calculate_total_crumbs(int old_count);
 int bsg_calculate_v1_start_index(int old_count);
 int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index);
 
-bool bsg_write_feature_flags(bsg_environment *env, bsg_buffered_writer *writer);
+bool bsg_write_feature_flags(bugsnag_event *event, bsg_buffered_writer *writer);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
@@ -11,5 +11,6 @@ add_library(bugsnag-ndk-test SHARED
     cpp/test_serializer.c
     cpp/test_breadcrumbs.c
     cpp/test_bsg_event.c
+    cpp/test_featureflags.c
 )
 target_link_libraries(bugsnag-ndk-test bugsnag-ndk)

--- a/bugsnag-plugin-android-ndk/src/test/cpp/main.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/main.c
@@ -18,6 +18,7 @@ SUITE(suite_event_app_mutators);
 SUITE(suite_event_device_mutators);
 SUITE(suite_struct_to_file);
 SUITE(suite_struct_migration);
+SUITE(suite_feature_flags);
 
 GREATEST_MAIN_DEFS();
 
@@ -87,6 +88,11 @@ JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_NativeEventAppMutatorsTest_ru
 JNIEXPORT int JNICALL Java_com_bugsnag_android_ndk_NativeEventDeviceMutatorsTest_run(
     JNIEnv *_env, jobject _this) {
     return run_test_suite(suite_event_device_mutators);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_bugsnag_android_ndk_NativeFeatureFlagsTest_run(JNIEnv *env, jobject thiz) {
+    return run_test_suite(suite_feature_flags);
 }
 
 JNIEXPORT jstring JNICALL Java_com_bugsnag_android_ndk_UserSerializationTest_run(

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_featureflags.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_featureflags.c
@@ -1,0 +1,57 @@
+#include <greatest/greatest.h>
+#include <featureflags.h>
+
+TEST test_set_feature_flag(void) {
+  bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+
+  bsg_set_feature_flag(event, "sample_group", "a");
+  bsg_set_feature_flag(event, "demo_mode", NULL);
+  bsg_set_feature_flag(event, "demo_mode", "yes");
+  bsg_set_feature_flag(event, "zzz", NULL);
+
+  ASSERT_EQ(3, event->feature_flag_count);
+
+  ASSERT_STR_EQ("demo_mode", event->feature_flags[0].name);
+  ASSERT_STR_EQ("yes", event->feature_flags[0].variant);
+
+  ASSERT_STR_EQ("sample_group", event->feature_flags[1].name);
+  ASSERT_STR_EQ("a", event->feature_flags[1].variant);
+
+  ASSERT_STR_EQ("zzz", event->feature_flags[2].name);
+  ASSERT_EQ(NULL, event->feature_flags[2].variant);
+
+  bsg_free_feature_flags(event);
+  free(event);
+
+  PASS();
+}
+
+TEST test_clear_feature_flag(void) {
+  bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+
+  bsg_set_feature_flag(event, "sample_group", "a");
+  bsg_set_feature_flag(event, "demo_mode", NULL);
+  bsg_set_feature_flag(event, "remaining", "flag");
+
+  ASSERT_EQ(3, event->feature_flag_count);
+
+  bsg_clear_feature_flag(event, "no_such_flag");
+  ASSERT_EQ(3, event->feature_flag_count);
+
+  bsg_clear_feature_flag(event, "sample_group");
+  bsg_clear_feature_flag(event, "demo_mode");
+
+  ASSERT_EQ(1, event->feature_flag_count);
+  ASSERT_STR_EQ("remaining", event->feature_flags[0].name);
+  ASSERT_STR_EQ("flag", event->feature_flags[0].variant);
+
+  bsg_free_feature_flags(event);
+  free(event);
+
+  PASS();
+}
+
+SUITE (suite_feature_flags) {
+  RUN_TEST(test_set_feature_flag);
+  RUN_TEST(test_clear_feature_flag);
+}

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -2,6 +2,7 @@
 #include <utils/serializer.h>
 #include <stdlib.h>
 #include <utils/migrate.h>
+#include <featureflags.h>
 
 #define SERIALIZE_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo.crash"
 
@@ -446,6 +447,22 @@ TEST test_report_to_file(void) {
   env->report_header.big_endian = 1;
   bugsnag_event *report = bsg_generate_event();
   memcpy(&env->next_event, report, sizeof(bugsnag_event));
+  strcpy(env->report_header.os_build, "macOS Sierra");
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
+  ASSERT(bsg_serialize_event_to_file(env));
+  free(report);
+  free(env);
+  PASS();
+}
+
+TEST test_report_with_feature_flags_to_file(void) {
+  bsg_environment *env = calloc(1, sizeof(bsg_environment));
+  env->report_header.version = 7;
+  env->report_header.big_endian = 1;
+  bugsnag_event *report = bsg_generate_event();
+  memcpy(&env->next_event, report, sizeof(bugsnag_event));
+  bsg_set_feature_flag(env, "sample_group", "a");
+  bsg_set_feature_flag(env, "demo_mode", NULL);
   strcpy(env->report_header.os_build, "macOS Sierra");
   strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
   ASSERT(bsg_serialize_event_to_file(env));
@@ -912,6 +929,7 @@ SUITE(suite_json_serialization) {
 SUITE(suite_struct_to_file) {
   RUN_TEST(test_report_to_file);
   RUN_TEST(test_file_to_report);
+  RUN_TEST(test_report_with_feature_flags_to_file);
 }
 
 SUITE(suite_struct_migration) {

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/bugsnag-java-scenarios.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/bugsnag-java-scenarios.cpp
@@ -100,4 +100,10 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXConfigurationMetadataNativeCras
   return 12167;
 }
 
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXFeatureFlagNativeCrashScenario_crash(JNIEnv *env,
+                                                                                      jobject instance) {
+  __builtin_trap();
+}
+
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXFeatureFlagNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXFeatureFlagNativeCrashScenario.java
@@ -1,0 +1,31 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class CXXFeatureFlagNativeCrashScenario extends Scenario {
+    static {
+        System.loadLibrary("cxx-scenarios");
+    }
+
+    public native void crash();
+
+    public CXXFeatureFlagNativeCrashScenario(@NonNull Configuration config,
+                                             @NonNull Context context,
+                                             @Nullable String eventMetadata) {
+        super(config, context, eventMetadata);
+    }
+
+    @Override
+    public void startScenario() {
+        super.startScenario();
+        Bugsnag.addFeatureFlag("demo_mode");
+        Bugsnag.addFeatureFlag("sample_group", "a");
+        crash();
+    }
+}

--- a/features/full_tests/batch_1/feature_flags.feature
+++ b/features/full_tests/batch_1/feature_flags.feature
@@ -1,0 +1,28 @@
+Feature: Reporting with feature flags
+
+Scenario: Sends handled exception which includes feature flags
+  When I run "FeatureFlagScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "java.lang.RuntimeException"
+  And the event "unhandled" is false
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 does not contain the feature flag "demo_mode" with no variant
+
+Scenario: Sends handled exception which includes feature flags added in the notify callback
+  When I configure the app to run in the "callback" state
+  And I run "FeatureFlagScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "java.lang.RuntimeException"
+  And the event "unhandled" is false
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 contains the feature flag "sample_group" with variant "a"
+
+Scenario: Sends unhandled exception which includes feature flags added in the notify callback
+  When I configure the app to run in the "unhandled callback" state
+  And I run "FeatureFlagScenario" and relaunch the app
+  And I configure Bugsnag for "FeatureFlagScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "java.lang.RuntimeException"
+  And the event "unhandled" is true
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 contains the feature flag "sample_group" with variant "a"

--- a/features/full_tests/batch_2/native_feature_flags.feature
+++ b/features/full_tests/batch_2/native_feature_flags.feature
@@ -1,0 +1,10 @@
+Feature: Synchronizing feature flags to the native layer
+
+  Scenario: Feature flags are synchronized to the native layer
+    When I run "CXXFeatureFlagNativeCrashScenario"
+    And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGILL"
+    And event 0 contains the feature flag "demo_mode" with no variant
+    And event 0 contains the feature flag "sample_group" with variant "a"


### PR DESCRIPTION
## Goal
Store feature flags in the NDK Bugsnag environment (`bsg_environment`) when they are changed on the JVM side, reproducing all existing JVM behaviour:

* Adding new flags
* Overwriting existing flags
* Clearing individual flags
* Clearing all flags

## Testing
New unit tests and end-to-end tests included.