### PR TITLE
Account for null termination in char array buuid

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -51,7 +51,7 @@ typedef struct {
   char version[32];
   char active_screen[64];
   int64_t version_code;
-  char build_uuid[64];
+  char build_uuid[65];
   int64_t duration;
   int64_t duration_in_foreground;
   /**

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_bsg_event.c
@@ -97,6 +97,15 @@ TEST test_app_build_uuid(void) {
     PASS();
 }
 
+TEST test_app_build_uuid_size(void) {
+    bugsnag_event *event = init_event();
+    char long_id[65] = "0123456789012345678901234567890123456789012345678901234567890123";
+    bugsnag_app_set_build_uuid(event, long_id);
+    ASSERT_STR_EQ(long_id, bugsnag_app_get_build_uuid(event));
+    free(event);
+    PASS();
+}
+
 TEST test_app_id(void) {
     bugsnag_event *event = init_event();
     ASSERT_STR_EQ("fa02", bugsnag_app_get_id(event));


### PR DESCRIPTION
This change allows to use for example sha256 as build uuids