### PR TITLE
Bump compileSdkVersion to apiLevel 31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Bump compileSdkVersion to apiLevel 31
+  [#1536](https://github.com/bugsnag/bugsnag-android/pull/1536)
+
 ## 5.16.0 (2021-11-29)
 
-## Bug fixes
+### Bug fixes
 
 * Increase resilience of NDK stackframe method capture
   [#1484](https://github.com/bugsnag/bugsnag-android/pull/1484)

--- a/bugsnag-benchmarks/build.gradle
+++ b/bugsnag-benchmarks/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
 
     compileOptions {

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/Versions.kt
@@ -8,7 +8,7 @@ import org.gradle.api.JavaVersion
 object Versions {
     // Note minSdkVersion must be >=21 for 64 bit architectures
     val minSdkVersion = 14
-    val compileSdkVersion = 30
+    val compileSdkVersion = 31
     val ndk = "17.2.4988734"
     val java = JavaVersion.VERSION_1_7
     val kotlin = "1.3.72"

--- a/dockerfiles/Dockerfile.android-common
+++ b/dockerfiles/Dockerfile.android-common
@@ -27,7 +27,7 @@ RUN rm $CMDLINE_TOOLS_NAME
 
 # Install Android tools using sdkmanager
 RUN yes | sdkmanager "platform-tools" > /dev/null
-RUN yes | sdkmanager "platforms;android-30" > /dev/null
+RUN yes | sdkmanager "platforms;android-31" > /dev/null
 RUN yes | sdkmanager "ndk;17.2.4988734" > /dev/null
 RUN yes | sdkmanager "cmake;3.6.4111459" > /dev/null
 RUN yes | sdkmanager "cmake;3.10.2.4988404" > /dev/null

--- a/examples/sdk-app-example/app/build.gradle
+++ b/examples/sdk-app-example/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     ndkVersion "17.2.4988734"
 
     defaultConfig {
         applicationId "com.example.bugsnag.android"
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/examples/sdk-app-example/app/src/main/AndroidManifest.xml
+++ b/examples/sdk-app-example/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
 
         <activity
             android:name=".ExampleActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/features/fixtures/mazerunner/app/build.gradle
+++ b/features/fixtures/mazerunner/app/build.gradle
@@ -4,11 +4,11 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 34
         versionName "1.1.14"
         manifestPlaceholders = [
@@ -55,7 +55,7 @@ android {
         pickFirst "**/*.so"
     }
     lintOptions {
-        tasks.lint.enabled = false
+        abortOnError false
     }
 
     if (project.hasProperty("TEST_FIXTURE_NDK_VERSION")) {

--- a/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
@@ -10,14 +10,20 @@
         android:gwpAsanMode="always"
         android:name=".MazerunnerApp"
         >
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
 
             </intent-filter>
         </activity>
-        <activity android:name=".SecondActivity">
+        <activity
+            android:name=".SecondActivity"
+            android:exported="true"
+            >
             <intent-filter>
                 <action android:name="com.bugsnag.android.mazerunner.UPDATE_CONTEXT" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.os.Build
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
@@ -24,8 +25,10 @@ class MainActivity : Activity() {
         prefs = getPreferences(Context.MODE_PRIVATE)
 
         // Attempt to dismiss any system dialogs (such as "MazeRunner crashed")
-        val closeDialog = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
-        sendBroadcast(closeDialog)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            val closeDialog = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
+            sendBroadcast(closeDialog)
+        }
 
         // load the scenario first, which initialises bugsnag without running any crashy code
         findViewById<Button>(R.id.start_bugsnag).setOnClickListener {

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/build.gradle
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/build.gradle
@@ -7,7 +7,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 14

--- a/features/fixtures/mazerunner/cxx-scenarios/build.gradle
+++ b/features/fixtures/mazerunner/cxx-scenarios/build.gradle
@@ -7,7 +7,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 14

--- a/features/fixtures/mazerunner/jvm-scenarios/build.gradle
+++ b/features/fixtures/mazerunner/jvm-scenarios/build.gradle
@@ -7,7 +7,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 14

--- a/features/fixtures/minimalapp/app/build.gradle
+++ b/features/fixtures/minimalapp/app/build.gradle
@@ -9,12 +9,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.bugsnag.android.minimalapp"
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
## Goal

Bumps the [compileSdkVersion](https://medium.com/androiddevelopers/picking-your-compilesdkversion-minsdkversion-targetsdkversion-a098a0341ebd) to apiLevel 31 from 30. This ensures that our SDK is compiled against the latest version of Android while retaining compatibility for previously supported versions.

## Changeset

- Bumped compileSdkVersion to 31
- Bumped targetSdkVersion where possible (bugsnag-benchmarks is the only place still targetting 30, as the microbenchmark library does not support this yet)
- Avoided closing the system dialogs in the mazerunner fixture as this is [no longer allowed in Android 12](https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs)

## Testing

Relied on existing test coverage and ran the example app.