### PR TITLE
Alter warning about non-application context

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -976,8 +976,15 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
 
     private void warnIfNotAppContext(Context androidContext) {
         if (!(androidContext instanceof Application)) {
-            logger.w("Warning - Non-Application context detected! Please ensure that you are "
-                + "initializing Bugsnag from a custom Application class.");
+            logger.w("You should initialize Bugsnag from the onCreate() callback of your "
+                    + "Application subclass, as this guarantees errors are captured as early "
+                    + "as possible. "
+                    + "If a custom Application subclass is not possible in your app then you "
+                    + "should suppress this warning by passing the Application context instead: "
+                    + "Bugsnag.start(context.getApplicationContext()). "
+                    + "For further info see: "
+                    + "https://docs.bugsnag.com/platforms/android/#basic-configuration");
+
         }
     }
 


### PR DESCRIPTION
## Goal

Alters the warning for when a non-application context is passed to `Bugsnag.start()`. This now lists why this may be a bad thing (it implies Bugsnag is being started in an activity and may miss certain errors), and gives steps on how to fix/suppress the warning.

The warning looks like this in Logcat:

>2021-11-23 10:26:54.536 7779-7779/com.example.bugsnag.android W/Bugsnag: You should initialize Bugsnag from the onCreate() callback of your Application subclass, as this guarantees errors are captured as early as possible. If a custom Application subclass is not possible in your app then you should suppress this warning by passing the Application context instead: Bugsnag.start(context.getApplicationContext()). For further info see: https://docs.bugsnag.com/platforms/android/#basic-configuration