### PR TITLE
Rework the background task service shutdown procedure to give more headroom against the 5s ANR timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Bug fixes
 
+* Fixed an issue where an uncaught exeption on the main thread could in rare cases trigger an ANR.
+  [#1624](https://github.com/bugsnag/bugsnag-android/pull/1624)
+
 * Fix inconsistencies in stack trace quality for C/C++ events. Resolves a few
   cases where file and line number information was not resolving to the correct
   locations. This change may result in grouping changes to more correctly

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BackgroundTaskService.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BackgroundTaskService.kt
@@ -158,18 +158,13 @@ internal class BackgroundTaskService(
         internalReportExecutor.shutdownNow()
         defaultExecutor.shutdownNow()
 
-        // shutdown the error/session executors first, waiting for existing tasks to complete.
-        // If a request fails it may perform IO to persist the payload for delivery next launch,
-        // which would submit tasks to the IO executor - therefore it's critical to
-        // shutdown the IO executor last.
+        // Wait a little while for these ones to shut down
         errorExecutor.shutdown()
         sessionExecutor.shutdown()
+        ioExecutor.shutdown()
 
         errorExecutor.awaitTerminationSafe()
         sessionExecutor.awaitTerminationSafe()
-
-        // shutdown the IO executor last, waiting for any existing tasks to complete
-        ioExecutor.shutdown()
         ioExecutor.awaitTerminationSafe()
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashDeliveryTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashDeliveryTest.kt
@@ -140,7 +140,7 @@ class LaunchCrashDeliveryTest {
             payload: EventPayload,
             deliveryParams: DeliveryParams
         ): DeliveryStatus {
-            Thread.sleep(3000)
+            Thread.sleep(2000)
             count.getAndIncrement()
             return DeliveryStatus.DELIVERED
         }


### PR DESCRIPTION
## Goal

In a worst case scenario, `BackgroundTaskService.shutdown()` could wait for 4.5 seconds to complete a shutdown, which is dangerously close to the 5s limit for an ANR if this happens on the main thread.

Rework so that all the shutdowns happen at the same time.

## Testing

Rerun all tests. Unfortunately this manifest as a flake in CI so there's no definitive test for it.
