### PR TITLE
test: allow larger delta for foreground ms range

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorForegroundTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorForegroundTest.kt
@@ -62,10 +62,10 @@ class AppDataCollectorForegroundTest {
 
         val appWithState = appDataCollector.generateAppWithState()
         assertEquals(true, appWithState.inForeground)
-        // allow for 20ms of error
+        // allow for 200ms of error
         assertTrue(
             "Unexpected durationInForeground: ${appWithState.durationInForeground}",
-            appWithState.durationInForeground in 1000L..1020L
+            appWithState.durationInForeground in 1000L..1200L
         )
 
         verify(sessionTracker, times(1)).isInForeground


### PR DESCRIPTION
This test fails regularly on lower spec'd x86 runs due to variance in the duration.