### PR TITLE
Backport persistenceDirectory config option

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -74,7 +74,6 @@ final class BugsnagTestUtils {
 
     @NonNull
     static SessionStore generateSessionStore() {
-        Context applicationContext = ApplicationProvider.getApplicationContext();
         return new SessionStore(generateConfiguration(), null);
     }
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagTestUtils.java
@@ -75,7 +75,7 @@ final class BugsnagTestUtils {
     @NonNull
     static SessionStore generateSessionStore() {
         Context applicationContext = ApplicationProvider.getApplicationContext();
-        return new SessionStore(generateConfiguration(), applicationContext, null);
+        return new SessionStore(generateConfiguration(), null);
     }
 
     @SuppressWarnings("deprecation")

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -19,6 +19,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 
@@ -362,5 +363,12 @@ public class ClientTest {
         assertNotNull(metaData.get("dpi"));
         assertNotNull(metaData.get("emulator"));
         assertNotNull(metaData.get("screenResolution"));
+    }
+
+    @Test
+    public void testPersistenceDir() {
+        File cacheDir = ApplicationProvider.getApplicationContext().getCacheDir();
+        client = generateClient();
+        assertEquals(cacheDir, client.config.getPersistenceDirectory());
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/FileStoreTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/FileStoreTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
@@ -9,6 +10,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.lang.Exception
 import java.lang.RuntimeException
+import java.util.Comparator
 
 class FileStoreTest {
     val appContext = ApplicationProvider.getApplicationContext<Context>()
@@ -20,7 +22,7 @@ class FileStoreTest {
         val dir = File(appContext.filesDir, "custom-store")
         dir.mkdir()
 
-        val store = CustomFileStore(config, appContext, dir.absolutePath, 1, null, delegate)
+        val store = CustomFileStore(config, dir.absolutePath, 1, null, delegate)
         val exc = RuntimeException("Whoops")
         store.write(CustomStreamable(exc))
 
@@ -36,7 +38,7 @@ class FileStoreTest {
         val dir = File(appContext.filesDir, "custom-store")
         dir.mkdir()
 
-        val store = CustomFileStore(config, appContext, "", 1, null, delegate)
+        val store = CustomFileStore(config, "", 1, null, delegate)
         store.enqueueContentForDelivery("foo")
 
         assertEquals("NDK Crash report copy", delegate.context)
@@ -63,11 +65,17 @@ class CustomStreamable(val exc: Throwable) : JsonStream.Streamable {
 
 internal class CustomFileStore(
     config: Configuration,
-    appContext: Context,
     val folder: String?,
     maxStoreCount: Int,
-    comparator: java.util.Comparator<File>?,
+    comparator: Comparator<File>?,
     delegate: Delegate?
-) : FileStore<CustomStreamable>(config, appContext, folder, maxStoreCount, comparator, delegate) {
+) : FileStore<CustomStreamable>(
+    config,
+    File(ApplicationProvider.getApplicationContext<Application>().cacheDir, "tmp"),
+    folder,
+    maxStoreCount,
+    comparator,
+    delegate
+) {
     override fun getFilename(`object`: Any?) = "$folder/foo.json"
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/NativeInterfaceTest.java
@@ -1,13 +1,18 @@
 package com.bugsnag.android;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+
+import androidx.test.core.app.ApplicationProvider;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+import java.nio.file.Files;
 import java.util.Map;
 
 public class NativeInterfaceTest {
@@ -63,5 +68,14 @@ public class NativeInterfaceTest {
         assertSame("0.1", app.get("buildno"));
         assertSame("-print 1", app.get("args"));
         assertNull(metadata.get("info"));
+    }
+
+    @Test
+    public void getPersistenceDir() {
+        Client client = BugsnagTestUtils.generateClient();
+        NativeInterface.setClient(client);
+        File cacheDir = ApplicationProvider.getApplicationContext().getCacheDir();
+        String observed = NativeInterface.getNativeReportPath();
+        assertEquals(cacheDir.getAbsolutePath() + "/bugsnag-native", observed);
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionStoreTest.java
@@ -29,8 +29,8 @@ public class SessionStoreTest {
     @Before
     public void setUp() throws Exception {
         Configuration config = new Configuration("api-key");
-        Context context = ApplicationProvider.getApplicationContext();
-        SessionStore sessionStore = new SessionStore(config, context, null);
+        config.setPersistenceDirectory(ApplicationProvider.getApplicationContext().getCacheDir());
+        SessionStore sessionStore = new SessionStore(config, null);
         assertNotNull(sessionStore.storeDirectory);
         storageDir = new File(sessionStore.storeDirectory);
         FileUtils.clearFilesInDir(storageDir);

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
@@ -44,7 +44,9 @@ public class SessionTrackingPayloadTest {
     public void setUp() throws Exception {
         Context context = ApplicationProvider.getApplicationContext();
         Configuration config = new Configuration("api-key");
-        sessionStore = new SessionStore(config, context, null);
+        File cacheDir = ApplicationProvider.getApplicationContext().getCacheDir();
+        config.setPersistenceDirectory(cacheDir);
+        sessionStore = new SessionStore(config, null);
 
         Assert.assertNotNull(sessionStore.storeDirectory);
         storageDir = new File(sessionStore.storeDirectory);

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/SessionTrackingPayloadTest.java
@@ -42,7 +42,6 @@ public class SessionTrackingPayloadTest {
      */
     @Before
     public void setUp() throws Exception {
-        Context context = ApplicationProvider.getApplicationContext();
         Configuration config = new Configuration("api-key");
         File cacheDir = ApplicationProvider.getApplicationContext().getCacheDir();
         config.setPersistenceDirectory(cacheDir);
@@ -53,6 +52,7 @@ public class SessionTrackingPayloadTest {
         FileUtils.clearFilesInDir(storageDir);
         session = generateSession();
         client = generateClient();
+        Context context = ApplicationProvider.getApplicationContext();
         payload = generatePayloadFromSession(context, session);
         rootNode = streamableToJson(payload);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -133,7 +133,7 @@ public class Client extends Observable implements Observer {
         warnIfNotAppContext(androidContext);
         appContext = androidContext.getApplicationContext();
         config = configuration;
-        sessionStore = new SessionStore(config, appContext, null);
+        sessionStore = new SessionStore(config, null);
         storageManager = (StorageManager) appContext.getSystemService(Context.STORAGE_SERVICE);
 
         connectivity = new ConnectivityCompat(appContext, new Function1<Boolean, Unit>() {
@@ -149,6 +149,9 @@ public class Client extends Observable implements Observer {
         //noinspection ConstantConditions
         if (configuration.getDelivery() == null) {
             configuration.setDelivery(new DefaultDelivery(connectivity));
+        }
+        if (configuration.getPersistenceDirectory() == null) {
+            configuration.setPersistenceDirectory(appContext.getCacheDir());
         }
 
         sessionTracker =
@@ -208,7 +211,7 @@ public class Client extends Observable implements Observer {
         }
 
         // Create the error store that is used in the exception handler
-        errorStore = new ErrorStore(config, appContext, new ErrorStore.Delegate() {
+        errorStore = new ErrorStore(config, new ErrorStore.Delegate() {
             @Override
             public void onErrorIOFailure(Exception exc, File errorFile, String context) {
                 // send an internal error to bugsnag with no cache

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -133,7 +133,6 @@ public class Client extends Observable implements Observer {
         warnIfNotAppContext(androidContext);
         appContext = androidContext.getApplicationContext();
         config = configuration;
-        sessionStore = new SessionStore(config, null);
         storageManager = (StorageManager) appContext.getSystemService(Context.STORAGE_SERVICE);
 
         connectivity = new ConnectivityCompat(appContext, new Function1<Boolean, Unit>() {
@@ -154,6 +153,7 @@ public class Client extends Observable implements Observer {
             configuration.setPersistenceDirectory(appContext.getCacheDir());
         }
 
+        sessionStore = new SessionStore(config, null);
         sessionTracker =
             new SessionTracker(configuration, this, sessionStore);
         eventReceiver = new EventReceiver(this);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
@@ -67,6 +68,7 @@ public class Configuration extends Observable implements Observer {
 
     private Delivery delivery;
     private int maxBreadcrumbs = DEFAULT_MAX_SIZE;
+    private File persistenceDirectory;
 
     /**
      * Construct a new Bugsnag configuration object
@@ -550,6 +552,37 @@ public class Configuration extends Observable implements Observer {
      */
     public void setPersistUserBetweenSessions(boolean persistUserBetweenSessions) {
         this.persistUserBetweenSessions = persistUserBetweenSessions;
+    }
+
+    /**
+     * Sets the directory where event and session JSON payloads should be persisted if a network
+     * request is not successful. If you use Bugsnag in multiple processes, then a unique
+     * persistenceDirectory <b>must</b> be configured for each process to prevent duplicate
+     * requests being made by each instantiation of Bugsnag.
+     * <p/>
+     * By default, bugsnag sets the persistenceDirectory to {@link Context#getCacheDir()}.
+     * <p/>
+     * If the persistenceDirectory is changed between application launches, no attempt will be made
+     * to deliver events or sessions cached in the previous location.
+     */
+    @Nullable
+    public File getPersistenceDirectory() {
+        return persistenceDirectory;
+    }
+
+    /**
+     * Sets the directory where event and session JSON payloads should be persisted if a network
+     * request is not successful. If you use Bugsnag in multiple processes, then a unique
+     * persistenceDirectory <b>must</b> be configured for each process to prevent duplicate
+     * requests being made by each instantiation of Bugsnag.
+     * <p/>
+     * By default, bugsnag sets the persistenceDirectory to {@link Context#getCacheDir()}.
+     * <p/>
+     * If the persistenceDirectory is changed between application launches, no attempt will be made
+     * to deliver events or sessions cached in the previous location.
+     */
+    public void setPersistenceDirectory(@Nullable File directory) {
+        persistenceDirectory = directory;
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -284,10 +284,10 @@ class DeviceData {
         String orientation = null;
 
         if (resources != null) {
-            int i = resources.getConfiguration().orientation;
-            if (i == Configuration.ORIENTATION_LANDSCAPE) {
+            int value = resources.getConfiguration().orientation;
+            if (value == Configuration.ORIENTATION_LANDSCAPE) {
                 orientation = "landscape";
-            } else if (i == Configuration.ORIENTATION_PORTRAIT) {
+            } else if (value == Configuration.ORIENTATION_PORTRAIT) {
                 orientation = "portrait";
             }
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceData.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.BatteryManager;
 import android.os.Build;
@@ -283,15 +284,11 @@ class DeviceData {
         String orientation = null;
 
         if (resources != null) {
-            switch (resources.getConfiguration().orientation) {
-                case android.content.res.Configuration.ORIENTATION_LANDSCAPE:
-                    orientation = "landscape";
-                    break;
-                case android.content.res.Configuration.ORIENTATION_PORTRAIT:
-                    orientation = "portrait";
-                    break;
-                default:
-                    break;
+            int i = resources.getConfiguration().orientation;
+            if (i == Configuration.ORIENTATION_LANDSCAPE) {
+                orientation = "landscape";
+            } else if (i == Configuration.ORIENTATION_PORTRAIT) {
+                orientation = "portrait";
             }
         }
         return orientation;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -48,7 +48,12 @@ class ErrorStore extends FileStore<Error> {
     };
 
     ErrorStore(@NonNull Configuration config, Delegate delegate) {
-        super(config, config.getPersistenceDirectory(), "bugsnag-errors", 128, ERROR_REPORT_COMPARATOR, delegate);
+        super(config,
+            config.getPersistenceDirectory(),
+            "bugsnag-errors",
+            128,
+            ERROR_REPORT_COMPARATOR,
+            delegate);
     }
 
     void flushOnLaunch() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorStore.java
@@ -47,8 +47,8 @@ class ErrorStore extends FileStore<Error> {
         }
     };
 
-    ErrorStore(@NonNull Configuration config, @NonNull Context appContext, Delegate delegate) {
-        super(config, appContext, "/bugsnag-errors/", 128, ERROR_REPORT_COMPARATOR, delegate);
+    ErrorStore(@NonNull Configuration config, Delegate delegate) {
+        super(config, config.getPersistenceDirectory(), "bugsnag-errors", 128, ERROR_REPORT_COMPARATOR, delegate);
     }
 
     void flushOnLaunch() {
@@ -210,7 +210,7 @@ class ErrorStore extends FileStore<Error> {
         }
         String uuid = UUID.randomUUID().toString();
         long timestamp = System.currentTimeMillis();
-        return String.format(Locale.US, "%s%d_%s%s.json",
+        return String.format(Locale.US, "%s/%d_%s%s.json",
             storeDirectory, timestamp, uuid, suffix);
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -59,7 +59,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
             path = outFile.getAbsolutePath();
             outFile.mkdirs();
             if (!outFile.exists()) {
-                Logger.warn("Could not prepare file storage directory");
+                Logger.warn("Could not prepare file storage directory for path " + path);
                 path = null;
             }
         } catch (Exception exception) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -46,8 +46,7 @@ abstract class FileStore<T extends JsonStream.Streamable> {
     final Collection<File> queuedFiles = new ConcurrentSkipListSet<>();
     protected final ErrorStore.Delegate delegate;
 
-
-    FileStore(@NonNull Configuration config, @NonNull Context appContext, String folder,
+    FileStore(@NonNull Configuration config, File storageDir, String folder,
               int maxStoreCount, Comparator<File> comparator, Delegate delegate) {
         this.config = config;
         this.maxStoreCount = maxStoreCount;
@@ -56,9 +55,8 @@ abstract class FileStore<T extends JsonStream.Streamable> {
 
         String path;
         try {
-            path = appContext.getCacheDir().getAbsolutePath() + folder;
-
-            File outFile = new File(path);
+            File outFile = new File(storageDir, folder);
+            path = outFile.getAbsolutePath();
             outFile.mkdirs();
             if (!outFile.exists()) {
                 Logger.warn("Could not prepare file storage directory");

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -195,6 +195,9 @@ public class NativeInterface {
         return Logger.getEnabled();
     }
 
+    /**
+     * Retrieves the path used to store native reports
+     */
     @NonNull
     public static String getNativeReportPath() {
         Configuration config = getClient().getConfig();

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -196,7 +197,9 @@ public class NativeInterface {
 
     @NonNull
     public static String getNativeReportPath() {
-        return getClient().appContext.getCacheDir().getAbsolutePath() + "/bugsnag-native/";
+        Configuration config = getClient().getConfig();
+        File persistenceDirectory = config.getPersistenceDirectory();
+        return new File(persistenceDirectory, "bugsnag-native").getAbsolutePath();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
@@ -33,16 +33,15 @@ class SessionStore extends FileStore<Session> {
         }
     };
 
-    SessionStore(@NonNull Configuration config, @NonNull Context appContext,
-                 @Nullable Delegate delegate) {
-        super(config, appContext, "/bugsnag-sessions/",
+    SessionStore(@NonNull Configuration config, @Nullable Delegate delegate) {
+        super(config, config.getPersistenceDirectory(), "bugsnag-sessions",
             128, SESSION_COMPARATOR, delegate);
     }
 
     @NonNull
     @Override
     String getFilename(Object object) {
-        return String.format(Locale.US, "%s%s%d.json",
+        return String.format(Locale.US, "%s/%s%d.json",
             storeDirectory, UUID.randomUUID().toString(), System.currentTimeMillis());
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -12,6 +12,9 @@ import androidx.annotation.NonNull;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Map;
 
 public class ConfigurationTest {
@@ -245,5 +248,14 @@ public class ConfigurationTest {
         assertNull(configuration.getVersionCode()); // populated in client ctor if null
         configuration.setVersionCode(577);
         assertEquals(577, (int) configuration.getVersionCode());
+    }
+
+    @Test
+    public void setPersistenceDirectoryValid() throws IOException {
+        File dir = Files.createTempDirectory("foo").toFile();
+        config.setPersistenceDirectory(dir);
+        assertEquals(dir, config.getPersistenceDirectory());
+        config.setPersistenceDirectory(null);
+        assertNull(config.getPersistenceDirectory());
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFilenameTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFilenameTest.kt
@@ -28,7 +28,7 @@ class ErrorFilenameTest {
      */
     @Before
     fun setUp() {
-        errorStore = ErrorStore(config, context, null)
+        errorStore = ErrorStore(config, null)
     }
 
     @Test

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -249,7 +249,7 @@ public class NativeBridge implements Observer {
                 List<Object> values = (List<Object>)arg;
                 if (values.size() > 0 && values.get(0) instanceof Configuration) {
                     Configuration config = (Configuration)values.get(0);
-                    String reportPath = reportDirectory + UUID.randomUUID().toString() + ".crash";
+                    String reportPath = reportDirectory + "/" + UUID.randomUUID().toString() + ".crash";
                     install(reportPath, config.getDetectNdkCrashes(), Build.VERSION.SDK_INT,
                         is32bit());
                     installed.set(true);

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.java
@@ -249,7 +249,8 @@ public class NativeBridge implements Observer {
                 List<Object> values = (List<Object>)arg;
                 if (values.size() > 0 && values.get(0) instanceof Configuration) {
                     Configuration config = (Configuration)values.get(0);
-                    String reportPath = reportDirectory + "/" + UUID.randomUUID().toString() + ".crash";
+                    String reportPath = reportDirectory + "/"
+                        + UUID.randomUUID().toString() + ".crash";
                     install(reportPath, config.getDetectNdkCrashes(), Build.VERSION.SDK_INT,
                         is32bit());
                     installed.set(true);


### PR DESCRIPTION
## Goal

Backports the `persistenceDirectory` option to allow controlling where errors/native crashes/sessions are stored: https://github.com/bugsnag/bugsnag-android/pull/998

## Testing

Manually verified that errors make it through to the dashboard in a vanilla Android app and they can be stored in either the cacheDir or filesDir. Added unit test coverage.

<img width="488" alt="Screenshot 2021-11-26 at 11 05 43" src="https://user-images.githubusercontent.com/11800640/143572496-6064806c-18c4-4916-91ed-7f04b824aa94.png">


