### PR TITLE
Fix React Native events that override the apiKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Fixed an issue where feature-flags were not always sent if an OnSendCallback was configured
   [#1589](https://github.com/bugsnag/bugsnag-android/pull/1589)
 
+* Fix a bug where api keys set in React Native callbacks were ignored
+  [#1592](https://github.com/bugsnag/bugsnag-android/pull/1592)
+
 ## 5.19.1 (2022-01-21)
 
 ### Bug fixes

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/EventDeserializer.kt
@@ -37,6 +37,10 @@ internal class EventDeserializer(
         event.context = map["context"] as String?
         event.groupingHash = map["groupingHash"] as String?
 
+        // apiKey if it exists in the map and is not empty
+        val apiKey = (map["apiKey"] as? String)?.takeIf { it.isNotEmpty() }
+        apiKey?.let { event.apiKey = apiKey }
+
         // app/device
         event.app = appDeserializer.deserialize(map["app"] as MutableMap<String, Any>)
         event.device = deviceDeserializer.deserialize(map["device"] as MutableMap<String, Any>)
@@ -62,7 +66,8 @@ internal class EventDeserializer(
         if (map.containsKey("nativeStack") && event.errors.isNotEmpty()) {
             runCatching {
                 val jsError = event.errors.first()
-                val nativeStackDeserializer = NativeStackDeserializer(projectPackages, client.config)
+                val nativeStackDeserializer =
+                    NativeStackDeserializer(projectPackages, client.config)
                 val nativeStack = nativeStackDeserializer.deserialize(map)
                 jsError.stacktrace.addAll(0, nativeStack)
             }

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -90,6 +90,7 @@ class EventDeserializerTest {
         assertEquals("app-id", event.app.id)
         assertEquals("device-id", event.device.id)
         assertEquals("123", event.getMetadata("custom", "id"))
+        assertEquals(TestData.generateConfig().apiKey, event.apiKey)
     }
 
     @Test
@@ -114,5 +115,31 @@ class EventDeserializerTest {
         val event = EventDeserializer(client, emptyList()).deserialize(map)
         assertFalse(event.isUnhandled)
         assertTrue(TestHooks.getUnhandledOverridden(event))
+    }
+
+    @Test
+    fun deserializeApiKeyOverridden() {
+        val map: MutableMap<String, Any?> = hashMapOf(
+            "apiKey" to "abc123",
+            "severity" to "info",
+            "user" to mapOf("id" to "123"),
+            "unhandled" to false,
+            "severityReason" to hashMapOf(
+                "type" to "unhandledException",
+                "unhandledOverridden" to true
+            ),
+            "breadcrumbs" to listOf(breadcrumbMap()),
+            "threads" to listOf(threadMap()),
+            "errors" to listOf(errorMap()),
+            "metadata" to metadataMap(),
+            "app" to mapOf("id" to "app-id"),
+            "device" to mapOf(
+                "id" to "device-id",
+                "runtimeVersions" to hashMapOf<String, Any>()
+            )
+        )
+
+        val event = EventDeserializer(client, emptyList()).deserialize(map)
+        assertEquals("abc123", event.apiKey)
     }
 }


### PR DESCRIPTION
## Goal
Allow React Native applications to override the `Event.apiKey` in their callbacks.

## Changeset
If the `apiKey` field is present and not empty, override it in the `Event` before delivery to the Android layer

## Testing
Additional unit tests added, and manually tested with the example React Native app.