### PR TITLE
Clear app data before all e2e tests

### DIFF
--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -10,6 +10,7 @@ import android.widget.Button
 import android.widget.EditText
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.mazerunner.scenarios.Scenario
+import java.io.File
 
 class MainActivity : Activity() {
 
@@ -28,6 +29,15 @@ class MainActivity : Activity() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             val closeDialog = Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS)
             sendBroadcast(closeDialog)
+        }
+
+        // Clear persistent data (used to stop scenarios bleeding into each other)
+        findViewById<Button>(R.id.clear_persistent_data).setOnClickListener {
+            clearFolder("last-run-info")
+            clearFolder("bugsnag-errors")
+            clearFolder("device-id")
+            clearFolder("user-info")
+            clearFolder("fake")
         }
 
         // load the scenario first, which initialises bugsnag without running any crashy code
@@ -71,6 +81,13 @@ class MainActivity : Activity() {
             apiKeyField.text.clear()
             apiKeyField.text.append(apiKey)
         }
+    }
+
+    private fun clearFolder(name: String) {
+        val context = MazerunnerApp.applicationContext()
+        val folder = File(context.cacheDir, name)
+        log("Clearing folder: ${folder.path}")
+        folder.deleteRecursively()
     }
 
     private fun loadScenarioFromUi(): Scenario {

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
@@ -1,10 +1,23 @@
 package com.bugsnag.android.mazerunner
 
 import android.app.Application
+import android.content.Context
 import android.os.Build
 import android.os.StrictMode
 
 class MazerunnerApp : Application() {
+
+    init {
+        instance = this
+    }
+
+    companion object {
+        private var instance: MazerunnerApp? = null
+
+        fun applicationContext() : Context {
+            return instance!!.applicationContext
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
@@ -14,7 +14,7 @@ class MazerunnerApp : Application() {
     companion object {
         private var instance: MazerunnerApp? = null
 
-        fun applicationContext() : Context {
+        fun applicationContext(): Context {
             return instance!!.applicationContext
         }
     }

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -23,18 +23,18 @@
           android:inputType="text" />
 
   <Button
+          android:id="@+id/clear_persistent_data"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:text="Clear app data" />
+
+  <Button
           android:id="@+id/start_bugsnag"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_weight="0"
           android:text="Start Bugsnag" />
-
-  <Button
-          android:id="@+id/clear_persistent_data"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_weight="0"
-          android:text="Clear data" />
 
   <Button
           android:id="@+id/run_scenario"

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -30,6 +30,13 @@
           android:text="Start Bugsnag" />
 
   <Button
+          android:id="@+id/clear_persistent_data"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:text="Clear data" />
+
+  <Button
           android:id="@+id/run_scenario"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"

--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -1,28 +1,31 @@
 Feature: Switching automatic error detection on/off for Unity
 
-Scenario: Handled JVM exceptions are captured with autoNotify=false
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Handled JVM exceptions are captured with autoNotify=false
     When I run "HandledJvmAutoNotifyFalseScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "message" equals "HandledJvmAutoNotifyFalseScenario"
 
-Scenario: JVM exception not captured with autoNotify=false
+  Scenario: JVM exception not captured with autoNotify=false
     When I run "UnhandledJvmAutoNotifyFalseScenario" and relaunch the app
     And I configure Bugsnag for "UnhandledJvmAutoNotifyFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
-Scenario: NDK signal not captured with autoNotify=false
+  Scenario: NDK signal not captured with autoNotify=false
     When I run "UnhandledNdkAutoNotifyFalseScenario" and relaunch the app
     And I configure Bugsnag for "UnhandledNdkAutoNotifyFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
-@skip_android_8_1
-Scenario: ANR not captured with autoDetectAnrs=false
+  @skip_android_8_1
+  Scenario: ANR not captured with autoDetectAnrs=false
     When I run "AutoDetectAnrsFalseScenario" and relaunch the app
     And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
-Scenario: JVM exception captured with autoNotify reenabled
+  Scenario: JVM exception captured with autoNotify reenabled
     When I run "UnhandledJvmAutoNotifyTrueScenario" and relaunch the app
     And I configure Bugsnag for "UnhandledJvmAutoNotifyTrueScenario"
     Then I wait to receive an error
@@ -34,7 +37,7 @@ Scenario: JVM exception captured with autoNotify reenabled
     And the event "unhandled" is true
     And the event "severity" equals "error"
 
-Scenario: NDK signal captured with autoNotify reenabled
+  Scenario: NDK signal captured with autoNotify reenabled
     When I run "UnhandledNdkAutoNotifyTrueScenario" and relaunch the app
     And I configure Bugsnag for "UnhandledNdkAutoNotifyTrueScenario"
     Then I wait to receive an error
@@ -48,8 +51,8 @@ Scenario: NDK signal captured with autoNotify reenabled
     And the event "severityReason.unhandledOverridden" is false
 
 # PLAT-6620
-@skip_android_8_1
-Scenario: ANR captured with autoDetectAnrs reenabled
+  @skip_android_8_1
+  Scenario: ANR captured with autoDetectAnrs reenabled
     When I run "AutoDetectAnrsTrueScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times

--- a/features/full_tests/breadcrumb.feature
+++ b/features/full_tests/breadcrumb.feature
@@ -1,6 +1,9 @@
 Feature: Reporting Breadcrumbs
 
-Scenario: Manually added breadcrumbs are sent in report
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Manually added breadcrumbs are sent in report
     When I run "BreadcrumbScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -17,19 +20,19 @@ Scenario: Manually added breadcrumbs are sent in report
     And the event "breadcrumbs.0.name" equals "Hello Breadcrumb!"
     And the event "breadcrumbs.0.type" equals "manual"
 
-Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
+  Scenario: Manually added breadcrumbs are sent in report when auto breadcrumbs are disabled
     When I run "BreadcrumbDisabledScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the event has 1 breadcrumbs
 
-Scenario: An automatic breadcrumb is sent in report when the appropriate type is enabled
+  Scenario: An automatic breadcrumb is sent in report when the appropriate type is enabled
     When I run "BreadcrumbAutoScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the event has a "state" breadcrumb with the message "Bugsnag loaded"
 
-Scenario: Error Breadcrumbs appear in subsequent events
+  Scenario: Error Breadcrumbs appear in subsequent events
     When I run "ErrorBreadcrumbsScenario" and relaunch the app
     And I configure Bugsnag for "ErrorBreadcrumbsScenario"
     Then I wait to receive 2 errors

--- a/features/full_tests/bugsnag_init.feature
+++ b/features/full_tests/bugsnag_init.feature
@@ -1,6 +1,9 @@
 Feature: Verify the Bugsnag Initialization methods
 
-Scenario: Test Bugsnag initializes correctly
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Test Bugsnag initializes correctly
     When I run "BugsnagInitScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/crash_handler.feature
+++ b/features/full_tests/crash_handler.feature
@@ -1,6 +1,9 @@
 Feature: Reporting with other exception handlers installed
 
-Scenario: Other uncaught exception handler installed
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Other uncaught exception handler installed
     When I run "CrashHandlerScenario" and relaunch the app
     And I configure Bugsnag for "CrashHandlerScenario"
     And I wait to receive an error

--- a/features/full_tests/custom_http_client.feature
+++ b/features/full_tests/custom_http_client.feature
@@ -1,6 +1,9 @@
 Feature: Using custom API clients for reporting errors
 
-Scenario: Set a custom HTTP client and flush a stored error + session
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Set a custom HTTP client and flush a stored error + session
     When I configure the app to run in the "offline" state
     And I run "CustomHttpClientFlushScenario" and relaunch the app
     And I configure Bugsnag for "CustomHttpClientFlushScenario"
@@ -15,7 +18,7 @@ Scenario: Set a custom HTTP client and flush a stored error + session
     And the session "Custom-Client" header equals "Hello World"
     And the session is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
 
-Scenario: Set a custom HTTP client and send an error + session
+  Scenario: Set a custom HTTP client and send an error + session
     When I run "CustomHttpClientScenario"
 
     # error received

--- a/features/full_tests/detect_anr_cxx.feature
+++ b/features/full_tests/detect_anr_cxx.feature
@@ -1,6 +1,9 @@
 Feature: ANRs triggered in CXX code are captured
 
-Scenario: ANR triggered in CXX code is captured
+  Background:
+    Given I clear all persistent data
+
+  Scenario: ANR triggered in CXX code is captured
     When I run "CXXAnrScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
@@ -14,7 +17,7 @@ Scenario: ANR triggered in CXX code is captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
-Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled
+  Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled
     When I run "CXXAnrNdkDisabledScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times

--- a/features/full_tests/detect_anr_jvm.feature
+++ b/features/full_tests/detect_anr_jvm.feature
@@ -1,6 +1,9 @@
 Feature: ANRs triggered in JVM code are captured
 
-Scenario: ANR triggered in JVM loop code is captured
+  Background:
+    Given I clear all persistent data
+
+  Scenario: ANR triggered in JVM loop code is captured
     When I run "JvmAnrLoopScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
@@ -16,8 +19,8 @@ Scenario: ANR triggered in JVM loop code is captured
 
 # Other scenarios use a deadlock to generate an ANR, which works on Samsung devices. This scenario remains skipped
 # on Samsung as it is explicitly design to test ANRs caused by a sleeping thread.
-@skip_samsung
-Scenario: ANR triggered in JVM sleep code is captured
+  @skip_samsung
+  Scenario: ANR triggered in JVM sleep code is captured
     When I run "JvmAnrSleepScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
@@ -30,7 +33,7 @@ Scenario: ANR triggered in JVM sleep code is captured
     And the error "Bugsnag-Stacktrace-Types" header equals "android,c"
     And the error payload field "events.0.exceptions.0.type" equals "android"
 
-Scenario: ANR triggered in JVM code is not captured when detectAnrs = false
+  Scenario: ANR triggered in JVM code is not captured when detectAnrs = false
     When I run "JvmAnrDisabledScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
@@ -40,7 +43,7 @@ Scenario: ANR triggered in JVM code is not captured when detectAnrs = false
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "JvmAnrDisabledScenario"
 
-Scenario: ANR triggered in JVM code is not captured when outside of release stage
+  Scenario: ANR triggered in JVM code is not captured when outside of release stage
     When I run "JvmAnrOutsideReleaseStagesScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times

--- a/features/full_tests/detect_ndk_crashes.feature
+++ b/features/full_tests/detect_ndk_crashes.feature
@@ -1,6 +1,9 @@
 Feature: Verifies autoDetectNdkCrashes controls when NDK crashes are reported
 
-Scenario: No crash reported when autoDetectNdkCrashes disabled
+  Background:
+    Given I clear all persistent data
+
+  Scenario: No crash reported when autoDetectNdkCrashes disabled
     When I run "AutoDetectNdkDisabledScenario" and relaunch the app
     And I configure Bugsnag for "AutoDetectNdkDisabledScenario"
     And I wait for 2 seconds

--- a/features/full_tests/empty_stacktrace.feature
+++ b/features/full_tests/empty_stacktrace.feature
@@ -1,6 +1,9 @@
 Feature: Empty Stacktrace reported
 
-Scenario: Exceptions with empty stacktraces are sent
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Exceptions with empty stacktraces are sent
     When I run "EmptyStacktraceScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/event_callback_alters_api_key.feature
+++ b/features/full_tests/event_callback_alters_api_key.feature
@@ -1,6 +1,9 @@
 Feature: When the api key is altered in an Event the JSON payload reflects this
 
-Scenario: Handled exception with altered API key
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Handled exception with altered API key
     When I run "HandledExceptionApiKeyChangeScenario"
     Then I wait to receive an error
     And the error payload field "events" is an array with 1 elements
@@ -8,7 +11,7 @@ Scenario: Handled exception with altered API key
     And the error payload field "apiKey" equals "0000111122223333aaaabbbbcccc9999"
     And the error "Bugsnag-Api-Key" header equals "0000111122223333aaaabbbbcccc9999"
 
-Scenario: Unhandled exception with altered API key
+  Scenario: Unhandled exception with altered API key
     When I run "UnhandledExceptionApiKeyChangeScenario" and relaunch the app
     And I configure Bugsnag for "UnhandledExceptionApiKeyChangeScenario"
     And I wait to receive an error

--- a/features/full_tests/feature_flags.feature
+++ b/features/full_tests/feature_flags.feature
@@ -1,57 +1,60 @@
 Feature: Reporting with feature flags
 
-Scenario: Sends handled exception which includes feature flags
-  When I run "FeatureFlagScenario"
-  Then I wait to receive an error
-  And the exception "errorClass" equals "java.lang.RuntimeException"
-  And the event "unhandled" is false
-  And event 0 contains the feature flag "demo_mode" with no variant
-  And event 0 does not contain the feature flag "should_not_be_reported_1"
-  And event 0 does not contain the feature flag "should_not_be_reported_2"
-  And event 0 does not contain the feature flag "should_not_be_reported_3"
+  Background:
+    Given I clear all persistent data
 
-Scenario: Sends handled exception which includes feature flags added in the notify callback
-  When I configure the app to run in the "callback" state
-  And I run "FeatureFlagScenario"
-  Then I wait to receive an error
-  And the exception "errorClass" equals "java.lang.RuntimeException"
-  And the event "unhandled" is false
-  And event 0 contains the feature flag "demo_mode" with no variant
-  And event 0 contains the feature flag "sample_group" with variant "a"
-  And event 0 does not contain the feature flag "should_not_be_reported_1"
-  And event 0 does not contain the feature flag "should_not_be_reported_2"
-  And event 0 does not contain the feature flag "should_not_be_reported_3"
+  Scenario: Sends handled exception which includes feature flags
+    When I run "FeatureFlagScenario"
+    Then I wait to receive an error
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the event "unhandled" is false
+    And event 0 contains the feature flag "demo_mode" with no variant
+    And event 0 does not contain the feature flag "should_not_be_reported_1"
+    And event 0 does not contain the feature flag "should_not_be_reported_2"
+    And event 0 does not contain the feature flag "should_not_be_reported_3"
 
-Scenario: Sends unhandled exception which includes feature flags added in the notify callback
-  When I configure the app to run in the "unhandled callback" state
-  And I run "FeatureFlagScenario" and relaunch the app
-  And I configure Bugsnag for "FeatureFlagScenario"
-  Then I wait to receive an error
-  And the exception "errorClass" equals "java.lang.RuntimeException"
-  And the event "unhandled" is true
-  And event 0 contains the feature flag "demo_mode" with no variant
-  And event 0 contains the feature flag "sample_group" with variant "a"
-  And event 0 does not contain the feature flag "should_not_be_reported_1"
-  And event 0 does not contain the feature flag "should_not_be_reported_2"
-  And event 0 does not contain the feature flag "should_not_be_reported_3"
+  Scenario: Sends handled exception which includes feature flags added in the notify callback
+    When I configure the app to run in the "callback" state
+    And I run "FeatureFlagScenario"
+    Then I wait to receive an error
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the event "unhandled" is false
+    And event 0 contains the feature flag "demo_mode" with no variant
+    And event 0 contains the feature flag "sample_group" with variant "a"
+    And event 0 does not contain the feature flag "should_not_be_reported_1"
+    And event 0 does not contain the feature flag "should_not_be_reported_2"
+    And event 0 does not contain the feature flag "should_not_be_reported_3"
 
-Scenario: Sends no feature flags after clearFeatureFlags()
-  When I configure the app to run in the "cleared" state
-  And I run "FeatureFlagScenario"
-  Then I wait to receive an error
-  And the exception "errorClass" equals "java.lang.RuntimeException"
-  And the event "unhandled" is false
-  And event 0 has no feature flags
+  Scenario: Sends unhandled exception which includes feature flags added in the notify callback
+    When I configure the app to run in the "unhandled callback" state
+    And I run "FeatureFlagScenario" and relaunch the app
+    And I configure Bugsnag for "FeatureFlagScenario"
+    Then I wait to receive an error
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the event "unhandled" is true
+    And event 0 contains the feature flag "demo_mode" with no variant
+    And event 0 contains the feature flag "sample_group" with variant "a"
+    And event 0 does not contain the feature flag "should_not_be_reported_1"
+    And event 0 does not contain the feature flag "should_not_be_reported_2"
+    And event 0 does not contain the feature flag "should_not_be_reported_3"
 
-Scenario: Sends feature flags added in OnSend Callbacks
-  When I configure the app to run in the "onsend" state
-  And I run "FeatureFlagScenario" and relaunch the app
-  And I configure Bugsnag for "FeatureFlagScenario"
-  Then I wait to receive an error
-  And the exception "errorClass" equals "java.lang.RuntimeException"
-  And the event "unhandled" is false
-  And event 0 contains the feature flag "demo_mode" with no variant
-  And event 0 contains the feature flag "on_send_callback" with no variant
-  And event 0 does not contain the feature flag "should_not_be_reported_1"
-  And event 0 does not contain the feature flag "should_not_be_reported_2"
-  And event 0 does not contain the feature flag "should_not_be_reported_3"
+  Scenario: Sends no feature flags after clearFeatureFlags()
+    When I configure the app to run in the "cleared" state
+    And I run "FeatureFlagScenario"
+    Then I wait to receive an error
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the event "unhandled" is false
+    And event 0 has no feature flags
+
+  Scenario: Sends feature flags added in OnSend Callbacks
+    When I configure the app to run in the "onsend" state
+    And I run "FeatureFlagScenario" and relaunch the app
+    And I configure Bugsnag for "FeatureFlagScenario"
+    Then I wait to receive an error
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the event "unhandled" is false
+    And event 0 contains the feature flag "demo_mode" with no variant
+    And event 0 contains the feature flag "on_send_callback" with no variant
+    And event 0 does not contain the feature flag "should_not_be_reported_1"
+    And event 0 does not contain the feature flag "should_not_be_reported_2"
+    And event 0 does not contain the feature flag "should_not_be_reported_3"

--- a/features/full_tests/filtering_metadata.feature
+++ b/features/full_tests/filtering_metadata.feature
@@ -1,6 +1,9 @@
 Feature: Metadata is filtered
 
-Scenario: Using the default metadata filter
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Using the default metadata filter
     When I run "AutoRedactKeysScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -9,7 +12,7 @@ Scenario: Using the default metadata filter
     And the event "metaData.custom.password" equals "[REDACTED]"
     And the event "metaData.user.password" equals "[REDACTED]"
 
-Scenario: Adding a custom metadata filter
+  Scenario: Adding a custom metadata filter
     When I run "ManualRedactKeysScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/handled_exception.feature
+++ b/features/full_tests/handled_exception.feature
@@ -1,10 +1,13 @@
 Feature: Reporting handled Exceptions
 
-    Scenario: Report a handled exception without a message
-        When I run "HandledExceptionWithoutMessageScenario"
-        Then I wait to receive an error
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the error payload field "events" is an array with 1 elements
-        And the exception "errorClass" equals "com.bugsnag.android.mazerunner.SomeException"
-        And the event "exceptions.0.message" is null
-        And the error payload field "events.0.device.cpuAbi" is a non-empty array
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Report a handled exception without a message
+    When I run "HandledExceptionWithoutMessageScenario"
+    Then I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "com.bugsnag.android.mazerunner.SomeException"
+    And the event "exceptions.0.message" is null
+    And the error payload field "events.0.device.cpuAbi" is a non-empty array

--- a/features/full_tests/identify_crashes_on_launch.feature
+++ b/features/full_tests/identify_crashes_on_launch.feature
@@ -1,105 +1,108 @@
 Feature: Identifying crashes on launch
 
-    Scenario: A JVM error captured after the launch period is false for app.isLaunching
-        When I run "JvmDelayedErrorScenario"
-        Then I wait to receive 2 errors
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "first error"
-        And the event "app.isLaunching" is true
-        Then I discard the oldest error
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "JvmDelayedErrorScenario"
-        And the event "app.isLaunching" is false
+  Background:
+    Given I clear all persistent data
 
-    Scenario: An NDK error captured after the launch period is false for app.isLaunching
-        When I run "CXXDelayedErrorScenario" and relaunch the app
-        And I configure Bugsnag for "CXXDelayedErrorScenario"
-        Then I wait to receive 2 errors
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "first error"
-        And the event "app.isLaunching" is true
-        Then I discard the oldest error
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "Abort program"
-        And the event "app.isLaunching" is false
+  Scenario: A JVM error captured after the launch period is false for app.isLaunching
+    When I run "JvmDelayedErrorScenario"
+    Then I wait to receive 2 errors
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "first error"
+    And the event "app.isLaunching" is true
+    Then I discard the oldest error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "JvmDelayedErrorScenario"
+    And the event "app.isLaunching" is false
 
-    Scenario: A JVM error captured after markLaunchComplete() is false for app.isLaunching
-        When I run "JvmMarkLaunchCompletedScenario"
-        Then I wait to receive 2 errors
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "first error"
-        And the event "app.isLaunching" is true
-        Then I discard the oldest error
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "JvmMarkLaunchCompletedScenario"
-        And the event "app.isLaunching" is false
+  Scenario: An NDK error captured after the launch period is false for app.isLaunching
+    When I run "CXXDelayedErrorScenario" and relaunch the app
+    And I configure Bugsnag for "CXXDelayedErrorScenario"
+    Then I wait to receive 2 errors
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "first error"
+    And the event "app.isLaunching" is true
+    Then I discard the oldest error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "Abort program"
+    And the event "app.isLaunching" is false
 
-    Scenario: An NDK error captured after markLaunchComplete() is false for app.isLaunching
-        When I run "CXXMarkLaunchCompletedScenario" and relaunch the app
-        And I configure Bugsnag for "CXXMarkLaunchCompletedScenario"
-        Then I wait to receive 2 errors
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "first error"
-        And the event "app.isLaunching" is true
-        Then I discard the oldest error
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "Abort program"
-        And the event "app.isLaunching" is false
+  Scenario: A JVM error captured after markLaunchComplete() is false for app.isLaunching
+    When I run "JvmMarkLaunchCompletedScenario"
+    Then I wait to receive 2 errors
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "first error"
+    And the event "app.isLaunching" is true
+    Then I discard the oldest error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "JvmMarkLaunchCompletedScenario"
+    And the event "app.isLaunching" is false
 
-    Scenario: Escaping from a crash loop by reading LastRunInfo in a JVM error
-        When I run "JvmCrashLoopScenario" and relaunch the app
-        When I run "JvmCrashLoopScenario" and relaunch the app
-        When I run "JvmCrashLoopScenario"
-        And I wait to receive 3 errors
+  Scenario: An NDK error captured after markLaunchComplete() is false for app.isLaunching
+    When I run "CXXMarkLaunchCompletedScenario" and relaunch the app
+    And I configure Bugsnag for "CXXMarkLaunchCompletedScenario"
+    Then I wait to receive 2 errors
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "first error"
+    And the event "app.isLaunching" is true
+    Then I discard the oldest error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "Abort program"
+    And the event "app.isLaunching" is false
 
-        # JVM crash
-        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "First JVM crash"
-        And the event "metaData.LastRunInfo.crashed" is null
-        And the event "metaData.LastRunInfo.crashedDuringLaunch" is null
-        And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" is null
-        And I discard the oldest error
+  Scenario: Escaping from a crash loop by reading LastRunInfo in a JVM error
+    When I run "JvmCrashLoopScenario" and relaunch the app
+    When I run "JvmCrashLoopScenario" and relaunch the app
+    When I run "JvmCrashLoopScenario"
+    And I wait to receive 3 errors
 
         # JVM crash
-        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "Second JVM crash"
-        And the event "metaData.LastRunInfo.crashed" is true
-        And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
-        And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 1
-        And I discard the oldest error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "First JVM crash"
+    And the event "metaData.LastRunInfo.crashed" is null
+    And the event "metaData.LastRunInfo.crashedDuringLaunch" is null
+    And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" is null
+    And I discard the oldest error
+
+        # JVM crash
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "Second JVM crash"
+    And the event "metaData.LastRunInfo.crashed" is true
+    And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
+    And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 1
+    And I discard the oldest error
 
         # Safe mode
-        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "Safe mode enabled"
-        And the event "metaData.LastRunInfo.crashed" is true
-        And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
-        And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 2
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "Safe mode enabled"
+    And the event "metaData.LastRunInfo.crashed" is true
+    And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
+    And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 2
 
-    Scenario: Escaping from a crash loop by reading LastRunInfo in an NDK error
-        When I run "CXXCrashLoopScenario" and relaunch the app
-        When I run "CXXCrashLoopScenario" and relaunch the app
-        When I run "CXXCrashLoopScenario"
-        And I wait to receive 3 errors
-
-        # NDK crash
-        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "Abort program"
-        And the event "metaData.LastRunInfo.crashed" is null
-        And the event "metaData.LastRunInfo.crashedDuringLaunch" is null
-        And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" is null
-        And I discard the oldest error
+  Scenario: Escaping from a crash loop by reading LastRunInfo in an NDK error
+    When I run "CXXCrashLoopScenario" and relaunch the app
+    When I run "CXXCrashLoopScenario" and relaunch the app
+    When I run "CXXCrashLoopScenario"
+    And I wait to receive 3 errors
 
         # NDK crash
-        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "Abort program"
-        And the event "metaData.LastRunInfo.crashed" is true
-        And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
-        And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 1
-        And I discard the oldest error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "Abort program"
+    And the event "metaData.LastRunInfo.crashed" is null
+    And the event "metaData.LastRunInfo.crashedDuringLaunch" is null
+    And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" is null
+    And I discard the oldest error
+
+        # NDK crash
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "Abort program"
+    And the event "metaData.LastRunInfo.crashed" is true
+    And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
+    And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 1
+    And I discard the oldest error
 
         # Safe mode
-        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "Safe mode enabled"
-        And the event "metaData.LastRunInfo.crashed" is true
-        And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
-        And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 2
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "Safe mode enabled"
+    And the event "metaData.LastRunInfo.crashed" is true
+    And the event "metaData.LastRunInfo.crashedDuringLaunch" is true
+    And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 2

--- a/features/full_tests/ignored_reports.feature
+++ b/features/full_tests/ignored_reports.feature
@@ -1,6 +1,9 @@
 Feature: Reports are ignored
 
-Scenario: Exception classname ignored
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Exception classname ignored
     When I run "IgnoredExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -8,17 +11,17 @@ Scenario: Exception classname ignored
     And the exception "message" equals "Is it me you're looking for?"
     And the event "unhandled" is false
 
-Scenario: Disabled Exception Handler
+  Scenario: Disabled Exception Handler
     When I run "DisableAutoDetectErrorsScenario" and relaunch the app
     And I configure Bugsnag for "DisableAutoDetectErrorsScenario"
     Then Bugsnag confirms it has no errors to send
 
-Scenario: Changing release stage to exclude the current stage settings before a POSIX signal
+  Scenario: Changing release stage to exclude the current stage settings before a POSIX signal
     When I run "CXXTrapOutsideReleaseStagesScenario" and relaunch the app
     And I configure Bugsnag for "CXXTrapOutsideReleaseStagesScenario"
     Then Bugsnag confirms it has no errors to send
 
-Scenario: Changing release stage settings to exclude the current stage before a native C++ crash
+  Scenario: Changing release stage settings to exclude the current stage before a native C++ crash
     When I run "CXXThrowSomethingOutsideReleaseStagesScenario" and relaunch the app
     And I configure Bugsnag for "CXXThrowSomethingOutsideReleaseStagesScenario"
     Then Bugsnag confirms it has no errors to send

--- a/features/full_tests/in_foreground.feature
+++ b/features/full_tests/in_foreground.feature
@@ -1,6 +1,9 @@
 Feature: In foreground field populates correctly
 
-Scenario: Test handled exception in background
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Test handled exception in background
     When I run "InForegroundScenario"
     And I send the app to the background for 1 seconds
     Then I wait to receive an error

--- a/features/full_tests/internal_error_reports.feature
+++ b/features/full_tests/internal_error_reports.feature
@@ -1,6 +1,9 @@
 Feature: Cached Error Reports
 
-Scenario: If an exception is thrown when sending errors/sessions then internal error reports should be sent
+  Background:
+    Given I clear all persistent data
+
+  Scenario: If an exception is thrown when sending errors/sessions then internal error reports should be sent
     When I run "InternalErrorScenario"
     And I wait to receive 1 errors
 

--- a/features/full_tests/load_configuration.feature
+++ b/features/full_tests/load_configuration.feature
@@ -1,6 +1,9 @@
 Feature: Loading values into the configuration
 
-Scenario: Load configuration initialised from the Manifest
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Load configuration initialised from the Manifest
     When I run "LoadConfigurationFromManifestScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier with the apiKey "abc12312312312312312312312312312"
@@ -15,7 +18,7 @@ Scenario: Load configuration initialised from the Manifest
     And the event "app.type" equals "test"
     And the error payload field "events.0.threads" is a non-empty array
 
-Scenario: Load configuration initialised with Kotlin
+  Scenario: Load configuration initialised with Kotlin
     When I run "LoadConfigurationKotlinScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier with the apiKey "45645645645645645645645645645645"
@@ -30,7 +33,7 @@ Scenario: Load configuration initialised with Kotlin
     And the event "app.type" equals "kotlin"
     And the error payload field "events.0.threads" is an array with 0 elements
 
-Scenario: Load configuration initialised with nulls
+  Scenario: Load configuration initialised with nulls
     When I run "LoadConfigurationNullsScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier with the apiKey "12312312312312312312312312312312"

--- a/features/full_tests/max_reported_threads.feature
+++ b/features/full_tests/max_reported_threads.feature
@@ -1,6 +1,9 @@
 Feature: Reporting with other exception handlers installed
 
-Scenario: Unhandled exception with max threads set
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Unhandled exception with max threads set
     When I run "UnhandledExceptionMaxThreadsScenario" and relaunch the app
     And I configure Bugsnag for "UnhandledExceptionMaxThreadsScenario"
     And I wait to receive an error
@@ -12,7 +15,7 @@ Scenario: Unhandled exception with max threads set
     And the error payload field "events.0.threads.2.id" equals -1
     And the error payload field "events.0.threads.2.name" ends with "threads omitted as the maxReportedThreads limit (2) was exceeded]"
 
-Scenario: Handled exception with max threads set
+  Scenario: Handled exception with max threads set
     When I run "HandledExceptionMaxThreadsScenario" and relaunch the app
     And I configure Bugsnag for "HandledExceptionMaxThreadsScenario"
     And I wait to receive an error

--- a/features/full_tests/meta_data_scenario.feature
+++ b/features/full_tests/meta_data_scenario.feature
@@ -1,12 +1,15 @@
 Feature: Reporting metadata
 
-Scenario: Sends a handled exception which includes custom metadata added in a notify callback
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Sends a handled exception which includes custom metadata added in a notify callback
     When I run "MetadataScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the event "metaData.Custom.foo" equals "Hello World!"
 
-Scenario: Add nested null value to metadata tab
+  Scenario: Add nested null value to metadata tab
     When I run "MetadataNestedNullScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/multi_process.feature
+++ b/features/full_tests/multi_process.feature
@@ -1,6 +1,9 @@
 Feature: Reporting errors in multi process apps
 
-Scenario: Handled JVM error
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Handled JVM error
     When I run "MultiProcessHandledExceptionScenario"
     Then I wait to receive 2 errors
     And I sort the errors by "events.0.metaData.app.processName"
@@ -29,7 +32,7 @@ Scenario: Handled JVM error
     And the error payload field "events.0.user.name" equals "MultiProcessHandledExceptionScenario"
     And the error payload field "events.0.user.email" equals "foreground@example.com"
 
-Scenario: Unhandled JVM error
+  Scenario: Unhandled JVM error
     And I configure the app to run in the "main-activity" state
     When I run "MultiProcessUnhandledExceptionScenario" and relaunch the app
     And I configure the app to run in the "multi-process-service" state
@@ -52,7 +55,7 @@ Scenario: Unhandled JVM error
     And the event "unhandled" is true
     And the error payload field "events.0.metaData.app.processName" equals "com.example.bugsnag.android.mazerunner.multiprocess"
 
-Scenario: Handled NDK error
+  Scenario: Handled NDK error
     When I run "MultiProcessHandledCXXErrorScenario"
     Then I wait to receive 2 errors
     And I sort the errors by "events.0.metaData.app.processName"
@@ -79,7 +82,7 @@ Scenario: Handled NDK error
     And the error payload field "events.0.device.id" equals the stored value "first_device_id"
     And the error payload field "events.0.user.id" equals the stored value "first_device_id"
 
-Scenario: Unhandled NDK error
+  Scenario: Unhandled NDK error
     And I configure the app to run in the "main-activity" state
     When I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the app
     And I configure the app to run in the "multi-process-service" state
@@ -112,7 +115,7 @@ Scenario: Unhandled NDK error
     And the error payload field "events.0.user.name" equals "MultiProcessUnhandledCXXErrorScenario"
     And the error payload field "events.0.user.email" equals "1@test.com"
 
-Scenario: User/device information is migrated from SharedPreferences
+  Scenario: User/device information is migrated from SharedPreferences
     When I run "SharedPrefMigrationScenario"
     Then I wait to receive 2 errors
     And I sort the errors by "events.0.metaData.app.processName"

--- a/features/full_tests/native_api.feature
+++ b/features/full_tests/native_api.feature
@@ -1,23 +1,26 @@
 Feature: Native API
 
-    Scenario: Set extraordinarily long app information
-        When I run "CXXExtraordinaryLongStringScenario" and relaunch the app
-        And I configure Bugsnag for "CXXExtraordinaryLongStringScenario"
-        And I wait to receive an error
-        And the error payload contains a completed handled native report
-        And the exception "errorClass" equals one of:
-          | SIGILL |
-          | SIGTRAP |
-        And the event "app.version" equals "22.312.749.78.300.810.24.167.32"
-        And the event "context" equals "ObservableSessionInitializerStringParserStringSessionProxyGloba"
-        And the event "unhandled" is true
+  Background:
+    Given I clear all persistent data
 
-    Scenario: Use the NDK methods without "env" after calling "bugsnag_start"
-        When I run "CXXStartScenario"
-        And I wait to receive an error
-        Then the error payload contains a completed handled native report
-        And the event "unhandled" is false
-        And the exception "errorClass" equals "Start scenario"
-        And the exception "message" equals "Testing env"
-        And the event "severity" equals "info"
-        And the event has a "log" breadcrumb named "Start scenario crumb"
+  Scenario: Set extraordinarily long app information
+    When I run "CXXExtraordinaryLongStringScenario" and relaunch the app
+    And I configure Bugsnag for "CXXExtraordinaryLongStringScenario"
+    And I wait to receive an error
+    And the error payload contains a completed handled native report
+    And the exception "errorClass" equals one of:
+      | SIGILL  |
+      | SIGTRAP |
+    And the event "app.version" equals "22.312.749.78.300.810.24.167.32"
+    And the event "context" equals "ObservableSessionInitializerStringParserStringSessionProxyGloba"
+    And the event "unhandled" is true
+
+  Scenario: Use the NDK methods without "env" after calling "bugsnag_start"
+    When I run "CXXStartScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the event "unhandled" is false
+    And the exception "errorClass" equals "Start scenario"
+    And the exception "message" equals "Testing env"
+    And the event "severity" equals "info"
+    And the event has a "log" breadcrumb named "Start scenario crumb"

--- a/features/full_tests/native_breadcrumbs.feature
+++ b/features/full_tests/native_breadcrumbs.feature
@@ -1,22 +1,25 @@
 Feature: Native Breadcrumbs API
 
-    Scenario: Leaving breadcrumbs in C followed by a Java crash
-        When I run "CXXNativeBreadcrumbJavaCrashScenario" and relaunch the app
-        And I configure Bugsnag for "CXXNativeBreadcrumbJavaCrashScenario"
-        And I wait to receive an error
-        And the error payload contains a completed handled native report
-        And the exception "errorClass" equals "java.lang.ArrayIndexOutOfBoundsException"
-        And the exception "message" equals "length=2; index=2"
-        And the event has a "log" breadcrumb named "Lack of cheese detected"
-        And the event "severity" equals "error"
-        And the event "unhandled" is true
+  Background:
+    Given I clear all persistent data
 
-    Scenario: Leaving breadcrumbs in C followed by notifying in Java
-        When I run "CXXNativeBreadcrumbJavaNotifyScenario"
-        And I wait to receive an error
-        And the error payload contains a completed handled native report
-        And the exception "errorClass" equals "java.lang.Exception"
-        And the exception "message" equals "Did not like"
-        And the event "severity" equals "warning"
-        And the event has a "process" breadcrumb named "Rerun field analysis"
-        And the event "unhandled" is false
+  Scenario: Leaving breadcrumbs in C followed by a Java crash
+    When I run "CXXNativeBreadcrumbJavaCrashScenario" and relaunch the app
+    And I configure Bugsnag for "CXXNativeBreadcrumbJavaCrashScenario"
+    And I wait to receive an error
+    And the error payload contains a completed handled native report
+    And the exception "errorClass" equals "java.lang.ArrayIndexOutOfBoundsException"
+    And the exception "message" equals "length=2; index=2"
+    And the event has a "log" breadcrumb named "Lack of cheese detected"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+
+  Scenario: Leaving breadcrumbs in C followed by notifying in Java
+    When I run "CXXNativeBreadcrumbJavaNotifyScenario"
+    And I wait to receive an error
+    And the error payload contains a completed handled native report
+    And the exception "errorClass" equals "java.lang.Exception"
+    And the exception "message" equals "Did not like"
+    And the event "severity" equals "warning"
+    And the event has a "process" breadcrumb named "Rerun field analysis"
+    And the event "unhandled" is false

--- a/features/full_tests/native_context.feature
+++ b/features/full_tests/native_context.feature
@@ -1,17 +1,20 @@
 Feature: Native Context API
 
-    Scenario: Changing intents followed by notifying in C
-        When I run "CXXAutoContextScenario"
-        Then I wait to receive 2 errors
+  Background:
+    Given I clear all persistent data
 
-        Then the error payload contains a completed handled native report
-        And the event "severity" equals "info"
-        And the event "context" equals "SecondActivity"
-        And the exception "errorClass" equals "Hello hello"
-        And the exception "message" equals "This is a new world"
-        And the event "unhandled" is false
-        And I discard the oldest error
+  Scenario: Changing intents followed by notifying in C
+    When I run "CXXAutoContextScenario"
+    Then I wait to receive 2 errors
 
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "CXXAutoContextScenario"
-        And the event "context" equals "SecondActivity"
+    Then the error payload contains a completed handled native report
+    And the event "severity" equals "info"
+    And the event "context" equals "SecondActivity"
+    And the exception "errorClass" equals "Hello hello"
+    And the exception "message" equals "This is a new world"
+    And the event "unhandled" is false
+    And I discard the oldest error
+
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "CXXAutoContextScenario"
+    And the event "context" equals "SecondActivity"

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -1,5 +1,8 @@
 Feature: Native crash reporting
 
+  Background:
+    Given I clear all persistent data
+
   Scenario: Dereference a null pointer
     When I run "CXXDereferenceNullScenario" and relaunch the app
     And I configure Bugsnag for "CXXDereferenceNullScenario"
@@ -44,7 +47,7 @@ Feature: Native crash reporting
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals one of:
-      | SIGILL |
+      | SIGILL  |
       | SIGTRAP |
     And the exception "message" equals one of:
       | Illegal instruction   |
@@ -65,7 +68,7 @@ Feature: Native crash reporting
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the first significant stack frames match:
-      | crash_write_read_only_mem(int) | CXXWriteReadOnlyMemoryScenario.cpp | 12 |
+      | crash_write_read_only_mem(int)                                                     | CXXWriteReadOnlyMemoryScenario.cpp | 12 |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXWriteReadOnlyMemoryScenario_crash | CXXWriteReadOnlyMemoryScenario.cpp | 22 |
 
   Scenario: Improper object type cast
@@ -78,7 +81,7 @@ Feature: Native crash reporting
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the first significant stack frames match:
-      | crash_improper_cast(void*) | CXXImproperTypecastScenario.cpp | 12 |
+      | crash_improper_cast(void*)                                                      | CXXImproperTypecastScenario.cpp | 12 |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXImproperTypecastScenario_crash | CXXImproperTypecastScenario.cpp | 20 |
 
   Scenario: Program abort()
@@ -90,13 +93,13 @@ Feature: Native crash reporting
       | SIGABRT |
       | SIGSEGV |
     And the exception "message" equals one of:
-      | Abort program |
+      | Abort program                                     |
       | Segmentation violation (invalid memory reference) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the first significant stack frames match:
-      | evictor::exit_with_style() | CXXAbortScenario.cpp | 5 |
+      | evictor::exit_with_style()                                           | CXXAbortScenario.cpp | 5  |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXAbortScenario_crash | CXXAbortScenario.cpp | 13 |
 
   Scenario: Undefined JNI method
@@ -124,12 +127,12 @@ Feature: Native crash reporting
       | Trace/breakpoint trap |
     And the exception "type" equals "c"
     And the first significant stack frames match:
-      | something_innocuous | libmonochrome.so | (ignore) |
-      | Java_com_bugsnag_android_mazerunner_scenarios_CXXExternalStackElementScenario_crash | CXXExternalStackElementScenario.cpp | 14 |
+      | something_innocuous                                                                 | libmonochrome.so                    | (ignore) |
+      | Java_com_bugsnag_android_mazerunner_scenarios_CXXExternalStackElementScenario_crash | CXXExternalStackElementScenario.cpp | 14       |
 
   Scenario: Call null function pointer
-    A null pointer should be the first element of a stack trace,
-    followed by the calling function
+  A null pointer should be the first element of a stack trace,
+  followed by the calling function
 
     When I run "CXXCallNullFunctionPointerScenario" and relaunch the app
     And I configure Bugsnag for "CXXCallNullFunctionPointerScenario"

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -1,43 +1,46 @@
 Feature: Synchronizing app/device metadata in the native layer
 
-    Scenario: Capture foreground state while in the foreground
-        When I run "CXXDelayedNotifyScenario"
-        And I wait to receive an error
-        Then the error payload contains a completed handled native report
-        And the event "app.inForeground" is true
-        And the event "app.duration" is greater than 0
-        And the event "unhandled" is false
+  Background:
+    Given I clear all persistent data
 
-    Scenario: Capture foreground state while in the background
-        When I run "CXXBackgroundNotifyScenario"
-        And I send the app to the background for 5 seconds
-        And I wait to receive an error
-        Then the error payload contains a completed handled native report
-        And the event "app.inForeground" is false
-        And the event "app.durationInForeground" equals 0
-        And the event "app.duration" is greater than 0
-        And the event "context" string is empty
-        And the event "unhandled" is false
+  Scenario: Capture foreground state while in the foreground
+    When I run "CXXDelayedNotifyScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the event "app.inForeground" is true
+    And the event "app.duration" is greater than 0
+    And the event "unhandled" is false
 
-    Scenario: Capture foreground state while in a foreground crash
-        When I run "CXXTrapScenario" and relaunch the app
-        And I configure Bugsnag for "CXXStartSessionScenario"
-        And I wait to receive an error
-        Then the error payload contains a completed handled native report
-        And the event "app.inForeground" is true
-        And the event "app.durationInForeground" is not null
-        And the event "app.duration" is not null
-        And the event "unhandled" is true
+  Scenario: Capture foreground state while in the background
+    When I run "CXXBackgroundNotifyScenario"
+    And I send the app to the background for 5 seconds
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the event "app.inForeground" is false
+    And the event "app.durationInForeground" equals 0
+    And the event "app.duration" is greater than 0
+    And the event "context" string is empty
+    And the event "unhandled" is false
 
-    Scenario: Capture foreground state while in a background crash
-        When I run "CXXDelayedCrashScenario"
-        And I send the app to the background for 10 seconds
-        And I clear any error dialogue
-        And I relaunch the app after a crash
-        And I configure Bugsnag for "CXXDelayedCrashScenario"
-        And I wait to receive an error
-        Then the error payload contains a completed handled native report
-        And the event "app.inForeground" is false
-        And the event "app.duration" is greater than 0
-        And the event "context" string is empty
-        And the event "unhandled" is true
+  Scenario: Capture foreground state while in a foreground crash
+    When I run "CXXTrapScenario" and relaunch the app
+    And I configure Bugsnag for "CXXStartSessionScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the event "app.inForeground" is true
+    And the event "app.durationInForeground" is not null
+    And the event "app.duration" is not null
+    And the event "unhandled" is true
+
+  Scenario: Capture foreground state while in a background crash
+    When I run "CXXDelayedCrashScenario"
+    And I send the app to the background for 10 seconds
+    And I clear any error dialogue
+    And I relaunch the app after a crash
+    And I configure Bugsnag for "CXXDelayedCrashScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the event "app.inForeground" is false
+    And the event "app.duration" is greater than 0
+    And the event "context" string is empty
+    And the event "unhandled" is true

--- a/features/full_tests/native_feature_flags.feature
+++ b/features/full_tests/native_feature_flags.feature
@@ -1,12 +1,15 @@
 Feature: Synchronizing feature flags to the native layer
 
+  Background:
+    Given I clear all persistent data
+
   Scenario: Feature flags are synchronized to the native layer
     When I run "CXXFeatureFlagNativeCrashScenario" and relaunch the app
     And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals one of:
-      | SIGILL |
+      | SIGILL  |
       | SIGTRAP |
     And event 0 contains the feature flag "demo_mode" with no variant
     And event 0 contains the feature flag "sample_group" with variant "a"
@@ -21,7 +24,7 @@ Feature: Synchronizing feature flags to the native layer
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals one of:
-      | SIGILL |
+      | SIGILL  |
       | SIGTRAP |
     And event 0 has no feature flags
 
@@ -32,7 +35,7 @@ Feature: Synchronizing feature flags to the native layer
     And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
     Then I wait to receive an error
     And the exception "errorClass" equals one of:
-      | SIGILL |
+      | SIGILL  |
       | SIGTRAP |
     And the event "unhandled" is true
     And event 0 contains the feature flag "demo_mode" with no variant

--- a/features/full_tests/native_metadata.feature
+++ b/features/full_tests/native_metadata.feature
@@ -1,52 +1,55 @@
 Feature: Native Metadata API
 
-    Scenario: Add custom metadata to configuration followed by a C crash
-        When I run "CXXConfigurationMetadataNativeCrashScenario" and relaunch the app
-        And I configure the app to run in the "non-metadata" state
-        And I configure Bugsnag for "CXXConfigurationMetadataNativeCrashScenario"
-        And I wait to receive an error
-        And the error payload contains a completed handled native report
-        And the exception "errorClass" equals one of:
-            | SIGILL |
-            | SIGTRAP |
-        And the event "severity" equals "error"
-        And the event "metaData.fruit.apple" equals "gala"
-        And the event "metaData.fruit.ripe" is true
-        And the event "metaData.fruit.counters" equals 47
-        And the event "unhandled" is true
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Add custom metadata to configuration followed by a C crash
+    When I run "CXXConfigurationMetadataNativeCrashScenario" and relaunch the app
+    And I configure the app to run in the "non-metadata" state
+    And I configure Bugsnag for "CXXConfigurationMetadataNativeCrashScenario"
+    And I wait to receive an error
+    And the error payload contains a completed handled native report
+    And the exception "errorClass" equals one of:
+      | SIGILL  |
+      | SIGTRAP |
+    And the event "severity" equals "error"
+    And the event "metaData.fruit.apple" equals "gala"
+    And the event "metaData.fruit.ripe" is true
+    And the event "metaData.fruit.counters" equals 47
+    And the event "unhandled" is true
 
 #TODO up to here
-    Scenario: Remove MetaData from the NDK layer
-        When I run "CXXRemoveDataScenario"
-        And I wait to receive 2 errors
-        Then the error payload contains a completed handled native report
-        And the event "unhandled" is false
-        And the exception "errorClass" equals "RemoveDataScenario"
-        And the exception "message" equals "oh no"
-        And the event "metaData.persist.keep" equals "foo"
-        And the event "metaData.persist.remove" equals "bar"
-        And the event "metaData.remove.foo" equals "bar"
-        Then I discard the oldest error
-        And the error payload contains a completed handled native report
-        And the event "unhandled" is false
-        And the exception "errorClass" equals "RemoveDataScenario"
-        And the exception "message" equals "oh no"
-        And the event "metaData.persist.keep" equals "foo"
-        And the event "metaData.persist.remove" is null
-        And the event "metaData.remove" is null
+  Scenario: Remove MetaData from the NDK layer
+    When I run "CXXRemoveDataScenario"
+    And I wait to receive 2 errors
+    Then the error payload contains a completed handled native report
+    And the event "unhandled" is false
+    And the exception "errorClass" equals "RemoveDataScenario"
+    And the exception "message" equals "oh no"
+    And the event "metaData.persist.keep" equals "foo"
+    And the event "metaData.persist.remove" equals "bar"
+    And the event "metaData.remove.foo" equals "bar"
+    Then I discard the oldest error
+    And the error payload contains a completed handled native report
+    And the event "unhandled" is false
+    And the exception "errorClass" equals "RemoveDataScenario"
+    And the exception "message" equals "oh no"
+    And the event "metaData.persist.keep" equals "foo"
+    And the event "metaData.persist.remove" is null
+    And the event "metaData.remove" is null
 
-    Scenario: Get Java data in the Native layer
-        When I run "CXXGetJavaDataScenario" and relaunch the app
-        And I configure Bugsnag for "CXXGetJavaDataScenario"
-        And I wait to receive an error
-        Then the error payload contains a completed unhandled native report
-        And the event "unhandled" is true
-        And the event "metaData.data.context" equals "passContext"
-        And the event "metaData.data.appVersion" equals "passAppVersion"
-        And the event "metaData.data.userName" equals "passUserName"
-        And the event "metaData.data.userEmail" equals "passUserEmail"
-        And the event "metaData.data.userId" equals "passUserId"
-        And the event "metaData.data.metadata" equals "passMetaData"
-        And the event "metaData.data.device" is not null
+  Scenario: Get Java data in the Native layer
+    When I run "CXXGetJavaDataScenario" and relaunch the app
+    And I configure Bugsnag for "CXXGetJavaDataScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed unhandled native report
+    And the event "unhandled" is true
+    And the event "metaData.data.context" equals "passContext"
+    And the event "metaData.data.appVersion" equals "passAppVersion"
+    And the event "metaData.data.userName" equals "passUserName"
+    And the event "metaData.data.userEmail" equals "passUserEmail"
+    And the event "metaData.data.userId" equals "passUserId"
+    And the event "metaData.data.metadata" equals "passMetaData"
+    And the event "metaData.data.device" is not null
         # TODO: Skipped pending PLAT-6176
         # And the event "metaData.data.password" equals "[REDACTED]"

--- a/features/full_tests/native_on_error.feature
+++ b/features/full_tests/native_on_error.feature
@@ -1,20 +1,23 @@
 Feature: Native on error callbacks are invoked
 
-    Scenario: on_error returning false prevents C signal being reported
-        When I run "CXXSignalOnErrorFalseScenario" and relaunch the app
-        And I configure Bugsnag for "CXXSignalOnErrorFalseScenario"
-        Then Bugsnag confirms it has no errors to send
+  Background:
+    Given I clear all persistent data
 
-    Scenario: on_error returning false prevents C++ exception being reported
-        When I run "CXXExceptionOnErrorFalseScenario" and relaunch the app
-        And I configure Bugsnag for "CXXExceptionOnErrorFalseScenario"
-        Then Bugsnag confirms it has no errors to send
+  Scenario: on_error returning false prevents C signal being reported
+    When I run "CXXSignalOnErrorFalseScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSignalOnErrorFalseScenario"
+    Then Bugsnag confirms it has no errors to send
 
-    Scenario: Removing on_error callback
-        When I run "CXXRemoveOnErrorScenario" and relaunch the app
-        And I configure Bugsnag for "CXXRemoveOnErrorScenario"
-        And I wait to receive an error
-        Then the error payload contains a completed handled native report
-        And the event "user.id" equals "default"
-        And the event "user.email" equals "default@default.df"
-        And the event "user.name" equals "default"
+  Scenario: on_error returning false prevents C++ exception being reported
+    When I run "CXXExceptionOnErrorFalseScenario" and relaunch the app
+    And I configure Bugsnag for "CXXExceptionOnErrorFalseScenario"
+    Then Bugsnag confirms it has no errors to send
+
+  Scenario: Removing on_error callback
+    When I run "CXXRemoveOnErrorScenario" and relaunch the app
+    And I configure Bugsnag for "CXXRemoveOnErrorScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the event "user.id" equals "default"
+    And the event "user.email" equals "default@default.df"
+    And the event "user.name" equals "default"

--- a/features/full_tests/native_session_tracking.feature
+++ b/features/full_tests/native_session_tracking.feature
@@ -1,6 +1,9 @@
 Feature: NDK Session Tracking
 
-Scenario: Paused session is not in payload of unhandled NDK error
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Paused session is not in payload of unhandled NDK error
     And I run "CXXPausedSessionScenario" and relaunch the app
     And I configure Bugsnag for "CXXPausedSessionScenario"
     And I wait to receive a session
@@ -10,7 +13,7 @@ Scenario: Paused session is not in payload of unhandled NDK error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events.0.session" is null
 
-Scenario: Started session is in payload of unhandled NDK error
+  Scenario: Started session is in payload of unhandled NDK error
     And I run "CXXStartSessionScenario" and relaunch the app
     And I configure Bugsnag for "CXXStartSessionScenario"
     And I wait to receive a session
@@ -20,7 +23,7 @@ Scenario: Started session is in payload of unhandled NDK error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events.0.session.events.unhandled" equals 1
 
-Scenario: Starting a session, notifying, followed by a C crash
+  Scenario: Starting a session, notifying, followed by a C crash
     When I run "CXXSessionInfoCrashScenario" and relaunch the app
     And I configure Bugsnag for "CXXSessionInfoCrashScenario"
     And I wait to receive a session

--- a/features/full_tests/native_signal_raise.feature
+++ b/features/full_tests/native_signal_raise.feature
@@ -1,69 +1,72 @@
 Feature: Raising native signals
 
-    Scenario: Raise SIGILL
-        When I run "CXXSigillScenario" and relaunch the app
-        And I configure Bugsnag for "CXXSigillScenario"
-        And I wait to receive an error
-        And the error payload contains a completed unhandled native report
-        And the exception "errorClass" equals "SIGILL"
-        And the exception "message" equals one of:
-        | Illegal instruction   |
-        | Trace/breakpoint trap |
-        And the exception "type" equals "c"
-        And the event "severity" equals "error"
-        And the event "unhandled" is true
+  Background:
+    Given I clear all persistent data
 
-    Scenario: Raise SIGSEGV
-        When I run "CXXSigsegvScenario" and relaunch the app
-        And I configure Bugsnag for "CXXSigsegvScenario"
-        And I wait to receive an error
-        And the error payload contains a completed unhandled native report
-        And the exception "errorClass" equals "SIGSEGV"
-        And the exception "message" equals "Segmentation violation (invalid memory reference)"
-        And the exception "type" equals "c"
-        And the event "severity" equals "error"
-        And the event "unhandled" is true
+  Scenario: Raise SIGILL
+    When I run "CXXSigillScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSigillScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGILL"
+    And the exception "message" equals one of:
+      | Illegal instruction   |
+      | Trace/breakpoint trap |
+    And the exception "type" equals "c"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
 
-    Scenario: Raise SIGABRT
-        When I run "CXXSigabrtScenario" and relaunch the app
-        And I configure Bugsnag for "CXXSigabrtScenario"
-        And I wait to receive an error
-        And the error payload contains a completed unhandled native report
-        And the exception "errorClass" equals "SIGABRT"
-        And the exception "message" equals "Abort program"
-        And the exception "type" equals "c"
-        And the event "severity" equals "error"
-        And the event "unhandled" is true
+  Scenario: Raise SIGSEGV
+    When I run "CXXSigsegvScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSigsegvScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGSEGV"
+    And the exception "message" equals "Segmentation violation (invalid memory reference)"
+    And the exception "type" equals "c"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
 
-    Scenario: Raise SIGBUS
-        When I run "CXXSigbusScenario" and relaunch the app
-        And I configure Bugsnag for "CXXSigbusScenario"
-        And I wait to receive an error
-        And the error payload contains a completed unhandled native report
-        And the exception "errorClass" equals "SIGBUS"
-        And the exception "message" equals "Bus error (bad memory access)"
-        And the exception "type" equals "c"
-        And the event "severity" equals "error"
-        And the event "unhandled" is true
+  Scenario: Raise SIGABRT
+    When I run "CXXSigabrtScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSigabrtScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGABRT"
+    And the exception "message" equals "Abort program"
+    And the exception "type" equals "c"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
 
-    Scenario: Raise SIGFPE
-        When I run "CXXSigfpeScenario" and relaunch the app
-        And I configure Bugsnag for "CXXSigfpeScenario"
-        And I wait to receive an error
-        And the error payload contains a completed unhandled native report
-        And the exception "errorClass" equals "SIGFPE"
-        And the exception "message" equals "Floating-point exception"
-        And the exception "type" equals "c"
-        And the event "severity" equals "error"
-        And the event "unhandled" is true
+  Scenario: Raise SIGBUS
+    When I run "CXXSigbusScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSigbusScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGBUS"
+    And the exception "message" equals "Bus error (bad memory access)"
+    And the exception "type" equals "c"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
 
-    Scenario: Raise SIGTRAP
-        When I run "CXXSigtrapScenario" and relaunch the app
-        And I configure Bugsnag for "CXXSigtrapScenario"
-        And I wait to receive an error
-        And the error payload contains a completed unhandled native report
-        And the exception "errorClass" equals "SIGTRAP"
-        And the exception "message" equals "Trace/breakpoint trap"
-        And the exception "type" equals "c"
-        And the event "severity" equals "error"
-        And the event "unhandled" is true
+  Scenario: Raise SIGFPE
+    When I run "CXXSigfpeScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSigfpeScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGFPE"
+    And the exception "message" equals "Floating-point exception"
+    And the exception "type" equals "c"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+
+  Scenario: Raise SIGTRAP
+    When I run "CXXSigtrapScenario" and relaunch the app
+    And I configure Bugsnag for "CXXSigtrapScenario"
+    And I wait to receive an error
+    And the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals "SIGTRAP"
+    And the exception "message" equals "Trace/breakpoint trap"
+    And the exception "type" equals "c"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true

--- a/features/full_tests/native_threads.feature
+++ b/features/full_tests/native_threads.feature
@@ -1,5 +1,8 @@
 Feature: Capture native threads
 
+  Background:
+    Given I clear all persistent data
+
   Scenario: Reports native threads for Unhandled errors
     When I run "CXXCaptureThreadsScenario" and relaunch the app
     And I configure Bugsnag for "CXXCaptureThreadsScenario"

--- a/features/full_tests/native_throw_crash.feature
+++ b/features/full_tests/native_throw_crash.feature
@@ -1,5 +1,8 @@
 Feature: Native crash reporting with thrown objects
 
+  Background:
+    Given I clear all persistent data
+
   Scenario: Throwing an exception in C++
     When I run "CXXExceptionScenario" and relaunch the app
     And I configure Bugsnag for "CXXExceptionScenario"
@@ -42,6 +45,6 @@ Feature: Native crash reporting with thrown objects
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And on arm64, the first significant stack frames match:
-      | FunkError::what() const | CXXThrowFromNoexcept.cpp | 13 |
+      | FunkError::what() const                                                  | CXXThrowFromNoexcept.cpp | 13 |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXThrowFromNoexcept_crash | CXXThrowFromNoexcept.cpp | 21 |
 

--- a/features/full_tests/native_user.feature
+++ b/features/full_tests/native_user.feature
@@ -1,25 +1,28 @@
 Feature: Native User API
 
-    Scenario: Adding user information in Java followed by a C crash
-        And I run "CXXJavaUserInfoNativeCrashScenario" and relaunch the app
-        And I configure Bugsnag for "CXXJavaUserInfoNativeCrashScenario"
-        And I wait to receive an error
-        Then the error payload contains a completed handled native report
-        And the exception "errorClass" equals one of:
-            | SIGILL |
-            | SIGTRAP |
-        And the event "severity" equals "error"
-        And the event "user.name" equals "Strulyegha  Ghaumon  Rabelban  Snefkal  Angengtai  Samperris  D"
-        And the event "user.id" equals "9816734"
-        And the event "user.email" equals "j@example.com"
-        And the event "unhandled" is true
+  Background:
+    Given I clear all persistent data
 
-    Scenario: Set user in Native layer followed by a Java crash
-        When I run "CXXNativeUserInfoJavaCrashScenario" and relaunch the app
-        And I configure Bugsnag for "CXXNativeUserInfoJavaCrashScenario"
-        And I wait to receive an error
-        Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the error payload field "events" is an array with 1 elements
-        And the event "user.id" equals "24601"
-        And the event "user.email" equals "test@test.test"
-        And the event "user.name" equals "test user"
+  Scenario: Adding user information in Java followed by a C crash
+    And I run "CXXJavaUserInfoNativeCrashScenario" and relaunch the app
+    And I configure Bugsnag for "CXXJavaUserInfoNativeCrashScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed handled native report
+    And the exception "errorClass" equals one of:
+      | SIGILL  |
+      | SIGTRAP |
+    And the event "severity" equals "error"
+    And the event "user.name" equals "Strulyegha  Ghaumon  Rabelban  Snefkal  Angengtai  Samperris  D"
+    And the event "user.id" equals "9816734"
+    And the event "user.email" equals "j@example.com"
+    And the event "unhandled" is true
+
+  Scenario: Set user in Native layer followed by a Java crash
+    When I run "CXXNativeUserInfoJavaCrashScenario" and relaunch the app
+    And I configure Bugsnag for "CXXNativeUserInfoJavaCrashScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "events" is an array with 1 elements
+    And the event "user.id" equals "24601"
+    And the event "user.email" equals "test@test.test"
+    And the event "user.name" equals "test user"

--- a/features/full_tests/naughty_strings.feature
+++ b/features/full_tests/naughty_strings.feature
@@ -1,6 +1,9 @@
 Feature: The notifier handles user data containing unusual strings
 
-Scenario: Test handled JVM error
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Test handled JVM error
     When I run "NaughtyStringScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -24,8 +27,8 @@ Scenario: Test handled JVM error
     And the error payload field "events.0.metaData.custom.val_14" equals "گچپژ"
 
 # commented out some failing unicode assertions and skipped Android <6 until PLAT-5606 is addressed
-@skip_below_android_6
-Scenario: Test unhandled NDK error
+  @skip_below_android_6
+  Scenario: Test unhandled NDK error
     When I run "CXXNaughtyStringsScenario" and relaunch the app
     And I configure Bugsnag for "CXXNaughtyStringsScenario"
     Then I wait to receive an error

--- a/features/full_tests/network_breadcrumbs.feature
+++ b/features/full_tests/network_breadcrumbs.feature
@@ -1,6 +1,9 @@
 Feature: Capturing network breadcrumbs
 
-Scenario: Breadcrumbs are captured for OkHttp network requests
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Breadcrumbs are captured for OkHttp network requests
     When I run "NetworkBreadcrumbScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/null_stacktrace.feature
+++ b/features/full_tests/null_stacktrace.feature
@@ -1,6 +1,9 @@
 Feature: Null Stacktrace reported
 
-Scenario: Exceptions with null stacktraces are sent
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Exceptions with null stacktraces are sent
     When I run "NullStackTraceScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/onsend_callback.feature
+++ b/features/full_tests/onsend_callback.feature
@@ -1,5 +1,8 @@
 Feature: OnSend Callbacks can alter Events before upload
 
+  Background:
+    Given I clear all persistent data
+
   Scenario: Unhandled exception altered by OnSendCallback
     When I run "OnSendCallbackScenario" and relaunch the app
     And I configure the app to run in the "start-only" state

--- a/features/full_tests/oom.feature
+++ b/features/full_tests/oom.feature
@@ -1,6 +1,9 @@
 Feature: Reporting OOMs
 
-Scenario: Out of Memory Error captured
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Out of Memory Error captured
     When I run "OomScenario" and relaunch the app
     And I configure Bugsnag for "OomScenario"
     Then I wait to receive an error

--- a/features/full_tests/override_unhandled.feature
+++ b/features/full_tests/override_unhandled.feature
@@ -1,6 +1,9 @@
 Feature: Overriding unhandled state
 
-Scenario: Non-fatal exception overridden to unhandled
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Non-fatal exception overridden to unhandled
     When I run "OverrideToUnhandledExceptionScenario"
     Then I wait to receive an error
     And I wait to receive a session
@@ -14,7 +17,7 @@ Scenario: Non-fatal exception overridden to unhandled
     And the event "session.events.handled" equals 0
     And the event "session.events.unhandled" equals 1
 
-Scenario: Fatal exception overridden to handled
+  Scenario: Fatal exception overridden to handled
     When I run "OverrideToHandledExceptionScenario" and relaunch the app
     And I configure Bugsnag for "OverrideToHandledExceptionScenario"
     And I wait to receive an error
@@ -29,7 +32,7 @@ Scenario: Fatal exception overridden to handled
     And the event "session.events.handled" equals 1
     And the event "session.events.unhandled" equals 0
 
-Scenario: CXX error overridden to handled
+  Scenario: CXX error overridden to handled
     When I run "CXXHandledOverrideScenario" and relaunch the app
     And I configure Bugsnag for "CXXHandledOverrideScenario"
     And I wait to receive an error

--- a/features/full_tests/plugin_interface.feature
+++ b/features/full_tests/plugin_interface.feature
@@ -1,14 +1,17 @@
 Feature: Add custom behavior through a plugin interface
 
-    Some internal libraries may build on top of the Bugsnag Android library and
-    require custom behavior prior to the library being fully initialized. This
-    interface allows for installing that behavior before calling the regular
-    initialization process.
+  Some internal libraries may build on top of the Bugsnag Android library and
+  require custom behavior prior to the library being fully initialized. This
+  interface allows for installing that behavior before calling the regular
+  initialization process.
 
-    Scenario: Changing payload notifier description
-        When I run "CustomPluginNotifierDescriptionScenario"
-        Then I wait to receive an error
-        Then the event "context" equals "Foo Handler Library"
-        And the error payload field "events" is an array with 1 elements
-        And the exception "errorClass" equals "java.lang.RuntimeException"
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Changing payload notifier description
+    When I run "CustomPluginNotifierDescriptionScenario"
+    Then I wait to receive an error
+    Then the event "context" equals "Foo Handler Library"
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "java.lang.RuntimeException"
 

--- a/features/full_tests/release_stage.feature
+++ b/features/full_tests/release_stage.feature
@@ -1,21 +1,24 @@
 Feature: Reporting exceptions with release stages
 
-Scenario: Exception not reported when outside release stage
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Exception not reported when outside release stage
     When I run "OutsideReleaseStageScenario"
     And I wait to receive 1 logs
     Then the "debug" level log message equals "Bugsnag loaded"
 
-Scenario: Exception not reported when release stage null
+  Scenario: Exception not reported when release stage null
     When I run "NullReleaseStageScenario"
     And I wait to receive 1 logs
     Then the "debug" level log message equals "Bugsnag loaded"
 
-Scenario: Exception reported when release stages empty
+  Scenario: Exception reported when release stages empty
     When I run "EmptyEnabledReleaseStageScenario"
     And I wait to receive 1 logs
     Then the "debug" level log message equals "Bugsnag loaded"
 
-Scenario: Exception reported when inside Notify release stage array
+  Scenario: Exception reported when inside Notify release stage array
     When I run "ArrayEnabledReleaseStageScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/session_stopping.feature
+++ b/features/full_tests/session_stopping.feature
@@ -1,6 +1,9 @@
 Feature: Pausing and resuming sessions
 
-Scenario: Stopping, resuming, and starting sessions are reflected in error and session payloads
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Stopping, resuming, and starting sessions are reflected in error and session payloads
     When I run "SessionStoppingScenario"
 
     # 2 sessions are received

--- a/features/full_tests/session_tracking.feature
+++ b/features/full_tests/session_tracking.feature
@@ -1,6 +1,9 @@
 Feature: Session Tracking
 
-Scenario: User is persisted between sessions
+  Background:
+    Given I clear all persistent data
+
+  Scenario: User is persisted between sessions
     When I run "SessionPersistUserScenario"
     And I wait to receive a session
     Then the session is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
@@ -20,7 +23,7 @@ Scenario: User is persisted between sessions
     And the session "user.email" equals "test@test.test"
     And the session "user.name" equals "test user"
 
-Scenario: User is not persisted between sessions
+  Scenario: User is not persisted between sessions
     When I run "SessionPersistUserDisabledScenario"
     And I wait to receive a session
     Then the session is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/stackoverflow.feature
+++ b/features/full_tests/stackoverflow.feature
@@ -1,6 +1,9 @@
 Feature: Reporting Stack overflow
 
-Scenario: Stack Overflow sends
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Stack Overflow sends
     When I run "StackOverflowScenario" and relaunch the app
     And I configure Bugsnag for "StackOverflowScenario"
     And I wait to receive an error

--- a/features/full_tests/startup_anr.feature
+++ b/features/full_tests/startup_anr.feature
@@ -1,13 +1,16 @@
 Feature: onCreate ANR
 
+  Background:
+    Given I clear all persistent data
+
 # Android 10 Note: Android 10 devices appear to allow much longer times for startup without an ANR
 # and then terminate the "misbehaving" app with a KILL (9) signal (almost like the ANR code doesn't
 # fire at all). Since we can't cover a KILL signal in a test, we skip Android 10.
-@skip_android_10
-Scenario: onCreate ANR is reported
-  When I run "ConfigureStartupAnrScenario"
-  And I relaunch the app after a crash
-  And I wait for 30 seconds
-  And I clear any error dialogue
-  Then I wait to receive an error
-  And the exception "errorClass" equals "ANR"
+  @skip_android_10
+  Scenario: onCreate ANR is reported
+    When I run "ConfigureStartupAnrScenario"
+    And I relaunch the app after a crash
+    And I wait for 30 seconds
+    And I clear any error dialogue
+    Then I wait to receive an error
+    And the exception "errorClass" equals "ANR"

--- a/features/full_tests/strict_mode_legacy.feature
+++ b/features/full_tests/strict_mode_legacy.feature
@@ -1,7 +1,10 @@
 Feature: Reporting Strict Mode Violations
 
-@skip_above_android_8
-Scenario: StrictMode DiscWrite violation
+  Background:
+    Given I clear all persistent data
+
+  @skip_above_android_8
+  Scenario: StrictMode DiscWrite violation
     When I run "StrictModeDiscScenario" and relaunch the app
     And I configure Bugsnag for "StrictModeDiscScenario"
     And I wait to receive an error
@@ -10,8 +13,8 @@ Scenario: StrictMode DiscWrite violation
     And the event "metaData.StrictMode.Violation" equals "DiskWrite"
     And the event "severityReason.type" equals "strictMode"
 
-@skip_above_android_8
-Scenario: StrictMode Network on Main Thread violation
+  @skip_above_android_8
+  Scenario: StrictMode Network on Main Thread violation
     When I run "StrictModeNetworkScenario" and relaunch the app
     And I configure Bugsnag for "StrictModeNetworkScenario"
     And I wait to receive an error
@@ -21,8 +24,8 @@ Scenario: StrictMode Network on Main Thread violation
     And the event "severityReason.type" equals "strictMode"
 
 # In Android <9 StrictMode kills VM policy violations with SIGKILL, so no requests are received.
-@skip_above_android_8
-Scenario: StrictMode Activity leak violation
+  @skip_above_android_8
+  Scenario: StrictMode Activity leak violation
     When I run "StrictModeFileUriExposeScenario" and relaunch the app
     And I configure Bugsnag for "StrictModeFileUriExposeScenario"
     Then I should receive no requests

--- a/features/full_tests/strict_mode_violations.feature
+++ b/features/full_tests/strict_mode_violations.feature
@@ -1,7 +1,10 @@
 Feature: Reporting Strict Mode Violations
 
-@skip_below_android_9
-Scenario: StrictMode Exposed File URI violation
+  Background:
+    Given I clear all persistent data
+
+  @skip_below_android_9
+  Scenario: StrictMode Exposed File URI violation
     When I run "StrictModeFileUriExposeScenario" and relaunch the app
     And I configure Bugsnag for "StrictModeFileUriExposeScenario"
     And I wait to receive an error
@@ -15,8 +18,8 @@ Scenario: StrictMode Exposed File URI violation
     And the event "exceptions.0.stacktrace.0.method" equals "android.os.StrictMode.onFileUriExposed"
     And the event "exceptions.0.stacktrace.0.file" equals "StrictMode.java"
 
-@skip_below_android_9
-Scenario: StrictMode DiscWrite violation
+  @skip_below_android_9
+  Scenario: StrictMode DiscWrite violation
     When I run "StrictModeDiscScenario" and relaunch the app
     And I configure Bugsnag for "StrictModeDiscScenario"
     And I wait to receive 2 errors
@@ -31,12 +34,12 @@ Scenario: StrictMode DiscWrite violation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
 
     And the exception "stacktrace.1.method" equals one of:
-        | libcore.io.BlockGuardOs.open |
-        | java.io.FileOutputStream.<init> |
+      | libcore.io.BlockGuardOs.open    |
+      | java.io.FileOutputStream.<init> |
 
     And the exception "stacktrace.1.file" equals one of:
-        | BlockGuardOs.java |
-        | FileOutputStream.java |
+      | BlockGuardOs.java     |
+      | FileOutputStream.java |
 
     # Second violation (triggered by writing to FileOutputStream)
     And I discard the oldest error

--- a/features/full_tests/trimmed_stacktrace.feature
+++ b/features/full_tests/trimmed_stacktrace.feature
@@ -1,6 +1,9 @@
 Feature: Reporting large stacktrace
 
-Scenario: A large stacktrace should have its frames trimmed to a reasonable number
+  Background:
+    Given I clear all persistent data
+
+  Scenario: A large stacktrace should have its frames trimmed to a reasonable number
     When I run "TrimmedStacktraceScenario"
     And I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/user.feature
+++ b/features/full_tests/user.feature
@@ -1,28 +1,31 @@
 Feature: Reporting User Information
 
-    Scenario: User fields set as null
-        When I run "UserDisabledScenario"
-        And I wait to receive an error
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "UserDisabledScenario"
-        And the event "user.id" is null
-        And the event "user.email" is null
-        And the event "user.name" is null
+  Background:
+    Given I clear all persistent data
 
-    Scenario: Only User ID field set
-        When I run "UserIdScenario"
-        And I wait to receive an error
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "UserIdScenario"
-        And the event "user.id" equals "abc"
-        And the event "user.email" is null
-        And the event "user.name" is null
+  Scenario: User fields set as null
+    When I run "UserDisabledScenario"
+    And I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "UserDisabledScenario"
+    And the event "user.id" is null
+    And the event "user.email" is null
+    And the event "user.name" is null
 
-    Scenario: Override user details in callback
-        When I run "UserCallbackScenario"
-        And I wait to receive an error
-        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-        And the exception "message" equals "UserCallbackScenario"
-        And the event "user.id" equals "Agent Pink"
-        And the event "user.email" equals "bob@example.com"
-        And the event "user.name" equals "Zebedee"
+  Scenario: Only User ID field set
+    When I run "UserIdScenario"
+    And I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "UserIdScenario"
+    And the event "user.id" equals "abc"
+    And the event "user.email" is null
+    And the event "user.name" is null
+
+  Scenario: Override user details in callback
+    When I run "UserCallbackScenario"
+    And I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "UserCallbackScenario"
+    And the event "user.id" equals "Agent Pink"
+    And the event "user.email" equals "bob@example.com"
+    And the event "user.name" equals "Zebedee"

--- a/features/minimal/detect_anr_minimal.feature
+++ b/features/minimal/detect_anr_minimal.feature
@@ -1,6 +1,9 @@
 Feature: ANRs triggered in a fixture with only bugsnag-android-core are captured
 
-Scenario: Triggering ANR does not crash the minimal app
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Triggering ANR does not crash the minimal app
     When I run "JvmAnrMinimalFixtureScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times

--- a/features/smoke_tests/handled.feature
+++ b/features/smoke_tests/handled.feature
@@ -1,6 +1,9 @@
 Feature: Handled smoke tests
 
-Scenario: Notify caught Java exception with default configuration
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Notify caught Java exception with default configuration
     When I run "HandledJavaSmokeScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -109,7 +112,7 @@ Scenario: Notify caught Java exception with default configuration
     And the event "threads.0.stacktrace.0.file" is not null
     And the event "threads.0.stacktrace.0.lineNumber" is not null
 
-Scenario: Notify Kotlin exception with overwritten configuration
+  Scenario: Notify Kotlin exception with overwritten configuration
     When I run "HandledKotlinSmokeScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -165,8 +168,8 @@ Scenario: Notify Kotlin exception with overwritten configuration
     And the event "threads.0.stacktrace.0.file" is not null
     And the event "threads.0.stacktrace.0.lineNumber" is not null
 
-@debug-safe
-Scenario: Handled C functionality
+  @debug-safe
+  Scenario: Handled C functionality
     When I run "CXXNotifySmokeScenario"
     And I wait to receive an error
 

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -1,7 +1,10 @@
 Feature: Session functionality smoke tests
 
-@debug-safe
-Scenario: Automated sessions send
+  Background:
+    Given I clear all persistent data
+
+  @debug-safe
+  Scenario: Automated sessions send
     When I run "AutoSessionSmokeScenario"
     And I wait to receive a session
 
@@ -52,8 +55,8 @@ Scenario: Automated sessions send
     And the event "session.events.unhandled" equals 0
     And the event "severityReason.unhandledOverridden" is false
 
-@debug-safe
-Scenario: Manual session control works
+  @debug-safe
+  Scenario: Manual session control works
     When I run "ManualSessionSmokeScenario" and relaunch the app
     And I configure Bugsnag for "ManualSessionSmokeScenario"
     And I wait to receive a session

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -1,6 +1,9 @@
 Feature: Unhandled smoke tests
 
-Scenario: Unhandled Java Exception with loaded configuration
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Unhandled Java Exception with loaded configuration
     When I run "UnhandledJavaLoadedConfigScenario" and relaunch the app
     And I configure Bugsnag for "UnhandledJavaLoadedConfigScenario"
     And I wait to receive an error
@@ -95,7 +98,7 @@ Scenario: Unhandled Java Exception with loaded configuration
     And the event "threads.0.stacktrace.0.file" is not null
     And the event "threads.0.stacktrace.0.lineNumber" is not null
 
-Scenario: Signal raised with overwritten config
+  Scenario: Signal raised with overwritten config
     When I run "CXXSignalSmokeScenario" and relaunch the app
     And I configure Bugsnag for "CXXSignalSmokeScenario"
     And I wait to receive an error
@@ -181,8 +184,8 @@ Scenario: Signal raised with overwritten config
     And the event "metaData.fruit.ripe" is true
     And the event "metaData.fruit.counters" equals 47
 
-@debug-safe
-Scenario: C++ exception thrown with overwritten config
+  @debug-safe
+  Scenario: C++ exception thrown with overwritten config
     When I run "CXXExceptionSmokeScenario" and relaunch the app
     And I configure Bugsnag for "CXXExceptionSmokeScenario"
     And I wait to receive an error
@@ -203,10 +206,10 @@ Scenario: C++ exception thrown with overwritten config
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event stacktrace identifies the program counter
     And the first significant stack frames match:
-        | magicstacks::top()    | CXXExceptionSmokeScenario.cpp | 13 |
-        | magicstacks::middle() | CXXExceptionSmokeScenario.cpp | 16 |
-        | magicstacks::start()  | CXXExceptionSmokeScenario.cpp | 18 |
-        | Java_com_bugsnag_android_mazerunner_scenarios_CXXExceptionSmokeScenario_crash | CXXExceptionSmokeScenario.cpp | 25 |
+      | magicstacks::top()                                                            | CXXExceptionSmokeScenario.cpp | 13 |
+      | magicstacks::middle()                                                         | CXXExceptionSmokeScenario.cpp | 16 |
+      | magicstacks::start()                                                          | CXXExceptionSmokeScenario.cpp | 18 |
+      | Java_com_bugsnag_android_mazerunner_scenarios_CXXExceptionSmokeScenario_crash | CXXExceptionSmokeScenario.cpp | 25 |
 
     # App data
     And the event binary arch field is valid
@@ -258,8 +261,8 @@ Scenario: C++ exception thrown with overwritten config
     # Breadcrumbs
     And the event has a "manual" breadcrumb named "CXXExceptionSmokeScenario"
 
-@skip_android_8_1
-Scenario: ANR detection
+  @skip_android_8_1
+  Scenario: ANR detection
     When I run "JvmAnrLoopScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -1,3 +1,7 @@
+When('I clear all persistent data') do
+  step 'I click the element "clear_persistent_data"'
+end
+
 # Waits 5s for an element to be present.  If it isn't assume a system error dialog is
 # blocking its view and dismiss it before trying once more.
 #


### PR DESCRIPTION
## Goal

Clear app data at the start of each e2e test scenarios, preventing them from bleeding into each other.

## Design

Test scenarios can occasionally flake because a full reset is not performed between each test scenario.  A new button on the UI allows all Bugsnag data to be cleared.

## Changeset

A `Background` step in every `.feature` file uses Appium to press the new button, clearing Bugsnag data.

I have also taken the opportunity to consistently format all `.feature` files.  Although the diff looks like scenarios have changed in some places, only whitespace changes have occurred other than the addition of the `Background` step.

## Testing

Covered by CI and I have manually checked the device logs to verify that the button is pressed.