### PR TITLE
Improve JNI safety

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library( # Specifies the name of the library.
     jni/bugsnag.c
     jni/metadata.c
     jni/safejni.c
+    jni/jni_cache.c
     jni/event.c
     jni/handlers/signal_handler.c
     jni/handlers/cpp_handler.cpp

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag.c
@@ -3,6 +3,7 @@
 #include "../assets/include/bugsnag.h"
 #include "bugsnag_ndk.h"
 #include "event.h"
+#include "jni_cache.h"
 #include "metadata.h"
 #include "safejni.h"
 #include "utils/stack_unwinder.h"
@@ -15,15 +16,6 @@
 static JNIEnv *bsg_global_jni_env = NULL;
 
 void bugsnag_start(JNIEnv *env) { bsg_global_jni_env = env; }
-
-void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
-                        bugsnag_severity severity);
-
-void bugsnag_set_user_env(JNIEnv *env, const char *id, const char *email,
-                          const char *name);
-
-void bugsnag_leave_breadcrumb_env(JNIEnv *env, const char *message,
-                                  bugsnag_breadcrumb_type type);
 
 void bugsnag_notify(const char *name, const char *message,
                     bugsnag_severity severity) {
@@ -53,8 +45,8 @@ void bugsnag_leave_breadcrumb(const char *message,
   }
 }
 
-jfieldID bsg_parse_jseverity(JNIEnv *env, bugsnag_severity severity,
-                             jclass severity_class) {
+static jfieldID parse_jseverity(JNIEnv *env, bugsnag_severity severity,
+                                jclass severity_class) {
   const char *severity_sig = "Lcom/bugsnag/android/Severity;";
   if (severity == BSG_SEVERITY_ERR) {
     return bsg_safe_get_static_field_id(env, severity_class, "ERROR",
@@ -68,10 +60,11 @@ jfieldID bsg_parse_jseverity(JNIEnv *env, bugsnag_severity severity,
   }
 }
 
-void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
-                                    ssize_t frame_count, jclass trace_class,
-                                    jmethodID trace_constructor,
-                                    jobjectArray trace) {
+static void populate_notify_stacktrace(JNIEnv *env,
+                                       bugsnag_stackframe *stacktrace,
+                                       ssize_t frame_count, jclass trace_class,
+                                       jmethodID trace_constructor,
+                                       jobjectArray trace) {
   for (int i = 0; i < frame_count; i++) {
     bugsnag_stackframe frame = stacktrace[i];
 
@@ -120,75 +113,42 @@ void bsg_populate_notify_stacktrace(JNIEnv *env, bugsnag_stackframe *stacktrace,
 
 void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
                         bugsnag_severity severity) {
-  jclass interface_class = NULL;
-  jmethodID notify_method = NULL;
-  jclass trace_class = NULL;
-  jclass severity_class = NULL;
-  jmethodID trace_constructor = NULL;
-  jobjectArray trace = NULL;
-  jfieldID severity_field = NULL;
+  jobjectArray jtrace = NULL;
   jobject jseverity = NULL;
   jbyteArray jname = NULL;
   jbyteArray jmessage = NULL;
+
+  if (!bsg_jni_cache_refresh(env)) {
+    BUGSNAG_LOG("Could not refresh JNI cache.");
+    goto exit;
+  }
 
   bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
   memset(stacktrace, 0, sizeof(stacktrace));
   ssize_t frame_count =
       bsg_unwind_stack(bsg_configured_unwind_style(), stacktrace, NULL, NULL);
 
-  // lookup com/bugsnag/android/NativeInterface
-  interface_class =
-      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
-  if (interface_class == NULL) {
-    goto exit;
-  }
-
-  // lookup NativeInterface.notify()
-  notify_method = bsg_safe_get_static_method_id(
-      env, interface_class, "notify",
-      "([B[BLcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
-  if (notify_method == NULL) {
-    goto exit;
-  }
-
-  // lookup java/lang/StackTraceElement
-  trace_class = bsg_safe_find_class(env, "java/lang/StackTraceElement");
-  if (trace_class == NULL) {
-    goto exit;
-  }
-
-  // lookup com/bugsnag/android/Severity
-  severity_class = bsg_safe_find_class(env, "com/bugsnag/android/Severity");
-  if (severity_class == NULL) {
-    goto exit;
-  }
-
-  // lookup StackTraceElement constructor
-  trace_constructor = bsg_safe_get_method_id(
-      env, trace_class, "<init>",
-      "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
-  if (trace_constructor == NULL) {
-    goto exit;
-  }
-
   // create StackTraceElement array
-  trace = bsg_safe_new_object_array(env, frame_count, trace_class);
-  if (trace == NULL) {
+  jtrace = bsg_safe_new_object_array(env, frame_count,
+                                     bsg_global_jni_cache->stack_trace_element);
+  if (jtrace == NULL) {
     goto exit;
   }
 
   // populate stacktrace object
-  bsg_populate_notify_stacktrace(env, stacktrace, frame_count, trace_class,
-                                 trace_constructor, trace);
+  populate_notify_stacktrace(env, stacktrace, frame_count,
+                             bsg_global_jni_cache->stack_trace_element,
+                             bsg_global_jni_cache->ste_constructor, jtrace);
 
   // get the severity field
-  severity_field = bsg_parse_jseverity(env, severity, severity_class);
+  jfieldID severity_field =
+      parse_jseverity(env, severity, bsg_global_jni_cache->severity);
   if (severity_field == NULL) {
     goto exit;
   }
   // get the error severity object
-  jseverity =
-      bsg_safe_get_static_object_field(env, severity_class, severity_field);
+  jseverity = bsg_safe_get_static_object_field(
+      env, bsg_global_jni_cache->severity, severity_field);
   if (jseverity == NULL) {
     goto exit;
   }
@@ -196,70 +156,47 @@ void bugsnag_notify_env(JNIEnv *env, const char *name, const char *message,
   jname = bsg_byte_ary_from_string(env, name);
   jmessage = bsg_byte_ary_from_string(env, message);
 
-  bsg_safe_call_static_void_method(env, interface_class, notify_method, jname,
-                                   jmessage, jseverity, trace);
+  bsg_safe_call_static_void_method(env, bsg_global_jni_cache->native_interface,
+                                   bsg_global_jni_cache->ni_notify, jname,
+                                   jmessage, jseverity, jtrace);
 
   goto exit;
 
 exit:
-  if (jname != NULL) {
-    bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name);
-  }
-  if (jmessage != NULL) {
-    bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message);
-  }
+  bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name);
   bsg_safe_delete_local_ref(env, jname);
+  bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message);
   bsg_safe_delete_local_ref(env, jmessage);
-
-  bsg_safe_delete_local_ref(env, interface_class);
-  bsg_safe_delete_local_ref(env, trace_class);
-  bsg_safe_delete_local_ref(env, severity_class);
-  bsg_safe_delete_local_ref(env, trace);
+  bsg_safe_delete_local_ref(env, jtrace);
   bsg_safe_delete_local_ref(env, jseverity);
 }
 
 void bugsnag_set_user_env(JNIEnv *env, const char *id, const char *email,
                           const char *name) {
-  // lookup com/bugsnag/android/NativeInterface
-  jclass interface_class = NULL;
-  jmethodID set_user_method = NULL;
-
-  interface_class =
-      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
-  if (interface_class == NULL) {
-    goto exit;
-  }
-
-  // lookup NativeInterface.setUser()
-  set_user_method = bsg_safe_get_static_method_id(env, interface_class,
-                                                  "setUser", "([B[B[B)V");
-  if (set_user_method == NULL) {
-    goto exit;
+  if (!bsg_jni_cache_refresh(env)) {
+    BUGSNAG_LOG("Could not refresh JNI cache.");
+    return;
   }
 
   jbyteArray jid = bsg_byte_ary_from_string(env, id);
   jbyteArray jemail = bsg_byte_ary_from_string(env, email);
   jbyteArray jname = bsg_byte_ary_from_string(env, name);
 
-  bsg_safe_call_static_void_method(env, interface_class, set_user_method, jid,
+  bsg_safe_call_static_void_method(env, bsg_global_jni_cache->native_interface,
+                                   bsg_global_jni_cache->ni_set_user, jid,
                                    jemail, jname);
 
   bsg_safe_release_byte_array_elements(env, jid, (jbyte *)id);
-  bsg_safe_release_byte_array_elements(env, jemail, (jbyte *)email);
-  bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name);
-
   bsg_safe_delete_local_ref(env, jid);
+  bsg_safe_release_byte_array_elements(env, jemail, (jbyte *)email);
   bsg_safe_delete_local_ref(env, jemail);
+  bsg_safe_release_byte_array_elements(env, jname, (jbyte *)name);
   bsg_safe_delete_local_ref(env, jname);
-
-  goto exit;
-
-exit:
-  bsg_safe_delete_local_ref(env, interface_class);
 }
 
-jfieldID bsg_parse_jcrumb_type(JNIEnv *env, const bugsnag_breadcrumb_type type,
-                               jclass type_class) {
+static jfieldID parse_jcrumb_type(JNIEnv *env,
+                                  const bugsnag_breadcrumb_type type,
+                                  jclass type_class) {
   const char *type_sig = "Lcom/bugsnag/android/BreadcrumbType;";
   if (type == BSG_CRUMB_USER) {
     return bsg_safe_get_static_field_id(env, type_class, "USER", type_sig);
@@ -283,56 +220,36 @@ jfieldID bsg_parse_jcrumb_type(JNIEnv *env, const bugsnag_breadcrumb_type type,
 
 void bugsnag_leave_breadcrumb_env(JNIEnv *env, const char *message,
                                   const bugsnag_breadcrumb_type type) {
-  jclass interface_class = NULL;
-  jmethodID leave_breadcrumb_method = NULL;
-  jclass type_class = NULL;
-  jfieldID crumb_type = NULL;
-  jobject jtype = NULL;
   jbyteArray jmessage = NULL;
+  jobject jtype = NULL;
 
-  // lookup com/bugsnag/android/NativeInterface
-  interface_class =
-      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
-  if (interface_class == NULL) {
-    goto exit;
-  }
-
-  // lookup NativeInterface.leaveBreadcrumb()
-  leave_breadcrumb_method = bsg_safe_get_static_method_id(
-      env, interface_class, "leaveBreadcrumb",
-      "([BLcom/bugsnag/android/BreadcrumbType;)V");
-  if (leave_breadcrumb_method == NULL) {
-    goto exit;
-  }
-
-  // lookup com/bugsnag/android/BreadcrumbType
-  type_class = bsg_safe_find_class(env, "com/bugsnag/android/BreadcrumbType");
-  if (type_class == NULL) {
+  if (!bsg_jni_cache_refresh(env)) {
+    BUGSNAG_LOG("Could not refresh JNI cache.");
     goto exit;
   }
 
   // get breadcrumb type fieldID
-  crumb_type = bsg_parse_jcrumb_type(env, type, type_class);
+  jfieldID crumb_type =
+      parse_jcrumb_type(env, type, bsg_global_jni_cache->breadcrumb_type);
   if (crumb_type == NULL) {
     goto exit;
   }
 
   // get the breadcrumb type
-  jtype = bsg_safe_get_static_object_field(env, type_class, crumb_type);
+  jtype = bsg_safe_get_static_object_field(
+      env, bsg_global_jni_cache->breadcrumb_type, crumb_type);
   if (jtype == NULL) {
     goto exit;
   }
   jmessage = bsg_byte_ary_from_string(env, message);
-  bsg_safe_call_static_void_method(env, interface_class,
-                                   leave_breadcrumb_method, jmessage, jtype);
+  bsg_safe_call_static_void_method(env, bsg_global_jni_cache->native_interface,
+                                   bsg_global_jni_cache->ni_leave_breadcrumb,
+                                   jmessage, jtype);
 
   goto exit;
 
-exit : {
+exit:
   bsg_safe_release_byte_array_elements(env, jmessage, (jbyte *)message);
-}
-  bsg_safe_delete_local_ref(env, interface_class);
-  bsg_safe_delete_local_ref(env, type_class);
-  bsg_safe_delete_local_ref(env, jtype);
   bsg_safe_delete_local_ref(env, jmessage);
+  bsg_safe_delete_local_ref(env, jtype);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.c
@@ -2,7 +2,7 @@
 #include "utils/string.h"
 #include <string.h>
 
-int bsg_find_next_free_metadata_index(bugsnag_metadata *const metadata) {
+static int find_next_free_metadata_index(bugsnag_metadata *const metadata) {
   if (metadata->value_count < BUGSNAG_METADATA_MAX) {
     return metadata->value_count;
   } else {
@@ -15,9 +15,9 @@ int bsg_find_next_free_metadata_index(bugsnag_metadata *const metadata) {
   return -1;
 }
 
-int bsg_allocate_metadata_index(bugsnag_metadata *metadata, const char *section,
-                                const char *name) {
-  int index = bsg_find_next_free_metadata_index(metadata);
+static int allocate_metadata_index(bugsnag_metadata *metadata,
+                                   const char *section, const char *name) {
+  int index = find_next_free_metadata_index(metadata);
   if (index < 0) {
     return index;
   }
@@ -34,7 +34,7 @@ int bsg_allocate_metadata_index(bugsnag_metadata *metadata, const char *section,
 void bsg_add_metadata_value_double(bugsnag_metadata *metadata,
                                    const char *section, const char *name,
                                    double value) {
-  int index = bsg_allocate_metadata_index(metadata, section, name);
+  int index = allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_NUMBER_VALUE;
     metadata->values[index].double_value = value;
@@ -43,7 +43,7 @@ void bsg_add_metadata_value_double(bugsnag_metadata *metadata,
 
 void bsg_add_metadata_value_str(bugsnag_metadata *metadata, const char *section,
                                 const char *name, const char *value) {
-  int index = bsg_allocate_metadata_index(metadata, section, name);
+  int index = allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_CHAR_VALUE;
     bsg_strncpy(metadata->values[index].char_value, value,
@@ -54,7 +54,7 @@ void bsg_add_metadata_value_str(bugsnag_metadata *metadata, const char *section,
 void bsg_add_metadata_value_bool(bugsnag_metadata *metadata,
                                  const char *section, const char *name,
                                  bool value) {
-  int index = bsg_allocate_metadata_index(metadata, section, name);
+  int index = allocate_metadata_index(metadata, section, name);
   if (index >= 0) {
     metadata->values[index].type = BSG_METADATA_BOOL_VALUE;
     metadata->values[index].bool_value = value;

--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.c
@@ -1,0 +1,296 @@
+//
+// Created by Karl Stenerud on 03.01.22.
+//
+
+#include "jni_cache.h"
+#include "safejni.h"
+#include <stdlib.h>
+
+#include <android/log.h>
+#ifndef BUGSNAG_LOG
+#define BUGSNAG_LOG(fmt, ...)                                                  \
+  __android_log_print(ANDROID_LOG_WARN, "BugsnagNDK", fmt, ##__VA_ARGS__)
+#endif
+
+#define report_contents(VALUE, TYPECODE)                                       \
+  BUGSNAG_LOG(#VALUE " == " TYPECODE, VALUE)
+
+static bsg_jni_cache global_jni_cache;
+bsg_jni_cache *bsg_global_jni_cache = &global_jni_cache;
+
+bool bsg_jni_cache_refresh(JNIEnv *env) {
+  if (bsg_global_jni_cache == NULL) {
+    return false;
+  }
+
+  // All objects here are local references, and MUST be refreshed on every
+  // transition from Java to native.
+
+  // Classes
+
+  bsg_global_jni_cache->integer = bsg_safe_find_class(env, "java/lang/Integer");
+  if (bsg_global_jni_cache->integer == NULL) {
+    report_contents(bsg_global_jni_cache->integer, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->boolean = bsg_safe_find_class(env, "java/lang/Boolean");
+  if (bsg_global_jni_cache->boolean == NULL) {
+    report_contents(bsg_global_jni_cache->boolean, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->long_class = bsg_safe_find_class(env, "java/lang/Long");
+  if (bsg_global_jni_cache->long_class == NULL) {
+    report_contents(bsg_global_jni_cache->long_class, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->float_class =
+      bsg_safe_find_class(env, "java/lang/Float");
+  if (bsg_global_jni_cache->float_class == NULL) {
+    report_contents(bsg_global_jni_cache->float_class, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->number = bsg_safe_find_class(env, "java/lang/Number");
+  if (bsg_global_jni_cache->number == NULL) {
+    report_contents(bsg_global_jni_cache->number, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->string = bsg_safe_find_class(env, "java/lang/String");
+  if (bsg_global_jni_cache->string == NULL) {
+    report_contents(bsg_global_jni_cache->string, "%p");
+    goto failed;
+  }
+
+  // Methods
+
+  bsg_global_jni_cache->arraylist =
+      bsg_safe_find_class(env, "java/util/ArrayList");
+  if (bsg_global_jni_cache->arraylist == NULL) {
+    report_contents(bsg_global_jni_cache->arraylist, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->hash_map =
+      bsg_safe_find_class(env, "java/util/HashMap");
+  if (bsg_global_jni_cache->hash_map == NULL) {
+    report_contents(bsg_global_jni_cache->hash_map, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->map = bsg_safe_find_class(env, "java/util/Map");
+  if (bsg_global_jni_cache->map == NULL) {
+    report_contents(bsg_global_jni_cache->map, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->native_interface =
+      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
+  if (bsg_global_jni_cache->native_interface == NULL) {
+    report_contents(bsg_global_jni_cache->native_interface, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->stack_trace_element =
+      bsg_safe_find_class(env, "java/lang/StackTraceElement");
+  if (bsg_global_jni_cache->stack_trace_element == NULL) {
+    report_contents(bsg_global_jni_cache->stack_trace_element, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->severity =
+      bsg_safe_find_class(env, "com/bugsnag/android/Severity");
+  if (bsg_global_jni_cache->severity == NULL) {
+    report_contents(bsg_global_jni_cache->severity, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->breadcrumb_type =
+      bsg_safe_find_class(env, "com/bugsnag/android/BreadcrumbType");
+  if (bsg_global_jni_cache->breadcrumb_type == NULL) {
+    report_contents(bsg_global_jni_cache->breadcrumb_type, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->integer_int_value = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->integer, "intValue", "()I");
+  if (bsg_global_jni_cache->integer_int_value == NULL) {
+    report_contents(bsg_global_jni_cache->integer_int_value, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->float_float_value = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->float_class, "floatValue", "()F");
+  if (bsg_global_jni_cache->float_float_value == NULL) {
+    report_contents(bsg_global_jni_cache->float_float_value, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->number_double_value = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->number, "doubleValue", "()D");
+  if (bsg_global_jni_cache->number_double_value == NULL) {
+    report_contents(bsg_global_jni_cache->number_double_value, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->long_long_value = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->integer, "longValue", "()J");
+  if (bsg_global_jni_cache->long_long_value == NULL) {
+    report_contents(bsg_global_jni_cache->long_long_value, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->boolean_bool_value = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->boolean, "booleanValue", "()Z");
+  if (bsg_global_jni_cache->boolean_bool_value == NULL) {
+    report_contents(bsg_global_jni_cache->boolean_bool_value, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->arraylist_init_with_obj =
+      bsg_safe_get_method_id(env, bsg_global_jni_cache->arraylist, "<init>",
+                             "(Ljava/util/Collection;)V");
+  if (bsg_global_jni_cache->arraylist_init_with_obj == NULL) {
+    report_contents(bsg_global_jni_cache->arraylist_init_with_obj, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->arraylist_get = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->arraylist, "get", "(I)Ljava/lang/Object;");
+  if (bsg_global_jni_cache->arraylist_get == NULL) {
+    report_contents(bsg_global_jni_cache->arraylist_get, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->hash_map_key_set = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->hash_map, "keySet", "()Ljava/util/Set;");
+  if (bsg_global_jni_cache->hash_map_key_set == NULL) {
+    report_contents(bsg_global_jni_cache->hash_map_key_set, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->hash_map_size = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->hash_map, "size", "()I");
+  if (bsg_global_jni_cache->hash_map_size == NULL) {
+    report_contents(bsg_global_jni_cache->hash_map_size, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->hash_map_get =
+      bsg_safe_get_method_id(env, bsg_global_jni_cache->hash_map, "get",
+                             "(Ljava/lang/Object;)Ljava/lang/Object;");
+  if (bsg_global_jni_cache->hash_map_get == NULL) {
+    report_contents(bsg_global_jni_cache->hash_map_get, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->map_key_set = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->map, "keySet", "()Ljava/util/Set;");
+  if (bsg_global_jni_cache->map_key_set == NULL) {
+    report_contents(bsg_global_jni_cache->map_key_set, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->map_size =
+      bsg_safe_get_method_id(env, bsg_global_jni_cache->map, "size", "()I");
+  if (bsg_global_jni_cache->map_size == NULL) {
+    report_contents(bsg_global_jni_cache->map_size, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->map_get =
+      bsg_safe_get_method_id(env, bsg_global_jni_cache->map, "get",
+                             "(Ljava/lang/Object;)Ljava/lang/Object;");
+  if (bsg_global_jni_cache->map_get == NULL) {
+    report_contents(bsg_global_jni_cache->map_get, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ni_get_app =
+      bsg_safe_get_static_method_id(env, bsg_global_jni_cache->native_interface,
+                                    "getApp", "()Ljava/util/Map;");
+  if (bsg_global_jni_cache->ni_get_app == NULL) {
+    report_contents(bsg_global_jni_cache->ni_get_app, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ni_get_device =
+      bsg_safe_get_static_method_id(env, bsg_global_jni_cache->native_interface,
+                                    "getDevice", "()Ljava/util/Map;");
+  if (bsg_global_jni_cache->ni_get_device == NULL) {
+    report_contents(bsg_global_jni_cache->ni_get_device, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ni_get_user =
+      bsg_safe_get_static_method_id(env, bsg_global_jni_cache->native_interface,
+                                    "getUser", "()Ljava/util/Map;");
+  if (bsg_global_jni_cache->ni_get_user == NULL) {
+    report_contents(bsg_global_jni_cache->ni_get_user, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ni_set_user = bsg_safe_get_static_method_id(
+      env, bsg_global_jni_cache->native_interface, "setUser", "([B[B[B)V");
+  if (bsg_global_jni_cache->ni_set_user == NULL) {
+    report_contents(bsg_global_jni_cache->ni_set_user, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ni_get_metadata =
+      bsg_safe_get_static_method_id(env, bsg_global_jni_cache->native_interface,
+                                    "getMetadata", "()Ljava/util/Map;");
+  if (bsg_global_jni_cache->ni_get_metadata == NULL) {
+    report_contents(bsg_global_jni_cache->ni_get_metadata, "%p");
+    goto failed;
+  }
+
+  // lookup NativeInterface.getContext()
+  bsg_global_jni_cache->ni_get_context =
+      bsg_safe_get_static_method_id(env, bsg_global_jni_cache->native_interface,
+                                    "getContext", "()Ljava/lang/String;");
+  if (bsg_global_jni_cache->ni_get_context == NULL) {
+    report_contents(bsg_global_jni_cache->ni_get_context, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ni_notify = bsg_safe_get_static_method_id(
+      env, bsg_global_jni_cache->native_interface, "notify",
+      "([B[BLcom/bugsnag/android/Severity;[Ljava/lang/StackTraceElement;)V");
+  if (bsg_global_jni_cache->ni_notify == NULL) {
+    report_contents(bsg_global_jni_cache->ni_notify, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ni_deliver_report = bsg_safe_get_static_method_id(
+      env, bsg_global_jni_cache->native_interface, "deliverReport",
+      "([B[BLjava/lang/String;Z)V");
+  if (bsg_global_jni_cache->ni_deliver_report == NULL) {
+    report_contents(bsg_global_jni_cache->ni_deliver_report, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ni_leave_breadcrumb = bsg_safe_get_static_method_id(
+      env, bsg_global_jni_cache->native_interface, "leaveBreadcrumb",
+      "([BLcom/bugsnag/android/BreadcrumbType;)V");
+  if (bsg_global_jni_cache->ni_leave_breadcrumb == NULL) {
+    report_contents(bsg_global_jni_cache->ni_leave_breadcrumb, "%p");
+    goto failed;
+  }
+
+  bsg_global_jni_cache->ste_constructor = bsg_safe_get_method_id(
+      env, bsg_global_jni_cache->stack_trace_element, "<init>",
+      "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;I)V");
+  if (bsg_global_jni_cache->ste_constructor == NULL) {
+    report_contents(bsg_global_jni_cache->ste_constructor, "%p");
+    goto failed;
+  }
+
+  return true;
+
+failed:
+  return false;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
@@ -1,0 +1,71 @@
+//
+// Created by Karl Stenerud on 03.01.22.
+//
+
+#ifndef BUGSNAG_ANDROID_JNI_CACHE_H
+#define BUGSNAG_ANDROID_JNI_CACHE_H
+
+#include <jni.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  jclass hash_map;
+  jclass map;
+  jclass arraylist;
+  jclass integer;
+  jclass boolean;
+  jclass metadata;
+  jclass native_interface;
+  jclass long_class;
+  jclass float_class;
+  jclass number;
+  jclass string;
+  jclass stack_trace_element;
+  jclass severity;
+  jclass breadcrumb_type;
+  jmethodID integer_int_value;
+  jmethodID long_long_value;
+  jmethodID float_float_value;
+  jmethodID boolean_bool_value;
+  jmethodID number_double_value;
+  jmethodID hash_map_get;
+  jmethodID hash_map_size;
+  jmethodID hash_map_key_set;
+  jmethodID map_get;
+  jmethodID map_size;
+  jmethodID map_key_set;
+  jmethodID arraylist_init_with_obj;
+  jmethodID arraylist_get;
+  jmethodID ni_get_app;
+  jmethodID ni_get_device;
+  jmethodID ni_get_user;
+  jmethodID ni_set_user;
+  jmethodID ni_get_metadata;
+  jmethodID ni_get_context;
+  jmethodID ni_notify;
+  jmethodID ni_leave_breadcrumb;
+  jmethodID ni_deliver_report;
+  jmethodID ste_constructor;
+} bsg_jni_cache;
+
+// Always check for null before using this!
+extern bsg_jni_cache *bsg_global_jni_cache;
+
+/**
+ * Refresh all references in the JNI cache.
+ * This MUST be called on every Java-to-native call!
+ *
+ * @param env The JNI env
+ * @return false if an error occurs, in which case the cache is unusable.
+ */
+bool bsg_jni_cache_refresh(JNIEnv *env);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BUGSNAG_ANDROID_JNI_CACHE_H

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -1,451 +1,216 @@
 #include "metadata.h"
+#include "jni_cache.h"
 #include "safejni.h"
 #include "utils/string.h"
 #include <malloc.h>
 #include <string.h>
 
-typedef struct {
-  jclass hash_map;
-  jclass map;
-  jclass arraylist;
-  jclass integer;
-  jclass boolean;
-  jclass metadata;
-  jclass native_interface;
-  jclass long_class;
-  jclass float_class;
-  jclass number;
-  jclass string;
-  jmethodID integer_int_value;
-  jmethodID long_long_value;
-  jmethodID float_float_value;
-  jmethodID boolean_bool_value;
-  jmethodID number_double_value;
-  jmethodID hash_map_get;
-  jmethodID hash_map_size;
-  jmethodID hash_map_key_set;
-  jmethodID map_get;
-  jmethodID map_size;
-  jmethodID map_key_set;
-  jmethodID arraylist_init_with_obj;
-  jmethodID arraylist_get;
-  jmethodID get_app_data;
-  jmethodID get_device_data;
-  jmethodID get_user_data;
-  jmethodID get_breadcrumbs;
-  jmethodID get_metadata;
-  jmethodID get_context;
-} bsg_jni_cache;
+static jobject get_map_value_obj(JNIEnv *env, jobject map, const char *_key) {
+  jobject obj = NULL;
+  jstring key = NULL;
 
-void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
-                                 bsg_jni_cache *jni_cache, const char *section,
-                                 const char *name, jobject _value);
-
-/**
- * Creates a cache of JNI methods/classes that are commonly used.
- *
- * Class and method objects can be kept safely since they aren't moved or
- * removed from the JVM - care should be taken not to load objects as local
- * references here.
- */
-bsg_jni_cache *bsg_populate_jni_cache(JNIEnv *env) {
-  bsg_jni_cache *jni_cache = calloc(1, sizeof(bsg_jni_cache));
-
-  // lookup java/lang/Integer
-  jni_cache->integer = bsg_safe_find_class(env, "java/lang/Integer");
-  if (jni_cache->integer == NULL) {
-    return NULL;
+  if (bsg_global_jni_cache == NULL) {
+    goto exit;
   }
 
-  // lookup java/lang/Boolean
-  jni_cache->boolean = bsg_safe_find_class(env, "java/lang/Boolean");
-  if (jni_cache->boolean == NULL) {
-    return NULL;
-  }
-
-  // lookup java/lang/Long
-  jni_cache->long_class = bsg_safe_find_class(env, "java/lang/Long");
-  if (jni_cache->long_class == NULL) {
-    return NULL;
-  }
-
-  // lookup java/lang/Float
-  jni_cache->float_class = bsg_safe_find_class(env, "java/lang/Float");
-  if (jni_cache->float_class == NULL) {
-    return NULL;
-  }
-
-  // lookup java/lang/Number
-  jni_cache->number = bsg_safe_find_class(env, "java/lang/Number");
-  if (jni_cache->number == NULL) {
-    return NULL;
-  }
-
-  // lookup java/lang/String
-  jni_cache->string = bsg_safe_find_class(env, "java/lang/String");
-  if (jni_cache->string == NULL) {
-    return NULL;
-  }
-
-  // lookup Integer.intValue()
-  jni_cache->integer_int_value =
-      bsg_safe_get_method_id(env, jni_cache->integer, "intValue", "()I");
-  if (jni_cache->integer_int_value == NULL) {
-    return NULL;
-  }
-
-  // lookup Integer.floatValue()
-  jni_cache->float_float_value =
-      bsg_safe_get_method_id(env, jni_cache->float_class, "floatValue", "()F");
-  if (jni_cache->float_float_value == NULL) {
-    return NULL;
-  }
-
-  // lookup Double.doubleValue()
-  jni_cache->number_double_value =
-      bsg_safe_get_method_id(env, jni_cache->number, "doubleValue", "()D");
-  if (jni_cache->number_double_value == NULL) {
-    return NULL;
-  }
-
-  // lookup Long.longValue()
-  jni_cache->long_long_value =
-      bsg_safe_get_method_id(env, jni_cache->integer, "longValue", "()J");
-  if (jni_cache->long_long_value == NULL) {
-    return NULL;
-  }
-
-  // lookup Boolean.booleanValue()
-  jni_cache->boolean_bool_value =
-      bsg_safe_get_method_id(env, jni_cache->boolean, "booleanValue", "()Z");
-  if (jni_cache->boolean_bool_value == NULL) {
-    return NULL;
-  }
-
-  // lookup java/util/ArrayList
-  jni_cache->arraylist = bsg_safe_find_class(env, "java/util/ArrayList");
-  if (jni_cache->arraylist == NULL) {
-    return NULL;
-  }
-
-  // lookup ArrayList constructor
-  jni_cache->arraylist_init_with_obj = bsg_safe_get_method_id(
-      env, jni_cache->arraylist, "<init>", "(Ljava/util/Collection;)V");
-  if (jni_cache->arraylist_init_with_obj == NULL) {
-    return NULL;
-  }
-
-  // lookup ArrayList.get()
-  jni_cache->arraylist_get = bsg_safe_get_method_id(
-      env, jni_cache->arraylist, "get", "(I)Ljava/lang/Object;");
-  if (jni_cache->arraylist_get == NULL) {
-    return NULL;
-  }
-
-  // lookup java/util/HashMap
-  jni_cache->hash_map = bsg_safe_find_class(env, "java/util/HashMap");
-  if (jni_cache->hash_map == NULL) {
-    return NULL;
-  }
-
-  // lookup java/util/Map
-  jni_cache->map = bsg_safe_find_class(env, "java/util/Map");
-  if (jni_cache->map == NULL) {
-    return NULL;
-  }
-
-  // lookup java/util/Set
-  jni_cache->hash_map_key_set = bsg_safe_get_method_id(
-      env, jni_cache->hash_map, "keySet", "()Ljava/util/Set;");
-  if (jni_cache->hash_map_key_set == NULL) {
-    return NULL;
-  }
-
-  // lookup HashMap.size()
-  jni_cache->hash_map_size =
-      bsg_safe_get_method_id(env, jni_cache->hash_map, "size", "()I");
-  if (jni_cache->hash_map_size == NULL) {
-    return NULL;
-  }
-
-  // lookup HashMap.get()
-  jni_cache->hash_map_get =
-      bsg_safe_get_method_id(env, jni_cache->hash_map, "get",
-                             "(Ljava/lang/Object;)Ljava/lang/Object;");
-  if (jni_cache->hash_map_get == NULL) {
-    return NULL;
-  }
-
-  // lookup Map.keySet()
-  jni_cache->map_key_set = bsg_safe_get_method_id(env, jni_cache->map, "keySet",
-                                                  "()Ljava/util/Set;");
-  if (jni_cache->map_key_set == NULL) {
-    return NULL;
-  }
-
-  // lookup Map.size()
-  jni_cache->map_size =
-      bsg_safe_get_method_id(env, jni_cache->map, "size", "()I");
-  if (jni_cache->map_size == NULL) {
-    return NULL;
-  }
-
-  // lookup Map.get()
-  jni_cache->map_get = bsg_safe_get_method_id(
-      env, jni_cache->map, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
-  if (jni_cache->map_get == NULL) {
-    return NULL;
-  }
-
-  // lookup com/bugsnag/android/NativeInterface
-  jni_cache->native_interface =
-      bsg_safe_find_class(env, "com/bugsnag/android/NativeInterface");
-  if (jni_cache->native_interface == NULL) {
-    return NULL;
-  }
-
-  // lookup NativeInterface.getApp()
-  jni_cache->get_app_data = bsg_safe_get_static_method_id(
-      env, jni_cache->native_interface, "getApp", "()Ljava/util/Map;");
-  if (jni_cache->get_app_data == NULL) {
-    return NULL;
-  }
-
-  // lookup NativeInterface.getDevice()
-  jni_cache->get_device_data = bsg_safe_get_static_method_id(
-      env, jni_cache->native_interface, "getDevice", "()Ljava/util/Map;");
-  if (jni_cache->get_device_data == NULL) {
-    return NULL;
-  }
-
-  // lookup NativeInterface.getUser()
-  jni_cache->get_user_data = bsg_safe_get_static_method_id(
-      env, jni_cache->native_interface, "getUser", "()Ljava/util/Map;");
-  if (jni_cache->get_user_data == NULL) {
-    return NULL;
-  }
-
-  // lookup NativeInterface.getMetadata()
-  jni_cache->get_metadata = bsg_safe_get_static_method_id(
-      env, jni_cache->native_interface, "getMetadata", "()Ljava/util/Map;");
-  if (jni_cache->get_metadata == NULL) {
-    return NULL;
-  }
-
-  // lookup NativeInterface.getContext()
-  jni_cache->get_context = bsg_safe_get_static_method_id(
-      env, jni_cache->native_interface, "getContext", "()Ljava/lang/String;");
-  if (jni_cache->get_context == NULL) {
-    return NULL;
-  }
-  return jni_cache;
-}
-
-jobject bsg_get_map_value_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
-                              jobject map, const char *_key) {
-  // create Java string object for map key
-  jstring key = bsg_safe_new_string_utf(env, _key);
+  key = bsg_safe_new_string_utf(env, _key);
   if (key == NULL) {
-    return NULL;
+    goto exit;
   }
 
-  jobject obj =
-      bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
+  obj = bsg_safe_call_object_method(env, map,
+                                    bsg_global_jni_cache->hash_map_get, key);
+
+exit:
   bsg_safe_delete_local_ref(env, key);
   return obj;
 }
 
-void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
-                               jobject map, const char *_key, char *dest,
-                               int len) {
-  jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
+static void copy_map_value_string(JNIEnv *env, jobject map, const char *_key,
+                                  char *dest, int len) {
+  jobject _value = get_map_value_obj(env, map, _key);
 
-  if (_value != NULL) {
-    const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_value);
-    if (value != NULL) {
-      bsg_strncpy(dest, value, len);
-      bsg_safe_release_string_utf_chars(env, _value, value);
-    }
+  if (_value == NULL) {
+    return;
   }
+
+  const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_value);
+  if (value == NULL) {
+    return;
+  }
+
+  bsg_strncpy(dest, value, len);
+  bsg_safe_release_string_utf_chars(env, _value, value);
+  bsg_safe_delete_local_ref(env, _value);
 }
 
-long bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
-                            const char *_key) {
-  jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
+static long get_map_value_long(JNIEnv *env, jobject map, const char *_key) {
+  jobject _value = NULL;
+  long value = 0;
 
-  if (_value != NULL) {
-    long value = bsg_safe_call_double_method(env, _value,
-                                             jni_cache->number_double_value);
-    bsg_safe_delete_local_ref(env, _value);
-    return value;
-  }
-  return 0;
-}
-
-float bsg_get_map_value_float(JNIEnv *env, bsg_jni_cache *jni_cache,
-                              jobject map, const char *_key) {
-  jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
-
-  if (_value != NULL) {
-    float value =
-        bsg_safe_call_float_method(env, _value, jni_cache->float_float_value);
-    bsg_safe_delete_local_ref(env, _value);
-    return value;
-  }
-  return 0;
-}
-
-int bsg_get_map_value_int(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
-                          const char *_key) {
-  jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
-
-  if (_value != NULL) {
-    jint value =
-        bsg_safe_call_int_method(env, _value, jni_cache->integer_int_value);
-    bsg_safe_delete_local_ref(env, _value);
-    return value;
-  }
-  return 0;
-}
-
-bool bsg_get_map_value_bool(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
-                            const char *_key) {
-  jobject obj = bsg_get_map_value_obj(env, jni_cache, map, _key);
-  return bsg_safe_call_boolean_method(env, obj, jni_cache->boolean_bool_value);
-}
-
-int bsg_populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                  jobject map, bsg_device_info *device) {
-  // create Java string object for map key
-  jstring key = bsg_safe_new_string_utf(env, "cpuAbi");
-  if (key == NULL) {
-    return 0;
-  }
-
-  jobjectArray _value =
-      bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
-  if (_value != NULL) {
-    int count = bsg_safe_get_array_length(env, _value);
-
-    // get the ABI as a Java string and copy it to bsg_device_info
-    for (int i = 0; i < count && i < sizeof(device->cpu_abi); i++) {
-      jstring jabi = bsg_safe_get_object_array_element(env, _value, i);
-      if (jabi == NULL) {
-        break;
-      }
-
-      const char *abi = bsg_safe_get_string_utf_chars(env, jabi);
-      if (abi != NULL) {
-        bsg_strncpy(device->cpu_abi[i].value, abi,
-                    sizeof(device->cpu_abi[i].value));
-        bsg_safe_release_string_utf_chars(env, jabi, abi);
-        device->cpu_abi_count++;
-      }
-    }
-    bsg_safe_delete_local_ref(env, _value);
-    return count;
-  }
-  return 0;
-}
-
-void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
-                                 jobject metadata) {
-  bsg_jni_cache *jni_cache = NULL;
-  jobject keyset = NULL;
-  jobject keylist = NULL;
-
-  if (metadata == NULL) {
-    goto exit;
-  }
-  jni_cache = bsg_populate_jni_cache(env);
-  if (jni_cache == NULL) {
+  if (bsg_global_jni_cache == NULL) {
     goto exit;
   }
 
-  // get size of metadata map
-  jint map_size = bsg_safe_call_int_method(env, metadata, jni_cache->map_size);
-  if (map_size == -1) {
+  _value = get_map_value_obj(env, map, _key);
+  if (_value == NULL) {
     goto exit;
   }
 
-  // create a list of metadata keys
-  keyset = bsg_safe_call_object_method(env, metadata, jni_cache->map_key_set);
-  if (keyset == NULL) {
-    goto exit;
-  }
-  keylist = bsg_safe_new_object(env, jni_cache->arraylist,
-                                jni_cache->arraylist_init_with_obj, keyset);
-  if (keylist == NULL) {
-    goto exit;
-  }
-
-  for (int i = 0; i < map_size; i++) {
-    jstring _key = bsg_safe_call_object_method(
-        env, keylist, jni_cache->arraylist_get, (jint)i);
-    jobject _value =
-        bsg_safe_call_object_method(env, metadata, jni_cache->map_get, _key);
-
-    if (_key == NULL || _value == NULL) {
-      bsg_safe_delete_local_ref(env, _key);
-      bsg_safe_delete_local_ref(env, _value);
-    } else {
-      const char *key = bsg_safe_get_string_utf_chars(env, _key);
-      if (key != NULL) {
-        bsg_populate_metadata_value(env, &crumb->metadata, jni_cache,
-                                    "metaData", key, _value);
-        bsg_safe_release_string_utf_chars(env, _key, key);
-      }
-    }
-  }
-  goto exit;
+  value = bsg_safe_call_double_method(
+      env, _value, bsg_global_jni_cache->number_double_value);
 
 exit:
-  free(jni_cache);
-  bsg_safe_delete_local_ref(env, keyset);
-  bsg_safe_delete_local_ref(env, keylist);
+  bsg_safe_delete_local_ref(env, _value);
+  return value;
 }
 
-void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
-                           bugsnag_event *event) {
+static float get_map_value_float(JNIEnv *env, jobject map, const char *_key) {
+  jobject _value = NULL;
+  float value = 0;
+
+  if (bsg_global_jni_cache == NULL) {
+    goto exit;
+  }
+
+  _value = get_map_value_obj(env, map, _key);
+  if (_value == NULL) {
+    goto exit;
+  }
+
+  value = bsg_safe_call_float_method(env, _value,
+                                     bsg_global_jni_cache->float_float_value);
+
+exit:
+  bsg_safe_delete_local_ref(env, _value);
+  return value;
+}
+
+static int get_map_value_int(JNIEnv *env, jobject map, const char *_key) {
+  jobject _value = NULL;
+  int value = 0;
+
+  if (bsg_global_jni_cache == NULL) {
+    goto exit;
+  }
+
+  _value = get_map_value_obj(env, map, _key);
+  if (_value == NULL) {
+    goto exit;
+  }
+
+  value = bsg_safe_call_int_method(env, _value,
+                                   bsg_global_jni_cache->integer_int_value);
+
+exit:
+  bsg_safe_delete_local_ref(env, _value);
+  return value;
+}
+
+static bool get_map_value_bool(JNIEnv *env, jobject map, const char *_key) {
+  jobject _value = NULL;
+  bool value = 0;
+
+  if (bsg_global_jni_cache == NULL) {
+    goto exit;
+  }
+
+  _value = get_map_value_obj(env, map, _key);
+  if (_value == NULL) {
+    goto exit;
+  }
+
+  value = bsg_safe_call_boolean_method(
+      env, _value, bsg_global_jni_cache->boolean_bool_value);
+
+exit:
+  bsg_safe_delete_local_ref(env, _value);
+  return value;
+}
+
+static int populate_cpu_abi_from_map(JNIEnv *env, jobject map,
+                                     bsg_device_info *device) {
+  jstring key = NULL;
+  jobjectArray _value = NULL;
+  int count = 0;
+
+  if (bsg_global_jni_cache == NULL) {
+    goto exit;
+  }
+
+  key = bsg_safe_new_string_utf(env, "cpuAbi");
+  if (key == NULL) {
+    goto exit;
+  }
+
+  _value = bsg_safe_call_object_method(env, map,
+                                       bsg_global_jni_cache->hash_map_get, key);
+  if (_value == NULL) {
+    goto exit;
+  }
+
+  count = bsg_safe_get_array_length(env, _value);
+
+  // get the ABI as a Java string and copy it to bsg_device_info
+  for (int i = 0; i < count && i < sizeof(device->cpu_abi); i++) {
+    jstring jabi = bsg_safe_get_object_array_element(env, _value, i);
+    if (jabi == NULL) {
+      break;
+    }
+
+    const char *abi = bsg_safe_get_string_utf_chars(env, jabi);
+    if (abi != NULL) {
+      bsg_strncpy(device->cpu_abi[i].value, abi,
+                  sizeof(device->cpu_abi[i].value));
+      bsg_safe_release_string_utf_chars(env, jabi, abi);
+      device->cpu_abi_count++;
+    }
+    bsg_safe_delete_local_ref(env, jabi);
+  }
+
+exit:
+  bsg_safe_delete_local_ref(env, key);
+  bsg_safe_delete_local_ref(env, _value);
+  return count;
+}
+
+static void populate_app_data(JNIEnv *env, bugsnag_event *event) {
+  if (bsg_global_jni_cache == NULL) {
+    return;
+  }
+
   jobject data = bsg_safe_call_static_object_method(
-      env, jni_cache->native_interface, jni_cache->get_app_data);
+      env, bsg_global_jni_cache->native_interface,
+      bsg_global_jni_cache->ni_get_app);
   if (data == NULL) {
     return;
   }
 
-  bsg_copy_map_value_string(env, jni_cache, data, "binaryArch",
-                            event->app.binary_arch,
-                            sizeof(event->app.binary_arch));
-  bsg_copy_map_value_string(env, jni_cache, data, "buildUUID",
-                            event->app.build_uuid,
-                            sizeof(event->app.build_uuid));
-  event->app.duration_ms_offset =
-      bsg_get_map_value_long(env, jni_cache, data, "duration");
+  copy_map_value_string(env, data, "binaryArch", event->app.binary_arch,
+                        sizeof(event->app.binary_arch));
+  copy_map_value_string(env, data, "buildUUID", event->app.build_uuid,
+                        sizeof(event->app.build_uuid));
+  event->app.duration_ms_offset = get_map_value_long(env, data, "duration");
   event->app.duration_in_foreground_ms_offset =
-      bsg_get_map_value_long(env, jni_cache, data, "durationInForeground");
+      get_map_value_long(env, data, "durationInForeground");
 
-  bsg_copy_map_value_string(env, jni_cache, data, "id", event->app.id,
-                            sizeof(event->app.id));
-  event->app.in_foreground =
-      bsg_get_map_value_bool(env, jni_cache, data, "inForeground");
+  copy_map_value_string(env, data, "id", event->app.id, sizeof(event->app.id));
+  event->app.in_foreground = get_map_value_bool(env, data, "inForeground");
   event->app.is_launching = true;
 
   char name[64];
-  bsg_copy_map_value_string(env, jni_cache, data, "name", name, sizeof(name));
+  copy_map_value_string(env, data, "name", name, sizeof(name));
   bugsnag_event_add_metadata_string(event, "app", "name", name);
 
-  bsg_copy_map_value_string(env, jni_cache, data, "releaseStage",
-                            event->app.release_stage,
-                            sizeof(event->app.release_stage));
-  bsg_copy_map_value_string(env, jni_cache, data, "type", event->app.type,
-                            sizeof(event->app.type));
-  bsg_copy_map_value_string(env, jni_cache, data, "version", event->app.version,
-                            sizeof(event->app.version));
-  event->app.version_code =
-      bsg_get_map_value_int(env, jni_cache, data, "versionCode");
+  copy_map_value_string(env, data, "releaseStage", event->app.release_stage,
+                        sizeof(event->app.release_stage));
+  copy_map_value_string(env, data, "type", event->app.type,
+                        sizeof(event->app.type));
+  copy_map_value_string(env, data, "version", event->app.version,
+                        sizeof(event->app.version));
+  event->app.version_code = get_map_value_int(env, data, "versionCode");
 
-  bool restricted =
-      bsg_get_map_value_bool(env, jni_cache, data, "backgroundWorkRestricted");
+  bool restricted = get_map_value_bool(env, data, "backgroundWorkRestricted");
 
   if (restricted) {
     bugsnag_event_add_metadata_bool(event, "app", "backgroundWorkRestricted",
@@ -453,132 +218,133 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   }
 
   char process_name[64];
-  bsg_copy_map_value_string(env, jni_cache, data, "processName", process_name,
-                            sizeof(process_name));
+  copy_map_value_string(env, data, "processName", process_name,
+                        sizeof(process_name));
   bugsnag_event_add_metadata_string(event, "app", "processName", process_name);
 
-  long total_memory =
-      bsg_get_map_value_long(env, jni_cache, data, "memoryLimit");
+  long total_memory = get_map_value_long(env, data, "memoryLimit");
   bugsnag_event_add_metadata_double(event, "app", "memoryLimit",
                                     (double)total_memory);
 
   bsg_safe_delete_local_ref(env, data);
 }
 
-const char *bsg_os_name() { return "android"; }
-
-void populate_device_metadata(JNIEnv *env, bsg_jni_cache *jni_cache,
-                              bugsnag_event *event, void *data) {
+static void populate_device_metadata(JNIEnv *env, bugsnag_event *event,
+                                     void *data) {
   char brand[64];
-  bsg_copy_map_value_string(env, jni_cache, data, "brand", brand,
-                            sizeof(brand));
+  copy_map_value_string(env, data, "brand", brand, sizeof(brand));
   bugsnag_event_add_metadata_string(event, "device", "brand", brand);
 
-  bugsnag_event_add_metadata_double(
-      event, "device", "dpi",
-      bsg_get_map_value_int(env, jni_cache, data, "dpi"));
-  bugsnag_event_add_metadata_bool(
-      event, "device", "emulator",
-      bsg_get_map_value_bool(env, jni_cache, data, "emulator"));
+  bugsnag_event_add_metadata_double(event, "device", "dpi",
+                                    get_map_value_int(env, data, "dpi"));
+  bugsnag_event_add_metadata_bool(event, "device", "emulator",
+                                  get_map_value_bool(env, data, "emulator"));
 
   char location_status[32];
-  bsg_copy_map_value_string(env, jni_cache, data, "locationStatus",
-                            location_status, sizeof(location_status));
+  copy_map_value_string(env, data, "locationStatus", location_status,
+                        sizeof(location_status));
   bugsnag_event_add_metadata_string(event, "device", "locationStatus",
                                     location_status);
 
   char network_access[64];
-  bsg_copy_map_value_string(env, jni_cache, data, "networkAccess",
-                            network_access, sizeof(network_access));
+  copy_map_value_string(env, data, "networkAccess", network_access,
+                        sizeof(network_access));
   bugsnag_event_add_metadata_string(event, "device", "networkAccess",
                                     network_access);
 
   bugsnag_event_add_metadata_double(
       event, "device", "screenDensity",
-      bsg_get_map_value_float(env, jni_cache, data, "screenDensity"));
+      get_map_value_float(env, data, "screenDensity"));
 
   char screen_resolution[32];
-  bsg_copy_map_value_string(env, jni_cache, data, "screenResolution",
-                            screen_resolution, sizeof(screen_resolution));
+  copy_map_value_string(env, data, "screenResolution", screen_resolution,
+                        sizeof(screen_resolution));
   bugsnag_event_add_metadata_string(event, "device", "screenResolution",
                                     screen_resolution);
 }
 
-void bsg_populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
-                              bugsnag_event *event) {
+static void populate_device_data(JNIEnv *env, bugsnag_event *event) {
+  if (bsg_global_jni_cache == NULL) {
+    return;
+  }
+
   jobject data = bsg_safe_call_static_object_method(
-      env, jni_cache->native_interface, jni_cache->get_device_data);
+      env, bsg_global_jni_cache->native_interface,
+      bsg_global_jni_cache->ni_get_device);
   if (data == NULL) {
     return;
   }
 
-  bsg_populate_cpu_abi_from_map(env, jni_cache, data, &event->device);
+  populate_cpu_abi_from_map(env, data, &event->device);
 
-  bsg_copy_map_value_string(env, jni_cache, data, "id", event->device.id,
-                            sizeof(event->device.id));
-  event->device.jailbroken =
-      bsg_get_map_value_bool(env, jni_cache, data, "jailbroken");
+  copy_map_value_string(env, data, "id", event->device.id,
+                        sizeof(event->device.id));
+  event->device.jailbroken = get_map_value_bool(env, data, "jailbroken");
 
-  bsg_copy_map_value_string(env, jni_cache, data, "locale",
-                            event->device.locale, sizeof(event->device.locale));
+  copy_map_value_string(env, data, "locale", event->device.locale,
+                        sizeof(event->device.locale));
 
-  bsg_copy_map_value_string(env, jni_cache, data, "manufacturer",
-                            event->device.manufacturer,
-                            sizeof(event->device.manufacturer));
-  bsg_copy_map_value_string(env, jni_cache, data, "model", event->device.model,
-                            sizeof(event->device.model));
+  copy_map_value_string(env, data, "manufacturer", event->device.manufacturer,
+                        sizeof(event->device.manufacturer));
+  copy_map_value_string(env, data, "model", event->device.model,
+                        sizeof(event->device.model));
 
-  bsg_copy_map_value_string(env, jni_cache, data, "orientation",
-                            event->device.orientation,
-                            sizeof(event->device.orientation));
+  copy_map_value_string(env, data, "orientation", event->device.orientation,
+                        sizeof(event->device.orientation));
   bsg_strncpy(event->device.os_name, bsg_os_name(),
               sizeof(event->device.os_name));
-  bsg_copy_map_value_string(env, jni_cache, data, "osVersion",
-                            event->device.os_version,
-                            sizeof(event->device.os_version));
+  copy_map_value_string(env, data, "osVersion", event->device.os_version,
+                        sizeof(event->device.os_version));
 
-  jobject _runtime_versions =
-      bsg_get_map_value_obj(env, jni_cache, data, "runtimeVersions");
-
+  jobject _runtime_versions = get_map_value_obj(env, data, "runtimeVersions");
   if (_runtime_versions != NULL) {
-    bsg_copy_map_value_string(env, jni_cache, _runtime_versions, "osBuild",
-                              event->device.os_build,
-                              sizeof(event->device.os_build));
+    copy_map_value_string(env, _runtime_versions, "osBuild",
+                          event->device.os_build,
+                          sizeof(event->device.os_build));
 
     char api_level[8];
-    bsg_copy_map_value_string(env, jni_cache, _runtime_versions,
-                              "androidApiLevel", api_level, sizeof(api_level));
+    copy_map_value_string(env, _runtime_versions, "androidApiLevel", api_level,
+                          sizeof(api_level));
     event->device.api_level = strtol(api_level, NULL, 10);
-    bsg_safe_delete_local_ref(env, _runtime_versions);
   }
-  event->device.total_memory =
-      bsg_get_map_value_long(env, jni_cache, data, "totalMemory");
+  event->device.total_memory = get_map_value_long(env, data, "totalMemory");
 
   // add fields to device metadata
-  populate_device_metadata(env, jni_cache, event, data);
+  populate_device_metadata(env, event, data);
+
   bsg_safe_delete_local_ref(env, data);
+  bsg_safe_delete_local_ref(env, _runtime_versions);
 }
 
-void bsg_populate_user_data(JNIEnv *env, bsg_jni_cache *jni_cache,
-                            bugsnag_event *event) {
+static void populate_user_data(JNIEnv *env, bugsnag_event *event) {
+  if (bsg_global_jni_cache == NULL) {
+    return;
+  }
+
   jobject data = bsg_safe_call_static_object_method(
-      env, jni_cache->native_interface, jni_cache->get_user_data);
+      env, bsg_global_jni_cache->native_interface,
+      bsg_global_jni_cache->ni_get_user);
   if (data == NULL) {
     return;
   }
-  bsg_copy_map_value_string(env, jni_cache, data, "id", event->user.id,
-                            sizeof(event->user.id));
-  bsg_copy_map_value_string(env, jni_cache, data, "name", event->user.name,
-                            sizeof(event->user.name));
-  bsg_copy_map_value_string(env, jni_cache, data, "email", event->user.email,
-                            sizeof(event->user.email));
+  copy_map_value_string(env, data, "id", event->user.id,
+                        sizeof(event->user.id));
+  copy_map_value_string(env, data, "name", event->user.name,
+                        sizeof(event->user.name));
+  copy_map_value_string(env, data, "email", event->user.email,
+                        sizeof(event->user.email));
+
   bsg_safe_delete_local_ref(env, data);
 }
 
-void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
-                          bugsnag_event *event) {
+static void populate_context(JNIEnv *env, bugsnag_event *event) {
+  if (bsg_global_jni_cache == NULL) {
+    return;
+  }
+
   jstring _context = bsg_safe_call_static_object_method(
-      env, jni_cache->native_interface, jni_cache->get_context);
+      env, bsg_global_jni_cache->native_interface,
+      bsg_global_jni_cache->ni_get_context);
   if (_context != NULL) {
     const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_context);
     if (value != NULL) {
@@ -588,72 +354,80 @@ void bsg_populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
   } else {
     memset(&event->context, 0, bsg_strlen(event->context));
   }
+
+  bsg_safe_delete_local_ref(env, _context);
 }
 
-void bsg_populate_event(JNIEnv *env, bugsnag_event *event) {
-  bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
-  if (jni_cache == NULL) {
+static void populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
+                                    const char *section, const char *name,
+                                    jobject _value) {
+  if (bsg_global_jni_cache == NULL) {
     return;
   }
-  bsg_populate_context(env, jni_cache, event);
-  bsg_populate_app_data(env, jni_cache, event);
-  bsg_populate_device_data(env, jni_cache, event);
-  bsg_populate_user_data(env, jni_cache, event);
-  free(jni_cache);
-}
 
-void bsg_populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
-                                 bsg_jni_cache *jni_cache, const char *section,
-                                 const char *name, jobject _value) {
-  if (bsg_safe_is_instance_of(env, _value, jni_cache->number)) {
+  if (bsg_safe_is_instance_of(env, _value, bsg_global_jni_cache->number)) {
     // add a double metadata value
-    double value = bsg_safe_call_double_method(env, _value,
-                                               jni_cache->number_double_value);
+    double value = bsg_safe_call_double_method(
+        env, _value, bsg_global_jni_cache->number_double_value);
     bsg_add_metadata_value_double(dst, section, name, value);
-  } else if (bsg_safe_is_instance_of(env, _value, jni_cache->boolean)) {
+  } else if (bsg_safe_is_instance_of(env, _value,
+                                     bsg_global_jni_cache->boolean)) {
     // add a boolean metadata value
-    bool value = bsg_safe_call_boolean_method(env, _value,
-                                              jni_cache->boolean_bool_value);
+    bool value = bsg_safe_call_boolean_method(
+        env, _value, bsg_global_jni_cache->boolean_bool_value);
     bsg_add_metadata_value_bool(dst, section, name, value);
-  } else if (bsg_safe_is_instance_of(env, _value, jni_cache->string)) {
+  } else if (bsg_safe_is_instance_of(env, _value,
+                                     bsg_global_jni_cache->string)) {
     const char *value = bsg_safe_get_string_utf_chars(env, _value);
     if (value != NULL) {
       bsg_add_metadata_value_str(dst, section, name, value);
-      free((char *)value);
     }
   }
 }
 
-void bsg_populate_metadata_obj(JNIEnv *env, bugsnag_metadata *dst,
-                               bsg_jni_cache *jni_cache, jobject section,
-                               jobject section_keylist, int index) {
-  jstring section_key = bsg_safe_call_object_method(
-      env, section_keylist, jni_cache->arraylist_get, (jint)index);
-  if (section_key == NULL) {
-    return;
+static void populate_metadata_obj(JNIEnv *env, bugsnag_metadata *dst,
+                                  jobject section, jobject section_keylist,
+                                  int index) {
+  jstring section_key = NULL;
+  const char *name = NULL;
+  jobject _value = NULL;
+
+  if (bsg_global_jni_cache == NULL) {
+    goto exit;
   }
 
-  jobject _value = bsg_safe_call_object_method(env, section, jni_cache->map_get,
-                                               section_key);
-  const char *name = bsg_safe_get_string_utf_chars(env, section_key);
-  if (name != NULL) {
-    bsg_populate_metadata_value(env, dst, jni_cache, section, name, _value);
-    bsg_safe_release_string_utf_chars(env, section_key, name);
+  section_key = bsg_safe_call_object_method(
+      env, section_keylist, bsg_global_jni_cache->arraylist_get, (jint)index);
+  if (section_key == NULL) {
+    goto exit;
   }
+
+  _value = bsg_safe_call_object_method(
+      env, section, bsg_global_jni_cache->map_get, section_key);
+  name = bsg_safe_get_string_utf_chars(env, section_key);
+  if (name == NULL) {
+    goto exit;
+  }
+
+  populate_metadata_value(env, dst, section, name, _value);
+
+exit:
+  bsg_safe_release_string_utf_chars(env, section_key, name);
+  bsg_safe_delete_local_ref(env, section_key);
   bsg_safe_delete_local_ref(env, _value);
 }
 
-void bsg_populate_metadata_section(JNIEnv *env, bugsnag_metadata *dst,
-                                   jobject metadata, bsg_jni_cache *jni_cache,
-                                   jobject keylist, int i) {
+static void populate_metadata_section(JNIEnv *env, bugsnag_metadata *dst,
+                                      jobject metadata, jobject keylist,
+                                      int i) {
   jstring _key = NULL;
   const char *section = NULL;
   jobject _section = NULL;
   jobject section_keyset = NULL;
   jobject section_keylist = NULL;
 
-  _key = bsg_safe_call_object_method(env, keylist, jni_cache->arraylist_get,
-                                     (jint)i);
+  _key = bsg_safe_call_object_method(
+      env, keylist, bsg_global_jni_cache->arraylist_get, (jint)i);
   if (_key == NULL) {
     goto exit;
   }
@@ -661,85 +435,155 @@ void bsg_populate_metadata_section(JNIEnv *env, bugsnag_metadata *dst,
   if (section == NULL) {
     goto exit;
   }
-  _section =
-      bsg_safe_call_object_method(env, metadata, jni_cache->map_get, _key);
+  _section = bsg_safe_call_object_method(env, metadata,
+                                         bsg_global_jni_cache->map_get, _key);
   if (_section == NULL) {
     goto exit;
   }
   jint section_size =
-      bsg_safe_call_int_method(env, _section, jni_cache->map_size);
+      bsg_safe_call_int_method(env, _section, bsg_global_jni_cache->map_size);
   if (section_size == -1) {
     goto exit;
   }
-  section_keyset =
-      bsg_safe_call_object_method(env, _section, jni_cache->map_key_set);
+  section_keyset = bsg_safe_call_object_method(
+      env, _section, bsg_global_jni_cache->map_key_set);
   if (section_keyset == NULL) {
     goto exit;
   }
 
-  section_keylist =
-      bsg_safe_new_object(env, jni_cache->arraylist,
-                          jni_cache->arraylist_init_with_obj, section_keyset);
+  section_keylist = bsg_safe_new_object(
+      env, bsg_global_jni_cache->arraylist,
+      bsg_global_jni_cache->arraylist_init_with_obj, section_keyset);
   if (section_keylist == NULL) {
     goto exit;
   }
   for (int j = 0; j < section_size; j++) {
-    bsg_populate_metadata_obj(env, dst, jni_cache, _section, section_keylist,
-                              j);
+    populate_metadata_obj(env, dst, _section, section_keylist, j);
   }
   goto exit;
 
 exit:
   bsg_safe_release_string_utf_chars(env, _key, section);
+  bsg_safe_delete_local_ref(env, _key);
+  bsg_safe_delete_local_ref(env, _section);
   bsg_safe_delete_local_ref(env, section_keyset);
   bsg_safe_delete_local_ref(env, section_keylist);
-  bsg_safe_delete_local_ref(env, _section);
 }
+
+// Internal API
 
 void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst,
                            jobject metadata) {
+  jobject _metadata = NULL;
   jobject keyset = NULL;
   jobject keylist = NULL;
-  bsg_jni_cache *jni_cache = bsg_populate_jni_cache(env);
 
-  if (jni_cache == NULL) {
+  if (bsg_global_jni_cache == NULL) {
     goto exit;
   }
   if (metadata == NULL) {
-    metadata = bsg_safe_call_static_object_method(
-        env, jni_cache->native_interface, jni_cache->get_metadata);
+    _metadata = bsg_safe_call_static_object_method(
+        env, bsg_global_jni_cache->native_interface,
+        bsg_global_jni_cache->ni_get_metadata);
+    metadata = _metadata;
   }
-  if (metadata != NULL) {
-    int size = bsg_safe_call_int_method(env, metadata, jni_cache->map_size);
-    if (size == -1) {
-      goto exit;
-    }
 
-    // create a list of metadata keys
-    keyset = bsg_safe_call_static_object_method(env, metadata,
-                                                jni_cache->map_key_set);
-    if (keyset == NULL) {
-      goto exit;
-    }
-    keylist = bsg_safe_new_object(env, jni_cache->arraylist,
-                                  jni_cache->arraylist_init_with_obj, keyset);
-    if (keylist == NULL) {
-      goto exit;
-    }
-
-    for (int i = 0; i < size; i++) {
-      bsg_populate_metadata_section(env, dst, metadata, jni_cache, keylist, i);
-    }
-  } else {
+  if (metadata == NULL) {
     dst->value_count = 0;
+    goto exit;
   }
-  goto exit;
 
-// cleanup
-exit:
-  if (jni_cache != NULL) {
-    free(jni_cache);
+  int size =
+      bsg_safe_call_int_method(env, metadata, bsg_global_jni_cache->map_size);
+  if (size == -1) {
+    goto exit;
   }
+
+  // create a list of metadata keys
+  keyset = bsg_safe_call_static_object_method(
+      env, metadata, bsg_global_jni_cache->map_key_set);
+  if (keyset == NULL) {
+    goto exit;
+  }
+  keylist = bsg_safe_new_object(env, bsg_global_jni_cache->arraylist,
+                                bsg_global_jni_cache->arraylist_init_with_obj,
+                                keyset);
+  if (keylist == NULL) {
+    goto exit;
+  }
+
+  for (int i = 0; i < size; i++) {
+    populate_metadata_section(env, dst, metadata, keylist, i);
+  }
+
+exit:
+  bsg_safe_delete_local_ref(env, _metadata);
   bsg_safe_delete_local_ref(env, keyset);
   bsg_safe_delete_local_ref(env, keylist);
 }
+
+void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
+                                 jobject metadata) {
+  jobject keyset = NULL;
+  jobject keylist = NULL;
+
+  if (metadata == NULL) {
+    goto exit;
+  }
+  if (bsg_global_jni_cache == NULL) {
+    goto exit;
+  }
+
+  // get size of metadata map
+  jint map_size =
+      bsg_safe_call_int_method(env, metadata, bsg_global_jni_cache->map_size);
+  if (map_size == -1) {
+    goto exit;
+  }
+
+  // create a list of metadata keys
+  keyset = bsg_safe_call_object_method(env, metadata,
+                                       bsg_global_jni_cache->map_key_set);
+  if (keyset == NULL) {
+    goto exit;
+  }
+  keylist = bsg_safe_new_object(env, bsg_global_jni_cache->arraylist,
+                                bsg_global_jni_cache->arraylist_init_with_obj,
+                                keyset);
+  if (keylist == NULL) {
+    goto exit;
+  }
+
+  for (int i = 0; i < map_size; i++) {
+    jstring _key = bsg_safe_call_object_method(
+        env, keylist, bsg_global_jni_cache->arraylist_get, (jint)i);
+    jobject _value = bsg_safe_call_object_method(
+        env, metadata, bsg_global_jni_cache->map_get, _key);
+
+    if (_key != NULL && _value != NULL) {
+      const char *key = bsg_safe_get_string_utf_chars(env, _key);
+      if (key != NULL) {
+        populate_metadata_value(env, &crumb->metadata, "metaData", key, _value);
+        bsg_safe_release_string_utf_chars(env, _key, key);
+      }
+    }
+    bsg_safe_delete_local_ref(env, _key);
+    bsg_safe_delete_local_ref(env, _value);
+  }
+
+exit:
+  bsg_safe_delete_local_ref(env, keyset);
+  bsg_safe_delete_local_ref(env, keylist);
+}
+
+void bsg_populate_event(JNIEnv *env, bugsnag_event *event) {
+  if (bsg_global_jni_cache == NULL) {
+    return;
+  }
+  populate_context(env, event);
+  populate_app_data(env, event);
+  populate_device_data(env, event);
+  populate_user_data(env, event);
+}
+
+const char *bsg_os_name() { return "android"; }

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -14,10 +14,7 @@ bool bsg_check_and_clear_exc(JNIEnv *env) {
 }
 
 jclass bsg_safe_find_class(JNIEnv *env, const char *clz_name) {
-  if (env == NULL) {
-    return NULL;
-  }
-  if (clz_name == NULL) {
+  if (env == NULL || clz_name == NULL) {
     return NULL;
   }
   jclass clz = (*env)->FindClass(env, clz_name);
@@ -56,7 +53,7 @@ jstring bsg_safe_new_string_utf(JNIEnv *env, const char *str) {
 
 jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
                                       jmethodID method) {
-  if (env == NULL || _value == NULL) {
+  if (env == NULL || _value == NULL || method == NULL) {
     return false;
   }
   jboolean value = (*env)->CallBooleanMethod(env, _value, method);
@@ -67,7 +64,7 @@ jboolean bsg_safe_call_boolean_method(JNIEnv *env, jobject _value,
 }
 
 jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
-  if (env == NULL || _value == NULL) {
+  if (env == NULL || _value == NULL || method == NULL) {
     return -1;
   }
   jint value = (*env)->CallIntMethod(env, _value, method);
@@ -79,7 +76,7 @@ jint bsg_safe_call_int_method(JNIEnv *env, jobject _value, jmethodID method) {
 
 jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
                                   jmethodID method) {
-  if (env == NULL || _value == NULL) {
+  if (env == NULL || _value == NULL || method == NULL) {
     return -1;
   }
   jfloat value = (*env)->CallFloatMethod(env, _value, method);
@@ -91,7 +88,7 @@ jfloat bsg_safe_call_float_method(JNIEnv *env, jobject _value,
 
 jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
                                     jmethodID method) {
-  if (env == NULL || _value == NULL) {
+  if (env == NULL || _value == NULL || method == NULL) {
     return -1;
   }
   jdouble value = (*env)->CallDoubleMethod(env, _value, method);
@@ -141,7 +138,7 @@ jfieldID bsg_safe_get_static_field_id(JNIEnv *env, jclass clz, const char *name,
 
 jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
                                          jfieldID field) {
-  if (env == NULL || clz == NULL) {
+  if (env == NULL || clz == NULL || field == NULL) {
     return NULL;
   }
   jobject obj = (*env)->GetStaticObjectField(env, clz, field);
@@ -150,7 +147,7 @@ jobject bsg_safe_get_static_object_field(JNIEnv *env, jclass clz,
 }
 
 jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...) {
-  if (env == NULL || clz == NULL) {
+  if (env == NULL || clz == NULL || method == NULL) {
     return NULL;
   }
   va_list args;
@@ -163,7 +160,7 @@ jobject bsg_safe_new_object(JNIEnv *env, jclass clz, jmethodID method, ...) {
 
 jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
                                     jmethodID method, ...) {
-  if (env == NULL || _value == NULL) {
+  if (env == NULL || _value == NULL || method == NULL) {
     return NULL;
   }
   va_list args;
@@ -176,7 +173,7 @@ jobject bsg_safe_call_object_method(JNIEnv *env, jobject _value,
 
 void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
                                       ...) {
-  if (env == NULL || clz == NULL) {
+  if (env == NULL || clz == NULL || method == NULL) {
     return;
   }
   va_list args;
@@ -188,7 +185,7 @@ void bsg_safe_call_static_void_method(JNIEnv *env, jclass clz, jmethodID method,
 
 jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
                                            jmethodID method, ...) {
-  if (env == NULL || clz == NULL) {
+  if (env == NULL || clz == NULL || method == NULL) {
     return NULL;
   }
   va_list args;
@@ -200,54 +197,57 @@ jobject bsg_safe_call_static_object_method(JNIEnv *env, jclass clz,
 }
 
 void bsg_safe_delete_local_ref(JNIEnv *env, jobject obj) {
-  if (env != NULL) {
-    (*env)->DeleteLocalRef(env, obj);
+  if (env == NULL || obj == NULL) {
+    return;
   }
+  (*env)->DeleteLocalRef(env, obj);
 }
 
 const char *bsg_safe_get_string_utf_chars(JNIEnv *env, jstring string) {
-  if (env != NULL && string != NULL) {
-    return (*env)->GetStringUTFChars(env, string, NULL);
+  if (env == NULL || string == NULL) {
+    return NULL;
   }
-  return NULL;
+  return (*env)->GetStringUTFChars(env, string, NULL);
 }
 
 void bsg_safe_release_string_utf_chars(JNIEnv *env, jstring string,
                                        const char *utf) {
-  if (env != NULL && string != NULL && utf != NULL) {
-    (*env)->ReleaseStringUTFChars(env, string, utf);
+  if (env == NULL || string == NULL || utf == NULL) {
+    return;
   }
+  (*env)->ReleaseStringUTFChars(env, string, utf);
 }
 
 void bsg_safe_release_byte_array_elements(JNIEnv *env, jbyteArray array,
                                           jbyte *elems) {
+  if (env == NULL || array == NULL || elems == NULL) {
+    return;
+  }
   // If mode is anything other than JNI_COMMIT, the JNI method will try and call
   // delete[] on the elems parameter, which leads to bad things happening (e.g.
   // aborting will cause it to free, blowing up any custom allocators).
   // Therefore JNI_COMMIT will always be called and the caller should free the
   // elems parameter themselves if necessary.
   // https://android.googlesource.com/platform/art/+/refs/heads/master/runtime/jni/jni_internal.cc#2689
-  if (env != NULL && array != NULL) {
-    (*env)->ReleaseByteArrayElements(env, array, elems, JNI_COMMIT);
-  }
+  (*env)->ReleaseByteArrayElements(env, array, elems, JNI_COMMIT);
 }
 
 jsize bsg_safe_get_array_length(JNIEnv *env, jarray array) {
-  if (env != NULL && array != NULL) {
-    return (*env)->GetArrayLength(env, array);
+  if (env == NULL || array == NULL) {
+    return -1;
   }
-  return -1;
+  return (*env)->GetArrayLength(env, array);
 }
 
 jboolean bsg_safe_is_instance_of(JNIEnv *env, jobject object, jclass clz) {
-  if (env != NULL && clz != NULL) {
-    return (*env)->IsInstanceOf(env, object, clz);
+  if (env == NULL || clz == NULL) {
+    return false;
   }
-  return false;
+  return (*env)->IsInstanceOf(env, object, clz);
 }
 
 jbyteArray bsg_byte_ary_from_string(JNIEnv *env, const char *text) {
-  if (text == NULL) {
+  if (env == NULL || text == NULL) {
     return NULL;
   }
   size_t text_length = bsg_strlen(text);


### PR DESCRIPTION
## Goal

Some Java objects were still leaking, or being removed at the wrong time, and the caches for the JVM handles were getting reloaded on every call (and leaking).

* All class and method handles have been consolidated to jni_cache.c
* Class handles are refreshed on each JNI call because they get deleted when the call returns.
* All JVM handles are now properly disposed of in sub-functions or loops (for top-level JNI functions there's no need since the handles will get reaped as soon as the function returns)
* Functions that weren't being used outside of their files have been marked static.

## Testing

Reran e2e tests, and tested manually.