### PR TITLE
Mazerunner test for the OnSend callback

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -23,6 +23,7 @@
     <ID>TooGenericExceptionThrown:CrashHandlerScenario.kt$CrashHandlerScenario$throw RuntimeException("CrashHandlerScenario")</ID>
     <ID>TooGenericExceptionThrown:CustomHttpClientFlushScenario.kt$CustomHttpClientFlushScenario$throw RuntimeException("ReportCacheScenario")</ID>
     <ID>TooGenericExceptionThrown:DisableAutoDetectErrorsScenario.kt$DisableAutoDetectErrorsScenario$throw RuntimeException("Should never appear")</ID>
+    <ID>TooGenericExceptionThrown:OnSendCallbackScenario.kt$OnSendCallbackScenario$throw RuntimeException("Unhandled Error")</ID>
     <ID>TooGenericExceptionThrown:ReportCacheScenario.kt$ReportCacheScenario$throw RuntimeException("ReportCacheScenario")</ID>
     <ID>TooGenericExceptionThrown:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$throw RuntimeException("Regular crash")</ID>
     <ID>TooGenericExceptionThrown:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$throw RuntimeException("Startup crash")</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/TestOnSendCallback.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/TestOnSendCallback.java
@@ -1,0 +1,15 @@
+package com.bugsnag.android;
+
+import java.util.Collections;
+
+public class TestOnSendCallback implements OnSendCallback {
+    @Override
+    public boolean onSend(Event event) {
+        event.addMetadata("mazerunner", Collections.singletonMap("onSendCallback", "true"));
+        return true;
+    }
+
+    public void register(Configuration config) {
+        config.addOnSend(this);
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OnSendCallbackScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OnSendCallbackScenario.kt
@@ -1,0 +1,25 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.TestOnSendCallback
+import java.lang.RuntimeException
+
+internal class OnSendCallbackScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
+        TestOnSendCallback().register(config)
+        super.startBugsnag(startBugsnagOnly)
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+
+        if (eventMetadata != "start-only") {
+            throw RuntimeException("Unhandled Error")
+        }
+    }
+}

--- a/features/full_tests/onsend_callback.feature
+++ b/features/full_tests/onsend_callback.feature
@@ -1,0 +1,10 @@
+Feature: OnSend Callbacks can alter Events before upload
+
+  Scenario: Handled exception with altered by OnSendCallback
+    When I run "OnSendCallbackScenario" and relaunch the app
+    And I configure the app to run in the "start-only" state
+    And I configure Bugsnag for "OnSendCallbackScenario"
+    Then I wait to receive an error
+    And the error payload field "events" is an array with 1 elements
+    And the exception "message" equals "Unhandled Error"
+    And the event "metaData.mazerunner.onSendCallback" equals "true"


### PR DESCRIPTION
## Goal
Add Mazerunner coverage for the OnSend Callback to target next.

## Testing
Copied the OnSend Mazerunner scenario from the Journal branch.