### PR TITLE
Parse FeatureFlags when OnSendCallbacks are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fixed an issue where feature-flags were not always sent if an OnSendCallback was configured
+  [#1589](https://github.com/bugsnag/bugsnag-android/pull/1589)
+
 ## 5.19.1 (2022-01-21)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
@@ -29,6 +29,14 @@ internal class BugsnagEventMapper(
             event.addMetadata(key, value)
         }
 
+        val featureFlagsList: List<Map<String, Any?>> = map.readEntry("featureFlags")
+        featureFlagsList.forEach { featureFlagMap ->
+            event.addFeatureFlag(
+                featureFlagMap.readEntry("featureFlag"),
+                featureFlagMap["variant"] as? String
+            )
+        }
+
         // populate breadcrumbs
         val breadcrumbList: List<MutableMap<String, Any?>> = map.readEntry("breadcrumbs")
         breadcrumbList.mapTo(event.breadcrumbs) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventSerializationTest.kt
@@ -74,6 +74,12 @@ internal class EventSerializationTest {
                         Error(ErrorInternal("WhoopsException", "Whoops", stacktrace), NoopLogger)
                     it.errors.clear()
                     it.errors.add(err)
+                },
+
+                // featureFlags included
+                createEvent {
+                    it.addFeatureFlag("no_variant")
+                    it.addFeatureFlag("flag", "with_variant")
                 }
             )
         }

--- a/bugsnag-android-core/src/test/resources/event_serialization_7.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_7.json
@@ -1,0 +1,45 @@
+{
+  "metaData": {},
+  "severity": "warning",
+  "severityReason": {
+    "type": "handledException",
+    "unhandledOverridden": false
+  },
+  "unhandled": false,
+  "exceptions": [],
+  "projectPackages": [
+    "com.example.foo"
+  ],
+  "user": {},
+  "app": {
+    "type": "android",
+    "versionCode": 0
+  },
+  "device": {
+    "cpuAbi": [],
+    "manufacturer": "samsung",
+    "model": "s7",
+    "osName": "android",
+    "osVersion": "7.1",
+    "runtimeVersions": {
+      "osBuild": "bulldog",
+      "androidApiLevel": "24"
+    },
+    "totalMemory": 109230923452,
+    "freeDisk": 22234423124,
+    "freeMemory": 92340255592,
+    "orientation": "portrait",
+    "time": "1970-01-01T00:00:00.000Z"
+  },
+  "breadcrumbs": [],
+  "threads": [],
+  "featureFlags": [
+    {
+      "featureFlag": "no_variant"
+    },
+    {
+      "featureFlag": "flag",
+      "variant": "with_variant"
+    }
+  ]
+}

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXFeatureFlagNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXFeatureFlagNativeCrashScenario.java
@@ -2,7 +2,9 @@ package com.bugsnag.android.mazerunner.scenarios;
 
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
+import com.bugsnag.android.Event;
 import com.bugsnag.android.FeatureFlag;
+import com.bugsnag.android.OnSendCallback;
 
 import android.content.Context;
 
@@ -18,10 +20,21 @@ public class CXXFeatureFlagNativeCrashScenario extends Scenario {
 
     public native void crash();
 
+    /**
+     */
     public CXXFeatureFlagNativeCrashScenario(@NonNull Configuration config,
                                              @NonNull Context context,
                                              @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
+
+        if (getEventMetadata() != null && getEventMetadata().contains("onsend")) {
+            config.addOnSend(new OnSendCallback() {
+                public boolean onSend(@NonNull Event event) {
+                    event.addFeatureFlag("on_send_callback");
+                    return true;
+                }
+            });
+        }
     }
 
     @Override

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/FeatureFlagScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/FeatureFlagScenario.kt
@@ -8,8 +8,18 @@ import com.bugsnag.android.FeatureFlag
 class FeatureFlagScenario(
     config: Configuration,
     context: Context,
-    eventMetadata: String
+    eventMetadata: String?
 ) : Scenario(config, context, eventMetadata) {
+
+    init {
+        if (eventMetadata?.contains("onsend") == true) {
+            config.addOnSend { event ->
+                event.addFeatureFlag("on_send_callback")
+                return@addOnSend true
+            }
+        }
+    }
+
     override fun startScenario() {
         super.startScenario()
 

--- a/features/full_tests/feature_flags.feature
+++ b/features/full_tests/feature_flags.feature
@@ -42,3 +42,16 @@ Scenario: Sends no feature flags after clearFeatureFlags()
   And the exception "errorClass" equals "java.lang.RuntimeException"
   And the event "unhandled" is false
   And event 0 has no feature flags
+
+Scenario: Sends feature flags added in OnSend Callbacks
+  When I configure the app to run in the "onsend" state
+  And I run "FeatureFlagScenario" and relaunch the app
+  And I configure Bugsnag for "FeatureFlagScenario"
+  Then I wait to receive an error
+  And the exception "errorClass" equals "java.lang.RuntimeException"
+  And the event "unhandled" is false
+  And event 0 contains the feature flag "demo_mode" with no variant
+  And event 0 contains the feature flag "on_send_callback" with no variant
+  And event 0 does not contain the feature flag "should_not_be_reported_1"
+  And event 0 does not contain the feature flag "should_not_be_reported_2"
+  And event 0 does not contain the feature flag "should_not_be_reported_3"

--- a/features/full_tests/native_feature_flags.feature
+++ b/features/full_tests/native_feature_flags.feature
@@ -24,3 +24,19 @@ Feature: Synchronizing feature flags to the native layer
       | SIGILL |
       | SIGTRAP |
     And event 0 has no feature flags
+
+  Scenario: Sends feature flags added in OnSend Callbacks
+    When I run "CXXFeatureFlagNativeCrashScenario"
+    And I relaunch the app after a crash
+    And I configure the app to run in the "onsend" state
+    And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
+    Then I wait to receive an error
+    And the exception "errorClass" equals one of:
+      | SIGILL |
+      | SIGTRAP |
+    And the event "unhandled" is true
+    And event 0 contains the feature flag "demo_mode" with no variant
+    And event 0 contains the feature flag "on_send_callback" with no variant
+    And event 0 does not contain the feature flag "should_not_be_reported_1"
+    And event 0 does not contain the feature flag "should_not_be_reported_2"
+    And event 0 does not contain the feature flag "should_not_be_reported_3"


### PR DESCRIPTION
## Goal
Fix a bug where configuring an `OnSendCallback` would potentially cause feature flags to be dropped from reports. This was caused by `BugsnagEventMapper` not parsing the feature flags list back into the in-memory model, causing them to be dropped from any `Event` that was stored on disk (although only if an `OnSendCallback` was configured).

## Testing
Additional unit tests, and new Mazerunner tests to cover this scenario.