### PR TITLE
build(ndk): remove unneeded test dep

### DIFF
--- a/bugsnag-plugin-android-ndk/build.gradle
+++ b/bugsnag-plugin-android-ndk/build.gradle
@@ -10,10 +10,6 @@ apply plugin: "com.android.library"
 
 dependencies {
     api(project(":bugsnag-android-core"))
-    // newest version that didn't require fiddling with sourceCompatibility -
-    // didn't use kotlin module to avoid runtime version conflicts
-    // FUTURE(df): Remove databind in favor of JsonHelper in the internal pkg
-    androidTestImplementation("com.fasterxml.jackson.core:jackson-databind:2.12.5")
 }
 
 apply from: "../gradle/kotlin.gradle"

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationTest.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationTest.kt
@@ -2,14 +2,14 @@ package com.bugsnag.android.ndk.migrations
 
 import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.bugsnag.android.repackaged.dslplatform.json.DslJson
 import org.junit.Before
 import java.io.File
 
 open class EventMigrationTest {
 
     private lateinit var context: Context
-    private val objectMapper = ObjectMapper()
+    private val json = DslJson<Map<String, Any>>()
 
     @Before
     fun setup() {
@@ -22,12 +22,18 @@ open class EventMigrationTest {
         }
     }
 
-    internal fun parseJSON(file: File): Map<*, *> {
-        return objectMapper.readValue(file, Map::class.java)
+    internal fun parseJSON(file: File): Map<String, Any> {
+        return deserialize(file.readBytes())
     }
 
-    internal fun parseJSON(text: String): Map<*, *> {
-        return objectMapper.readValue(text, Map::class.java)
+    internal fun parseJSON(text: String): Map<String, Any> {
+        return deserialize(text.toByteArray())
+    }
+
+    private fun deserialize(contents: ByteArray): Map<String, Any> {
+        val result = json.deserialize(Map::class.java, contents, contents.size)
+        @Suppress("UNCHECKED_CAST")
+        return result as Map<String, Any>
     }
 
     companion object NativeLibs {

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV4Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV4Tests.kt
@@ -42,15 +42,15 @@ class EventMigrationV4Tests : EventMigrationTest() {
             mapOf(
                 "binaryArch" to "mips",
                 "buildUUID" to "1234-9876-adfe",
-                "duration" to 6502,
-                "durationInForeground" to 12,
+                "duration" to 6502L,
+                "durationInForeground" to 12L,
                 "id" to "com.example.PhotoSnapPlus",
                 "inForeground" to true,
                 "isLaunching" to false, // not available in this version
                 "releaseStage" to "リリース",
                 "type" to "red",
                 "version" to "2.0.52",
-                "versionCode" to 57
+                "versionCode" to 57L
             ),
             output["app"]
         )
@@ -95,7 +95,7 @@ class EventMigrationV4Tests : EventMigrationTest() {
                     "androidApiLevel" to "32"
                 ),
                 "time" to "2021-12-08T19:43:50Z",
-                "totalMemory" to 3278623
+                "totalMemory" to 3278623L
             ),
             output["device"]
         )
@@ -112,19 +112,19 @@ class EventMigrationV4Tests : EventMigrationTest() {
                     "type" to "c",
                     "stacktrace" to listOf(
                         mapOf(
-                            "frameAddress" to 454379,
-                            "lineNumber" to 0,
-                            "loadAddress" to 2367523,
-                            "symbolAddress" to 776,
+                            "frameAddress" to 454379L,
+                            "lineNumber" to 0L,
+                            "loadAddress" to 2367523L,
+                            "symbolAddress" to 776L,
                             "method" to "makinBacon",
                             "file" to "lib64/libfoo.so",
                             "isPC" to true
                         ),
                         mapOf(
-                            "frameAddress" to 342334,
-                            "lineNumber" to 0,
-                            "loadAddress" to 0,
-                            "symbolAddress" to 0,
+                            "frameAddress" to 342334L,
+                            "lineNumber" to 0L,
+                            "loadAddress" to 0L,
+                            "symbolAddress" to 0L,
                             "method" to "0x5393e" // test address to method hex
                         )
                     )
@@ -143,7 +143,7 @@ class EventMigrationV4Tests : EventMigrationTest() {
                 "metrics" to mapOf(
                     "experimentX" to false,
                     "subject" to "percy",
-                    "counter" to 47.8
+                    "counter" to 47.5.toBigDecimal()
                 )
             ),
             output["metaData"]
@@ -155,8 +155,8 @@ class EventMigrationV4Tests : EventMigrationTest() {
                 "id" to "aaaaaaaaaaaaaaaa",
                 "startedAt" to "2031-07-09T11:08:21+00:00",
                 "events" to mapOf(
-                    "handled" to 5,
-                    "unhandled" to 2
+                    "handled" to 5L,
+                    "unhandled" to 2L
                 )
             ),
             output["session"]

--- a/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV4Tests.cpp
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV4Tests.cpp
@@ -80,7 +80,7 @@ static void *create_full_event() {
   bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
   bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
   bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
-  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.8);
+  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.5);
 
   // session info
   event->handled_events = 5;


### PR DESCRIPTION
Clean up following discussion in #1551 :broom: - use DSL JSON for deserialization component of migration tests, required a few tweaks to number formatting since internally the library uses longs, big decimal, and a different floating point implementation.

## Testing

If it passes, it ships :ship: 