### PR TITLE
[PLAT-7680] Use signal stack unwinding mechanism when unwinding an ANR

### DIFF
--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -78,7 +78,7 @@ internal class AnrPlugin : Plugin {
         if (clz != null) {
             val ndkPlugin = client.getPlugin(clz)
             if (ndkPlugin != null) {
-                val method = ndkPlugin.javaClass.getMethod("getUnwindStackFunction")
+                val method = ndkPlugin.javaClass.getMethod("getSignalUnwindStackFunction")
 
                 @Suppress("UNCHECKED_CAST")
                 val function = method.invoke(ndkPlugin) as Long

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -64,10 +64,10 @@ internal class NdkPlugin : Plugin {
         }
     }
 
-    fun getUnwindStackFunction(): Long {
+    fun getSignalUnwindStackFunction(): Long {
         val bridge = nativeBridge
         if (bridge != null) {
-            return bridge.getUnwindStackFunction()
+            return bridge.getSignalUnwindStackFunction()
         }
         return 0
     }

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -76,7 +76,7 @@ class NativeBridge : StateObserver {
     external fun updateUserId(newValue: String)
     external fun updateUserEmail(newValue: String)
     external fun updateUserName(newValue: String)
-    external fun getUnwindStackFunction(): Long
+    external fun getSignalUnwindStackFunction(): Long
     external fun updateLowMemory(newValue: Boolean, memoryTrimLevelDescription: String)
 
     override fun onStateChange(event: StateEvent) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -335,13 +335,3 @@ exit : {
   bsg_safe_delete_local_ref(env, jtype);
   bsg_safe_delete_local_ref(env, jmessage);
 }
-
-// Unwind the stack using the default unwind style.
-// This function gets exposed via
-// Java_com_bugsnag_android_ndk_NativeBridge_getUnwindStackFunction()
-ssize_t
-bsg_unwind_stack_default(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
-                         siginfo_t *info, void *user_context) __asyncsafe {
-  return bsg_unwind_stack(bsg_configured_unwind_style(), stacktrace, info,
-                          user_context);
-}

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -81,6 +81,10 @@ typedef struct {
   bsg_thread_send_policy send_threads;
 } bsg_environment;
 
+/**
+ * Get the configured unwind style for non-async-safe environments.
+ * DO NOT USE THIS IN A SIGNAL HANDLER!
+ */
 bsg_unwinder bsg_configured_unwind_style();
 
 /**


### PR DESCRIPTION
## Goal

The ANR plugin was being initialized with a stack unwinder function that used `bsg_global_env->unwind_style` instead of the `bsg_global_env->signal_unwind_style` that signal handlers require (for safety in an async-safe environment).

The ANR handler is triggered from a signal handler, so this PR updates it to use the proper signal-safe unwind style.

## Testing

Reran all tests and also tested manually.