### PR TITLE
Delete persisted NDK events earlier in delivery process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Improve the memory use and performance overhead when handling the delivery response status codes
   [#1558](https://github.com/bugsnag/bugsnag-android/pull/1558)
 
+### Bug fixes
+
+* Delete persisted NDK events earlier in delivery process
+  [#1562](https://github.com/bugsnag/bugsnag-android/pull/1562)
+
 ## 5.17.0 (2021-12-08)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -224,6 +224,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   }
   event = bsg_deserialize_event_from_file((char *)event_path);
 
+  // remove persisted NDK struct early - this reduces the chance of crash loops
+  // in delivery.
+  remove(event_path);
+
   if (event != NULL) {
     payload = bsg_serialize_event_to_json_string(event);
     if (payload != NULL) {
@@ -269,7 +273,6 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   } else {
     BUGSNAG_LOG("Failed to read event at file: %s", event_path);
   }
-  remove(event_path);
   goto exit;
 
 exit:


### PR DESCRIPTION
## Goal

Deletes persisted NDK events as soon as they are read back into a `bsg_event` struct. This avoids the chance of a crash loop happening if `NativeInterface.deliverReport()` throws an exception.

## Testing

Relied on existing E2E test coverage.