### PR TITLE
Publish should only have one worker

### DIFF
--- a/scripts/docker-publish.sh
+++ b/scripts/docker-publish.sh
@@ -10,5 +10,5 @@ echo "NEXUS_PASSWORD=$PUBLISH_PASS" >> ~/.gradle/gradle.properties
 echo "nexusUsername=$PUBLISH_USER" >> ~/.gradle/gradle.properties
 echo "nexusPassword=$PUBLISH_PASS" >> ~/.gradle/gradle.properties
 
-/app/gradlew assembleRelease publish && \
+/app/gradlew assembleRelease publish --no-daemon --max-workers=1 && \
  echo "Go to https://oss.sonatype.org/ to release the final artefact. For the full release instructions, please read https://github.com/bugsnag/bugsnag-android/blob/next/docs/RELEASING.md"


### PR DESCRIPTION
## Goal
Avoid creating multiple Sonatype Nexus repositories when publishing releases. Sonatype automatically creates staging repositories based on inbound connections, so using more than one worker can cause multiple staging repositories to be created each one with a subset of the entire release (forcing us to re-run the release).

## Testing
Manually tested locally