### PR TITLE
Leave error breadcrumbs before attempting event delivery

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -18,20 +18,17 @@ class DeliveryDelegate extends BaseObservable {
     final Logger logger;
     private final EventStore eventStore;
     private final ImmutableConfig immutableConfig;
-    final BreadcrumbState breadcrumbState;
     private final Notifier notifier;
     final BackgroundTaskService backgroundTaskService;
 
     DeliveryDelegate(Logger logger,
                      EventStore eventStore,
                      ImmutableConfig immutableConfig,
-                     BreadcrumbState breadcrumbState,
                      Notifier notifier,
                      BackgroundTaskService backgroundTaskService) {
         this.logger = logger;
         this.eventStore = eventStore;
         this.immutableConfig = immutableConfig;
-        this.breadcrumbState = breadcrumbState;
         this.notifier = notifier;
         this.backgroundTaskService = backgroundTaskService;
     }
@@ -92,13 +89,11 @@ class DeliveryDelegate extends BaseObservable {
         switch (deliveryStatus) {
             case DELIVERED:
                 logger.i("Sent 1 new event to Bugsnag");
-                leaveErrorBreadcrumb(event);
                 break;
             case UNDELIVERED:
                 logger.w("Could not send event(s) to Bugsnag,"
                         + " saving to disk to send later");
                 cacheEvent(event, false);
-                leaveErrorBreadcrumb(event);
                 break;
             case FAILURE:
                 logger.w("Problem sending event to Bugsnag");
@@ -113,24 +108,6 @@ class DeliveryDelegate extends BaseObservable {
         eventStore.write(event);
         if (attemptSend) {
             eventStore.flushAsync();
-        }
-    }
-
-    private void leaveErrorBreadcrumb(@NonNull Event event) {
-        // Add a breadcrumb for this event occurring
-        List<Error> errors = event.getErrors();
-
-        if (errors.size() > 0) {
-            String errorClass = errors.get(0).getErrorClass();
-            String message = errors.get(0).getErrorMessage();
-
-            Map<String, Object> data = new HashMap<>();
-            data.put("errorClass", errorClass);
-            data.put("message", message);
-            data.put("unhandled", String.valueOf(event.isUnhandled()));
-            data.put("severity", event.getSeverity().toString());
-            breadcrumbState.add(new Breadcrumb(errorClass,
-                    BreadcrumbType.ERROR, data, new Date(), logger));
         }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -1,5 +1,6 @@
 package com.bugsnag.android;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
@@ -18,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -514,6 +516,43 @@ public class ClientFacadeTest {
         verify(contextState, times(1)).removeObserver(observer);
         verify(deliveryDelegate, times(1)).removeObserver(observer);
         verify(launchCrashTracker, times(1)).removeObserver(observer);
+    }
+
+    @Test
+    public void notifyLeavesErrorBreadcrumb() {
+        client.notify(new RuntimeException("Whoops!"));
+
+        ArgumentCaptor<Breadcrumb> breadcrumbCaptor = ArgumentCaptor.forClass(Breadcrumb.class);
+        verify(breadcrumbState).add(breadcrumbCaptor.capture());
+        Breadcrumb breadcrumb = breadcrumbCaptor.getValue();
+
+        assertEquals(BreadcrumbType.ERROR, breadcrumb.getType());
+        assertEquals("java.lang.RuntimeException", breadcrumb.getMessage());
+        assertEquals("java.lang.RuntimeException", breadcrumb.getMetadata().get("errorClass"));
+        assertEquals("Whoops!", breadcrumb.getMetadata().get("message"));
+        assertEquals("false", breadcrumb.getMetadata().get("unhandled"));
+        assertEquals("WARNING", breadcrumb.getMetadata().get("severity"));
+    }
+
+    @Test
+    public void notifyUnhandledLeavesErrorBreadcrumb() {
+        client.notifyUnhandledException(
+                new RuntimeException("Whoops!"),
+                new Metadata(),
+                SeverityReason.REASON_UNHANDLED_EXCEPTION,
+                null
+        );
+
+        ArgumentCaptor<Breadcrumb> breadcrumbCaptor = ArgumentCaptor.forClass(Breadcrumb.class);
+        verify(breadcrumbState).add(breadcrumbCaptor.capture());
+        Breadcrumb breadcrumb = breadcrumbCaptor.getValue();
+
+        assertEquals(BreadcrumbType.ERROR, breadcrumb.getType());
+        assertEquals("java.lang.RuntimeException", breadcrumb.getMessage());
+        assertEquals("java.lang.RuntimeException", breadcrumb.getMetadata().get("errorClass"));
+        assertEquals("Whoops!", breadcrumb.getMetadata().get("message"));
+        assertEquals("true", breadcrumb.getMetadata().get("unhandled"));
+        assertEquals("ERROR", breadcrumb.getMetadata().get("severity"));
     }
 
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -20,7 +20,6 @@ internal class DeliveryDelegateTest {
 
     private val notifier = Notifier()
     val config = generateImmutableConfig()
-    val breadcrumbState = BreadcrumbState(50, CallbackState(), NoopLogger)
     private val logger = InterceptingLogger()
     lateinit var deliveryDelegate: DeliveryDelegate
     val handledState = SeverityReason.newInstance(
@@ -35,7 +34,6 @@ internal class DeliveryDelegateTest {
                 logger,
                 eventStore,
                 config,
-                breadcrumbState,
                 notifier,
                 BackgroundTaskService()
             )
@@ -110,14 +108,6 @@ internal class DeliveryDelegateTest {
         val status = deliveryDelegate.deliverPayloadInternal(eventPayload, event)
         assertEquals(DeliveryStatus.DELIVERED, status)
         assertEquals("Sent 1 new event to Bugsnag", logger.msg)
-
-        val breadcrumb = requireNotNull(breadcrumbState.copy().first())
-        assertEquals(BreadcrumbType.ERROR, breadcrumb.type)
-        assertEquals("java.lang.RuntimeException", breadcrumb.message)
-        assertEquals("java.lang.RuntimeException", breadcrumb.metadata!!["errorClass"])
-        assertEquals("Whoops!", breadcrumb.metadata!!["message"])
-        assertEquals("true", breadcrumb.metadata!!["unhandled"])
-        assertEquals("ERROR", breadcrumb.metadata!!["severity"])
     }
 
     private class InterceptingLogger : Logger {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ErrorBreadcrumbsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ErrorBreadcrumbsScenario.kt
@@ -1,0 +1,23 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.BreadcrumbType
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+class ErrorBreadcrumbsScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(
+    config.apply {
+        enabledBreadcrumbTypes = setOf(BreadcrumbType.ERROR)
+    },
+    context,
+    eventMetadata
+) {
+    override fun startScenario() {
+        Bugsnag.notify(RuntimeException("first error"))
+        throw NullPointerException("something broke")
+    }
+}

--- a/features/full_tests/breadcrumb.feature
+++ b/features/full_tests/breadcrumb.feature
@@ -28,3 +28,24 @@ Scenario: An automatic breadcrumb is sent in report when the appropriate type is
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the event has a "state" breadcrumb with the message "Bugsnag loaded"
+
+Scenario: Error Breadcrumbs appear in subsequent events
+    When I run "ErrorBreadcrumbsScenario" and relaunch the app
+    And I configure Bugsnag for "ErrorBreadcrumbsScenario"
+    Then I wait to receive 2 errors
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the exception "message" equals "first error"
+    And the event "unhandled" is false
+    And the event has 0 breadcrumbs
+    Then I discard the oldest error
+    And the exception "errorClass" equals "java.lang.NullPointerException"
+    And the exception "message" equals "something broke"
+    And the event "unhandled" is true
+    And the event has 1 breadcrumbs
+    And the event "breadcrumbs.0.timestamp" is not null
+    And the event "breadcrumbs.0.name" equals "java.lang.RuntimeException"
+    And the event "breadcrumbs.0.type" equals "error"
+    And the event "breadcrumbs.0.metaData.errorClass" equals "java.lang.RuntimeException"
+    And the event "breadcrumbs.0.metaData.message" equals "first error"
+    And the event "breadcrumbs.0.metaData.unhandled" equals "false"
+    And the event "breadcrumbs.0.metaData.severity" equals "WARNING"


### PR DESCRIPTION
## Goal
Ensure the at Error Breadcrumbs are created and stored as soon as an `Event` is populated, rather than after the `Event` has been delivered.

## Changeset
Moved the `leaveErrorBreadcrumb` from `DeliveryDelegate` into the `Client` so that it can be called directly after the `Event` has been populated.

## Testing
Added new unit tests for the `Client` facade, and a new Mazerunner scenario that create an handled error directly followed by an unhandled exception. The unhandled exception should include an Error breadcrumb with details of the handled error.