### PR TITLE
Fix feature flags in NDK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.3.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.6.0'
 
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: c9d5240f9ccbc5a3440e8aa72330f52cbdc6a082
-  tag: v6.3.0
+  revision: efa902bd6a6c1bc42633585177d6f330b665eee4
+  tag: v6.6.0
   specs:
-    bugsnag-maze-runner (6.3.0)
+    bugsnag-maze-runner (6.6.0)
       appium_lib (~> 11.2.0)
+      bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -27,8 +28,11 @@ GEM
     appium_lib_core (4.7.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
+    bugsnag (6.24.1)
+      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
+    concurrent-ruby (1.1.9)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -46,7 +50,7 @@ GEM
       cucumber-gherkin (~> 22.0, >= 22.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
       cucumber-tag-expressions (~> 4.0, >= 4.0.2)
-    cucumber-create-meta (6.0.2)
+    cucumber-create-meta (6.0.4)
       cucumber-messages (~> 17.1, >= 17.1.1)
       sys-uname (~> 1.2, >= 1.2.2)
     cucumber-cucumber-expressions (14.0.0)
@@ -75,9 +79,9 @@ GEM
       tomlrb (>= 1.3, < 2.1)
       with_env (= 1.1.0)
       xml-simple (~> 1.1.5)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
+    mime-types-data (3.2021.1115)
     minitest (5.14.4)
     multi_test (0.1.2)
     nokogiri (1.12.5-x86_64-darwin)
@@ -108,10 +112,11 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   bugsnag-maze-runner!
   license_finder (~> 6.13)
 
 BUNDLED WITH
-   2.2.20
+   2.2.24

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -408,6 +408,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         deliveryDelegate.addObserver(observer);
         launchCrashTracker.addObserver(observer);
         memoryTrimState.addObserver(observer);
+        featureFlagState.addObserver(observer);
     }
 
     void removeObserver(StateObserver observer) {
@@ -420,6 +421,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         deliveryDelegate.removeObserver(observer);
         launchCrashTracker.removeObserver(observer);
         memoryTrimState.removeObserver(observer);
+        featureFlagState.removeObserver(observer);
     }
 
     /**

--- a/features/full_tests/native_feature_flags.feature
+++ b/features/full_tests/native_feature_flags.feature
@@ -1,22 +1,26 @@
-#Feature: Synchronizing feature flags to the native layer
-#
-#  Scenario: Feature flags are synchronized to the native layer
-#    When I run "CXXFeatureFlagNativeCrashScenario"
-#    And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
-#    And I wait to receive an error
-#    And the error payload contains a completed unhandled native report
-#    And the exception "errorClass" equals "SIGILL"
-#    And event 0 contains the feature flag "demo_mode" with no variant
-#    And event 0 contains the feature flag "sample_group" with variant "a"
-#    And event 0 does not contain the feature flag "should_not_be_reported_1"
-#    And event 0 does not contain the feature flag "should_not_be_reported_2"
-#    And event 0 does not contain the feature flag "should_not_be_reported_3"
-#
-#  Scenario: clearFeatureFlags() is synchronized to the native layer
-#    When I configure the app to run in the "cleared" state
-#    And I run "CXXFeatureFlagNativeCrashScenario"
-#    And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
-#    And I wait to receive an error
-#    And the error payload contains a completed unhandled native report
-#    And the exception "errorClass" equals "SIGILL"
-#    And event 0 has no feature flags
+Feature: Synchronizing feature flags to the native layer
+
+  Scenario: Feature flags are synchronized to the native layer
+    When I run "CXXFeatureFlagNativeCrashScenario" and relaunch the app
+    And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals one of:
+      | SIGILL |
+      | SIGTRAP |
+    And event 0 contains the feature flag "demo_mode" with no variant
+    And event 0 contains the feature flag "sample_group" with variant "a"
+    And event 0 does not contain the feature flag "should_not_be_reported_1"
+    And event 0 does not contain the feature flag "should_not_be_reported_2"
+    And event 0 does not contain the feature flag "should_not_be_reported_3"
+
+  Scenario: clearFeatureFlags() is synchronized to the native layer
+    When I configure the app to run in the "cleared" state
+    And I run "CXXFeatureFlagNativeCrashScenario" and relaunch the app
+    And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals one of:
+      | SIGILL |
+      | SIGTRAP |
+    And event 0 has no feature flags


### PR DESCRIPTION
## Goal
Feature Flags added in Java / Kotlin code need to be included as an array in unhandled NDK events. This requires that the `FeatureFlagState` be observed by the NDK plugin, and that the `featureFlags` be correctly encoded as a JSON array (and not as an object).

## Testing
Fixed existing Mazerunner tests and upgraded Mazerunner to ensure coverage. This PR will also go through a full CI run to ensure all of the tests are exercised.