### PR TITLE
Catch IOException when logging response status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 * Add null checks for strlen()
   [#1563](https://github.com/bugsnag/bugsnag-android/pull/1563)
 
+* Catch IOException when logging response status code
+  [#1567](https://github.com/bugsnag/bugsnag-android/pull/1567)
+
 ## 5.17.0 (2021-12-08)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt
@@ -105,19 +105,24 @@ internal class DefaultDelivery(
     }
 
     private fun logRequestInfo(code: Int, conn: HttpURLConnection, status: DeliveryStatus) {
-        logger.i(
-            "Request completed with code $code, " +
-                "message: ${conn.responseMessage}, " +
-                "headers: ${conn.headerFields}"
-        )
-
-        conn.inputStream.bufferedReader().use {
-            logger.d("Received request response: ${it.readText()}")
+        runCatching {
+            logger.i(
+                "Request completed with code $code, " +
+                    "message: ${conn.responseMessage}, " +
+                    "headers: ${conn.headerFields}"
+            )
+        }
+        runCatching {
+            conn.inputStream.bufferedReader().use {
+                logger.d("Received request response: ${it.readText()}")
+            }
         }
 
-        if (status != DeliveryStatus.DELIVERED) {
-            conn.errorStream.bufferedReader().use {
-                logger.w("Request error details: ${it.readText()}")
+        runCatching {
+            if (status != DeliveryStatus.DELIVERED) {
+                conn.errorStream.bufferedReader().use {
+                    logger.w("Request error details: ${it.readText()}")
+                }
             }
         }
     }


### PR DESCRIPTION
## Goal

Performs a null check if `conn.inputstream` is null, which is the case for unsuccessful requests. This avoids an `IOException` when reading the body that results in the response status code logic being bypassed, which effectively results in large payloads getting stuck on the device.

For good measure this also catches `IOException` that can be thrown when reading the `InputStream/OutputStream` too.

This change was introduced when adding extra logging info [here](https://github.com/bugsnag/bugsnag-android/pull/1077/files#diff-a0f6af1bfd1263d58911c6694d204e09ecac00307eefa65dd4a4f255485e5443R105) so will be present from v5.5.1 onwards.

## Testing

Manually verified that the request is now sent if it has a 400 status code, and that exceptions are not thrown.