### PR TITLE
Flush in memory session first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Bump compileSdkVersion to apiLevel 31
   [#1536](https://github.com/bugsnag/bugsnag-android/pull/1536)
 
+### Bug fixes
+
+* Flush in-memory sessions first
+  [#1538](https://github.com/bugsnag/bugsnag-android/pull/1538)
+
 ## 5.16.0 (2021-11-29)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -181,12 +181,10 @@ class SessionTracker extends BaseObservable {
         if (deliverSession && session.isTracked().compareAndSet(false, true)) {
             currentSession = session;
             notifySessionStartObserver(session);
-            flushAsync();
             flushInMemorySession(session);
-
+            flushAsync();
             return true;
         }
-
         return false;
     }
 


### PR DESCRIPTION
## Goal

The in-memory session should be sent first in precedence over sessions which are already persisted. This will reduce the chance of losing the session completely if a signal is raised as it reduces the time spent waiting for sessions to be sent.

## Testing

Relied on existing test coverage.