### PR TITLE
fix(ndk): support storing large ints for memory and time values 

### DIFF
--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV8Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV8Tests.kt
@@ -50,15 +50,15 @@ class EventMigrationV8Tests : EventMigrationTest() {
             mapOf(
                 "binaryArch" to "mips",
                 "buildUUID" to "1234-9876-adfe",
-                "duration" to 6502L,
-                "durationInForeground" to 12L,
+                "duration" to 81395165021L,
+                "durationInForeground" to 81395165010L,
                 "id" to "com.example.PhotoSnapPlus",
                 "inForeground" to true,
                 "isLaunching" to true,
                 "releaseStage" to "リリース",
                 "type" to "red",
                 "version" to "2.0.52",
-                "versionCode" to 57L
+                "versionCode" to 8139512718L
             ),
             output["app"]
         )
@@ -101,7 +101,7 @@ class EventMigrationV8Tests : EventMigrationTest() {
                     "androidApiLevel" to "32"
                 ),
                 "time" to "2021-12-08T19:43:50Z",
-                "totalMemory" to 3278623L
+                "totalMemory" to 3839512576L
             ),
             output["device"]
         )
@@ -135,8 +135,8 @@ class EventMigrationV8Tests : EventMigrationTest() {
                     "type" to "c",
                     "stacktrace" to listOf(
                         mapOf(
-                            "frameAddress" to 454379L,
-                            "lineNumber" to 0L,
+                            "frameAddress" to 4294967294L,
+                            "lineNumber" to 4194967233L,
                             "loadAddress" to 2367523L,
                             "symbolAddress" to 776L,
                             "method" to "makinBacon",
@@ -144,11 +144,11 @@ class EventMigrationV8Tests : EventMigrationTest() {
                             "isPC" to true
                         ),
                         mapOf(
-                            "frameAddress" to 342334L,
+                            "frameAddress" to 3011142731L,
                             "lineNumber" to 0L,
                             "loadAddress" to 0L,
                             "symbolAddress" to 0L,
-                            "method" to "0x5393e" // test address to method hex
+                            "method" to "0xb37a644b" // test address to method hex
                         )
                     )
                 )

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -50,15 +50,15 @@ typedef struct {
   char type[32];
   char version[32];
   char active_screen[64];
-  int version_code;
+  int64_t version_code;
   char build_uuid[64];
-  time_t duration;
-  time_t duration_in_foreground;
+  int64_t duration;
+  int64_t duration_in_foreground;
   /**
    * The elapsed time in milliseconds between when the system clock starts and
    * when bugsnag-ndk install() is called
    */
-  time_t duration_ms_offset;
+  int64_t duration_ms_offset;
   /**
    * The elapsed time in the foreground in milliseconds between when the app
    * first enters the foreground and when bugsnag-ndk install() is called, if
@@ -89,7 +89,7 @@ typedef struct {
   char os_build[64];
   char os_version[64];
   char os_name[64];
-  long total_memory;
+  int64_t total_memory;
 } bsg_device_info;
 
 /**

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -17,7 +17,7 @@ typedef struct {
   jclass number;
   jclass string;
   jmethodID integer_int_value;
-  jmethodID long_long_value;
+  jmethodID number_long_value;
   jmethodID float_float_value;
   jmethodID boolean_bool_value;
   jmethodID number_double_value;
@@ -108,10 +108,10 @@ bsg_jni_cache *bsg_populate_jni_cache(JNIEnv *env) {
     return NULL;
   }
 
-  // lookup Long.longValue()
-  jni_cache->long_long_value =
-      bsg_safe_get_method_id(env, jni_cache->integer, "longValue", "()J");
-  if (jni_cache->long_long_value == NULL) {
+  // lookup Number.longValue()
+  jni_cache->number_long_value =
+      bsg_safe_get_method_id(env, jni_cache->number, "longValue", "()J");
+  if (jni_cache->number_long_value == NULL) {
     return NULL;
   }
 
@@ -269,13 +269,13 @@ void bsg_copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
   }
 }
 
-long bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
-                            const char *_key) {
+jlong bsg_get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache, jobject map,
+                             const char *_key) {
   jobject _value = bsg_get_map_value_obj(env, jni_cache, map, _key);
 
   if (_value != NULL) {
-    long value = bsg_safe_call_double_method(env, _value,
-                                             jni_cache->number_double_value);
+    jlong value =
+        bsg_safe_call_long_method(env, _value, jni_cache->number_long_value);
     bsg_safe_delete_local_ref(env, _value);
     return value;
   }
@@ -442,7 +442,7 @@ void bsg_populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   bsg_copy_map_value_string(env, jni_cache, data, "version", event->app.version,
                             sizeof(event->app.version));
   event->app.version_code =
-      bsg_get_map_value_int(env, jni_cache, data, "versionCode");
+      bsg_get_map_value_long(env, jni_cache, data, "versionCode");
 
   bool restricted =
       bsg_get_map_value_bool(env, jni_cache, data, "backgroundWorkRestricted");

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -101,6 +101,15 @@ jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
   return value;
 }
 
+jlong bsg_safe_call_long_method(JNIEnv *env, jobject _value, jmethodID method) {
+  if (env == NULL || _value == NULL) {
+    return 0;
+  }
+  jlong value = (*env)->CallLongMethod(env, _value, method);
+  bsg_check_and_clear_exc(env);
+  return value;
+}
+
 jobjectArray bsg_safe_new_object_array(JNIEnv *env, jsize size, jclass clz) {
   if (env == NULL || clz == NULL) {
     return NULL;

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.h
@@ -81,6 +81,14 @@ jdouble bsg_safe_call_double_method(JNIEnv *env, jobject _value,
                                     jmethodID method);
 
 /**
+ * A safe wrapper for the JNI's CallLongMethod. This method checks if an
+ * exception is pending and if so clears it so that execution can continue.
+ * If an exception was thrown this method returns 0 (same as invoking
+ * CallLongMethod directly).
+ */
+jlong bsg_safe_call_long_method(JNIEnv *env, jobject _value, jmethodID method);
+
+/**
  * A safe wrapper for the JNI's NewObjectArray. This method checks if an
  * exception is pending and if so clears it so that execution can continue.
  * The caller is responsible for handling the invalid return value of NULL.

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_reader.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_reader.c
@@ -55,6 +55,9 @@ void migrate_breadcrumb_v1(bugsnag_report_v2 *report_v2,
                            bugsnag_report_v3 *event);
 void migrate_breadcrumb_v2(bugsnag_report_v5 *report_v5, bugsnag_event *event);
 
+void migrate_device_v2(bsg_device_info *output, bsg_device_info_v2 *input);
+void migrate_app_v3(bsg_app_info *output, bsg_app_info_v3 *input);
+
 void bsg_read_feature_flags(int fd, bsg_feature_flag **out_feature_flags,
                             size_t *out_feature_flag_count);
 
@@ -213,7 +216,29 @@ bugsnag_event *bsg_map_v6_to_report(bugsnag_report_v6 *report_v6) {
   bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
 
   if (event != NULL) {
-    memcpy(event, report_v6, sizeof(bugsnag_report_v6));
+    event->notifier = report_v6->notifier;
+    event->metadata = report_v6->metadata;
+    migrate_app_v3(&event->app, &report_v6->app);
+    migrate_device_v2(&event->device, &report_v6->device);
+    event->user = report_v6->user;
+    event->error = report_v6->error;
+    event->crumb_count = report_v6->crumb_count;
+    event->crumb_first_index = report_v6->crumb_first_index;
+    memcpy(&event->breadcrumbs, report_v6->breadcrumbs,
+           sizeof(report_v6->breadcrumbs));
+    memcpy(&event->context, report_v6->context, sizeof(report_v6->context));
+    event->severity = report_v6->severity;
+    memcpy(&event->session_id, report_v6->session_id,
+           sizeof(report_v6->session_id));
+    memcpy(&event->session_start, report_v6->session_start,
+           sizeof(report_v6->session_start));
+    event->handled_events = report_v6->handled_events;
+    event->unhandled_events = report_v6->unhandled_events;
+    memcpy(&event->grouping_hash, report_v6->grouping_hash,
+           sizeof(report_v6->grouping_hash));
+    event->unhandled = report_v6->unhandled;
+    memcpy(&event->api_key, report_v6->api_key, sizeof(report_v6->api_key));
+
     free(report_v6);
   }
   return event;
@@ -226,7 +251,31 @@ bugsnag_event *bsg_map_v7_to_report(bugsnag_report_v7 *report_v7) {
   bugsnag_event *event = calloc(1, sizeof(bugsnag_event));
 
   if (event != NULL) {
-    memcpy(event, report_v7, sizeof(bugsnag_report_v7));
+    event->notifier = report_v7->notifier;
+    event->metadata = report_v7->metadata;
+    migrate_app_v3(&event->app, &report_v7->app);
+    migrate_device_v2(&event->device, &report_v7->device);
+    event->user = report_v7->user;
+    event->error = report_v7->error;
+    event->crumb_count = report_v7->crumb_count;
+    event->crumb_first_index = report_v7->crumb_first_index;
+    memcpy(&event->breadcrumbs, report_v7->breadcrumbs,
+           sizeof(report_v7->breadcrumbs));
+    memcpy(&event->context, report_v7->context, sizeof(report_v7->context));
+    event->severity = report_v7->severity;
+    memcpy(&event->session_id, report_v7->session_id,
+           sizeof(report_v7->session_id));
+    memcpy(&event->session_start, report_v7->session_start,
+           sizeof(report_v7->session_start));
+    event->handled_events = report_v7->handled_events;
+    event->unhandled_events = report_v7->unhandled_events;
+    memcpy(&event->grouping_hash, report_v7->grouping_hash,
+           sizeof(report_v7->grouping_hash));
+    event->unhandled = report_v7->unhandled;
+    memcpy(&event->api_key, report_v7->api_key, sizeof(report_v7->api_key));
+    event->thread_count = report_v7->thread_count;
+    memcpy(&event->threads, report_v7->threads, sizeof(report_v7->threads));
+
     free(report_v7);
   }
   return event;
@@ -240,12 +289,12 @@ bugsnag_event *bsg_map_v5_to_report(bugsnag_report_v5 *report_v5) {
 
   if (event != NULL) {
     event->notifier = report_v5->notifier;
-    event->app = report_v5->app;
-    event->device = report_v5->device;
+    event->metadata = report_v5->metadata;
+    migrate_app_v3(&event->app, &report_v5->app);
+    migrate_device_v2(&event->device, &report_v5->device);
     bsg_strcpy(event->context, report_v5->context);
     event->user = report_v5->user;
     event->error = report_v5->error;
-    event->metadata = report_v5->metadata;
     event->severity = report_v5->severity;
     bsg_strncpy_safe(event->session_id, report_v5->session_id,
                      sizeof(report_v5->session_id));
@@ -273,10 +322,10 @@ bugsnag_event *bsg_map_v4_to_report(bugsnag_report_v4 *report_v4) {
 
   if (event != NULL) {
     event->notifier = report_v4->notifier;
-    event->device = report_v4->device;
+    event->metadata = report_v4->metadata;
+    migrate_device_v2(&event->device, &report_v4->device);
     event->user = report_v4->user;
     event->error = report_v4->error;
-    event->metadata = report_v4->metadata;
     event->crumb_count = report_v4->crumb_count;
     event->crumb_first_index = report_v4->crumb_first_index;
     memcpy(event->breadcrumbs, report_v4->breadcrumbs,
@@ -317,7 +366,7 @@ bugsnag_event *bsg_map_v3_to_report(bugsnag_report_v3 *report_v3) {
     event->crumb_count = report_v3->crumb_count;
     event->crumb_first_index = report_v3->crumb_first_index;
     memcpy(event->breadcrumbs, report_v3->breadcrumbs,
-           sizeof(event->breadcrumbs));
+           sizeof(report_v3->breadcrumbs));
     event->severity = report_v3->severity;
     strcpy(event->session_id, report_v3->session_id);
     strcpy(event->session_start, report_v3->session_start);
@@ -376,6 +425,42 @@ bugsnag_event *bsg_map_v2_to_report(bugsnag_report_v2 *report_v2) {
   return bsg_map_v3_to_report(event);
 }
 
+static void add_metadata_string(bugsnag_metadata *meta, char *section,
+                                char *name, char *value) {
+  if (meta->value_count < BUGSNAG_METADATA_MAX) {
+    bsg_metadata_value *item = &meta->values[meta->value_count];
+    strncpy(item->section, section, sizeof(item->section));
+    strncpy(item->name, name, sizeof(item->name));
+    strncpy(item->char_value, value, sizeof(item->char_value));
+    item->type = BSG_METADATA_CHAR_VALUE;
+    meta->value_count++;
+  }
+}
+
+static void add_metadata_double(bugsnag_metadata *meta, char *section,
+                                char *name, double value) {
+  if (meta->value_count < BUGSNAG_METADATA_MAX) {
+    bsg_metadata_value *item = &meta->values[meta->value_count];
+    strncpy(item->section, section, sizeof(item->section));
+    strncpy(item->name, name, sizeof(item->name));
+    item->type = BSG_METADATA_NUMBER_VALUE;
+    item->double_value = value;
+    meta->value_count++;
+  }
+}
+
+static void add_metadata_bool(bugsnag_metadata *meta, char *section, char *name,
+                              bool value) {
+  if (meta->value_count < BUGSNAG_METADATA_MAX) {
+    bsg_metadata_value *item = &meta->values[meta->value_count];
+    strncpy(item->section, section, sizeof(item->section));
+    strncpy(item->name, name, sizeof(item->name));
+    item->type = BSG_METADATA_BOOL_VALUE;
+    item->bool_value = value;
+    meta->value_count++;
+  }
+}
+
 void migrate_device_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event) {
   bsg_strcpy(event->device.os_name,
              "android"); // os_name was not a field in v2
@@ -402,22 +487,39 @@ void migrate_device_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event) {
   bsg_strcpy(event->device.os_version, report_v2->device.os_version);
 
   // migrate legacy fields to metadata
-  bugsnag_event_add_metadata_bool(event, "device", "emulator",
-                                  report_v2->device.emulator);
-  bugsnag_event_add_metadata_double(event, "device", "dpi",
-                                    report_v2->device.dpi);
-  bugsnag_event_add_metadata_double(event, "device", "screenDensity",
-                                    report_v2->device.screen_density);
-  bugsnag_event_add_metadata_double(event, "device", "batteryLevel",
-                                    report_v2->device.battery_level);
-  bugsnag_event_add_metadata_string(event, "device", "locationStatus",
-                                    report_v2->device.location_status);
-  bugsnag_event_add_metadata_string(event, "device", "brand",
-                                    report_v2->device.brand);
-  bugsnag_event_add_metadata_string(event, "device", "networkAccess",
-                                    report_v2->device.network_access);
-  bugsnag_event_add_metadata_string(event, "device", "screenResolution",
-                                    report_v2->device.screen_resolution);
+  add_metadata_bool(&event->metadata, "device", "emulator",
+                    report_v2->device.emulator);
+  add_metadata_double(&event->metadata, "device", "dpi", report_v2->device.dpi);
+  add_metadata_double(&event->metadata, "device", "screenDensity",
+                      report_v2->device.screen_density);
+  add_metadata_double(&event->metadata, "device", "batteryLevel",
+                      report_v2->device.battery_level);
+  add_metadata_string(&event->metadata, "device", "locationStatus",
+                      report_v2->device.location_status);
+  add_metadata_string(&event->metadata, "device", "brand",
+                      report_v2->device.brand);
+  add_metadata_string(&event->metadata, "device", "networkAccess",
+                      report_v2->device.network_access);
+  add_metadata_string(&event->metadata, "device", "screenResolution",
+                      report_v2->device.screen_resolution);
+}
+
+void migrate_device_v2(bsg_device_info *output, bsg_device_info_v2 *input) {
+  output->api_level = input->api_level;
+  output->cpu_abi_count = input->cpu_abi_count;
+  memcpy(&output->cpu_abi, input->cpu_abi, sizeof(input->cpu_abi));
+  memcpy(&output->orientation, input->orientation, sizeof(input->orientation));
+  output->time = input->time;
+  memcpy(&output->id, input->id, sizeof(input->id));
+  output->jailbroken = input->jailbroken;
+  memcpy(&output->locale, input->locale, sizeof(input->locale));
+  memcpy(&output->manufacturer, input->manufacturer,
+         sizeof(input->manufacturer));
+  memcpy(&output->model, input->model, sizeof(input->model));
+  memcpy(&output->os_build, input->os_build, sizeof(input->os_build));
+  memcpy(&output->os_version, input->os_version, sizeof(input->os_version));
+  memcpy(&output->os_name, input->os_name, sizeof(input->os_name));
+  output->total_memory = input->total_memory;
 }
 
 void bugsnag_report_v3_add_breadcrumb(bugsnag_report_v3 *event,
@@ -549,12 +651,13 @@ void migrate_app_v1(bugsnag_report_v2 *report_v2, bugsnag_report_v3 *event) {
   event->app.in_foreground = report_v2->app.in_foreground;
 
   // migrate legacy fields to metadata
-  bugsnag_event_add_metadata_string(event, "app", "packageName",
-                                    report_v2->app.package_name);
-  bugsnag_event_add_metadata_string(event, "app", "versionName",
-                                    report_v2->app.version_name);
-  bugsnag_event_add_metadata_string(event, "app", "name", report_v2->app.name);
+  add_metadata_string(&event->metadata, "app", "packageName",
+                      report_v2->app.package_name);
+  add_metadata_string(&event->metadata, "app", "versionName",
+                      report_v2->app.version_name);
+  add_metadata_string(&event->metadata, "app", "name", report_v2->app.name);
 }
+
 void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event) {
   bsg_strncpy_safe(event->app.id, report_v4->app.id, sizeof(event->app.id));
   bsg_strncpy_safe(event->app.release_stage, report_v4->app.release_stage,
@@ -579,6 +682,26 @@ void migrate_app_v2(bugsnag_report_v4 *report_v4, bugsnag_event *event) {
 
   // no info available, set to sensible default
   event->app.is_launching = false;
+}
+
+void migrate_app_v3(bsg_app_info *output, bsg_app_info_v3 *input) {
+  memcpy(&output->id, input->id, sizeof(input->id));
+  memcpy(&output->release_stage, input->release_stage,
+         sizeof(input->release_stage));
+  memcpy(&output->type, input->type, sizeof(input->type));
+  memcpy(&output->version, input->version, sizeof(input->version));
+  memcpy(&output->active_screen, input->active_screen,
+         sizeof(input->active_screen));
+  output->version_code = input->version_code;
+  memcpy(&output->build_uuid, input->build_uuid, sizeof(input->build_uuid));
+  output->duration = input->duration;
+  output->duration_in_foreground = input->duration_in_foreground;
+  output->duration_ms_offset = input->duration_ms_offset;
+  output->duration_in_foreground_ms_offset =
+      input->duration_in_foreground_ms_offset;
+  output->in_foreground = input->in_foreground;
+  output->is_launching = input->is_launching;
+  memcpy(&output->binary_arch, input->binary_arch, sizeof(input->binary_arch));
 }
 
 static char *read_string(int fd) {

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/migrate.h
@@ -108,6 +108,23 @@ typedef struct {
 } bsg_app_info_v2;
 
 typedef struct {
+  char id[64];
+  char release_stage[64];
+  char type[32];
+  char version[32];
+  char active_screen[64];
+  int version_code;
+  char build_uuid[64];
+  time_t duration;
+  time_t duration_in_foreground;
+  time_t duration_ms_offset;
+  time_t duration_in_foreground_ms_offset;
+  bool in_foreground;
+  bool is_launching;
+  char binary_arch[32];
+} bsg_app_info_v3;
+
+typedef struct {
   int api_level;
   double battery_level;
   char brand[64];
@@ -130,6 +147,23 @@ typedef struct {
   char screen_resolution[32];
   long total_memory;
 } bsg_device_info_v1;
+
+typedef struct {
+  int api_level;
+  int cpu_abi_count;
+  bsg_cpu_abi cpu_abi[8];
+  char orientation[32];
+  time_t time;
+  char id[64];
+  bool jailbroken;
+  char locale[32];
+  char manufacturer[64];
+  char model[64];
+  char os_build[64];
+  char os_version[64];
+  char os_name[64];
+  long total_memory;
+} bsg_device_info_v2;
 
 typedef struct {
   bsg_library notifier;
@@ -179,7 +213,7 @@ typedef struct {
 typedef struct {
   bsg_notifier notifier;
   bsg_app_info_v2 app;
-  bsg_device_info device;
+  bsg_device_info_v2 device;
   bugsnag_user user;
   bsg_error error;
   bugsnag_metadata metadata;
@@ -204,7 +238,7 @@ typedef struct {
 typedef struct {
   bsg_notifier notifier;
   bsg_app_info_v2 app;
-  bsg_device_info device;
+  bsg_device_info_v2 device;
   bugsnag_user user;
   bsg_error error;
   bugsnag_metadata metadata;
@@ -229,8 +263,8 @@ typedef struct {
 
 typedef struct {
   bsg_notifier notifier;
-  bsg_app_info app;
-  bsg_device_info device;
+  bsg_app_info_v3 app;
+  bsg_device_info_v2 device;
   bugsnag_user user;
   bsg_error error;
   bugsnag_metadata metadata;
@@ -255,8 +289,8 @@ typedef struct {
 
 typedef struct {
   bsg_notifier notifier;
-  bsg_app_info app;
-  bsg_device_info device;
+  bsg_app_info_v3 app;
+  bsg_device_info_v2 device;
   bugsnag_user user;
   bsg_error error;
   bugsnag_metadata metadata;
@@ -281,8 +315,8 @@ typedef struct {
 
 typedef struct {
   bsg_notifier notifier;
-  bsg_app_info app;
-  bsg_device_info device;
+  bsg_app_info_v3 app;
+  bsg_device_info_v2 device;
   bugsnag_user user;
   bsg_error error;
   bugsnag_metadata metadata;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV4Tests.cpp
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV4Tests.cpp
@@ -79,10 +79,31 @@ static void *create_full_event() {
 
   // metadata
   strcpy(event->app.active_screen, "Menu");
-  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
-  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
-  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
-  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.5);
+  event->metadata.value_count = 4;
+  event->metadata.values[0] = {
+    .name = {"weather"},
+    .section = {"app"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"rain"},
+  };
+  event->metadata.values[1] = {
+    .name = {"experimentX"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_BOOL_VALUE,
+    .bool_value = false,
+  };
+  event->metadata.values[2] = {
+    .name = {"subject"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"percy"},
+  };
+  event->metadata.values[3] = {
+    .name = {"counter"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_NUMBER_VALUE,
+    .double_value = 47.5,
+  };
 
   // session info
   event->handled_events = 5;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV5Tests.cpp
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV5Tests.cpp
@@ -80,10 +80,31 @@ static void *create_full_event() {
 
   // metadata
   strcpy(event->app.active_screen, "Menu");
-  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
-  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
-  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
-  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.5);
+  event->metadata.value_count = 4;
+  event->metadata.values[0] = {
+    .name = {"weather"},
+    .section = {"app"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"rain"},
+  };
+  event->metadata.values[1] = {
+    .name = {"experimentX"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_BOOL_VALUE,
+    .bool_value = false,
+  };
+  event->metadata.values[2] = {
+    .name = {"subject"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"percy"},
+  };
+  event->metadata.values[3] = {
+    .name = {"counter"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_NUMBER_VALUE,
+    .double_value = 47.5,
+  };
 
   // session info
   event->handled_events = 5;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV6Tests.cpp
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV6Tests.cpp
@@ -88,10 +88,31 @@ static void *create_full_event() {
 
   // metadata
   strcpy(event->app.active_screen, "Menu");
-  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
-  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
-  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
-  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.5);
+  event->metadata.value_count = 4;
+  event->metadata.values[0] = {
+      .name = {"weather"},
+      .section = {"app"},
+      .type = BSG_METADATA_CHAR_VALUE,
+      .char_value = {"rain"},
+  };
+  event->metadata.values[1] = {
+      .name = {"experimentX"},
+      .section = {"metrics"},
+      .type = BSG_METADATA_BOOL_VALUE,
+      .bool_value = false,
+  };
+  event->metadata.values[2] = {
+      .name = {"subject"},
+      .section = {"metrics"},
+      .type = BSG_METADATA_CHAR_VALUE,
+      .char_value = {"percy"},
+  };
+  event->metadata.values[3] = {
+      .name = {"counter"},
+      .section = {"metrics"},
+      .type = BSG_METADATA_NUMBER_VALUE,
+      .double_value = 47.5,
+  };
 
   // session info
   event->handled_events = 5;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV7Tests.cpp
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV7Tests.cpp
@@ -88,10 +88,31 @@ static void *create_full_event() {
 
   // metadata
   strcpy(event->app.active_screen, "Menu");
-  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
-  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
-  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
-  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.5);
+  event->metadata.value_count = 4;
+  event->metadata.values[0] = {
+    .name = {"weather"},
+    .section = {"app"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"rain"},
+  };
+  event->metadata.values[1] = {
+    .name = {"experimentX"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_BOOL_VALUE,
+    .bool_value = false,
+  };
+  event->metadata.values[2] = {
+    .name = {"subject"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"percy"},
+  };
+  event->metadata.values[3] = {
+    .name = {"counter"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_NUMBER_VALUE,
+    .double_value = 47.5,
+  };
 
   // session info
   event->handled_events = 5;

--- a/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV8Tests.cpp
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV8Tests.cpp
@@ -30,15 +30,15 @@ static void *create_full_event() {
   // app
   strcpy(event->app.binary_arch, "mips");
   strcpy(event->app.build_uuid, "1234-9876-adfe");
-  event->app.duration = 6502;
-  event->app.duration_in_foreground = 12;
+  event->app.duration = 81395165021;
+  event->app.duration_in_foreground = 81395165010;
   event->app.in_foreground = true;
   event->app.is_launching = true;
   strcpy(event->app.id, "com.example.PhotoSnapPlus");
   strcpy(event->app.release_stage, "リリース");
   strcpy(event->app.type, "red");
   strcpy(event->app.version, "2.0.52");
-  event->app.version_code = 57;
+  event->app.version_code = 8139512718;
 
   // breadcrumbs
   auto max = 50;
@@ -72,7 +72,7 @@ static void *create_full_event() {
     event->device.api_level = 32;
   }
   event->device.time = 1638992630;
-  event->device.total_memory = 3278623;
+  event->device.total_memory = 3839512576;
 
   // feature flags
   event->feature_flag_count = 4;
@@ -91,12 +91,14 @@ static void *create_full_event() {
   strcpy(event->error.errorMessage, "POSIX is serious about oncoming traffic");
   strcpy(event->error.type, "C");
   event->error.frame_count = 2;
-  event->error.stacktrace[0].frame_address = 454379;
-  event->error.stacktrace[0].load_address = 2367523;
+  event->error.stacktrace[0].frame_address = (uintptr_t)4294967294;
+  event->error.stacktrace[0].load_address = (uintptr_t)2367523;
   event->error.stacktrace[0].symbol_address = 776;
+  event->error.stacktrace[0].line_number = (uintptr_t)4194967233;
   strcpy(event->error.stacktrace[0].method, "makinBacon");
   strcpy(event->error.stacktrace[0].filename, "lib64/libfoo.so");
-  event->error.stacktrace[1].frame_address = 342334; // will become method hex
+  event->error.stacktrace[1].frame_address =
+      (uintptr_t)3011142731; // will become method hex
 
   // metadata
   strcpy(event->app.active_screen, "Menu");

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_serialize.c
@@ -8,6 +8,7 @@
 #include <featureflags.h>
 #include <utils/serializer.h>
 #include <utils/serializer/migrate.h>
+#include <utils/serializer/event_reader.h>
 
 #define SERIALIZE_TEST_FILE "/data/data/com.bugsnag.android.ndk.test/cache/foo.crash"
 
@@ -124,10 +125,31 @@ void generate_basic_report(bugsnag_event *event) {
   strcpy(event->user.id, "fex");
   event->device.total_memory = 234678100;
   event->app.duration = 6502;
-  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
-  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
-  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
-  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.8);
+  event->metadata.value_count = 4;
+  event->metadata.values[0] = (bsg_metadata_value) {
+    .name = {"weather"},
+    .section = {"app"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"rain"},
+  };
+  event->metadata.values[1] = (bsg_metadata_value) {
+    .name = {"experimentX"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_BOOL_VALUE,
+    .bool_value = false,
+  };
+  event->metadata.values[2] = (bsg_metadata_value) {
+    .name = {"subject"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"percy"},
+  };
+  event->metadata.values[3] = (bsg_metadata_value) {
+    .name = {"counter"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_NUMBER_VALUE,
+    .double_value = 47.8,
+  };
 
   event->crumb_count = 0;
   event->crumb_first_index = 0;
@@ -311,11 +333,31 @@ bugsnag_report_v2 *bsg_generate_report_v2(void) {
   strcpy(event->user.id, "fex");
   event->device.total_memory = 234678100;
   event->app.duration = 6502;
-  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
-  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
-  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
-  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.8);
-
+  event->metadata.value_count = 4;
+  event->metadata.values[0] = (bsg_metadata_value) {
+    .name = {"weather"},
+    .section = {"app"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"rain"},
+  };
+  event->metadata.values[1] = (bsg_metadata_value) {
+    .name = {"experimentX"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_BOOL_VALUE,
+    .bool_value = false,
+  };
+  event->metadata.values[2] = (bsg_metadata_value) {
+    .name = {"subject"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_CHAR_VALUE,
+    .char_value = {"percy"},
+  };
+  event->metadata.values[3] = (bsg_metadata_value) {
+    .name = {"counter"},
+    .section = {"metrics"},
+    .type = BSG_METADATA_NUMBER_VALUE,
+    .double_value = 47.8,
+  };
 
   event->handled_events = 1;
   event->unhandled_events = 1;
@@ -478,7 +520,7 @@ TEST test_report_with_feature_flags_to_file(void) {
 
 TEST test_file_to_report(void) {
   bsg_environment *env = calloc(1, sizeof(bsg_environment));
-  env->report_header.version = 5;
+  env->report_header.version = BSG_MIGRATOR_CURRENT_VERSION;
   env->report_header.big_endian = 1;
   strcpy(env->report_header.os_build, "macOS Sierra");
   bugsnag_event *generated_report = bsg_generate_event();
@@ -574,8 +616,8 @@ TEST test_report_v2_migration(void) {
   ASSERT_STR_EQ("android", event->device.os_name);
 
   // package_name/version_name are migrated to metadata
-  ASSERT_STR_EQ("com.example.foo", event->metadata.values[0].char_value);
-  ASSERT_STR_EQ("2.5", event->metadata.values[1].char_value);
+  ASSERT_STR_EQ("com.example.foo", event->metadata.values[4].char_value);
+  ASSERT_STR_EQ("2.5", event->metadata.values[5].char_value);
 
   // breadcrumbs are migrated correctly
   ASSERT_EQ(2, event->crumb_count);

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -1,3 +1,5 @@
+require 'minitest/spec'
+
 # Waits 5s for an element to be present.  If it isn't assume a system error dialog is
 # blocking its view and dismiss it before trying once more.
 #


### PR DESCRIPTION
## Goal

Added additional changes to event format v8 to expand the size of version code, total memory, and duration values to fit 64-bit integers.

Technically any stored values can now be as large as ~52 bits when delivered as that is how much can fit in a number within the current JSON format (though #1554 mitigates this).

## Changeset

* Fetched values as longs where needed instead of doubles
* Updated storage type of total memory and friends to be `int64_t`
* Added migration for existing app and device contents of events

## Testing

* Updated existing assertions to use big big numbers