### PR TITLE
Improve the memory and performance handling delivery response status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Improve the memory use and performance overhead when handling the delivery response status codes
+  [#1558](https://github.com/bugsnag/bugsnag-android/pull/1558)
+
 ## 5.17.0 (2021-12-08)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
@@ -123,14 +123,15 @@ internal class DefaultDelivery(
     }
 
     internal fun getDeliveryStatus(responseCode: Int): DeliveryStatus {
-        val unrecoverableCodes = IntRange(HTTP_BAD_REQUEST, 499).filter {
-            it != HTTP_CLIENT_TIMEOUT && it != 429
-        }
-
-        return when (responseCode) {
-            in HTTP_OK..299 -> DeliveryStatus.DELIVERED
-            in unrecoverableCodes -> DeliveryStatus.FAILURE
+        return when {
+            responseCode in HTTP_OK..299 -> DeliveryStatus.DELIVERED
+            isUnrecoverableStatusCode(responseCode) -> DeliveryStatus.FAILURE
             else -> DeliveryStatus.UNDELIVERED
         }
     }
+
+    private fun isUnrecoverableStatusCode(responseCode: Int) =
+        responseCode in HTTP_BAD_REQUEST..499 && // 400-499 are considered unrecoverable
+            responseCode != HTTP_CLIENT_TIMEOUT && // except for 408
+            responseCode != 429 // and 429
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryTest.kt
@@ -14,5 +14,10 @@ class DeliveryTest {
         assertEquals(DeliveryStatus.UNDELIVERED, delivery.getDeliveryStatus(408))
         assertEquals(DeliveryStatus.UNDELIVERED, delivery.getDeliveryStatus(429))
         assertEquals(DeliveryStatus.FAILURE, delivery.getDeliveryStatus(400))
+        assertEquals(DeliveryStatus.FAILURE, delivery.getDeliveryStatus(401))
+        assertEquals(DeliveryStatus.FAILURE, delivery.getDeliveryStatus(498))
+        assertEquals(DeliveryStatus.FAILURE, delivery.getDeliveryStatus(499))
+        assertEquals(DeliveryStatus.UNDELIVERED, delivery.getDeliveryStatus(408))
+        assertEquals(DeliveryStatus.UNDELIVERED, delivery.getDeliveryStatus(429))
     }
 }


### PR DESCRIPTION
## Goal
Improve the memory use and performance of `DefaultDelivery.getDeliveryStatus` by avoiding the allocation and searching of a `List<Int>`.

## Changeset
Replaced the `IntRange` and `filter` with an equivalent method `isUnrecoverableStatusCode` which performs a simple set of comparisons.

## Testing
Additional unit tests added to cover more of the unrecoverable errors