### PR TITLE
Bump example app dependencies

### DIFF
--- a/examples/sdk-app-example/app/build.gradle
+++ b/examples/sdk-app-example/app/build.gradle
@@ -38,9 +38,9 @@ android {
 }
 
 dependencies {
-    implementation "com.bugsnag:bugsnag-android:5.12.0"
+    implementation "com.bugsnag:bugsnag-android:5.16.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.appcompat:appcompat:1.3.1"
+    implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "com.google.android.material:material:1.4.0"
 }
 

--- a/examples/sdk-app-example/build.gradle
+++ b/examples/sdk-app-example/build.gradle
@@ -6,9 +6,9 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.2"
+        classpath "com.android.tools.build:gradle:7.0.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.bugsnag:bugsnag-android-gradle-plugin:7.0.0"
+        classpath "com.bugsnag:bugsnag-android-gradle-plugin:7.1.0"
     }
 }
 


### PR DESCRIPTION
## Goal

Increases the bugsnag version used in the example app to the latest, as this was getting a bit out of date. This also bumps the appcompat version + AGP version.

## Testing

Ran the example app manually, ensured that it builds on CI.