### PR TITLE
Read long map values as longs rather than doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Avoid unnecessary network connectivity change breadcrumb
   [#1540](https://github.com/bugsnag/bugsnag-android/pull/1540)
 
+* Read long map values as longs rather than doubles
+  [#1544](https://github.com/bugsnag/bugsnag-android/pull/1544)
+
 ## 5.16.0 (2021-11-29)
 
 ### Bug fixes

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -21,6 +21,7 @@ typedef struct {
   jmethodID float_float_value;
   jmethodID boolean_bool_value;
   jmethodID number_double_value;
+  jmethodID number_long_value;
   jmethodID hash_map_get;
   jmethodID hash_map_size;
   jmethodID hash_map_key_set;
@@ -98,6 +99,13 @@ bsg_jni_cache *bsg_populate_jni_cache(JNIEnv *env) {
   jni_cache->float_float_value =
       bsg_safe_get_method_id(env, jni_cache->float_class, "floatValue", "()F");
   if (jni_cache->float_float_value == NULL) {
+    return NULL;
+  }
+
+  // lookup Number.longValue()
+  jni_cache->number_long_value =
+      bsg_safe_get_method_id(env, jni_cache->number, "longValue", "()J");
+  if (jni_cache->number_long_value == NULL) {
     return NULL;
   }
 
@@ -269,13 +277,13 @@ void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
   }
 }
 
-long bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
-                            const char *_key) {
+jlong bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
+                             const char *_key) {
   jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
 
   if (_value != NULL) {
-    long value = bsg_safe_call_double_method(env, _value,
-                                             jni_cache->number_double_value);
+    jlong value =
+        bsg_safe_call_long_method(env, _value, jni_cache->number_long_value);
     bsg_safe_delete_local_ref(env, _value);
     return value;
   }
@@ -457,7 +465,7 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
                             sizeof(process_name));
   bugsnag_event_add_metadata_string(event, "app", "processName", process_name);
 
-  long total_memory =
+  jlong total_memory =
       bsg_get_map_value_long(env, jni_cache, data, "memoryLimit");
   bugsnag_event_add_metadata_double(event, "app", "memoryLimit",
                                     (double)total_memory);

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -101,6 +101,17 @@ jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
   return value;
 }
 
+jlong bsg_safe_call_long_method(JNIEnv *env, jobject _value, jmethodID method) {
+  if (env == NULL || _value == NULL) {
+    return -1;
+  }
+  jlong value = (*env)->CallLongMethod(env, _value, method);
+  if (bsg_check_and_clear_exc(env)) {
+    return -1; // default to -1
+  }
+  return value;
+}
+
 jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
   if (env == NULL || clz == NULL) {
     return NULL;

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -81,6 +81,13 @@ jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
                                     jmethodID method);
 
 /**
+ * A safe wrapper for the JNI's CallLongMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns -1.
+ */
+jlong bsg_safe_call_long_method(JNIEnv *env, jobject _value, jmethodID method);
+
+/**
  * A safe wrapper for the JNI's NewObjectArray. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
  * The caller is responsible for handling the invalid return value of NULL.


### PR DESCRIPTION
## Goal

Reads integer values in a map as a `long`, rather than calling `Number.doubleValue()` - which can lose precision for extreme values.

## Testing

Relied on existing test coverage, and manually verified that `device.totalMemory` was populated correctly in both an arm32 + arm64 device.