### PR TITLE
Serialize NDK Feature Flags

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -428,6 +428,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         contextState.emitObservableEvent();
         userState.emitObservableEvent();
         memoryTrimState.emitObservableEvent();
+        featureFlagState.emitObservableEvent();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FeatureFlagState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FeatureFlagState.kt
@@ -37,6 +37,14 @@ internal data class FeatureFlagState(
         }
     }
 
+    fun emitObservableEvent() {
+        val flags = toList()
+
+        flags.forEach { (name, variant) ->
+            updateState { StateEvent.AddFeatureFlag(name, variant) }
+        }
+    }
+
     fun toList(): List<FeatureFlag> = featureFlags.toList()
     fun copy() = FeatureFlagState(featureFlags.copy())
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/FeatureFlagStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/FeatureFlagStateTest.kt
@@ -93,4 +93,32 @@ internal class FeatureFlagStateTest {
 
         assertNotNull(events.find { it is StateEvent.ClearFeatureFlags })
     }
+
+    @Test
+    fun emitObservableEvent() {
+        state.addFeatureFlag("sample_group", "4321")
+        state.addFeatureFlag("listing_view", "legacy")
+        state.addFeatureFlag("demo_mode")
+
+        // clear the events
+        events.clear()
+
+        state.emitObservableEvent()
+        assertEquals(3, events.size)
+        val addSampleGroup = events
+            .filterIsInstance<StateEvent.AddFeatureFlag>()
+            .find { it.name == "sample_group" }
+        assertEquals("4321", addSampleGroup?.variant)
+
+        val addListingView = events
+            .filterIsInstance<StateEvent.AddFeatureFlag>()
+            .find { it.name == "listing_view" }
+        assertEquals("legacy", addListingView?.variant)
+
+        val addDemoMode = events
+            .filterIsInstance<StateEvent.AddFeatureFlag>()
+            .find { it.name == "demo_mode" }
+        assertNotNull(addDemoMode)
+        assertNull(addDemoMode!!.variant)
+    }
 }

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library( # Specifies the name of the library.
     jni/utils/serializer.c
     jni/utils/string.c
     jni/utils/threads.c
+    jni/utils/buffered_writer.c
     jni/deps/parson/parson.c
              )
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -21,11 +21,6 @@ extern "C" {
 #endif
 
 typedef struct {
-  char *name;
-  char *variant;
-} bsg_feature_flag;
-
-typedef struct {
   /**
    * Unwinding style used for signal-safe handling
    */

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -21,6 +21,11 @@ extern "C" {
 #endif
 
 typedef struct {
+  char *name;
+  char *variant;
+} bsg_feature_flag;
+
+typedef struct {
   /**
    * Unwinding style used for signal-safe handling
    */
@@ -79,6 +84,16 @@ typedef struct {
    * at the time of an error.
    */
   bsg_thread_send_policy send_threads;
+
+  /**
+   * The number of feature flags currently specified.
+   */
+  size_t feature_flag_count;
+
+  /**
+   * Pointer to the current feature flags.
+   */
+  bsg_feature_flag *feature_flags;
 } bsg_environment;
 
 bsg_unwinder bsg_configured_unwind_style();

--- a/bugsnag-plugin-android-ndk/src/main/jni/featureflags.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/featureflags.c
@@ -4,6 +4,10 @@
 #include "featureflags.h"
 #include "utils/string.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Implementation notes:
  *
@@ -139,3 +143,7 @@ void bsg_free_feature_flags(bugsnag_event *env) {
   env->feature_flags = NULL;
   env->feature_flag_count = 0;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.c
@@ -1,0 +1,114 @@
+//
+// Created by Jason Morris on 19/11/2021.
+//
+
+#include "buffered_writer.h"
+#include "bugsnag_ndk.h"
+#include <fcntl.h>
+#include <inttypes.h>
+#include <malloc.h>
+#include <memory.h>
+#include <unistd.h>
+
+static bool bsg_flush_impl(const int fd, const char *buff,
+                           size_t bytes_to_write) {
+  if (bytes_to_write == 0) {
+    return true;
+  }
+
+  // Try a few times, then give up.
+  // write() will write less bytes on signal interruption, disk full, or
+  // resource limit.
+  for (int i = 0; i < 10; i++) {
+    ssize_t written_count = write(fd, buff, bytes_to_write);
+    if (written_count == bytes_to_write) {
+      return true;
+    }
+    if (written_count < 0) {
+      return false;
+    }
+    buff += written_count;
+    bytes_to_write -= written_count;
+  }
+
+  return false;
+}
+
+static bool bsg_buffered_writer_flush(struct bsg_buffered_writer *writer) {
+  if (bsg_flush_impl(writer->fd, writer->buffer, writer->pos)) {
+    writer->pos = 0;
+    return true;
+  }
+
+  return false;
+}
+
+// The compiler keeps changing sizeof(size_t) on different platforms, which
+// breaks printf().
+#if __SIZEOF_SIZE_T__ == 8
+#define PRIsize_t PRIu64
+#else
+#define PRIsize_t PRIu32
+#endif
+
+static bool bsg_buffered_writer_write(struct bsg_buffered_writer *writer,
+                                      const void *data, size_t length) {
+
+  if (length > BSG_BUFFER_SIZE) {
+    // this data won't fit in the buffer, so we first flush anything already in
+    // the buffer
+    if (!writer->flush(writer)) {
+      return false;
+    }
+
+    // then we flush the data we're needing to write
+    if (!bsg_flush_impl(writer->fd, data, length)) {
+      return false;
+    }
+
+    // then we return
+    return true;
+  }
+
+  // the data will fit into the buffer, but the data doesn't have the space
+  if (length > BSG_BUFFER_SIZE - writer->pos) {
+    // so we flush the buffer first
+    if (!writer->flush(writer)) {
+      return false;
+    }
+  }
+
+  memcpy(writer->buffer + writer->pos, data, length);
+  writer->pos += length;
+  return true;
+}
+
+static bool bsg_buffered_writer_close(bsg_buffered_writer *writer) {
+  writer->flush(writer);
+  if (close(writer->fd) < 0) {
+    return false;
+  }
+  return true;
+}
+
+bool bsg_buffered_writer_open(struct bsg_buffered_writer *writer,
+                              const char *path) {
+  int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY, 0600);
+  if (fd < 0) {
+    goto fail;
+  }
+
+  writer->fd = fd;
+  writer->pos = 0;
+  writer->write = bsg_buffered_writer_write;
+  writer->flush = bsg_buffered_writer_flush;
+  writer->dispose = bsg_buffered_writer_close;
+
+  return true;
+
+fail:
+  if (fd > 0) {
+    close(fd);
+  }
+  return false;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
@@ -1,0 +1,66 @@
+/**
+ * Async-safe buffered writer.
+ *
+ * This writer buffers up data and flushes to disk as needed, using primitive
+ * async-safe functions open(), close(), and write() under the hood.
+ */
+#ifndef BUGSNAG_BUFFERED_WRITER_H
+#define BUGSNAG_BUFFERED_WRITER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define BSG_BUFFER_SIZE 128
+
+typedef struct bsg_buffered_writer {
+  int fd;
+  size_t pos;
+  char buffer[BSG_BUFFER_SIZE];
+
+  /**
+   * Write to this writer. If the internal buffer size is exceeded, it will
+   * automatically flush to file.
+   *
+   * Note: This method is async-safe.
+   *
+   * @param writer This writer.
+   * @param data The data to write.
+   * @param length The length of the data to write.
+   * @return True on success. Check errno on error.
+   */
+  bool (*write)(struct bsg_buffered_writer *writer, const void *data,
+                size_t length);
+
+  /**
+   * Force a flush to file.
+   *
+   * Note: This method is async-safe.
+   *
+   * @param writer This writer.
+   * @return True on success. Check errno on error.
+   */
+  bool (*flush)(struct bsg_buffered_writer *writer);
+
+  /**
+   * Dispose of this writer, closing and freeing all resources. The pointer to
+   * writer will be invalid after this call.
+   *
+   * Note: This method is NOT async-safe!
+   *
+   * @param writer This writer.
+   * @return True on success. Check errno on error.
+   */
+  bool (*dispose)(struct bsg_buffered_writer *writer);
+} bsg_buffered_writer;
+
+/**
+ * Create a new buffered writer.
+ *
+ * @param buffer_size The size of the buffer to use.
+ * @param path The path of the file to write to.
+ * @return A buffered writer, or NULL on error. Check errno on error.
+ */
+bool bsg_buffered_writer_open(struct bsg_buffered_writer *writer,
+                              const char *path);
+
+#endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -1,4 +1,5 @@
 #include "../bugsnag_ndk.h"
+#include "buffered_writer.h"
 #include "build.h"
 #include <fcntl.h>
 #include <parson/parson.h>
@@ -49,6 +50,8 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 int bsg_calculate_total_crumbs(int old_count);
 int bsg_calculate_v1_start_index(int old_count);
 int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index);
+
+bool bsg_write_feature_flags(bsg_environment *env, bsg_buffered_writer *writer);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -2,6 +2,7 @@
 #include <utils/serializer.h>
 #include <stdlib.h>
 #include <utils/migrate.h>
+#include <featureflags.h>
 
 #define SERIALIZE_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo.crash"
 
@@ -446,6 +447,22 @@ TEST test_report_to_file(void) {
   env->report_header.big_endian = 1;
   bugsnag_event *report = bsg_generate_event();
   memcpy(&env->next_event, report, sizeof(bugsnag_event));
+  strcpy(env->report_header.os_build, "macOS Sierra");
+  strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
+  ASSERT(bsg_serialize_event_to_file(env));
+  free(report);
+  free(env);
+  PASS();
+}
+
+TEST test_report_with_feature_flags_to_file(void) {
+  bsg_environment *env = calloc(1, sizeof(bsg_environment));
+  env->report_header.version = 7;
+  env->report_header.big_endian = 1;
+  bugsnag_event *report = bsg_generate_event();
+  memcpy(&env->next_event, report, sizeof(bugsnag_event));
+  bsg_set_feature_flag(env, "sample_group", "a");
+  bsg_set_feature_flag(env, "demo_mode", NULL);
   strcpy(env->report_header.os_build, "macOS Sierra");
   strcpy(env->next_event_path, SERIALIZE_TEST_FILE);
   ASSERT(bsg_serialize_event_to_file(env));
@@ -912,6 +929,7 @@ SUITE(suite_json_serialization) {
 SUITE(suite_struct_to_file) {
   RUN_TEST(test_report_to_file);
   RUN_TEST(test_file_to_report);
+  RUN_TEST(test_report_with_feature_flags_to_file);
 }
 
 SUITE(suite_struct_migration) {


### PR DESCRIPTION
## Goal
Ensure that feature flags collected by the NDK are stored during a crash so that they can be recovered later for reporting.

## Design
Copied the `buffered_writer` from the Journal with two major changes:
* the buffer is now a fixed size, and stack-local so that no dynamic memory is required.
* writing blocks larger than the buffer is now permitted: the buffer is first flushed, and then the block of data is written through the same function that flushes the buffer (handling `write` retries, etc.)
The buffered writer is used to reduce the number of `write` calls as the feature flags are dynamic and written field-by-field.

## Testing
Introduced new native unit tests to ensure that the Feature Flags do not cause the serialization of events to fail. The deserialization PR will include checks to ensure the data is recoverable.