### PR TITLE
Sync feature flags from Android -> ReactNative

### DIFF
--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativeBridge.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/BugsnagReactNativeBridge.kt
@@ -1,6 +1,9 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.StateEvent.AddFeatureFlag
 import com.bugsnag.android.StateEvent.AddMetadata
+import com.bugsnag.android.StateEvent.ClearFeatureFlag
+import com.bugsnag.android.StateEvent.ClearFeatureFlags
 import com.bugsnag.android.StateEvent.ClearMetadataSection
 import com.bugsnag.android.StateEvent.ClearMetadataValue
 import com.bugsnag.android.StateEvent.UpdateContext
@@ -32,6 +35,29 @@ internal class BugsnagReactNativeBridge(
                         Pair("email", event.user.email),
                         Pair("name", event.user.name)
                     )
+                )
+            }
+            is AddFeatureFlag -> {
+                MessageEvent(
+                    "AddFeatureFlag",
+                    mapOf(
+                        Pair("name", event.name),
+                        Pair("variant", event.variant)
+                    )
+                )
+            }
+            is ClearFeatureFlag -> {
+                MessageEvent(
+                    "ClearFeatureFlag",
+                    mapOf(
+                        Pair("name", event.name)
+                    )
+                )
+            }
+            is ClearFeatureFlags -> {
+                MessageEvent(
+                    "ClearFeatureFlag",
+                    null
                 )
             }
             else -> null

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -17,6 +17,7 @@ internal class EventDeserializer(
     @Suppress("UNCHECKED_CAST")
     override fun deserialize(map: MutableMap<String, Any?>): Event {
         val severityReason = map["severityReason"] as Map<String, Any>
+        val featureFlags = map["featureFlags"] as? List<Map<String, Any?>>
         val severityReasonType = severityReason["type"] as String
         val severity = map["severity"] as String
         val unhandled = map["unhandled"] as Boolean
@@ -43,6 +44,12 @@ internal class EventDeserializer(
         // user
         val user = UserDeserializer().deserialize(map["user"] as MutableMap<String, Any>)
         event.setUser(user.id, user.email, user.name)
+
+        // featureFlags
+        event.clearFeatureFlags() // we discard the featureFlags from Android native
+        featureFlags?.forEach { flagMap ->
+            event.addFeatureFlag(flagMap["featureFlag"] as String, flagMap["variant"] as String?)
+        }
 
         // errors
         val errors = map["errors"] as List<Map<String, Any?>>

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativeBridgeTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/BugsnagReactNativeBridgeTest.java
@@ -2,10 +2,10 @@ package com.bugsnag.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import kotlin.Unit;
 import kotlin.jvm.functions.Function1;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,8 +14,8 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Observable;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BugsnagReactNativeBridgeTest {
@@ -97,6 +97,46 @@ public class BugsnagReactNativeBridgeTest {
         assertNotNull(cb.event);
         assertEquals("MetadataUpdate", cb.event.getType());
         assertEquals(metadata, cb.event.getData());
+    }
+
+    @Test
+    public void addFeatureFlag() {
+        MessageEventCb cb = new MessageEventCb();
+        BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
+
+        StateEvent.AddFeatureFlag arg = new StateEvent.AddFeatureFlag("feature", "var");
+        bridge.onStateChange(arg);
+        assertNotNull(cb.event);
+        assertEquals("AddFeatureFlag", cb.event.getType());
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "feature");
+        data.put("variant", "var");
+        assertEquals(data, cb.event.getData());
+    }
+
+    @Test
+    public void clearFeatureFlag() {
+        MessageEventCb cb = new MessageEventCb();
+        BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
+
+        StateEvent.ClearFeatureFlag arg = new StateEvent.ClearFeatureFlag("feature");
+        bridge.onStateChange(arg);
+        assertNotNull(cb.event);
+        assertEquals("ClearFeatureFlag", cb.event.getType());
+        assertEquals(Collections.singletonMap("name", "feature"), cb.event.getData());
+    }
+
+    @Test
+    public void clearAllFeatureFlags() {
+        MessageEventCb cb = new MessageEventCb();
+        BugsnagReactNativeBridge bridge = new BugsnagReactNativeBridge(client, cb);
+
+        StateEvent.ClearFeatureFlags arg = StateEvent.ClearFeatureFlags.INSTANCE;
+        bridge.onStateChange(arg);
+        assertNotNull(cb.event);
+        assertEquals("ClearFeatureFlag", cb.event.getType());
+        assertNull(cb.event.getData());
     }
 
     static class MessageEventCb implements Function1<MessageEvent, Unit> {


### PR DESCRIPTION
## Goal
Deliver FeatureFlag events that occur in Android to the ReactNative bridge and JavaScript code. This ensures that the two layers remain in-sync and that events modified in JavaScript contain the expected feature flags.

JavaScript implementation is here: https://github.com/bugsnag/bugsnag-js/pull/1618

## Testing
New unit test to check the expected event format of the events