### PR TITLE
Clear the stack-trace memory to avoid UTF-8 encoding problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Avoid unnecessary network connectivity change breadcrumb
   [#1540](https://github.com/bugsnag/bugsnag-android/pull/1540)
 
+* Clear native stacktrace memory in `bugsnag_notify_env` before attempting to unwind the stack
+  [#1543](https://github.com/bugsnag/bugsnag-android/pull/1543)
+
 ## 5.16.0 (2021-11-29)
 
 ### Bug fixes

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -132,6 +132,7 @@ void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
   jbyteArray jmessage = NULL;
 
   bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+  memset(stacktrace, 0, sizeof(stacktrace));
   ssize_t frame_count =
       bsg_unwind_stack(bsg_configured_unwind_style(), stacktrace, NULL, NULL);
 

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
@@ -6,6 +6,16 @@
 extern "C" {
 
 
+bool __attribute__((noinline)) make_dirty_stack() {
+  const size_t depth = 1024 * 1024; // 1Mb random data
+  unsigned char junk[depth];
+  for(size_t i = 0; i < depth; i++) {
+    junk[i] = i & 0xff;
+  }
+
+  return junk[depth / 2] != 0;
+}
+
 bool on_err_true(void *event_ptr) {
   bugsnag_event_set_context(event_ptr, (char *) "Some custom context");
   return true;
@@ -157,6 +167,7 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXStartScenario_activate(
     JNIEnv *env,
     jobject instance) {
+  make_dirty_stack();
   bugsnag_start(env);
   bugsnag_leave_breadcrumb((char *) "Start scenario crumb", BSG_CRUMB_LOG);
   bugsnag_notify((char *) "Start scenario",
@@ -183,6 +194,7 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXRemoveOnErrorScenario_activate(
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXRemoveDataScenario_activate(JNIEnv *env,
                                                                              jobject instance) {
+  make_dirty_stack();
   bugsnag_notify_env(env, (char *) "RemoveDataScenario", (char *) "oh no", BSG_SEVERITY_ERR);
 }
 
@@ -252,12 +264,14 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXGetJavaDataScenario_activate(JN
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXBackgroundNotifyScenario_activate(JNIEnv *env,
                                                                                    jobject instance) {
+  make_dirty_stack();
   bugsnag_notify_env(env, (char *)"Ferret Escape!", (char *)"oh no", BSG_SEVERITY_ERR);
 }
 
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXNotifySmokeScenario_activate(JNIEnv *env, jobject instance) {
+  make_dirty_stack();
   bugsnag_set_user_env(env, (char *)"324523", NULL, (char *)"Jack Mill");
   bugsnag_leave_breadcrumb_env(env, (char *)"Cold beans detected", BSG_CRUMB_LOG);
   bugsnag_notify_env(env, (char *)"CXXNotifySmokeScenario",
@@ -281,6 +295,7 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXHandledOverrideScenario_activat
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_MultiProcessHandledCXXErrorScenario_activate(JNIEnv *env,
                                                                                            jobject instance) {
+  make_dirty_stack();
   bugsnag_notify_env(env, (char *)"activate",
                      (char *)"MultiProcessHandledCXXErrorScenario", BSG_SEVERITY_ERR);
 }
@@ -318,6 +333,7 @@ Java_com_bugsnag_android_mazerunner_scenarios_CXXCaptureThreadsScenario_crash(JN
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_mazerunner_scenarios_CXXCaptureThreadsNotifyScenario_activate(JNIEnv *env,
                                                                                        jobject instance) {
+  make_dirty_stack();
   bugsnag_notify_env(env, (char *)"activate",
     (char *)"CXXCaptureThreadStatesNotifyScenario", BSG_SEVERITY_ERR);
 }


### PR DESCRIPTION
## Goal
Ensure that `bugsnag_notify_env` does not fail due to uninitialised memory in the captured stack trace.

## Testing
Added a new function to the native mazerunner scenarios which will "dirty" the stack to emulate the behaviour of a longer running application. The function simply populates a 1Mb temporary array with data and returns.