### PR TITLE
Add null checks for strlen()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Delete persisted NDK events earlier in delivery process
   [#1562](https://github.com/bugsnag/bugsnag-android/pull/1562)
 
+* Add null checks for strlen()
+  [#1563](https://github.com/bugsnag/bugsnag-android/pull/1563)
+
 ## 5.17.0 (2021-12-08)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -89,7 +89,7 @@ void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
 
     // populate method
     jstring method = NULL;
-    if (strlen(frame.method) == 0) {
+    if (bsg_strlen(frame.method) == 0) {
       char frame_address[32];
       snprintf(frame_address, sizeof(frame_address), "0x%lx",
                (unsigned long)frame.frame_address);

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -189,7 +189,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   }
 
   // If set, save os build info to report info header
-  if (strlen(bugsnag_env->next_event.device.os_build) > 0) {
+  if (bsg_strlen(bugsnag_env->next_event.device.os_build) > 0) {
     bsg_strncpy_safe(bugsnag_env->report_header.os_build,
                      bugsnag_env->next_event.device.os_build,
                      sizeof(bugsnag_env->report_header.os_build));
@@ -346,8 +346,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_pausedSession(
   }
   bsg_request_env_write_lock();
   bugsnag_event *event = &bsg_global_env->next_event;
-  memset(event->session_id, 0, strlen(event->session_id));
-  memset(event->session_start, 0, strlen(event->session_start));
+  memset(event->session_id, 0, bsg_strlen(event->session_id));
+  memset(event->session_start, 0, bsg_strlen(event->session_start));
   event->handled_events = 0;
   event->unhandled_events = 0;
   bsg_release_env_write_lock();

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -221,7 +221,7 @@ void bugsnag_event_clear_breadcrumbs(bugsnag_event *event) {
 }
 
 bool bugsnag_event_has_session(bugsnag_event *event) {
-  return strlen(event->session_id) > 0;
+  return bsg_strlen(event->session_id) > 0;
 }
 
 /* Accessors for event.app */

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -585,7 +585,7 @@ void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
       bsg_safe_release_string_utf_chars(env, _context, value);
     }
   } else {
-    memset(&event->context, 0, strlen(event->context));
+    memset(&event->context, 0, bsg_strlen(event->context));
   }
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -408,7 +408,7 @@ void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2,
     for (int j = 0; j < 8; j++) {
       bsg_char_metadata_pair pair = old_crumb->metadata[j];
 
-      if (strlen(pair.value) > 0 && strlen(pair.key) > 0) {
+      if (bsg_strlen(pair.value) > 0 && bsg_strlen(pair.key) > 0) {
         bsg_add_metadata_value_str(&new_crumb->metadata, "metaData", pair.key,
                                    pair.value);
       }
@@ -624,7 +624,7 @@ void bsg_serialize_context(const bugsnag_event *event, JSON_Object *event_obj) {
 
 void bsg_serialize_grouping_hash(const bugsnag_event *event,
                                  JSON_Object *event_obj) {
-  if (strlen(event->grouping_hash) > 0) {
+  if (bsg_strlen(event->grouping_hash) > 0) {
     json_object_set_string(event_obj, "groupingHash", event->grouping_hash);
   }
 }
@@ -655,7 +655,7 @@ void bsg_serialize_app(const bsg_app_info app, JSON_Object *event_obj) {
 
   json_object_dotset_string(event_obj, "app.releaseStage", app.release_stage);
   json_object_dotset_number(event_obj, "app.versionCode", app.version_code);
-  if (strlen(app.build_uuid) > 0) {
+  if (bsg_strlen(app.build_uuid) > 0) {
     json_object_dotset_string(event_obj, "app.buildUUID", app.build_uuid);
   }
   json_object_dotset_string(event_obj, "app.binaryArch", app.binary_arch);
@@ -764,11 +764,11 @@ void bsg_serialize_breadcrumb_metadata(const bugsnag_metadata metadata,
 }
 
 void bsg_serialize_user(const bugsnag_user user, JSON_Object *event_obj) {
-  if (strlen(user.name) > 0)
+  if (bsg_strlen(user.name) > 0)
     json_object_dotset_string(event_obj, "user.name", user.name);
-  if (strlen(user.email) > 0)
+  if (bsg_strlen(user.email) > 0)
     json_object_dotset_string(event_obj, "user.email", user.email);
-  if (strlen(user.id) > 0)
+  if (bsg_strlen(user.id) > 0)
     json_object_dotset_string(event_obj, "user.id", user.id);
 }
 
@@ -815,10 +815,10 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
     // the field keeps payload sizes smaller.
     json_object_set_boolean(frame, "isPC", true);
   }
-  if (strlen((*stackframe).filename) > 0) {
+  if (bsg_strlen((*stackframe).filename) > 0) {
     json_object_set_string(frame, "file", (*stackframe).filename);
   }
-  if (strlen((*stackframe).method) == 0) {
+  if (bsg_strlen((*stackframe).method) == 0) {
     char *frame_address = calloc(1, sizeof(char) * 32);
     sprintf(frame_address, "0x%lx", (unsigned long)(*stackframe).frame_address);
     json_object_set_string(frame, "method", frame_address);

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -18,6 +18,9 @@ void bsg_strncpy(char *dst, const char *src, size_t len) {
 }
 
 size_t bsg_strlen(const char *str) {
+  if (str == NULL) {
+    return 0;
+  }
   size_t i = 0;
   while (true) {
     char current = str[i];

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -14,7 +14,7 @@ extern "C" {
 void bsg_strcpy(char *dst, const char *src) __asyncsafe;
 
 /**
- * Return the length of a string
+ * Return the length of a string, or 0 if the pointer is NULL.
  */
 size_t bsg_strlen(const char *str) __asyncsafe;
 

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
@@ -35,8 +35,14 @@ TEST length_literal_string(void) {
     ASSERT_EQ(11, bsg_strlen("C h a n g e"));
     PASS();
 }
+
 TEST length_empty_string(void) {
     ASSERT_EQ(0, bsg_strlen(""));
+    PASS();
+}
+
+TEST length_null_string(void) {
+    ASSERT_EQ(0, bsg_strlen(NULL));
     PASS();
 }
 
@@ -45,5 +51,6 @@ SUITE(suite_string_utils) {
     RUN_TEST(test_copy_literal_string);
     RUN_TEST(length_empty_string);
     RUN_TEST(length_literal_string);
+    RUN_TEST(length_null_string);
 }
 


### PR DESCRIPTION
## Goal

Adds null checks for calls to `strlen()` as some input could conceivably be `null` and lead to segfaults.

## Testing

Relied on existing test coverage.