### PR TITLE
Avoid unnecessary network connectivity change breadcrumb on API <24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Avoid unnecessary network connectivity change breadcrumb
   [#1540](https://github.com/bugsnag/bugsnag-android/pull/1540)
+  [#1546](https://github.com/bugsnag/bugsnag-android/pull/1546)
 
 * Clear native stacktrace memory in `bugsnag_notify_env` before attempting to unwind the stack
   [#1543](https://github.com/bugsnag/bugsnag-android/pull/1543)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConnectivityCompat.kt
@@ -96,8 +96,12 @@ internal class ConnectivityLegacy(
         private val cb: NetworkChangeCallback?
     ) : BroadcastReceiver() {
 
+        private val receivedFirstCallback = AtomicBoolean(false)
+
         override fun onReceive(context: Context, intent: Intent) {
-            cb?.invoke(hasNetworkConnection(), retrieveNetworkAccessState())
+            if (receivedFirstCallback.getAndSet(true)) {
+                cb?.invoke(hasNetworkConnection(), retrieveNetworkAccessState())
+            }
         }
     }
 }


### PR DESCRIPTION
## Goal

Builds on #1540 so that an unnecessary network change breadcrumb is not logged on devices running API <24. The `CONNECTIVITY_ACTION` intent is sticky so will always trigger the broadcast receiver.

## Testing

Verified that E2E tests don't fail on Android 6, and otherwise relied on existing test coverage + manual testing.