### PR TITLE
[PLAT-7915] Init JNI cache once, and don't store JNIEnv

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -150,10 +150,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
     jboolean auto_detect_ndk_crashes, jint _api_level, jboolean is32bit,
     jint send_threads) {
 
-  bsg_jni_cache jni_cache;
-
-  if (!bsg_jni_cache_init(env, &jni_cache)) {
-    BUGSNAG_LOG("Could not refresh JNI jni_cache.");
+  if (!bsg_jni_cache_init(env)) {
+    BUGSNAG_LOG("Could not init JNI jni_cache.");
   }
 
   bsg_environment *bugsnag_env = calloc(1, sizeof(bsg_environment));
@@ -191,7 +189,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   }
 
   // populate metadata from Java layer
-  bsg_populate_event(env, &jni_cache, &bugsnag_env->next_event);
+  bsg_populate_event(env, &bugsnag_env->next_event);
   time(&bugsnag_env->start_time);
   if (bugsnag_env->next_event.app.in_foreground) {
     bugsnag_env->foreground_start_time = bugsnag_env->start_time;
@@ -226,8 +224,6 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   static pthread_mutex_t bsg_native_delivery_mutex = PTHREAD_MUTEX_INITIALIZER;
   pthread_mutex_lock(&bsg_native_delivery_mutex);
 
-  bsg_jni_cache jni_cache;
-
   const char *event_path = NULL;
   bugsnag_event *event = NULL;
   jbyteArray jpayload = NULL;
@@ -235,8 +231,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   char *payload = NULL;
   jstring japi_key = NULL;
 
-  if (!bsg_jni_cache_init(env, &jni_cache)) {
-    BUGSNAG_LOG("Could not refresh JNI cache.");
+  if (!bsg_jni_cache->initialized) {
+    BUGSNAG_LOG("deliverReportAtPath failed: JNI cache not initialized.");
     goto exit;
   }
 
@@ -277,9 +273,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_deliverReportAtPath(
   japi_key = bsg_safe_new_string_utf(env, event->api_key);
   if (japi_key != NULL) {
     bool is_launching = event->app.is_launching;
-    bsg_safe_call_static_void_method(env, jni_cache.native_interface,
-                                     jni_cache.ni_deliver_report, jstage,
-                                     jpayload, japi_key, is_launching);
+    bsg_safe_call_static_void_method(
+        env, bsg_jni_cache->NativeInterface,
+        bsg_jni_cache->NativeInterface_deliverReport, jstage, jpayload,
+        japi_key, is_launching);
   }
 
 exit:
@@ -362,10 +359,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
     JNIEnv *env, jobject _this, jstring name_, jstring crumb_type,
     jstring timestamp_, jobject metadata) {
 
-  bsg_jni_cache jni_cache;
-
-  if (!bsg_jni_cache_init(env, &jni_cache)) {
-    BUGSNAG_LOG("Could not refresh JNI cache.");
+  if (!bsg_jni_cache->initialized) {
+    BUGSNAG_LOG("addBreadcrumb failed: JNI cache not initialized.");
     return;
   }
   const char *name = bsg_safe_get_string_utf_chars(env, name_);
@@ -394,7 +389,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
       crumb->type = BSG_CRUMB_MANUAL;
     }
 
-    bsg_populate_crumb_metadata(env, &jni_cache, crumb, metadata);
+    bsg_populate_crumb_metadata(env, crumb, metadata);
     request_env_write_lock();
     bugsnag_event_add_breadcrumb(&bsg_global_env->next_event, crumb);
     release_env_write_lock();
@@ -717,14 +712,12 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateMetadata(
     return;
   }
 
-  bsg_jni_cache jni_cache;
-  if (!bsg_jni_cache_init(env, &jni_cache)) {
-    BUGSNAG_LOG("Could not refresh JNI cache.");
+  if (!bsg_jni_cache->initialized) {
+    BUGSNAG_LOG("updateMetadata failed: JNI cache not initialized.");
     return;
   }
   request_env_write_lock();
-  bsg_populate_metadata(env, &jni_cache, &bsg_global_env->next_event.metadata,
-                        metadata);
+  bsg_populate_metadata(env, &bsg_global_env->next_event.metadata, metadata);
   release_env_write_lock();
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
@@ -13,55 +13,71 @@ extern "C" {
 #endif
 
 typedef struct {
-  jclass hash_map;
-  jclass map;
-  jclass arraylist;
-  jclass integer;
-  jclass boolean;
-  jclass metadata;
-  jclass native_interface;
-  jclass long_class;
-  jclass float_class;
+  bool initialized;
+
+  JavaVM *jvm;
+
+  jclass Boolean;
+  jmethodID Boolean_booleanValue;
+
+  jclass Float;
+  jmethodID Float_floatValue;
+
   jclass number;
-  jclass string;
-  jclass stack_trace_element;
-  jclass severity;
-  jclass breadcrumb_type;
-  jmethodID integer_int_value;
-  jmethodID long_long_value;
-  jmethodID float_float_value;
-  jmethodID boolean_bool_value;
   jmethodID number_double_value;
-  jmethodID hash_map_get;
-  jmethodID hash_map_size;
-  jmethodID hash_map_key_set;
-  jmethodID map_get;
-  jmethodID map_size;
-  jmethodID map_key_set;
-  jmethodID arraylist_init_with_obj;
-  jmethodID arraylist_get;
-  jmethodID ni_get_app;
-  jmethodID ni_get_device;
-  jmethodID ni_get_user;
-  jmethodID ni_set_user;
-  jmethodID ni_get_metadata;
-  jmethodID ni_get_context;
-  jmethodID ni_notify;
-  jmethodID ni_leave_breadcrumb;
-  jmethodID ni_deliver_report;
-  jmethodID ste_constructor;
-} bsg_jni_cache;
+
+  jclass String;
+
+  jclass Map;
+  jmethodID Map_get;
+  jmethodID Map_size;
+  jmethodID Map_keySet;
+
+  jclass HashMap;
+  jmethodID HashMap_get;
+  jmethodID HashMap_size;
+  jmethodID HashMap_keySet;
+
+  jclass ArrayList;
+  jmethodID ArrayList_constructor;
+  jmethodID ArrayList_get;
+
+  jclass NativeInterface;
+  jmethodID NativeInterface_getApp;
+  jmethodID NativeInterface_getDevice;
+  jmethodID NativeInterface_getUser;
+  jmethodID NativeInterface_setUser;
+  jmethodID NativeInterface_getMetadata;
+  jmethodID NativeInterface_getContext;
+  jmethodID NativeInterface_notify;
+  jmethodID NativeInterface_leaveBreadcrumb;
+  jmethodID NativeInterface_deliverReport;
+
+  jclass StackTraceElement;
+  jmethodID StackTraceElement_constructor;
+
+  jclass Severity;
+
+  jclass BreadcrumbType;
+} bsg_jni_cache_t;
+
+extern bsg_jni_cache_t *const bsg_jni_cache;
 
 /**
  * Populate all references in the JNI cache.
- * This MUST be called on every Java-to-native call to ensure that references
- * remain bound to the correct JNIEnv.
  *
  * @param env The JNI env
- * @param cache The cache to refresh
  * @return false if an error occurs, in which case the cache is unusable.
  */
-bool bsg_jni_cache_init(JNIEnv *env, bsg_jni_cache *cache);
+bool bsg_jni_cache_init(JNIEnv *env);
+
+/**
+ * Get the current JNI environment, attaching if necessary.
+ * The environment will be detached automatically on thread termination.
+ * @return The current JNI environment, or NULL in case of JNI error (which will
+ * be logged).
+ */
+JNIEnv *bsg_jni_cache_get_env();
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.c
@@ -5,12 +5,11 @@
 #include <malloc.h>
 #include <string.h>
 
-static jobject get_map_value_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                 jobject map, const char *_key) {
+static jobject get_map_value_obj(JNIEnv *env, jobject map, const char *_key) {
   jobject obj = NULL;
   jstring key = NULL;
 
-  if (jni_cache == NULL) {
+  if (!bsg_jni_cache->initialized) {
     goto exit;
   }
 
@@ -19,17 +18,16 @@ static jobject get_map_value_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
     goto exit;
   }
 
-  obj = bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
+  obj = bsg_safe_call_object_method(env, map, bsg_jni_cache->HashMap_get, key);
 
 exit:
   bsg_safe_delete_local_ref(env, key);
   return obj;
 }
 
-static void copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                  jobject map, const char *_key, char *dest,
-                                  int len) {
-  jobject _value = get_map_value_obj(env, jni_cache, map, _key);
+static void copy_map_value_string(JNIEnv *env, jobject map, const char *_key,
+                                  char *dest, int len) {
+  jobject _value = get_map_value_obj(env, map, _key);
 
   if (_value == NULL) {
     return;
@@ -45,78 +43,76 @@ static void copy_map_value_string(JNIEnv *env, bsg_jni_cache *jni_cache,
   bsg_safe_delete_local_ref(env, _value);
 }
 
-static long get_map_value_long(JNIEnv *env, bsg_jni_cache *jni_cache,
-                               jobject map, const char *_key) {
+static long get_map_value_long(JNIEnv *env, jobject map, const char *_key) {
   jobject _value = NULL;
   long value = 0;
 
-  if (jni_cache == NULL) {
+  if (!bsg_jni_cache->initialized) {
     goto exit;
   }
 
-  _value = get_map_value_obj(env, jni_cache, map, _key);
+  _value = get_map_value_obj(env, map, _key);
   if (_value == NULL) {
     goto exit;
   }
 
-  value =
-      bsg_safe_call_double_method(env, _value, jni_cache->number_double_value);
+  value = bsg_safe_call_double_method(env, _value,
+                                      bsg_jni_cache->number_double_value);
 
 exit:
   bsg_safe_delete_local_ref(env, _value);
   return value;
 }
 
-static float get_map_value_float(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                 jobject map, const char *_key) {
+static float get_map_value_float(JNIEnv *env, jobject map, const char *_key) {
   jobject _value = NULL;
   float value = 0;
 
-  if (jni_cache == NULL) {
+  if (!bsg_jni_cache->initialized) {
     goto exit;
   }
 
-  _value = get_map_value_obj(env, jni_cache, map, _key);
-  if (_value == NULL) {
-    goto exit;
-  }
-
-  value = bsg_safe_call_float_method(env, _value, jni_cache->float_float_value);
-
-exit:
-  bsg_safe_delete_local_ref(env, _value);
-  return value;
-}
-
-static bool get_map_value_bool(JNIEnv *env, bsg_jni_cache *jni_cache,
-                               jobject map, const char *_key) {
-  jobject _value = NULL;
-  bool value = 0;
-
-  if (jni_cache == NULL) {
-    goto exit;
-  }
-
-  _value = get_map_value_obj(env, jni_cache, map, _key);
+  _value = get_map_value_obj(env, map, _key);
   if (_value == NULL) {
     goto exit;
   }
 
   value =
-      bsg_safe_call_boolean_method(env, _value, jni_cache->boolean_bool_value);
+      bsg_safe_call_float_method(env, _value, bsg_jni_cache->Float_floatValue);
 
 exit:
   bsg_safe_delete_local_ref(env, _value);
   return value;
 }
 
-static int populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                     jobject map, bsg_device_info *device) {
+static bool get_map_value_bool(JNIEnv *env, jobject map, const char *_key) {
+  jobject _value = NULL;
+  bool value = 0;
+
+  if (!bsg_jni_cache->initialized) {
+    goto exit;
+  }
+
+  _value = get_map_value_obj(env, map, _key);
+  if (_value == NULL) {
+    goto exit;
+  }
+
+  value = bsg_safe_call_boolean_method(env, _value,
+                                       bsg_jni_cache->Boolean_booleanValue);
+
+exit:
+  bsg_safe_delete_local_ref(env, _value);
+  return value;
+}
+
+static int populate_cpu_abi_from_map(JNIEnv *env, jobject map,
+                                     bsg_device_info *device) {
   jstring key = NULL;
   jobjectArray _value = NULL;
   int count = 0;
 
-  if (jni_cache == NULL) {
+  if (!bsg_jni_cache->initialized) {
     goto exit;
   }
 
@@ -125,7 +121,8 @@ static int populate_cpu_abi_from_map(JNIEnv *env, bsg_jni_cache *jni_cache,
     goto exit;
   }
 
-  _value = bsg_safe_call_object_method(env, map, jni_cache->hash_map_get, key);
+  _value =
+      bsg_safe_call_object_method(env, map, bsg_jni_cache->HashMap_get, key);
   if (_value == NULL) {
     goto exit;
   }
@@ -155,49 +152,43 @@ exit:
   return count;
 }
 
-static void populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
-                              bugsnag_event *event) {
-  if (jni_cache == NULL) {
+static void populate_app_data(JNIEnv *env, bugsnag_event *event) {
+  if (!bsg_jni_cache->initialized) {
     return;
   }
 
-  jobject data = bsg_safe_call_static_object_method(
-      env, jni_cache->native_interface, jni_cache->ni_get_app);
+  jobject data =
+      bsg_safe_call_static_object_method(env, bsg_jni_cache->NativeInterface,
+                                         bsg_jni_cache->NativeInterface_getApp);
   if (data == NULL) {
     return;
   }
 
-  copy_map_value_string(env, jni_cache, data, "binaryArch",
-                        event->app.binary_arch, sizeof(event->app.binary_arch));
-  copy_map_value_string(env, jni_cache, data, "buildUUID",
-                        event->app.build_uuid, sizeof(event->app.build_uuid));
-  event->app.duration_ms_offset =
-      get_map_value_long(env, jni_cache, data, "duration");
+  copy_map_value_string(env, data, "binaryArch", event->app.binary_arch,
+                        sizeof(event->app.binary_arch));
+  copy_map_value_string(env, data, "buildUUID", event->app.build_uuid,
+                        sizeof(event->app.build_uuid));
+  event->app.duration_ms_offset = get_map_value_long(env, data, "duration");
   event->app.duration_in_foreground_ms_offset =
-      get_map_value_long(env, jni_cache, data, "durationInForeground");
+      get_map_value_long(env, data, "durationInForeground");
 
-  copy_map_value_string(env, jni_cache, data, "id", event->app.id,
-                        sizeof(event->app.id));
-  event->app.in_foreground =
-      get_map_value_bool(env, jni_cache, data, "inForeground");
+  copy_map_value_string(env, data, "id", event->app.id, sizeof(event->app.id));
+  event->app.in_foreground = get_map_value_bool(env, data, "inForeground");
   event->app.is_launching = true;
 
   char name[64];
-  copy_map_value_string(env, jni_cache, data, "name", name, sizeof(name));
+  copy_map_value_string(env, data, "name", name, sizeof(name));
   bugsnag_event_add_metadata_string(event, "app", "name", name);
 
-  copy_map_value_string(env, jni_cache, data, "releaseStage",
-                        event->app.release_stage,
+  copy_map_value_string(env, data, "releaseStage", event->app.release_stage,
                         sizeof(event->app.release_stage));
-  copy_map_value_string(env, jni_cache, data, "type", event->app.type,
+  copy_map_value_string(env, data, "type", event->app.type,
                         sizeof(event->app.type));
-  copy_map_value_string(env, jni_cache, data, "version", event->app.version,
+  copy_map_value_string(env, data, "version", event->app.version,
                         sizeof(event->app.version));
-  event->app.version_code =
-      get_map_value_long(env, jni_cache, data, "versionCode");
+  event->app.version_code = get_map_value_long(env, data, "versionCode");
 
-  bool restricted =
-      get_map_value_bool(env, jni_cache, data, "backgroundWorkRestricted");
+  bool restricted = get_map_value_bool(env, data, "backgroundWorkRestricted");
 
   if (restricted) {
     bugsnag_event_add_metadata_bool(event, "app", "backgroundWorkRestricted",
@@ -205,140 +196,133 @@ static void populate_app_data(JNIEnv *env, bsg_jni_cache *jni_cache,
   }
 
   char process_name[64];
-  copy_map_value_string(env, jni_cache, data, "processName", process_name,
+  copy_map_value_string(env, data, "processName", process_name,
                         sizeof(process_name));
   bugsnag_event_add_metadata_string(event, "app", "processName", process_name);
 
-  long total_memory = get_map_value_long(env, jni_cache, data, "memoryLimit");
+  long total_memory = get_map_value_long(env, data, "memoryLimit");
   bugsnag_event_add_metadata_double(event, "app", "memoryLimit",
                                     (double)total_memory);
 
   bsg_safe_delete_local_ref(env, data);
 }
 
-static void populate_device_metadata(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                     bugsnag_event *event, void *data) {
+static void populate_device_metadata(JNIEnv *env, bugsnag_event *event,
+                                     void *data) {
   char brand[64];
-  copy_map_value_string(env, jni_cache, data, "brand", brand, sizeof(brand));
+  copy_map_value_string(env, data, "brand", brand, sizeof(brand));
   bugsnag_event_add_metadata_string(event, "device", "brand", brand);
 
-  bugsnag_event_add_metadata_double(
-      event, "device", "dpi", get_map_value_long(env, jni_cache, data, "dpi"));
-  bugsnag_event_add_metadata_bool(
-      event, "device", "emulator",
-      get_map_value_bool(env, jni_cache, data, "emulator"));
+  bugsnag_event_add_metadata_double(event, "device", "dpi",
+                                    get_map_value_long(env, data, "dpi"));
+  bugsnag_event_add_metadata_bool(event, "device", "emulator",
+                                  get_map_value_bool(env, data, "emulator"));
 
   char location_status[32];
-  copy_map_value_string(env, jni_cache, data, "locationStatus", location_status,
+  copy_map_value_string(env, data, "locationStatus", location_status,
                         sizeof(location_status));
   bugsnag_event_add_metadata_string(event, "device", "locationStatus",
                                     location_status);
 
   char network_access[64];
-  copy_map_value_string(env, jni_cache, data, "networkAccess", network_access,
+  copy_map_value_string(env, data, "networkAccess", network_access,
                         sizeof(network_access));
   bugsnag_event_add_metadata_string(event, "device", "networkAccess",
                                     network_access);
 
   bugsnag_event_add_metadata_double(
       event, "device", "screenDensity",
-      get_map_value_float(env, jni_cache, data, "screenDensity"));
+      get_map_value_float(env, data, "screenDensity"));
 
   char screen_resolution[32];
-  copy_map_value_string(env, jni_cache, data, "screenResolution",
-                        screen_resolution, sizeof(screen_resolution));
+  copy_map_value_string(env, data, "screenResolution", screen_resolution,
+                        sizeof(screen_resolution));
   bugsnag_event_add_metadata_string(event, "device", "screenResolution",
                                     screen_resolution);
 }
 
-static void populate_device_data(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                 bugsnag_event *event) {
-  if (jni_cache == NULL) {
+static void populate_device_data(JNIEnv *env, bugsnag_event *event) {
+  if (!bsg_jni_cache->initialized) {
     return;
   }
 
   jobject data = bsg_safe_call_static_object_method(
-      env, jni_cache->native_interface, jni_cache->ni_get_device);
+      env, bsg_jni_cache->NativeInterface,
+      bsg_jni_cache->NativeInterface_getDevice);
   if (data == NULL) {
     return;
   }
 
-  populate_cpu_abi_from_map(env, jni_cache, data, &event->device);
+  populate_cpu_abi_from_map(env, data, &event->device);
 
-  copy_map_value_string(env, jni_cache, data, "id", event->device.id,
+  copy_map_value_string(env, data, "id", event->device.id,
                         sizeof(event->device.id));
-  event->device.jailbroken =
-      get_map_value_bool(env, jni_cache, data, "jailbroken");
+  event->device.jailbroken = get_map_value_bool(env, data, "jailbroken");
 
-  copy_map_value_string(env, jni_cache, data, "locale", event->device.locale,
+  copy_map_value_string(env, data, "locale", event->device.locale,
                         sizeof(event->device.locale));
 
-  copy_map_value_string(env, jni_cache, data, "manufacturer",
-                        event->device.manufacturer,
+  copy_map_value_string(env, data, "manufacturer", event->device.manufacturer,
                         sizeof(event->device.manufacturer));
-  copy_map_value_string(env, jni_cache, data, "model", event->device.model,
+  copy_map_value_string(env, data, "model", event->device.model,
                         sizeof(event->device.model));
 
-  copy_map_value_string(env, jni_cache, data, "orientation",
-                        event->device.orientation,
+  copy_map_value_string(env, data, "orientation", event->device.orientation,
                         sizeof(event->device.orientation));
   bsg_strncpy(event->device.os_name, bsg_os_name(),
               sizeof(event->device.os_name));
-  copy_map_value_string(env, jni_cache, data, "osVersion",
-                        event->device.os_version,
+  copy_map_value_string(env, data, "osVersion", event->device.os_version,
                         sizeof(event->device.os_version));
 
-  jobject _runtime_versions =
-      get_map_value_obj(env, jni_cache, data, "runtimeVersions");
+  jobject _runtime_versions = get_map_value_obj(env, data, "runtimeVersions");
   if (_runtime_versions != NULL) {
-    copy_map_value_string(env, jni_cache, _runtime_versions, "osBuild",
+    copy_map_value_string(env, _runtime_versions, "osBuild",
                           event->device.os_build,
                           sizeof(event->device.os_build));
 
     char api_level[8];
-    copy_map_value_string(env, jni_cache, _runtime_versions, "androidApiLevel",
-                          api_level, sizeof(api_level));
+    copy_map_value_string(env, _runtime_versions, "androidApiLevel", api_level,
+                          sizeof(api_level));
     event->device.api_level = strtol(api_level, NULL, 10);
   }
-  event->device.total_memory =
-      get_map_value_long(env, jni_cache, data, "totalMemory");
+  event->device.total_memory = get_map_value_long(env, data, "totalMemory");
 
   // add fields to device metadata
-  populate_device_metadata(env, jni_cache, event, data);
+  populate_device_metadata(env, event, data);
 
   bsg_safe_delete_local_ref(env, data);
   bsg_safe_delete_local_ref(env, _runtime_versions);
 }
 
-static void populate_user_data(JNIEnv *env, bsg_jni_cache *jni_cache,
-                               bugsnag_event *event) {
-  if (jni_cache == NULL) {
+static void populate_user_data(JNIEnv *env, bugsnag_event *event) {
+  if (!bsg_jni_cache->initialized) {
     return;
   }
 
   jobject data = bsg_safe_call_static_object_method(
-      env, jni_cache->native_interface, jni_cache->ni_get_user);
+      env, bsg_jni_cache->NativeInterface,
+      bsg_jni_cache->NativeInterface_getUser);
   if (data == NULL) {
     return;
   }
-  copy_map_value_string(env, jni_cache, data, "id", event->user.id,
+  copy_map_value_string(env, data, "id", event->user.id,
                         sizeof(event->user.id));
-  copy_map_value_string(env, jni_cache, data, "name", event->user.name,
+  copy_map_value_string(env, data, "name", event->user.name,
                         sizeof(event->user.name));
-  copy_map_value_string(env, jni_cache, data, "email", event->user.email,
+  copy_map_value_string(env, data, "email", event->user.email,
                         sizeof(event->user.email));
 
   bsg_safe_delete_local_ref(env, data);
 }
 
-static void populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
-                             bugsnag_event *event) {
-  if (jni_cache == NULL) {
+static void populate_context(JNIEnv *env, bugsnag_event *event) {
+  if (!bsg_jni_cache->initialized) {
     return;
   }
 
   jstring _context = bsg_safe_call_static_object_method(
-      env, jni_cache->native_interface, jni_cache->ni_get_context);
+      env, bsg_jni_cache->NativeInterface,
+      bsg_jni_cache->NativeInterface_getContext);
   if (_context != NULL) {
     const char *value = bsg_safe_get_string_utf_chars(env, (jstring)_context);
     if (value != NULL) {
@@ -352,24 +336,24 @@ static void populate_context(JNIEnv *env, bsg_jni_cache *jni_cache,
   bsg_safe_delete_local_ref(env, _context);
 }
 
-static void populate_metadata_value(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                    bugsnag_metadata *dst, const char *section,
-                                    const char *name, jobject _value) {
-  if (jni_cache == NULL) {
+static void populate_metadata_value(JNIEnv *env, bugsnag_metadata *dst,
+                                    const char *section, const char *name,
+                                    jobject _value) {
+  if (!bsg_jni_cache->initialized) {
     return;
   }
 
-  if (bsg_safe_is_instance_of(env, _value, jni_cache->number)) {
+  if (bsg_safe_is_instance_of(env, _value, bsg_jni_cache->number)) {
     // add a double metadata value
-    double value = bsg_safe_call_double_method(env, _value,
-                                               jni_cache->number_double_value);
+    double value = bsg_safe_call_double_method(
+        env, _value, bsg_jni_cache->number_double_value);
     bsg_add_metadata_value_double(dst, section, name, value);
-  } else if (bsg_safe_is_instance_of(env, _value, jni_cache->boolean)) {
+  } else if (bsg_safe_is_instance_of(env, _value, bsg_jni_cache->Boolean)) {
     // add a boolean metadata value
-    bool value = bsg_safe_call_boolean_method(env, _value,
-                                              jni_cache->boolean_bool_value);
+    bool value = bsg_safe_call_boolean_method(
+        env, _value, bsg_jni_cache->Boolean_booleanValue);
     bsg_add_metadata_value_bool(dst, section, name, value);
-  } else if (bsg_safe_is_instance_of(env, _value, jni_cache->string)) {
+  } else if (bsg_safe_is_instance_of(env, _value, bsg_jni_cache->String)) {
     const char *value = bsg_safe_get_string_utf_chars(env, _value);
     if (value != NULL) {
       bsg_add_metadata_value_str(dst, section, name, value);
@@ -377,31 +361,31 @@ static void populate_metadata_value(JNIEnv *env, bsg_jni_cache *jni_cache,
   }
 }
 
-static void populate_metadata_obj(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                  bugsnag_metadata *dst, jobject section,
-                                  jobject section_keylist, int index) {
+static void populate_metadata_obj(JNIEnv *env, bugsnag_metadata *dst,
+                                  jobject section, jobject section_keylist,
+                                  int index) {
   jstring section_key = NULL;
   const char *name = NULL;
   jobject _value = NULL;
 
-  if (jni_cache == NULL) {
+  if (!bsg_jni_cache->initialized) {
     goto exit;
   }
 
   section_key = bsg_safe_call_object_method(
-      env, section_keylist, jni_cache->arraylist_get, (jint)index);
+      env, section_keylist, bsg_jni_cache->ArrayList_get, (jint)index);
   if (section_key == NULL) {
     goto exit;
   }
 
-  _value = bsg_safe_call_object_method(env, section, jni_cache->map_get,
+  _value = bsg_safe_call_object_method(env, section, bsg_jni_cache->Map_get,
                                        section_key);
   name = bsg_safe_get_string_utf_chars(env, section_key);
   if (name == NULL) {
     goto exit;
   }
 
-  populate_metadata_value(env, jni_cache, dst, section, name, _value);
+  populate_metadata_value(env, dst, section, name, _value);
 
 exit:
   bsg_safe_release_string_utf_chars(env, section_key, name);
@@ -409,16 +393,20 @@ exit:
   bsg_safe_delete_local_ref(env, _value);
 }
 
-static void populate_metadata_section(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                      bugsnag_metadata *dst, jobject metadata,
-                                      jobject keylist, int i) {
+static void populate_metadata_section(JNIEnv *env, bugsnag_metadata *dst,
+                                      jobject metadata, jobject keylist,
+                                      int i) {
   jstring _key = NULL;
   const char *section = NULL;
   jobject _section = NULL;
   jobject section_keyset = NULL;
   jobject section_keylist = NULL;
 
-  _key = bsg_safe_call_object_method(env, keylist, jni_cache->arraylist_get,
+  if (!bsg_jni_cache->initialized) {
+    goto exit;
+  }
+
+  _key = bsg_safe_call_object_method(env, keylist, bsg_jni_cache->ArrayList_get,
                                      (jint)i);
   if (_key == NULL) {
     goto exit;
@@ -428,29 +416,29 @@ static void populate_metadata_section(JNIEnv *env, bsg_jni_cache *jni_cache,
     goto exit;
   }
   _section =
-      bsg_safe_call_object_method(env, metadata, jni_cache->map_get, _key);
+      bsg_safe_call_object_method(env, metadata, bsg_jni_cache->Map_get, _key);
   if (_section == NULL) {
     goto exit;
   }
   jint section_size =
-      bsg_safe_call_int_method(env, _section, jni_cache->map_size);
+      bsg_safe_call_int_method(env, _section, bsg_jni_cache->Map_size);
   if (section_size == -1) {
     goto exit;
   }
   section_keyset =
-      bsg_safe_call_object_method(env, _section, jni_cache->map_key_set);
+      bsg_safe_call_object_method(env, _section, bsg_jni_cache->Map_keySet);
   if (section_keyset == NULL) {
     goto exit;
   }
 
   section_keylist =
-      bsg_safe_new_object(env, jni_cache->arraylist,
-                          jni_cache->arraylist_init_with_obj, section_keyset);
+      bsg_safe_new_object(env, bsg_jni_cache->ArrayList,
+                          bsg_jni_cache->ArrayList_constructor, section_keyset);
   if (section_keylist == NULL) {
     goto exit;
   }
   for (int j = 0; j < section_size; j++) {
-    populate_metadata_obj(env, jni_cache, dst, _section, section_keylist, j);
+    populate_metadata_obj(env, dst, _section, section_keylist, j);
   }
   goto exit;
 
@@ -464,18 +452,20 @@ exit:
 
 // Internal API
 
-void bsg_populate_metadata(JNIEnv *env, bsg_jni_cache *jni_cache,
-                           bugsnag_metadata *dst, jobject metadata) {
+void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst,
+                           jobject metadata) {
   jobject _metadata = NULL;
   jobject keyset = NULL;
   jobject keylist = NULL;
 
-  if (jni_cache == NULL) {
+  if (!bsg_jni_cache->initialized) {
     goto exit;
   }
+
   if (metadata == NULL) {
     _metadata = bsg_safe_call_static_object_method(
-        env, jni_cache->native_interface, jni_cache->ni_get_metadata);
+        env, bsg_jni_cache->NativeInterface,
+        bsg_jni_cache->NativeInterface_getMetadata);
     metadata = _metadata;
   }
 
@@ -484,25 +474,25 @@ void bsg_populate_metadata(JNIEnv *env, bsg_jni_cache *jni_cache,
     goto exit;
   }
 
-  int size = bsg_safe_call_int_method(env, metadata, jni_cache->map_size);
+  int size = bsg_safe_call_int_method(env, metadata, bsg_jni_cache->Map_size);
   if (size == -1) {
     goto exit;
   }
 
   // create a list of metadata keys
-  keyset =
-      bsg_safe_call_static_object_method(env, metadata, jni_cache->map_key_set);
+  keyset = bsg_safe_call_static_object_method(env, metadata,
+                                              bsg_jni_cache->Map_keySet);
   if (keyset == NULL) {
     goto exit;
   }
-  keylist = bsg_safe_new_object(env, jni_cache->arraylist,
-                                jni_cache->arraylist_init_with_obj, keyset);
+  keylist = bsg_safe_new_object(env, bsg_jni_cache->ArrayList,
+                                bsg_jni_cache->ArrayList_constructor, keyset);
   if (keylist == NULL) {
     goto exit;
   }
 
   for (int i = 0; i < size; i++) {
-    populate_metadata_section(env, jni_cache, dst, metadata, keylist, i);
+    populate_metadata_section(env, dst, metadata, keylist, i);
   }
 
 exit:
@@ -511,46 +501,47 @@ exit:
   bsg_safe_delete_local_ref(env, keylist);
 }
 
-void bsg_populate_crumb_metadata(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                 bugsnag_breadcrumb *crumb, jobject metadata) {
+void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
+                                 jobject metadata) {
   jobject keyset = NULL;
   jobject keylist = NULL;
 
   if (metadata == NULL) {
     goto exit;
   }
-  if (jni_cache == NULL) {
+  if (!bsg_jni_cache->initialized) {
     goto exit;
   }
 
   // get size of metadata map
-  jint map_size = bsg_safe_call_int_method(env, metadata, jni_cache->map_size);
+  jint map_size =
+      bsg_safe_call_int_method(env, metadata, bsg_jni_cache->Map_size);
   if (map_size == -1) {
     goto exit;
   }
 
   // create a list of metadata keys
-  keyset = bsg_safe_call_object_method(env, metadata, jni_cache->map_key_set);
+  keyset =
+      bsg_safe_call_object_method(env, metadata, bsg_jni_cache->Map_keySet);
   if (keyset == NULL) {
     goto exit;
   }
-  keylist = bsg_safe_new_object(env, jni_cache->arraylist,
-                                jni_cache->arraylist_init_with_obj, keyset);
+  keylist = bsg_safe_new_object(env, bsg_jni_cache->ArrayList,
+                                bsg_jni_cache->ArrayList_constructor, keyset);
   if (keylist == NULL) {
     goto exit;
   }
 
   for (int i = 0; i < map_size; i++) {
     jstring _key = bsg_safe_call_object_method(
-        env, keylist, jni_cache->arraylist_get, (jint)i);
-    jobject _value =
-        bsg_safe_call_object_method(env, metadata, jni_cache->map_get, _key);
+        env, keylist, bsg_jni_cache->ArrayList_get, (jint)i);
+    jobject _value = bsg_safe_call_object_method(env, metadata,
+                                                 bsg_jni_cache->Map_get, _key);
 
     if (_key != NULL && _value != NULL) {
       const char *key = bsg_safe_get_string_utf_chars(env, _key);
       if (key != NULL) {
-        populate_metadata_value(env, jni_cache, &crumb->metadata, "metaData",
-                                key, _value);
+        populate_metadata_value(env, &crumb->metadata, "metaData", key, _value);
         bsg_safe_release_string_utf_chars(env, _key, key);
       }
     }
@@ -563,15 +554,14 @@ exit:
   bsg_safe_delete_local_ref(env, keylist);
 }
 
-void bsg_populate_event(JNIEnv *env, bsg_jni_cache *jni_cache,
-                        bugsnag_event *event) {
-  if (jni_cache == NULL) {
+void bsg_populate_event(JNIEnv *env, bugsnag_event *event) {
+  if (!bsg_jni_cache->initialized) {
     return;
   }
-  populate_context(env, jni_cache, event);
-  populate_app_data(env, jni_cache, event);
-  populate_device_data(env, jni_cache, event);
-  populate_user_data(env, jni_cache, event);
+  populate_context(env, event);
+  populate_app_data(env, event);
+  populate_device_data(env, event);
+  populate_user_data(env, event);
 }
 
 const char *bsg_os_name() { return "android"; }

--- a/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/metadata.h
@@ -9,21 +9,20 @@
  * Load all app, device, user, and custom metadata from NativeInterface into a
  * event
  */
-void bsg_populate_event(JNIEnv *env, bsg_jni_cache *jni_cache,
-                        bugsnag_event *event);
+void bsg_populate_event(JNIEnv *env, bugsnag_event *event);
 /**
  * Load custom metadata from NativeInterface into a native metadata struct,
  * optionally from an object. If metadata is not provided, load from
  * NativeInterface
  */
-void bsg_populate_metadata(JNIEnv *env, bsg_jni_cache *jni_cache,
-                           bugsnag_metadata *dst, jobject metadata);
+void bsg_populate_metadata(JNIEnv *env, bugsnag_metadata *dst,
+                           jobject metadata);
 
 /**
  * Parse as java.util.Map<String, String> to populate crumb metadata
  */
-void bsg_populate_crumb_metadata(JNIEnv *env, bsg_jni_cache *jni_cache,
-                                 bugsnag_breadcrumb *crumb, jobject metadata);
+void bsg_populate_crumb_metadata(JNIEnv *env, bugsnag_breadcrumb *crumb,
+                                 jobject metadata);
 
 const char *bsg_os_name();
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/safejni.c
@@ -1,5 +1,9 @@
 #include "safejni.h"
+#include "bugsnag_ndk.h"
+#include "utils/logger.h"
+#include "utils/stack_unwinder.h"
 #include <stdbool.h>
+#include <string.h>
 #include <utils/string.h>
 
 bool bsg_check_and_clear_exc(JNIEnv *env) {
@@ -7,6 +11,17 @@ bool bsg_check_and_clear_exc(JNIEnv *env) {
     return false;
   }
   if ((*env)->ExceptionCheck(env)) {
+    BUGSNAG_LOG("BUG: JNI Native->Java call threw an exception:");
+
+    // Print a trace to stderr so that we can debug it
+    (*env)->ExceptionDescribe(env);
+
+    // Trigger more accurate dalvik trace (this will also crash the app).
+
+    // Code review check: THIS MUST BE COMMENTED OUT IN CHECKED IN CODE!
+    //(*env)->FindClass(env, NULL);
+
+    // Clear the exception so that we don't crash.
     (*env)->ExceptionClear(env);
     return true;
   }


### PR DESCRIPTION
## Goal

JNIEnv is only valid for the current thread, so we shouldn't be permanently storing it as a global. Store JavaVM instead.

Complete the JNI cache fix by making the cache once again global, ensuring that all object references have been first made global.

## Testing

Re-ran all automated tests, did manual testing using the example app.
