### PR TITLE
[PLAT-8185] Limit retries of event payloads based on size and age, and session payloads based on age

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -22,6 +22,7 @@
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$429</ID>
     <ID>MagicNumber:DefaultDelivery.kt$DefaultDelivery$499</ID>
     <ID>MagicNumber:LastRunInfoStore.kt$LastRunInfoStore$3</ID>
+    <ID>MagicNumber:SessionFilenameInfo.kt$SessionFilenameInfo.Companion$35</ID>
     <ID>MaxLineLength:LastRunInfo.kt$LastRunInfo$return "LastRunInfo(consecutiveLaunchCrashes=$consecutiveLaunchCrashes, crashed=$crashed, crashedDuringLaunch=$crashedDuringLaunch)"</ID>
     <ID>MaxLineLength:ThreadState.kt$ThreadState$"[${allThreads.size - maxThreadCount} threads omitted as the maxReportedThreads limit ($maxThreadCount) was exceeded]"</ID>
     <ID>ProtectedMemberInFinalClass:ConfigInternal.kt$ConfigInternal$protected val plugins = HashSet&lt;Plugin>()</ID>
@@ -38,7 +39,9 @@
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get battery status") }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get locationStatus") }</ID>
     <ID>SwallowedException:DeviceIdStore.kt$DeviceIdStore$catch (exc: OverlappingFileLockException) { Thread.sleep(FILE_LOCK_WAIT_MS) }</ID>
+    <ID>SwallowedException:EventFilenameInfo.kt$EventFilenameInfo.Companion$catch (e: Exception) { return -1 }</ID>
     <ID>SwallowedException:PluginClient.kt$PluginClient$catch (exc: ClassNotFoundException) { logger.d("Plugin '$clz' is not on the classpath - functionality will not be enabled.") null }</ID>
+    <ID>SwallowedException:SessionFilenameInfo.kt$SessionFilenameInfo.Companion$catch (e: Exception) { return 0 }</ID>
     <ID>TooManyFunctions:ConfigInternal.kt$ConfigInternal : CallbackAwareMetadataAwareUserAwareFeatureFlagAware</ID>
     <ID>TooManyFunctions:EventInternal.kt$EventInternal : FeatureFlagAwareStreamableMetadataAwareUserAware</ID>
     <ID>UnnecessaryAbstractClass:DependencyModule.kt$DependencyModule</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -7,9 +7,11 @@ import androidx.annotation.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -119,7 +121,7 @@ class EventStore extends FileStore {
         List<File> launchCrashes = new ArrayList<>();
 
         for (File file : storedFiles) {
-            EventFilenameInfo filenameInfo = EventFilenameInfo.Companion.fromFile(file, config);
+            EventFilenameInfo filenameInfo = EventFilenameInfo.fromFile(file, config);
             if (filenameInfo.isLaunchCrashReport()) {
                 launchCrashes.add(file);
             }
@@ -163,7 +165,7 @@ class EventStore extends FileStore {
 
     private void flushEventFile(File eventFile) {
         try {
-            EventFilenameInfo eventInfo = EventFilenameInfo.Companion.fromFile(eventFile, config);
+            EventFilenameInfo eventInfo = EventFilenameInfo.fromFile(eventFile, config);
             String apiKey = eventInfo.getApiKey();
             EventPayload payload = createEventPayload(eventFile, apiKey);
 
@@ -188,9 +190,21 @@ class EventStore extends FileStore {
                 logger.i("Deleting sent error file " + eventFile.getName());
                 break;
             case UNDELIVERED:
-                cancelQueuedFiles(Collections.singleton(eventFile));
-                logger.w("Could not send previously saved error(s)"
-                        + " to Bugsnag, will try again later");
+                if (isTooBig(eventFile)) {
+                    logger.w("Discarding over-sized event ("
+                            + eventFile.length()
+                            + ") after failed delivery");
+                    deleteStoredFiles(Collections.singleton(eventFile));
+                } else if (isTooOld(eventFile)) {
+                    logger.w("Discarding historical event (from "
+                            + getCreationDate(eventFile)
+                            + ") after failed delivery");
+                    deleteStoredFiles(Collections.singleton(eventFile));
+                } else {
+                    cancelQueuedFiles(Collections.singleton(eventFile));
+                    logger.w("Could not send previously saved error(s)"
+                            + " to Bugsnag, will try again later");
+                }
                 break;
             case FAILURE:
                 Exception exc = new RuntimeException("Failed to deliver event payload");
@@ -234,13 +248,29 @@ class EventStore extends FileStore {
     @Override
     String getFilename(Object object) {
         EventFilenameInfo eventInfo
-                = EventFilenameInfo.Companion.fromEvent(object, null, config);
+                = EventFilenameInfo.fromEvent(object, null, config);
         return eventInfo.encode();
     }
 
     String getNdkFilename(Object object, String apiKey) {
         EventFilenameInfo eventInfo
-                = EventFilenameInfo.Companion.fromEvent(object, apiKey, config);
+                = EventFilenameInfo.fromEvent(object, apiKey, config);
         return eventInfo.encode();
+    }
+
+    private static long oneMegabyte = 1024 * 1024;
+
+    public boolean isTooBig(File file) {
+        return file.length() > oneMegabyte;
+    }
+
+    public boolean isTooOld(File file) {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DATE, -60);
+        return EventFilenameInfo.findTimestampInFilename(file) < cal.getTimeInMillis();
+    }
+
+    public Date getCreationDate(File file) {
+        return new Date(EventFilenameInfo.findTimestampInFilename(file));
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.java
@@ -39,7 +39,7 @@ abstract class FileStore {
 
     private final Lock lock = new ReentrantLock();
     private final Collection<File> queuedFiles = new ConcurrentSkipListSet<>();
-    private final Logger logger;
+    protected final Logger logger;
     private final EventStore.Delegate delegate;
 
     FileStore(@NonNull File storageDir,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionFilenameInfo.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionFilenameInfo.kt
@@ -1,0 +1,55 @@
+package com.bugsnag.android
+
+import java.io.File
+import java.util.UUID
+
+/**
+ * Represents important information about a session filename.
+ * Currently the following information is encoded:
+ *
+ * uuid - to disambiguate stored error reports
+ * timestamp - to sort error reports by time of capture
+ */
+internal data class SessionFilenameInfo(
+    val timestamp: Long,
+    val uuid: String,
+) {
+
+    fun encode(): String {
+        return toFilename(timestamp, uuid)
+    }
+
+    internal companion object {
+
+        const val uuidLength = 36
+
+        /**
+         * Generates a filename for the session in the format
+         * "[UUID][timestamp]_v2.json"
+         */
+        fun toFilename(timestamp: Long, uuid: String): String {
+            return "${uuid}${timestamp}_v2.json"
+        }
+
+        @JvmStatic
+        fun defaultFilename(): String {
+            return toFilename(System.currentTimeMillis(), UUID.randomUUID().toString())
+        }
+
+        fun fromFile(file: File): SessionFilenameInfo {
+            return SessionFilenameInfo(
+                findTimestampInFilename(file),
+                findUuidInFilename(file)
+            )
+        }
+
+        private fun findUuidInFilename(file: File): String {
+            return file.name.substring(0, uuidLength - 1)
+        }
+
+        @JvmStatic
+        fun findTimestampInFilename(file: File): Long {
+            return file.name.substring(uuidLength, file.name.indexOf("_")).toLongOrNull() ?: -1
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionStore.java
@@ -6,7 +6,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.io.File;
+import java.util.Calendar;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.UUID;
 
 /**
@@ -46,7 +48,16 @@ class SessionStore extends FileStore {
     @NonNull
     @Override
     String getFilename(Object object) {
-        return UUID.randomUUID().toString() + System.currentTimeMillis() + "_v2.json";
+        return SessionFilenameInfo.defaultFilename();
     }
 
+    public boolean isTooOld(File file) {
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.DATE, -60);
+        return SessionFilenameInfo.findTimestampInFilename(file) < cal.getTimeInMillis();
+    }
+
+    public Date getCreationDate(File file) {
+        return new Date(SessionFilenameInfo.findTimestampInFilename(file));
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -270,8 +270,15 @@ class SessionTracker extends BaseObservable {
                 logger.d("Sent 1 new session to Bugsnag");
                 break;
             case UNDELIVERED:
-                sessionStore.cancelQueuedFiles(Collections.singletonList(storedFile));
-                logger.w("Leaving session payload for future delivery");
+                if (sessionStore.isTooOld(storedFile)) {
+                    logger.w("Discarding historical session (from {"
+                            + sessionStore.getCreationDate(storedFile)
+                            + "}) after failed delivery");
+                    sessionStore.deleteStoredFiles(Collections.singletonList(storedFile));
+                } else {
+                    sessionStore.cancelQueuedFiles(Collections.singletonList(storedFile));
+                    logger.w("Leaving session payload for future delivery");
+                }
                 break;
             case FAILURE:
                 // drop bad data

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -7,6 +7,14 @@
     <ID>MagicNumber:AutoDetectAnrsFalseScenario.kt$AutoDetectAnrsFalseScenario$100000</ID>
     <ID>MagicNumber:AutoDetectAnrsTrueScenario.kt$AutoDetectAnrsTrueScenario$100000</ID>
     <ID>MagicNumber:BugsnagInitScenario.kt$BugsnagInitScenario$25</ID>
+    <ID>MagicNumber:DiscardBigEventsScenario.kt$DiscardBigEventsScenario$100</ID>
+    <ID>MagicNumber:DiscardBigEventsScenario.kt$DiscardBigEventsScenario$1024</ID>
+    <ID>MagicNumber:DiscardOldEventsScenario.kt$DiscardOldEventsScenario$100</ID>
+    <ID>MagicNumber:DiscardOldEventsScenario.kt$DiscardOldEventsScenario$60</ID>
+    <ID>MagicNumber:DiscardOldSessionScenario.kt$DiscardOldSessionScenario$100</ID>
+    <ID>MagicNumber:DiscardOldSessionScenario.kt$DiscardOldSessionScenario$35</ID>
+    <ID>MagicNumber:DiscardOldSessionScenario.kt$DiscardOldSessionScenario$60</ID>
+    <ID>MagicNumber:DiscardOldSessionScenarioPart2.kt$DiscardOldSessionScenarioPart2$1000</ID>
     <ID>MagicNumber:HandledExceptionMaxThreadsScenario.kt$HandledExceptionMaxThreadsScenario$3</ID>
     <ID>MagicNumber:HandledKotlinSmokeScenario.kt$HandledKotlinSmokeScenario$999</ID>
     <ID>MagicNumber:JvmAnrSleepScenario.kt$JvmAnrSleepScenario$100000</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
@@ -1,0 +1,42 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import java.io.File
+
+internal class DiscardBigEventsScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.launchDurationMillis = 0
+        config.addOnSend {
+            it.addMetadata("big", "stuff", generateBigText())
+            true
+        }
+    }
+
+    fun generateBigText(): String {
+        return "*".repeat(1024 * 1024)
+    }
+
+    fun waitForEventFile() {
+        val dir = File(context.cacheDir, "bugsnag-errors")
+        while (dir.listFiles()!!.isEmpty()) {
+            Thread.sleep(100)
+        }
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+        Bugsnag.markLaunchCompleted()
+        Bugsnag.notify(MyThrowable("DiscardBigEventsScenario"))
+
+        waitForEventFile()
+
+        Bugsnag.notify(MyThrowable("To keep maze-runner from shutting me down prematurely"))
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
@@ -1,0 +1,59 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import java.io.File
+import java.util.Calendar
+
+internal class DiscardOldEventsScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.launchDurationMillis = 0
+    }
+
+    fun setEventFileTimestamp(file: File, timestamp: Long) {
+        val name = file.name
+        val suffix = name.substringAfter("_")
+        val dstFile = File(file.parent, "${timestamp}_$suffix")
+        assert(file.renameTo(dstFile))
+    }
+
+    fun errorsDir(): File {
+        return File(context.cacheDir, "bugsnag-errors")
+    }
+
+    fun waitForEventFile() {
+        val dir = errorsDir()
+        while (dir.listFiles()!!.isEmpty()) {
+            Thread.sleep(100)
+        }
+    }
+
+    fun oldifyEventFiles() {
+        val cal = Calendar.getInstance()
+        cal.add(Calendar.DATE, -60)
+        cal.add(Calendar.MINUTE, -1)
+        val timestamp = cal.timeInMillis
+
+        val files = errorsDir().listFiles()
+        for (file in files!!) {
+            setEventFileTimestamp(file, timestamp)
+        }
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+        Bugsnag.markLaunchCompleted()
+        Bugsnag.notify(MyThrowable("DiscardOldEventsScenario"))
+
+        waitForEventFile()
+        oldifyEventFiles()
+
+        Bugsnag.notify(MyThrowable("To keep maze-runner from shutting me down prematurely"))
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
@@ -1,0 +1,64 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.EndpointConfiguration
+import java.io.File
+import java.util.Calendar
+
+internal class DiscardOldSessionScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.launchDurationMillis = 0
+        // We set an endpoint so that attempts to send the session will fail.
+        config.endpoints = EndpointConfiguration(config.endpoints.notify, "https://nonexistent.bugsnag.com")
+    }
+
+    fun setSessionFileTimestamp(file: File, timestamp: Long) {
+        val name = file.name
+        val uuid = name.substring(0, 35)
+        val suffix = name.substringAfter("_")
+        val dstFile = File(file.parent, "${uuid}${timestamp}_$suffix")
+        assert(file.renameTo(dstFile))
+    }
+
+    fun sessionDir(): File {
+        return File(context.cacheDir, "bugsnag-sessions")
+    }
+
+    fun waitForSessionFile() {
+        val dir = sessionDir()
+        while (dir.listFiles()!!.isEmpty()) {
+            Thread.sleep(100)
+        }
+    }
+
+    fun oldifySessionFiles() {
+        val cal = Calendar.getInstance()
+        cal.add(Calendar.DATE, -60)
+        cal.add(Calendar.MINUTE, -1)
+        val timestamp = cal.timeInMillis
+
+        val files = sessionDir().listFiles()
+        for (file in files!!) {
+            setSessionFileTimestamp(file, timestamp)
+        }
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+        Bugsnag.markLaunchCompleted()
+        Bugsnag.startSession()
+
+        waitForSessionFile()
+        oldifySessionFiles()
+
+        System.out.println("DiscardOldSessionScenario: Finished oldifying files; sending placeholder event.")
+        Bugsnag.notify(MyThrowable("To keep maze-runner from shutting me down prematurely"))
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenarioPart2.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenarioPart2.kt
@@ -1,0 +1,28 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.EndpointConfiguration
+
+internal class DiscardOldSessionScenarioPart2(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.launchDurationMillis = 0
+        // We set an endpoint so that attempts to send the session will fail.
+        config.endpoints = EndpointConfiguration(config.endpoints.notify, "https://nonexistent.bugsnag.com")
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+
+        // Give Bugsnag time to try sending the serialized session again.
+        Thread.sleep(1000)
+
+        Bugsnag.notify(MyThrowable("To keep maze-runner from shutting me down prematurely"))
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenarioPart3.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenarioPart3.kt
@@ -1,0 +1,16 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+
+internal class DiscardOldSessionScenarioPart3(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.launchDurationMillis = 0
+        // Note: No impediments to sending.
+    }
+}

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -1,0 +1,49 @@
+Feature: Discarding events
+
+    Scenario: Discard an on-disk error that failed to send and is too old
+        # Fail to send initial handled error. Client stores it to disk.
+        When I set the HTTP status code for the next request to 500
+        And I run "DiscardOldEventsScenario"
+        And I wait to receive an error
+        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+
+        # Fail to send event that was reloaded from disk. Event is too old, so the client discards it.
+        Then I discard the oldest error
+        # We send another error to keep maze-runner from shutting down the app prematurely.
+        And I wait to receive an error
+        And I discard the oldest error
+        And I set the HTTP status code for the next request to 500
+        And I close and relaunch the app
+        And I configure Bugsnag for "DiscardOldEventsScenario"
+        And I wait to receive an error
+        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+
+        # Now there is no event on disk, so there's nothing to send.
+        Then I discard the oldest error
+        And I close and relaunch the app
+        And I configure Bugsnag for "DiscardOldEventsScenario"
+        Then I should receive no requests
+
+    Scenario: Discard an on-disk error that failed to send and is too big
+        # Fail to send initial handled error. Client stores it to disk.
+        When I set the HTTP status code for the next request to 500
+        And I run "DiscardBigEventsScenario"
+        And I wait to receive an error
+        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+
+        # Fail to send event that was reloaded from disk. Event is too old, so the client discards it.
+        Then I discard the oldest error
+        # We send another error to keep maze-runner from shutting down the app prematurely.
+        And I wait to receive an error
+        And I discard the oldest error
+        And I set the HTTP status code for the next request to 500
+        And I close and relaunch the app
+        And I configure Bugsnag for "DiscardBigEventsScenario"
+        And I wait to receive an error
+        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+
+        # Now there is no event on disk, so there's nothing to send.
+        Then I discard the oldest error
+        And I close and relaunch the app
+        And I configure Bugsnag for "DiscardBigEventsScenario"
+        Then I should receive no requests

--- a/features/full_tests/discarded_session.feature
+++ b/features/full_tests/discarded_session.feature
@@ -1,0 +1,33 @@
+Feature: Discarding sessions
+
+    Scenario: Discard an on-disk session that failed to send and is too old
+        # Part 1 sets a bogus session endpoint so that all attempts to send the session fail.
+        # Note: The app will make two attempts.
+        When I run "DiscardOldSessionScenario"
+
+        # Part 1 sleeps to let bg tasks run, then manually renames the session file to oldify it.
+
+        # Send an error to keep maze-runner from shutting down the app prematurely.
+        And I wait to receive an error
+        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+        And I discard the oldest error
+
+        # The important part is that no sessions are received at this point.
+        Then I should receive no sessions
+
+        # Part 2 loads the session, fails to send it, then discards it because it's too old.
+        Then I close and relaunch the app
+        And I run "DiscardOldSessionScenarioPart2"
+
+        # Send an error to keep maze-runner from shutting down the app prematurely.
+        And I wait to receive an error
+        And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+        And I discard the oldest error
+
+        # Part 2 will always fail to send sessions.
+        Then I should receive no sessions
+
+        # Part 3 has no sending impediments, but there are no more session files so nothing to send.
+        Then I close and relaunch the app
+        And I configure Bugsnag for "DiscardOldSessionScenarioPart3"
+        Then I should receive no sessions


### PR DESCRIPTION
## Goal

To prevent the buildup of old or large files, event and session files will be deleted on a failed send if they meet certain criteria:

- Events if they are older than 60 days or larger than 1MB
- Sessions if they are older than 60 days

## Testing

 New e2e tests
