### PR TITLE
ReactNative Feature Flags

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativePlugin.kt
@@ -115,6 +115,18 @@ class BugsnagReactNativePlugin : Plugin {
         client.codeBundleId = id
     }
 
+    fun addFeatureFlag(name: String, variant: String?) {
+        client.addFeatureFlag(name, variant)
+    }
+
+    fun clearFeatureFlag(name: String) {
+        client.clearFeatureFlag(name)
+    }
+
+    fun clearFeatureFlags() {
+        client.clearFeatureFlags()
+    }
+
     fun clearMetadata(section: String, key: String?) {
         when (key) {
             null -> client.clearMetadata(section)

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativePluginTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativePluginTest.kt
@@ -68,4 +68,22 @@ internal class BugsnagReactNativePluginTest {
         plugin.updateCodeBundleId("123")
         verify(client, times(1)).codeBundleId = "123"
     }
+
+    @Test
+    fun addFeatureFlag() {
+        plugin.addFeatureFlag("flag name", "variant")
+        verify(client, times(1)).addFeatureFlag("flag name", "variant")
+    }
+
+    @Test
+    fun clearFeatureFlag() {
+        plugin.clearFeatureFlag("flag name")
+        verify(client, times(1)).clearFeatureFlag("flag name")
+    }
+
+    @Test
+    fun clearFeatureFla() {
+        plugin.clearFeatureFlags()
+        verify(client, times(1)).clearFeatureFlags()
+    }
 }


### PR DESCRIPTION
## Goal
Allow ReactNative applications to manipulate feature flags collected and stored in the native Android notifier. The PR covers only the methods required by the ReactNative bridge in [bugsnag-js](https://github.com/bugsnag/bugsnag-js/blob/next/packages/react-native/android/src/main/java/com/bugsnag/android/BugsnagReactNative.kt).

## Testing
Covered the direct logic with the same style of unit tests as we already use for the `BugsnagReactNativePlugin`, and also manually ran several end-to-end tests with a ReactNative application and modified `bugsnag-js/react-native` module.