### PR TITLE
`redactedKeys` now correctly apply to metadata on Breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+## Bug fixes
+
+* `redactedKeys` now correctly apply to metadata on Event breadcrumbs
+  [#1526](https://github.com/bugsnag/bugsnag-android/pull/1526)
+
 ## 5.15.0 (2021-11-04)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -20,6 +20,7 @@ import kotlin.jvm.functions.Function1;
 import kotlin.jvm.functions.Function2;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -740,9 +741,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware {
                         @Nullable OnErrorCallback onError) {
         // set the redacted keys on the event as this
         // will not have been set for RN/Unity events
-        Set<String> redactedKeys = metadataState.getMetadata().getRedactedKeys();
-        Metadata eventMetadata = event.getImpl().getMetadata();
-        eventMetadata.setRedactedKeys(redactedKeys);
+        Collection<String> redactedKeys = metadataState.getMetadata().getRedactedKeys();
+        event.setRedactedKeys(redactedKeys);
 
         // get session for event
         Session currentSession = sessionTracker.getCurrentSession();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -6,8 +6,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * An Event object represents a Throwable captured by Bugsnag and is available as a parameter on
@@ -347,5 +349,9 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware {
 
     EventInternal getImpl() {
         return impl;
+    }
+
+    void setRedactedKeys(Collection<String> redactedKeys) {
+        impl.setRedactedKeys(redactedKeys);
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/JsonStream.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/JsonStream.java
@@ -33,6 +33,13 @@ public class JsonStream extends JsonWriter {
         objectJsonStreamer = new ObjectJsonStreamer();
     }
 
+    JsonStream(@NonNull JsonStream stream, @NonNull ObjectJsonStreamer streamer) {
+        super(stream.out);
+        setSerializeNulls(stream.getSerializeNulls());
+        this.out = stream.out;
+        this.objectJsonStreamer = streamer;
+    }
+
     // Allow chaining name().value()
     @NonNull
     public JsonStream name(@Nullable String name) throws IOException {

--- a/bugsnag-android-core/src/test/resources/event_default_redaction.json
+++ b/bugsnag-android-core/src/test/resources/event_default_redaction.json
@@ -47,7 +47,7 @@
       "name": "Whoops",
       "type": "log",
       "metaData": {
-        "changeme": "[REDACTED]"
+        "changeme": "whoops"
       }
     }
   ],


### PR DESCRIPTION
## Goal
Configured `redactedKeys` should be applied to metadata within Breadcrumbs, and not just metadata associated with Events.

## Design
Allowed the `JsonStream` class to wrap another `JsonStream` so that the `redactedKeys` can be enforced in `Event.toStream`. This naturally enforces the `redactedKeys` for the entire sub-tree.

## Testing
Adjusted existing unit tests.
