### PR TITLE
[PLAT-6090] Harmonize all string copying in the NDK layer

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -171,8 +171,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   if (last_run_info_path == NULL) {
     return;
   }
-  bsg_strncpy_safe(bugsnag_env->last_run_info_path, last_run_info_path,
-                   sizeof(bugsnag_env->last_run_info_path));
+  bsg_strncpy(bugsnag_env->last_run_info_path, last_run_info_path,
+              sizeof(bugsnag_env->last_run_info_path));
   bsg_safe_release_string_utf_chars(env, _last_run_info_path,
                                     last_run_info_path);
 
@@ -190,15 +190,15 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
 
   // If set, save os build info to report info header
   if (bsg_strlen(bugsnag_env->next_event.device.os_build) > 0) {
-    bsg_strncpy_safe(bugsnag_env->report_header.os_build,
-                     bugsnag_env->next_event.device.os_build,
-                     sizeof(bugsnag_env->report_header.os_build));
+    bsg_strncpy(bugsnag_env->report_header.os_build,
+                bugsnag_env->next_event.device.os_build,
+                sizeof(bugsnag_env->report_header.os_build));
   }
 
   const char *api_key = bsg_safe_get_string_utf_chars(env, _api_key);
   if (api_key != NULL) {
-    bsg_strncpy_safe(bugsnag_env->next_event.api_key, (char *)api_key,
-                     sizeof(bugsnag_env->next_event.api_key));
+    bsg_strncpy(bugsnag_env->next_event.api_key, (char *)api_key,
+                sizeof(bugsnag_env->next_event.api_key));
     bsg_safe_release_string_utf_chars(env, _api_key, api_key);
   }
 
@@ -365,8 +365,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
 
   if (name != NULL && type != NULL && timestamp != NULL) {
     bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
-    bsg_strncpy_safe(crumb->name, name, sizeof(crumb->name));
-    bsg_strncpy_safe(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
+    bsg_strncpy(crumb->name, name, sizeof(crumb->name));
+    bsg_strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
     if (strcmp(type, "user") == 0) {
       crumb->type = BSG_CRUMB_USER;
     } else if (strcmp(type, "error") == 0) {
@@ -458,8 +458,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
   bsg_request_env_write_lock();
   bool was_in_foreground = bsg_global_env->next_event.app.in_foreground;
   bsg_global_env->next_event.app.in_foreground = (bool)new_value;
-  bsg_strncpy_safe(bsg_global_env->next_event.app.active_screen, activity,
-                   sizeof(bsg_global_env->next_event.app.active_screen));
+  bsg_strncpy(bsg_global_env->next_event.app.active_screen, activity,
+              sizeof(bsg_global_env->next_event.app.active_screen));
   if ((bool)new_value) {
     if (!was_in_foreground) {
       time(&bsg_global_env->foreground_start_time);

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -21,10 +21,10 @@ int bsg_allocate_metadata_index(bugsnag_metadata *metadata, const char *section,
   if (index < 0) {
     return index;
   }
-  bsg_strncpy_safe(metadata->values[index].section, section,
-                   sizeof(metadata->values[index].section));
-  bsg_strncpy_safe(metadata->values[index].name, name,
-                   sizeof(metadata->values[index].name));
+  bsg_strncpy(metadata->values[index].section, section,
+              sizeof(metadata->values[index].section));
+  bsg_strncpy(metadata->values[index].name, name,
+              sizeof(metadata->values[index].name));
   if (metadata->value_count < BUGSNAG_METADATA_MAX) {
     metadata->value_count = index + 1;
   }
@@ -46,8 +46,8 @@ void bsg_add_metadata_value_str(bugsnag_metadata *metadata, const char *section,
   int index = bsg_allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_CHAR_VALUE;
-    bsg_strncpy_safe(metadata->values[index].char_value, value,
-                     sizeof(metadata->values[index].char_value));
+    bsg_strncpy(metadata->values[index].char_value, value,
+                sizeof(metadata->values[index].char_value));
   }
 }
 
@@ -167,9 +167,8 @@ void bugsnag_event_start_session(bugsnag_event *event, const char *session_id,
                                  const char *started_at,
                                  const int handled_count,
                                  const int unhandled_count) {
-  bsg_strncpy_safe(event->session_id, session_id, sizeof(event->session_id));
-  bsg_strncpy_safe(event->session_start, started_at,
-                   sizeof(event->session_start));
+  bsg_strncpy(event->session_id, session_id, sizeof(event->session_id));
+  bsg_strncpy(event->session_start, started_at, sizeof(event->session_start));
   event->handled_events = handled_count;
   event->unhandled_events = unhandled_count;
 }
@@ -181,7 +180,7 @@ char *bugsnag_event_get_api_key(void *event_ptr) {
 
 void bugsnag_event_set_api_key(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->api_key, value, sizeof(event->api_key));
+  bsg_strncpy(event->api_key, value, sizeof(event->api_key));
 }
 
 char *bugsnag_event_get_context(void *event_ptr) {
@@ -191,15 +190,15 @@ char *bugsnag_event_get_context(void *event_ptr) {
 
 void bugsnag_event_set_context(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->context, value, sizeof(event->context));
+  bsg_strncpy(event->context, value, sizeof(event->context));
 }
 
 void bugsnag_event_set_user(void *event_ptr, const char *id, const char *email,
                             const char *name) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->user.id, id, sizeof(event->user.id));
-  bsg_strncpy_safe(event->user.email, email, sizeof(event->user.email));
-  bsg_strncpy_safe(event->user.name, name, sizeof(event->user.name));
+  bsg_strncpy(event->user.id, id, sizeof(event->user.id));
+  bsg_strncpy(event->user.email, email, sizeof(event->user.email));
+  bsg_strncpy(event->user.name, name, sizeof(event->user.name));
 }
 
 void bugsnag_event_add_breadcrumb(bugsnag_event *event,
@@ -234,8 +233,7 @@ char *bugsnag_app_get_binary_arch(void *event_ptr) {
 
 void bugsnag_app_set_binary_arch(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->app.binary_arch, value,
-                   sizeof(event->app.binary_arch));
+  bsg_strncpy(event->app.binary_arch, value, sizeof(event->app.binary_arch));
 }
 
 char *bugsnag_app_get_build_uuid(void *event_ptr) {
@@ -245,7 +243,7 @@ char *bugsnag_app_get_build_uuid(void *event_ptr) {
 
 void bugsnag_app_set_build_uuid(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->app.build_uuid, value, sizeof(event->app.build_uuid));
+  bsg_strncpy(event->app.build_uuid, value, sizeof(event->app.build_uuid));
 }
 
 char *bugsnag_app_get_id(void *event_ptr) {
@@ -255,7 +253,7 @@ char *bugsnag_app_get_id(void *event_ptr) {
 
 void bugsnag_app_set_id(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->app.id, value, sizeof(event->app.id));
+  bsg_strncpy(event->app.id, value, sizeof(event->app.id));
 }
 
 char *bugsnag_app_get_release_stage(void *event_ptr) {
@@ -265,8 +263,8 @@ char *bugsnag_app_get_release_stage(void *event_ptr) {
 
 void bugsnag_app_set_release_stage(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->app.release_stage, value,
-                   sizeof(event->app.release_stage));
+  bsg_strncpy(event->app.release_stage, value,
+              sizeof(event->app.release_stage));
 }
 
 char *bugsnag_app_get_type(void *event_ptr) {
@@ -276,7 +274,7 @@ char *bugsnag_app_get_type(void *event_ptr) {
 
 void bugsnag_app_set_type(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->app.type, value, sizeof(event->app.type));
+  bsg_strncpy(event->app.type, value, sizeof(event->app.type));
 }
 
 char *bugsnag_app_get_version(void *event_ptr) {
@@ -286,7 +284,7 @@ char *bugsnag_app_get_version(void *event_ptr) {
 
 void bugsnag_app_set_version(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->app.version, value, sizeof(event->app.version));
+  bsg_strncpy(event->app.version, value, sizeof(event->app.version));
 }
 
 int bugsnag_app_get_version_code(void *event_ptr) {
@@ -358,7 +356,7 @@ char *bugsnag_device_get_id(void *event_ptr) {
 
 void bugsnag_device_set_id(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->device.id, value, sizeof(event->device.id));
+  bsg_strncpy(event->device.id, value, sizeof(event->device.id));
 }
 
 char *bugsnag_device_get_locale(void *event_ptr) {
@@ -368,7 +366,7 @@ char *bugsnag_device_get_locale(void *event_ptr) {
 
 void bugsnag_device_set_locale(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->device.locale, value, sizeof(event->device.locale));
+  bsg_strncpy(event->device.locale, value, sizeof(event->device.locale));
 }
 
 char *bugsnag_device_get_manufacturer(void *event_ptr) {
@@ -378,8 +376,8 @@ char *bugsnag_device_get_manufacturer(void *event_ptr) {
 
 void bugsnag_device_set_manufacturer(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->device.manufacturer, value,
-                   sizeof(event->device.manufacturer));
+  bsg_strncpy(event->device.manufacturer, value,
+              sizeof(event->device.manufacturer));
 }
 
 char *bugsnag_device_get_model(void *event_ptr) {
@@ -389,7 +387,7 @@ char *bugsnag_device_get_model(void *event_ptr) {
 
 void bugsnag_device_set_model(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->device.model, value, sizeof(event->device.model));
+  bsg_strncpy(event->device.model, value, sizeof(event->device.model));
 }
 
 char *bugsnag_device_get_os_version(void *event_ptr) {
@@ -399,8 +397,8 @@ char *bugsnag_device_get_os_version(void *event_ptr) {
 
 void bugsnag_device_set_os_version(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->device.os_version, value,
-                   sizeof(event->device.os_version));
+  bsg_strncpy(event->device.os_version, value,
+              sizeof(event->device.os_version));
 }
 
 long bugsnag_device_get_total_memory(void *event_ptr) {
@@ -420,8 +418,8 @@ char *bugsnag_device_get_orientation(void *event_ptr) {
 
 void bugsnag_device_set_orientation(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->device.orientation, value,
-                   sizeof(event->device.orientation));
+  bsg_strncpy(event->device.orientation, value,
+              sizeof(event->device.orientation));
 }
 
 time_t bugsnag_device_get_time(void *event_ptr) {
@@ -441,7 +439,7 @@ char *bugsnag_device_get_os_name(void *event_ptr) {
 
 void bugsnag_device_set_os_name(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->device.os_name, value, sizeof(event->device.os_name));
+  bsg_strncpy(event->device.os_name, value, sizeof(event->device.os_name));
 }
 
 char *bugsnag_error_get_error_class(void *event_ptr) {
@@ -451,8 +449,7 @@ char *bugsnag_error_get_error_class(void *event_ptr) {
 
 void bugsnag_error_set_error_class(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->error.errorClass, value,
-                   sizeof(event->error.errorClass));
+  bsg_strncpy(event->error.errorClass, value, sizeof(event->error.errorClass));
 }
 
 char *bugsnag_error_get_error_message(void *event_ptr) {
@@ -462,8 +459,8 @@ char *bugsnag_error_get_error_message(void *event_ptr) {
 
 void bugsnag_error_set_error_message(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->error.errorMessage, value,
-                   sizeof(event->error.errorMessage));
+  bsg_strncpy(event->error.errorMessage, value,
+              sizeof(event->error.errorMessage));
 }
 
 char *bugsnag_error_get_error_type(void *event_ptr) {
@@ -473,7 +470,7 @@ char *bugsnag_error_get_error_type(void *event_ptr) {
 
 void bugsnag_error_set_error_type(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->error.type, value, sizeof(event->error.type));
+  bsg_strncpy(event->error.type, value, sizeof(event->error.type));
 }
 
 bugsnag_severity bugsnag_event_get_severity(void *event_ptr) {
@@ -508,7 +505,7 @@ char *bugsnag_event_get_grouping_hash(void *event_ptr) {
 
 void bugsnag_event_set_grouping_hash(void *event_ptr, const char *value) {
   bugsnag_event *event = (bugsnag_event *)event_ptr;
-  bsg_strncpy_safe(event->grouping_hash, value, sizeof(event->grouping_hash));
+  bsg_strncpy(event->grouping_hash, value, sizeof(event->grouping_hash));
 }
 
 int bugsnag_event_get_stacktrace_size(void *event_ptr) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -196,10 +196,12 @@ void bsg_handle_signal(int signum, siginfo_t *info,
   for (int i = 0; i < BSG_HANDLED_SIGNAL_COUNT; i++) {
     const int signal = bsg_native_signals[i];
     if (signal == signum) {
-      bsg_strcpy(bsg_global_env->next_event.error.errorClass,
-                 (char *)bsg_native_signal_names[i]);
-      bsg_strcpy(bsg_global_env->next_event.error.errorMessage,
-                 (char *)bsg_native_signal_msgs[i]);
+      bsg_strncpy(bsg_global_env->next_event.error.errorClass,
+                  (char *)bsg_native_signal_names[i],
+                  sizeof(bsg_global_env->next_event.error.errorClass));
+      bsg_strncpy(bsg_global_env->next_event.error.errorMessage,
+                  (char *)bsg_native_signal_msgs[i],
+                  sizeof(bsg_global_env->next_event.error.errorMessage));
       break;
     }
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -263,7 +263,7 @@ void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
   if (_value != NULL) {
     const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_value);
     if (value != NULL) {
-      bsg_strncpy_safe(dest, value, len);
+      bsg_strncpy(dest, value, len);
       bsg_safe_release_string_utf_chars(env, _value, value);
     }
   }
@@ -336,8 +336,8 @@ int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
 
       const char *abi = bsg_safe_get_string_utf_chars(env, jabi);
       if (abi != NULL) {
-        bsg_strncpy_safe(device->cpu_abi[i].value, abi,
-                         sizeof(device->cpu_abi[i].value));
+        bsg_strncpy(device->cpu_abi[i].value, abi,
+                    sizeof(device->cpu_abi[i].value));
         bsg_safe_release_string_utf_chars(env, jabi, abi);
         device->cpu_abi_count++;
       }
@@ -531,7 +531,8 @@ void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   bsg_copy_map_value_string(env, jni_cache, data, "orientation",
                             event->device.orientation,
                             sizeof(event->device.orientation));
-  bsg_strcpy(event->device.os_name, bsg_os_name());
+  bsg_strncpy(event->device.os_name, bsg_os_name(),
+              sizeof(event->device.os_name));
   bsg_copy_map_value_string(env, jni_cache, data, "osVersion",
                             event->device.os_version,
                             sizeof(event->device.os_version));
@@ -581,7 +582,7 @@ void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
   if (_context != NULL) {
     const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_context);
     if (value != NULL) {
-      bsg_strncpy_safe(event->context, value, sizeof(event->context) - 1);
+      bsg_strncpy(event->context, value, sizeof(event->context) - 1);
       bsg_safe_release_string_utf_chars(env, _context, value);
     }
   } else {

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer.c
@@ -223,22 +223,21 @@ bugsnag_event *bsg_map_v5_to_report(bugsnag_report_v5 *report_v5) {
     event->notifier = report_v5->notifier;
     event->app = report_v5->app;
     event->device = report_v5->device;
-    bsg_strcpy(event->context, report_v5->context);
+    bsg_strncpy(event->context, report_v5->context, sizeof(event->context));
     event->user = report_v5->user;
     event->error = report_v5->error;
     event->metadata = report_v5->metadata;
     event->severity = report_v5->severity;
-    bsg_strncpy_safe(event->session_id, report_v5->session_id,
-                     sizeof(event->session_id));
-    bsg_strncpy_safe(event->session_start, report_v5->session_start,
-                     sizeof(event->session_id));
+    bsg_strncpy(event->session_id, report_v5->session_id,
+                sizeof(event->session_id));
+    bsg_strncpy(event->session_start, report_v5->session_start,
+                sizeof(event->session_id));
     event->handled_events = report_v5->handled_events;
     event->unhandled_events = report_v5->unhandled_events;
-    bsg_strncpy_safe(event->grouping_hash, report_v5->grouping_hash,
-                     sizeof(event->session_id));
+    bsg_strncpy(event->grouping_hash, report_v5->grouping_hash,
+                sizeof(event->session_id));
     event->unhandled = report_v5->unhandled;
-    bsg_strncpy_safe(event->api_key, report_v5->api_key,
-                     sizeof(event->api_key));
+    bsg_strncpy(event->api_key, report_v5->api_key, sizeof(event->api_key));
 
     migrate_breadcrumb_v2(report_v5, event);
     free(report_v5);
@@ -263,17 +262,16 @@ bugsnag_event *bsg_map_v4_to_report(bugsnag_report_v4 *report_v4) {
     memcpy(event->breadcrumbs, report_v4->breadcrumbs,
            sizeof(event->breadcrumbs));
     event->severity = report_v4->severity;
-    bsg_strncpy_safe(event->session_id, report_v4->session_id,
-                     sizeof(event->session_id));
-    bsg_strncpy_safe(event->session_start, report_v4->session_start,
-                     sizeof(event->session_id));
+    bsg_strncpy(event->session_id, report_v4->session_id,
+                sizeof(event->session_id));
+    bsg_strncpy(event->session_start, report_v4->session_start,
+                sizeof(event->session_id));
     event->handled_events = report_v4->handled_events;
     event->unhandled_events = report_v4->unhandled_events;
-    bsg_strncpy_safe(event->grouping_hash, report_v4->grouping_hash,
-                     sizeof(event->session_id));
+    bsg_strncpy(event->grouping_hash, report_v4->grouping_hash,
+                sizeof(event->session_id));
     event->unhandled = report_v4->unhandled;
-    bsg_strncpy_safe(event->api_key, report_v4->api_key,
-                     sizeof(event->api_key));
+    bsg_strncpy(event->api_key, report_v4->api_key, sizeof(event->api_key));
     migrate_app_v2(report_v4, event);
     free(report_v4);
   }
@@ -298,15 +296,18 @@ bugsnag_event *bsg_map_v3_to_report(bugsnag_report_v3 *report_v3) {
     memcpy(event->breadcrumbs, report_v3->breadcrumbs,
            sizeof(event->breadcrumbs));
     event->severity = report_v3->severity;
-    strcpy(event->session_id, report_v3->session_id);
-    strcpy(event->session_start, report_v3->session_start);
+    bsg_strncpy(event->session_id, report_v3->session_id,
+                sizeof(event->session_id));
+    bsg_strncpy(event->session_start, report_v3->session_start,
+                sizeof(event->session_start));
     event->handled_events = report_v3->handled_events;
     event->unhandled_events = report_v3->unhandled_events;
-    strcpy(event->grouping_hash, report_v3->grouping_hash);
+    bsg_strncpy(event->grouping_hash, report_v3->grouping_hash,
+                sizeof(event->grouping_hash));
     event->unhandled = report_v3->unhandled;
 
     // set a default value for the api key
-    strcpy(event->api_key, "");
+    event->api_key[0] = 0;
     free(report_v3);
   }
   return bsg_map_v4_to_report(event);
@@ -326,22 +327,30 @@ bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2) {
     event->user = report_v2->user;
     migrate_breadcrumb_v1(report_v2, event);
 
-    strcpy(event->context, report_v2->context);
+    bsg_strncpy(event->context, report_v2->context, sizeof(event->context));
     event->severity = report_v2->severity;
-    strcpy(event->session_id, report_v2->session_id);
-    strcpy(event->session_start, report_v2->session_start);
+    bsg_strncpy(event->session_id, report_v2->session_id,
+                sizeof(event->session_id));
+    bsg_strncpy(event->session_start, report_v2->session_start,
+                sizeof(event->session_start));
     event->handled_events = report_v2->handled_events;
     event->unhandled_events = report_v2->unhandled_events;
 
     // migrate changed notifier fields
-    strcpy(event->notifier.version, report_v2->notifier.version);
-    strcpy(event->notifier.name, report_v2->notifier.name);
-    strcpy(event->notifier.url, report_v2->notifier.url);
+    bsg_strncpy(event->notifier.version, report_v2->notifier.version,
+                sizeof(event->notifier.version));
+    bsg_strncpy(event->notifier.name, report_v2->notifier.name,
+                sizeof(event->notifier.name));
+    bsg_strncpy(event->notifier.url, report_v2->notifier.url,
+                sizeof(event->notifier.url));
 
     // migrate changed error fields
-    strcpy(event->error.errorClass, report_v2->exception.name);
-    strcpy(event->error.errorMessage, report_v2->exception.message);
-    strcpy(event->error.type, report_v2->exception.type);
+    bsg_strncpy(event->error.errorClass, report_v2->exception.name,
+                sizeof(event->error.errorClass));
+    bsg_strncpy(event->error.errorMessage, report_v2->exception.message,
+                sizeof(event->error.errorMessage));
+    bsg_strncpy(event->error.type, report_v2->exception.type,
+                sizeof(event->error.type));
     event->error.frame_count = report_v2->exception.frame_count;
     size_t error_size = sizeof(bugsnag_stackframe) * BUGSNAG_FRAMES_MAX;
     memcpy(&event->error.stacktrace, report_v2->exception.stacktrace,
@@ -402,9 +411,9 @@ void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2,
 
     // copy old crumb fields to new
     new_crumb->type = old_crumb->type;
-    bsg_strncpy_safe(new_crumb->name, old_crumb->name, sizeof(new_crumb->name));
-    bsg_strncpy_safe(new_crumb->timestamp, old_crumb->timestamp,
-                     sizeof(new_crumb->timestamp));
+    bsg_strncpy(new_crumb->name, old_crumb->name, sizeof(new_crumb->name));
+    bsg_strncpy(new_crumb->timestamp, old_crumb->timestamp,
+                sizeof(new_crumb->timestamp));
 
     for (int j = 0; j < 8; j++) {
       bsg_char_metadata_pair pair = old_crumb->metadata[j];
@@ -422,13 +431,18 @@ void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2,
 }
 
 void migrate_app_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event) {
-  bsg_strcpy(event->app.id, report_v2->app.id);
-  bsg_strcpy(event->app.release_stage, report_v2->app.release_stage);
-  bsg_strcpy(event->app.type, report_v2->app.type);
-  bsg_strcpy(event->app.version, report_v2->app.version);
-  bsg_strcpy(event->app.active_screen, report_v2->app.active_screen);
-  bsg_strcpy(event->app.build_uuid, report_v2->app.build_uuid);
-  bsg_strcpy(event->app.binary_arch, report_v2->app.binaryArch);
+  bsg_strncpy(event->app.id, report_v2->app.id, sizeof(event->app.id));
+  bsg_strncpy(event->app.release_stage, report_v2->app.release_stage,
+              sizeof(event->app.release_stage));
+  bsg_strncpy(event->app.type, report_v2->app.type, sizeof(event->app.type));
+  bsg_strncpy(event->app.version, report_v2->app.version,
+              sizeof(event->app.version));
+  bsg_strncpy(event->app.active_screen, report_v2->app.active_screen,
+              sizeof(event->app.active_screen));
+  bsg_strncpy(event->app.build_uuid, report_v2->app.build_uuid,
+              sizeof(event->app.build_uuid));
+  bsg_strncpy(event->app.binary_arch, report_v2->app.binaryArch,
+              sizeof(event->app.binary_arch));
   event->app.version_code = report_v2->app.version_code;
   event->app.duration = report_v2->app.duration;
   event->app.duration_in_foreground = report_v2->app.duration_in_foreground;
@@ -459,19 +473,18 @@ void migrate_breadcrumb_v2(bugsnag_report_v5 *report_v5, bugsnag_event *event) {
 }
 
 void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event) {
-  bsg_strncpy_safe(event->app.id, report_v4->app.id, sizeof(event->app.id));
-  bsg_strncpy_safe(event->app.release_stage, report_v4->app.release_stage,
-                   sizeof(event->app.release_stage));
-  bsg_strncpy_safe(event->app.type, report_v4->app.type,
-                   sizeof(event->app.type));
-  bsg_strncpy_safe(event->app.version, report_v4->app.version,
-                   sizeof(event->app.version));
-  bsg_strncpy_safe(event->app.active_screen, report_v4->app.active_screen,
-                   sizeof(event->app.active_screen));
-  bsg_strncpy_safe(event->app.build_uuid, report_v4->app.build_uuid,
-                   sizeof(event->app.build_uuid));
-  bsg_strncpy_safe(event->app.binary_arch, report_v4->app.binary_arch,
-                   sizeof(event->app.binary_arch));
+  bsg_strncpy(event->app.id, report_v4->app.id, sizeof(event->app.id));
+  bsg_strncpy(event->app.release_stage, report_v4->app.release_stage,
+              sizeof(event->app.release_stage));
+  bsg_strncpy(event->app.type, report_v4->app.type, sizeof(event->app.type));
+  bsg_strncpy(event->app.version, report_v4->app.version,
+              sizeof(event->app.version));
+  bsg_strncpy(event->app.active_screen, report_v4->app.active_screen,
+              sizeof(event->app.active_screen));
+  bsg_strncpy(event->app.build_uuid, report_v4->app.build_uuid,
+              sizeof(event->app.build_uuid));
+  bsg_strncpy(event->app.binary_arch, report_v4->app.binary_arch,
+              sizeof(event->app.binary_arch));
   event->app.version_code = report_v4->app.version_code;
   event->app.duration = report_v4->app.duration;
   event->app.duration_in_foreground = report_v4->app.duration_in_foreground;
@@ -485,8 +498,8 @@ void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event) {
 }
 
 void migrate_device_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event) {
-  bsg_strcpy(event->device.os_name,
-             bsg_os_name()); // os_name was not a field in v2
+  bsg_strncpy(event->device.os_name, bsg_os_name(),
+              sizeof(event->device.os_name)); // os_name was not a field in v2
   event->device.api_level = report_v2->device.api_level;
   event->device.cpu_abi_count = report_v2->device.cpu_abi_count;
   event->device.time = report_v2->device.time;
@@ -496,18 +509,25 @@ void migrate_device_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event) {
   for (int k = 0; k < report_v2->device.cpu_abi_count &&
                   k < sizeof(report_v2->device.cpu_abi);
        k++) {
-    bsg_strcpy(event->device.cpu_abi[k].value,
-               report_v2->device.cpu_abi[k].value);
+    bsg_strncpy(event->device.cpu_abi[k].value,
+                report_v2->device.cpu_abi[k].value,
+                sizeof(event->device.cpu_abi[k].value));
     event->device.cpu_abi_count++;
   }
 
-  bsg_strcpy(event->device.orientation, report_v2->device.orientation);
-  bsg_strcpy(event->device.id, report_v2->device.id);
-  bsg_strcpy(event->device.locale, report_v2->device.locale);
-  bsg_strcpy(event->device.manufacturer, report_v2->device.manufacturer);
-  bsg_strcpy(event->device.model, report_v2->device.model);
-  bsg_strcpy(event->device.os_build, report_v2->device.os_build);
-  bsg_strcpy(event->device.os_version, report_v2->device.os_version);
+  bsg_strncpy(event->device.orientation, report_v2->device.orientation,
+              sizeof(event->device.orientation));
+  bsg_strncpy(event->device.id, report_v2->device.id, sizeof(event->device.id));
+  bsg_strncpy(event->device.locale, report_v2->device.locale,
+              sizeof(event->device.locale));
+  bsg_strncpy(event->device.manufacturer, report_v2->device.manufacturer,
+              sizeof(event->device.manufacturer));
+  bsg_strncpy(event->device.model, report_v2->device.model,
+              sizeof(event->device.model));
+  bsg_strncpy(event->device.os_build, report_v2->device.os_build,
+              sizeof(event->device.os_build));
+  bsg_strncpy(event->device.os_version, report_v2->device.os_version,
+              sizeof(event->device.os_version));
 
   // migrate legacy fields to metadata
   bugsnag_event_add_metadata_bool(event, "device", "emulator",
@@ -549,10 +569,13 @@ bugsnag_event *bsg_map_v1_to_report(bugsnag_report_v1 *report_v1) {
         sizeof(bugsnag_breadcrumb_v1) * V1_BUGSNAG_CRUMBS_MAX;
     memcpy(&event_v2->breadcrumbs, report_v1->breadcrumbs, breadcrumb_size);
 
-    strcpy(event_v2->context, report_v1->context);
+    bsg_strncpy(event_v2->context, report_v1->context,
+                sizeof(event_v2->context));
     event_v2->severity = report_v1->severity;
-    strcpy(event_v2->session_id, report_v1->session_id);
-    strcpy(event_v2->session_start, report_v1->session_start);
+    bsg_strncpy(event_v2->session_id, report_v1->session_id,
+                sizeof(event_v2->session_id));
+    bsg_strncpy(event_v2->session_start, report_v1->session_start,
+                sizeof(event_v2->session_start));
     event_v2->handled_events = report_v1->handled_events;
     event_v2->unhandled_events = 1;
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.c
@@ -51,10 +51,12 @@ void bsg_insert_fileinfo(ssize_t frame_count,
       stacktrace[i].line_number =
           stacktrace[i].frame_address - stacktrace[i].load_address;
       if (info.dli_fname != NULL) {
-        bsg_strcpy(stacktrace[i].filename, (char *)info.dli_fname);
+        bsg_strncpy(stacktrace[i].filename, (char *)info.dli_fname,
+                    sizeof(stacktrace[i].filename));
       }
       if (info.dli_sname != NULL) {
-        bsg_strcpy(stacktrace[i].method, (char *)info.dli_sname);
+        bsg_strncpy(stacktrace[i].method, (char *)info.dli_sname,
+                    sizeof(stacktrace[i].method));
       }
     }
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libcorkscrew.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder_libcorkscrew.c
@@ -111,7 +111,8 @@ bsg_unwind_stack_libcorkscrew(bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX],
       continue; // already seen this
     }
     if (backtrace_symbol.symbol_name != NULL) {
-      bsg_strcpy(stacktrace[frame_count].method, backtrace_symbol.symbol_name);
+      bsg_strncpy(stacktrace[frame_count].method, backtrace_symbol.symbol_name,
+                  sizeof(stacktrace[frame_count].method));
     }
 
     stacktrace[frame_count].frame_address = backtrace_frame.absolute_pc;

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -3,41 +3,20 @@
 #include <stdbool.h>
 #include <string.h>
 
-void bsg_strcpy(char *dst, const char *src) { bsg_strncpy(dst, src, INT_MAX); }
-
-void bsg_strncpy(char *dst, const char *src, size_t len) {
-  int i = 0;
-  while (i <= len) {
-    char current = src[i];
-    dst[i] = current;
-    if (current == '\0') {
-      break;
-    }
-    i++;
-  }
-}
+// Anything more than this and we shouldn't even be sending or using it.
+const size_t STRING_MAX_LENGTH = 1024 * 1024 * 10;
 
 size_t bsg_strlen(const char *str) {
   if (str == NULL) {
     return 0;
   }
-  size_t i = 0;
-  while (true) {
-    char current = str[i];
-    if (current == '\0') {
-      return i;
-    } else if (i == INT_MAX) {
-      return INT_MAX;
-    }
-    i++;
-  }
+  return strnlen(str, STRING_MAX_LENGTH);
 }
 
-void bsg_strncpy_safe(char *dst, const char *src, int dst_size) {
-  if (dst_size == 0)
+void bsg_strncpy(char *dst, const char *src, size_t dst_size) {
+  if (src == NULL || dst == NULL || dst_size == 0) {
     return;
-  dst[0] = '\0';
-  if (src != NULL) {
-    strncat(dst, src, dst_size - 1);
   }
+  dst[0] = '\0';
+  strncat(dst, src, dst_size - 1);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -1,17 +1,12 @@
 #ifndef BUGSNAG_UTILS_STRING_H
 #define BUGSNAG_UTILS_STRING_H
-#include "build.h"
 
+#include "build.h"
 #include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * Copy the contents of src to dst where src is null-terminated
- */
-void bsg_strcpy(char *dst, const char *src) __asyncsafe;
 
 /**
  * Return the length of a string, or 0 if the pointer is NULL.
@@ -23,10 +18,6 @@ size_t bsg_strlen(const char *str) __asyncsafe;
  */
 void bsg_strncpy(char *dst, const char *src, size_t len) __asyncsafe;
 
-/**
- * Copy a string from src to dst, null padding the rest
- */
-void bsg_strncpy_safe(char *dst, const char *src, int dst_size);
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.c
@@ -42,11 +42,12 @@ static const char *const task_state_array[] = {
     "X dead",    "Z zombie",   "P parked",     "I idle",
 };
 
-static void get_task_state_description(const char code, char *dest) {
+static void get_task_state_description(const char code, char *dest,
+                                       size_t dest_size) {
   for (size_t index = 0; index < (sizeof(task_state_array) / sizeof(char *));
        index++) {
     if (task_state_array[index][0] == code) {
-      bsg_strcpy(dest, &task_state_array[index][2]);
+      bsg_strncpy(dest, &task_state_array[index][2], dest_size);
       return;
     }
   }
@@ -121,7 +122,7 @@ static bool parse_stat_content(bsg_thread *dest, char *content, size_t len) {
       }
       break;
     case PARSE_STATUS:
-      get_task_state_description(current, dest->state);
+      get_task_state_description(current, dest->state, sizeof(dest->state));
       state = PARSE_DONE;
       break;
     case PARSE_DONE:

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -6,48 +6,48 @@
 
 bugsnag_event *init_event() {
     bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
-    bsg_strncpy_safe(event->api_key, "5d1e5fbd39a74caa1200142706a90b20", sizeof(event->api_key));
-    bsg_strncpy_safe(event->context, "Foo", sizeof(event->context));
-    bsg_strncpy_safe(event->user.id, "123", sizeof(event->user.id));
-    bsg_strncpy_safe(event->user.email, "jane@example.com", sizeof(event->user.email));
-    bsg_strncpy_safe(event->user.name, "Jane Doe", sizeof(event->user.name));
+    bsg_strncpy(event->api_key, "5d1e5fbd39a74caa1200142706a90b20", sizeof(event->api_key));
+    bsg_strncpy(event->context, "Foo", sizeof(event->context));
+    bsg_strncpy(event->user.id, "123", sizeof(event->user.id));
+    bsg_strncpy(event->user.email, "jane@example.com", sizeof(event->user.email));
+    bsg_strncpy(event->user.name, "Jane Doe", sizeof(event->user.name));
     event->severity = BSG_SEVERITY_INFO;
     event->unhandled = true;
-    bsg_strncpy_safe(event->user.id, "123", sizeof(event->user.id));
-    bsg_strncpy_safe(event->user.email, "bob@example.com", sizeof(event->user.email));
-    bsg_strncpy_safe(event->user.name, "Bob Bobbiton", sizeof(event->user.name));
+    bsg_strncpy(event->user.id, "123", sizeof(event->user.id));
+    bsg_strncpy(event->user.email, "bob@example.com", sizeof(event->user.email));
+    bsg_strncpy(event->user.name, "Bob Bobbiton", sizeof(event->user.name));
 
-    bsg_strncpy_safe(event->app.binary_arch, "x86", sizeof(event->app.binary_arch));
-    bsg_strncpy_safe(event->app.build_uuid, "123", sizeof(event->app.build_uuid));
-    bsg_strncpy_safe(event->app.id, "fa02", sizeof(event->app.id));
-    bsg_strncpy_safe(event->app.release_stage, "dev", sizeof(event->app.release_stage));
-    bsg_strncpy_safe(event->app.type, "C", sizeof(event->app.type));
-    bsg_strncpy_safe(event->app.version, "1.0", sizeof(event->app.version));
+    bsg_strncpy(event->app.binary_arch, "x86", sizeof(event->app.binary_arch));
+    bsg_strncpy(event->app.build_uuid, "123", sizeof(event->app.build_uuid));
+    bsg_strncpy(event->app.id, "fa02", sizeof(event->app.id));
+    bsg_strncpy(event->app.release_stage, "dev", sizeof(event->app.release_stage));
+    bsg_strncpy(event->app.type, "C", sizeof(event->app.type));
+    bsg_strncpy(event->app.version, "1.0", sizeof(event->app.version));
     event->app.version_code = 55;
     event->app.duration = 9019;
     event->app.duration_in_foreground = 7017;
     event->app.in_foreground = true;
     event->app.is_launching = true;
-    bsg_strncpy_safe(event->grouping_hash, "Bar", sizeof(event->grouping_hash));
+    bsg_strncpy(event->grouping_hash, "Bar", sizeof(event->grouping_hash));
 
     event->device.jailbroken = true;
     event->device.total_memory = 1095092340;
-    bsg_strncpy_safe(event->device.id, "my-id-123", sizeof(event->device.id));
-    bsg_strncpy_safe(event->device.locale, "en", sizeof(event->device.locale));
-    bsg_strncpy_safe(event->device.os_name, "android", sizeof(event->device.os_name));
-    bsg_strncpy_safe(event->device.manufacturer, "Google", sizeof(event->device.manufacturer));
-    bsg_strncpy_safe(event->device.model, "Nexus", sizeof(event->device.model));
-    bsg_strncpy_safe(event->device.os_version, "9.1", sizeof(event->device.os_version));
-    bsg_strncpy_safe(event->device.orientation, "portrait", sizeof(event->device.orientation));
+    bsg_strncpy(event->device.id, "my-id-123", sizeof(event->device.id));
+    bsg_strncpy(event->device.locale, "en", sizeof(event->device.locale));
+    bsg_strncpy(event->device.os_name, "android", sizeof(event->device.os_name));
+    bsg_strncpy(event->device.manufacturer, "Google", sizeof(event->device.manufacturer));
+    bsg_strncpy(event->device.model, "Nexus", sizeof(event->device.model));
+    bsg_strncpy(event->device.os_version, "9.1", sizeof(event->device.os_version));
+    bsg_strncpy(event->device.orientation, "portrait", sizeof(event->device.orientation));
     event->device.time = 7609;
 
-    bsg_strncpy_safe(event->error.errorClass, "SIGSEGV", sizeof(event->error.errorClass));
-    bsg_strncpy_safe(event->error.errorMessage, "Whoops!", sizeof(event->error.errorMessage));
-    bsg_strncpy_safe(event->error.type, "C", sizeof(event->error.type));
+    bsg_strncpy(event->error.errorClass, "SIGSEGV", sizeof(event->error.errorClass));
+    bsg_strncpy(event->error.errorMessage, "Whoops!", sizeof(event->error.errorMessage));
+    bsg_strncpy(event->error.type, "C", sizeof(event->error.type));
 
     event->error.frame_count = 1;
-    bsg_strncpy_safe(event->error.stacktrace->method, "foo()", sizeof(event->error.stacktrace->method));
-    bsg_strncpy_safe(event->error.stacktrace->filename, "Something.c", sizeof(event->error.stacktrace->filename));
+    bsg_strncpy(event->error.stacktrace->method, "foo()", sizeof(event->error.stacktrace->method));
+    bsg_strncpy(event->error.stacktrace->filename, "Something.c", sizeof(event->error.stacktrace->filename));
     event->error.stacktrace->line_number = 58;
     return event;
 }
@@ -376,7 +376,7 @@ TEST test_event_stacktrace(void) {
     ASSERT_EQ(58, frame->line_number);
 
     // modify and copy into a new array
-    bsg_strncpy_safe(frame->method, "bar()", sizeof(frame->method));
+    bsg_strncpy(frame->method, "bar()", sizeof(frame->method));
     bugsnag_stackframe *another_frame = bugsnag_event_get_stackframe(event, 0);
     ASSERT_EQ(frame, another_frame);
 

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_serializer.c
@@ -45,7 +45,7 @@ void loadAppMetadataTestCase(bugsnag_event *event) {
 void loadDeviceTestCase(bugsnag_event *event) {
     bsg_device_info *device = &event->device;
     device->api_level = 29;
-    bsg_strncpy_safe(device->cpu_abi[0].value, "x86", sizeof(device->cpu_abi[0].value));
+    bsg_strncpy(device->cpu_abi[0].value, "x86", sizeof(device->cpu_abi[0].value));
     device->cpu_abi_count = 1;
     strcpy(device->orientation, "portrait");
 

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
@@ -4,8 +4,9 @@
 
 TEST test_copy_empty_string(void) {
     char *src = "";
-    char *dst = calloc(sizeof(char), 10);
-    bsg_strcpy(dst, src);
+    int dst_len = 10;
+    char *dst = calloc(sizeof(char), dst_len);
+    bsg_strncpy(dst, src, dst_len);
     ASSERT(dst[0] == '\0');
     free(dst);
     PASS();
@@ -13,8 +14,9 @@ TEST test_copy_empty_string(void) {
 
 TEST test_copy_literal_string(void) {
     char *src = "C h a n g e";
-    char *dst = calloc(sizeof(char), 10);
-    bsg_strcpy(dst, src);
+    int dst_len = 10;
+    char *dst = calloc(sizeof(char), dst_len);
+    bsg_strncpy(dst, src, dst_len);
     ASSERT(dst[0] == 'C');
     ASSERT(dst[1] == ' ');
     ASSERT(dst[2] == 'h');
@@ -24,9 +26,7 @@ TEST test_copy_literal_string(void) {
     ASSERT(dst[6] == 'n');
     ASSERT(dst[7] == ' ');
     ASSERT(dst[8] == 'g');
-    ASSERT(dst[9] == ' ');
-    ASSERT(dst[10] == 'e');
-    ASSERT(dst[11] == '\0');
+    ASSERT(dst[9] == '\0');
     free(dst);
     PASS();
 }


### PR DESCRIPTION
## Goal

We're currently using two `strlen` implementations and three `strcpy` implementations. Pick one proper implementation of each and use it exclusively.

## Testing

Re-ran all tests, and tested manually.
