### PR TITLE
Propagate discarded exceptions to previously registered handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Discarded unhandled exceptions are propagated to any previously registered handlers
+  [#1584](https://github.com/bugsnag/bugsnag-android/pull/1584)
+
 ## 5.19.0 (2022-01-12)
 
 * New APIs to support forthcoming feature flag and experiment functionality. For more information, please see https://docs.bugsnag.com/product/features-experiments.

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ExceptionHandlerTest.kt
@@ -75,6 +75,19 @@ internal class ExceptionHandlerTest {
     }
 
     @Test
+    fun exceptionPropagatedWhenDiscarded() {
+        val runtimeException = RuntimeException("Whoops")
+        `when`(cfg.shouldDiscardError(runtimeException)).thenReturn(true)
+
+        var propagated = false
+        Thread.setDefaultUncaughtExceptionHandler { _, _ -> propagated = true }
+        val exceptionHandler = ExceptionHandler(client, NoopLogger)
+        val thread = Thread.currentThread()
+        exceptionHandler.uncaughtException(thread, runtimeException)
+        assertTrue(propagated)
+    }
+
+    @Test
     fun uncaughtExceptionOutsideReleaseStages() {
         val exceptionHandler = ExceptionHandler(client, NoopLogger)
         val thread = Thread.currentThread()


### PR DESCRIPTION
## Goal
Fix edge cases where crashing the app in a disabled `releaseStage` in the `Application.onCreate` method caused the app to hang instead of terminating. This appears to be caused by an interaction between the Android Runtime and it's startup behaviour, and the fact that we were not forwarding the uncaught exception to the default `UncaughtExceptionHandler` leaving the application partly running.

## Design
By forwarding uncaught exceptions before discarding them, we allow the default handler to do it's work and the app cleans up and terminates as expected.

## Changeset
Uncaught exceptions that will be discarded by Bugsnag are first forwarded to any previously registered `UncaughtExceptionHandler`.

## Testing
Manually tested the edge case as described in the ticket, and added a unit test for the new `ExceptionHandler` behaviour.