### PR TITLE
Load feature flags stored in NDK events

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -271,6 +271,7 @@ exit:
   if (event != NULL) {
     bsg_safe_release_byte_array_elements(env, jstage,
                                          (jbyte *)event->app.release_stage);
+    bsg_free_feature_flags(event);
     free(event);
   }
   if (payload != NULL) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -79,16 +79,6 @@ typedef struct {
    * at the time of an error.
    */
   bsg_thread_send_policy send_threads;
-
-  /**
-   * The number of feature flags currently specified.
-   */
-  size_t feature_flag_count;
-
-  /**
-   * Pointer to the current feature flags.
-   */
-  bsg_feature_flag *feature_flags;
 } bsg_environment;
 
 bsg_unwinder bsg_configured_unwind_style();

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -34,7 +34,7 @@
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
-#define BUGSNAG_EVENT_VERSION 7
+#define BUGSNAG_EVENT_VERSION 8
 
 #ifdef __cplusplus
 extern "C" {

--- a/bugsnag-plugin-android-ndk/src/main/jni/featureflags.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/featureflags.h
@@ -9,11 +9,11 @@
  * name. Setting a `variant` to NULL is *not* the same as clearing the feature
  * flag, which must be done with `bsg_clear_feature_flag`.
  *
- * @param env the environment to populate with the given feature flag
+ * @param event the environment to populate with the given feature flag
  * @param name the name of the feature flag (may not be NULL)
  * @param variant if non-NULL: the variant to set the feature flag to
  */
-void bsg_set_feature_flag(bugsnag_event *env, const char *name,
+void bsg_set_feature_flag(bugsnag_event *event, const char *name,
                           const char *variant);
 
 /**
@@ -22,10 +22,10 @@ void bsg_set_feature_flag(bugsnag_event *env, const char *name,
  * will remain untouched. Any dynamic memory associated with the cleared feature
  * flag is correctly released.
  *
- * @param env the environment to clear the given feature flag in
+ * @param event the environment to clear the given feature flag in
  * @param name the name of the feature flag to clear
  */
-void bsg_clear_feature_flag(bugsnag_event *env, const char *name);
+void bsg_clear_feature_flag(bugsnag_event *event, const char *name);
 
 /**
  * Release all of the memory for all of the feature flags stored in the given
@@ -33,8 +33,8 @@ void bsg_clear_feature_flag(bugsnag_event *env, const char *name);
  * and cleans up the array pointers, effectively clearing all of the feature
  * flags.
  *
- * @param env the environment to remove all the feature flags from
+ * @param event the environment to remove all the feature flags from
  */
-void bsg_free_feature_flags(bugsnag_event *env);
+void bsg_free_feature_flags(bugsnag_event *event);
 
 #endif // BUGSNAG_ANDROID_FEATUREFLAGS_H

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/buffered_writer.h
@@ -32,6 +32,26 @@ typedef struct bsg_buffered_writer {
                 size_t length);
 
   /**
+   * Write a single byte-value to this writer.
+   *
+   * @param writer This writer
+   * @param byte the single byte to be written
+   * @return True on success. Check errno on error.
+   */
+  bool (*write_byte)(struct bsg_buffered_writer *writer, const uint8_t byte);
+
+  /**
+   * Write a length-prefixed string to this writer. This will first write 4
+   * bytes for the length of the string, and then the string itself (without
+   * it's null-terminator character).
+   *
+   * @param writer This writer
+   * @param string the string to write, may not be NULL
+   * @return True on success. Check errno on error.
+   */
+  bool (*write_string)(struct bsg_buffered_writer *writer, const char *string);
+
+  /**
    * Force a flush to file.
    *
    * Note: This method is async-safe.
@@ -45,7 +65,7 @@ typedef struct bsg_buffered_writer {
    * Dispose of this writer, closing and freeing all resources. The pointer to
    * writer will be invalid after this call.
    *
-   * Note: This method is NOT async-safe!
+   * Note: This method is async-safe!
    *
    * @param writer This writer.
    * @return True on success. Check errno on error.

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/migrate.h
@@ -279,6 +279,35 @@ typedef struct {
   char api_key[64];
 } bugsnag_report_v6;
 
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
+
+  int thread_count;
+  bsg_thread threads[BUGSNAG_THREADS_MAX];
+} bugsnag_report_v7;
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -22,12 +22,16 @@ bool bsg_event_write(struct bsg_buffered_writer *writer,
 
 bugsnag_event *bsg_event_read(int fd);
 bsg_report_header *bsg_report_header_read(int fd);
+bugsnag_event *bsg_map_v7_to_report(bugsnag_report_v7 *report_v7);
 bugsnag_event *bsg_map_v6_to_report(bugsnag_report_v6 *report_v6);
 bugsnag_event *bsg_map_v5_to_report(bugsnag_report_v5 *report_v5);
 bugsnag_event *bsg_map_v4_to_report(bugsnag_report_v4 *report_v4);
 bugsnag_event *bsg_map_v3_to_report(bugsnag_report_v3 *report_v3);
 bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2);
 bugsnag_event *bsg_map_v1_to_report(bugsnag_report_v1 *report_v1);
+
+void bsg_read_feature_flags(int fd, bsg_feature_flag **out_feature_flags,
+                            size_t *out_feature_flag_count);
 
 void migrate_app_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event);
 void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event);
@@ -66,10 +70,11 @@ bool bsg_serialize_event_to_file(bsg_environment *env) {
     goto fail;
   }
 
-  if (!bsg_write_feature_flags(env, &writer)) {
+  if (!bsg_write_feature_flags(&env->next_event, &writer)) {
     goto fail;
   }
 
+  writer.dispose(&writer);
   return true;
 
 fail:
@@ -158,7 +163,52 @@ bugsnag_report_v6 *bsg_report_v6_read(int fd) {
   return event;
 }
 
-bugsnag_event *bsg_report_v7_read(int fd) {
+bugsnag_report_v7 *bsg_report_v7_read(int fd) {
+  size_t event_size = sizeof(bugsnag_report_v7);
+  bugsnag_report_v7 *event = calloc(1, event_size);
+
+  ssize_t len = read(fd, event, event_size);
+  if (len != event_size) {
+    free(event);
+    return NULL;
+  }
+  return event;
+}
+
+static char *read_string(int fd) {
+  ssize_t len;
+  uint32_t string_length;
+  len = read(fd, &string_length, sizeof(string_length));
+
+  if (len != sizeof(string_length)) {
+    return NULL;
+  }
+
+  // allocate enough space, zero filler, and with a trailing '\0' terminator
+  char *string_buffer = calloc(1, (string_length + 1));
+  if (!string_buffer) {
+    return NULL;
+  }
+
+  len = read(fd, string_buffer, string_length);
+  if (len != string_length) {
+    free(string_buffer);
+    return NULL;
+  }
+
+  return string_buffer;
+}
+
+int read_byte(int fd) {
+  char value;
+  if (read(fd, &value, 1) != 1) {
+    return -1;
+  }
+
+  return value;
+}
+
+bugsnag_event *bsg_report_v8_read(int fd) {
   size_t event_size = sizeof(bugsnag_event);
   bugsnag_event *event = calloc(1, event_size);
 
@@ -167,6 +217,10 @@ bugsnag_event *bsg_report_v7_read(int fd) {
     free(event);
     return NULL;
   }
+
+  // read the feature flags, if possible
+  bsg_read_feature_flags(fd, &event->feature_flags, &event->feature_flag_count);
+
   return event;
 }
 
@@ -209,7 +263,10 @@ bugsnag_event *bsg_event_read(int fd) {
     bugsnag_report_v6 *report_v6 = bsg_report_v6_read(fd);
     event = bsg_map_v6_to_report(report_v6);
   } else if (event_version == 7) {
-    event = bsg_report_v7_read(fd);
+    bugsnag_report_v7 *report_v7 = bsg_report_v7_read(fd);
+    event = bsg_map_v7_to_report(report_v7);
+  } else if (event_version == 8) {
+    event = bsg_report_v8_read(fd);
   }
   return event;
 }
@@ -223,6 +280,19 @@ bugsnag_event *bsg_map_v6_to_report(bugsnag_report_v6 *report_v6) {
   if (event != NULL) {
     memcpy(event, report_v6, sizeof(bugsnag_report_v6));
     free(report_v6);
+  }
+  return event;
+}
+
+bugsnag_event *bsg_map_v7_to_report(bugsnag_report_v7 *report_v7) {
+  if (report_v7 == NULL) {
+    return NULL;
+  }
+  bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
+
+  if (event != NULL) {
+    memcpy(event, report_v7, sizeof(bugsnag_report_v7));
+    free(report_v7);
   }
   return event;
 }
@@ -885,6 +955,26 @@ void bsg_serialize_threads(const bugsnag_event *event, JSON_Array *threads) {
   }
 }
 
+void bsg_serialize_feature_flags(const bugsnag_event *event,
+                                 JSON_Array *feature_flags) {
+  if (event->feature_flag_count <= 0) {
+    return;
+  }
+
+  for (int index = 0; index < event->feature_flag_count; index++) {
+    JSON_Value *feature_flag_val = json_value_init_object();
+    JSON_Object *feature_flag = json_value_get_object(feature_flag_val);
+    json_array_append_value(feature_flags, feature_flag_val);
+
+    const bsg_feature_flag *flag = &event->feature_flags[index];
+    json_object_set_string(feature_flag, "featureFlag", flag->name);
+
+    if (flag->variant) {
+      json_object_set_string(feature_flag, "variant", flag->variant);
+    }
+  }
+}
+
 char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   JSON_Value *event_val = json_value_init_object();
   JSON_Object *event_obj = json_value_get_object(event_val);
@@ -898,10 +988,13 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   JSON_Array *threads = json_value_get_array(threads_val);
   JSON_Value *stack_val = json_value_init_array();
   JSON_Array *stacktrace = json_value_get_array(stack_val);
+  JSON_Value *feature_flags_val = json_value_init_object();
+  JSON_Array *feature_flags = json_value_get_array(feature_flags_val);
   json_object_set_value(event_obj, "exceptions", exceptions_val);
   json_object_set_value(event_obj, "breadcrumbs", crumbs_val);
   json_object_set_value(event_obj, "threads", threads_val);
   json_object_set_value(exception, "stacktrace", stack_val);
+  json_object_set_value(event_obj, "featureFlags", feature_flags_val);
   json_array_append_value(exceptions, ex_val);
   char *serialized_string = NULL;
   {
@@ -918,6 +1011,7 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
     bsg_serialize_error(event->error, exception, stacktrace);
     bsg_serialize_breadcrumbs(event, crumbs);
     bsg_serialize_threads(event, threads);
+    bsg_serialize_feature_flags(event, feature_flags);
 
     serialized_string = json_serialize_to_string(event_val);
     json_value_free(event_val);
@@ -925,41 +1019,22 @@ char *bsg_serialize_event_to_json_string(bugsnag_event *event) {
   return serialized_string;
 }
 
-static bool write_string(bsg_buffered_writer *writer, const char *s) {
-  // prefix with the string length uint32
-  const uint32_t length = bsg_strlen(s);
-  if (!writer->write(writer, &length, sizeof(length))) {
-    return false;
-  }
-
-  // then write the string data without trailing '\0'
-  if (!writer->write(writer, s, length)) {
-    return false;
-  }
-
-  return true;
-}
-
-static bool write_byte(bsg_buffered_writer *writer, const char value) {
-  return writer->write(writer, &value, 1);
-}
-
 static bool write_feature_flag(bsg_buffered_writer *writer,
                                bsg_feature_flag *flag) {
-  if (!write_string(writer, flag->name)) {
+  if (!writer->write_string(writer, flag->name)) {
     return false;
   }
 
   if (flag->variant) {
-    if (!write_byte(writer, 1)) {
+    if (!writer->write_byte(writer, 1)) {
       return false;
     }
 
-    if (!write_string(writer, flag->variant)) {
+    if (!writer->write_string(writer, flag->variant)) {
       return false;
     }
   } else {
-    if (!write_byte(writer, 0)) {
+    if (!writer->write_byte(writer, 0)) {
       return false;
     }
   }
@@ -967,18 +1042,77 @@ static bool write_feature_flag(bsg_buffered_writer *writer,
   return true;
 }
 
-bool bsg_write_feature_flags(bsg_environment *env,
+bool bsg_write_feature_flags(bugsnag_event *event,
                              bsg_buffered_writer *writer) {
-  const uint32_t feature_flag_count = env->feature_flag_count;
+  const uint32_t feature_flag_count = event->feature_flag_count;
   if (!writer->write(writer, &feature_flag_count, sizeof(feature_flag_count))) {
     return false;
   }
 
   for (uint32_t index = 0; index < feature_flag_count; index++) {
-    if (!write_feature_flag(writer, &env->feature_flags[index])) {
+    if (!write_feature_flag(writer, &event->feature_flags[index])) {
       return false;
     }
   }
 
   return true;
+}
+
+void bsg_read_feature_flags(int fd, bsg_feature_flag **out_feature_flags,
+                            size_t *out_feature_flag_count) {
+
+  ssize_t len;
+  uint32_t feature_flag_count = 0;
+  len = read(fd, &feature_flag_count, sizeof(feature_flag_count));
+  if (len != sizeof(feature_flag_count)) {
+    goto feature_flags_error;
+  }
+
+  bsg_feature_flag *flags =
+      calloc(feature_flag_count, sizeof(bsg_feature_flag));
+  for (uint32_t index = 0; index < feature_flag_count; index++) {
+    char *name = read_string(fd);
+    if (!name) {
+      goto feature_flags_error;
+    }
+
+    int variant_exists = read_byte(fd);
+    if (variant_exists < 0) {
+      goto feature_flags_error;
+    }
+
+    char *variant = NULL;
+    if (variant_exists) {
+      variant = read_string(fd);
+      if (!variant) {
+        goto feature_flags_error;
+      }
+    }
+
+    flags[index].name = name;
+    flags[index].variant = variant;
+  }
+
+  *out_feature_flag_count = feature_flag_count;
+  *out_feature_flags = flags;
+
+  return;
+
+feature_flags_error:
+  // something wrong - we release all allocated memory
+  for (uint32_t index = 0; index < feature_flag_count; index++) {
+    if (flags[index].name) {
+      free(flags[index].name);
+    }
+
+    if (flags[index].variant) {
+      free(flags[index].variant);
+    }
+  }
+
+  free(flags);
+
+  // clear the out fields to indicate no feature-flags are availables
+  *out_feature_flag_count = 0;
+  *out_feature_flags = NULL;
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.h
@@ -45,13 +45,15 @@ void bsg_serialize_error(bsg_error exc, JSON_Object *exception,
                          JSON_Array *stacktrace);
 void bsg_serialize_breadcrumbs(const bugsnag_event *event, JSON_Array *crumbs);
 void bsg_serialize_threads(const bugsnag_event *event, JSON_Array *threads);
+void bsg_serialize_feature_flags(const bugsnag_event *event,
+                                 JSON_Array *feature_flags);
 char *bsg_serialize_event_to_json_string(bugsnag_event *event);
 
 int bsg_calculate_total_crumbs(int old_count);
 int bsg_calculate_v1_start_index(int old_count);
 int bsg_calculate_v1_crumb_index(int crumb_pos, int first_index);
 
-bool bsg_write_feature_flags(bsg_environment *env, bsg_buffered_writer *writer);
+bool bsg_write_feature_flags(bugsnag_event *event, bsg_buffered_writer *writer);
 
 #ifdef __cplusplus
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/bugsnag-java-scenarios.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/bugsnag-java-scenarios.cpp
@@ -100,4 +100,10 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXConfigurationMetadataNativeCras
   return 12167;
 }
 
+JNIEXPORT void JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXFeatureFlagNativeCrashScenario_crash(JNIEnv *env,
+                                                                                      jobject instance) {
+  __builtin_trap();
+}
+
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXFeatureFlagNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXFeatureFlagNativeCrashScenario.java
@@ -1,0 +1,31 @@
+package com.bugsnag.android.mazerunner.scenarios;
+
+import com.bugsnag.android.Bugsnag;
+import com.bugsnag.android.Configuration;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class CXXFeatureFlagNativeCrashScenario extends Scenario {
+    static {
+        System.loadLibrary("cxx-scenarios");
+    }
+
+    public native void crash();
+
+    public CXXFeatureFlagNativeCrashScenario(@NonNull Configuration config,
+                                             @NonNull Context context,
+                                             @Nullable String eventMetadata) {
+        super(config, context, eventMetadata);
+    }
+
+    @Override
+    public void startScenario() {
+        super.startScenario();
+        Bugsnag.addFeatureFlag("demo_mode");
+        Bugsnag.addFeatureFlag("sample_group", "a");
+        crash();
+    }
+}

--- a/features/full_tests/batch_2/native_feature_flags.feature
+++ b/features/full_tests/batch_2/native_feature_flags.feature
@@ -1,0 +1,10 @@
+Feature: Synchronizing feature flags to the native layer
+
+  Scenario: Feature flags are synchronized to the native layer
+    When I run "CXXFeatureFlagNativeCrashScenario"
+    And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGILL"
+    And event 0 contains the feature flag "demo_mode" with no variant
+    And event 0 contains the feature flag "sample_group" with variant "a"


### PR DESCRIPTION
## Goal
Load the feature flags stored in NDK events back into memory, and convert them to JSON for delivery.

## Changeset
* Moved `write_string` and `write_byte` functions into the `bsg_buffered_writer`
* Incremented the `bugsnag_event` version from 7 to 8 for feature flag detection
* Serialize feature flags to JSON

## Testing
Includes both a unit test and a new native Mazerunner scenario to ensure that Feature Flags are synchronised between the Java layer and Native layer.