### PR TITLE
strncpy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Calling `bugsnag_event_set_context` with NULL `context` correctly clears the event context again
+  [#1636](https://github.com/bugsnag/bugsnag-android/pull/1636)
+
 ## 5.21.0 (2022-03-17)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -16,9 +16,11 @@ size_t bsg_strlen(const char *str) {
 }
 
 void bsg_strncpy(char *dst, const char *src, size_t dst_size) {
-  if (src == NULL || dst == NULL || dst_size == 0) {
+  if (dst == NULL || dst_size == 0) {
     return;
   }
   dst[0] = '\0';
-  strncat(dst, src, dst_size - 1);
+  if (src != NULL) {
+    strncat(dst, src, dst_size - 1);
+  }
 }

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
@@ -12,6 +12,16 @@ TEST test_copy_empty_string(void) {
     PASS();
 }
 
+TEST test_copy_null_string(void) {
+    int dst_len = 10;
+    char *dst = calloc(sizeof(char), dst_len);
+    strcpy(dst, "C h a n g e");
+    bsg_strncpy(dst, NULL, dst_len);
+    ASSERT(dst[0] == '\0');
+    free(dst);
+    PASS();
+}
+
 TEST test_copy_literal_string(void) {
     char *src = "C h a n g e";
     int dst_len = 10;
@@ -48,6 +58,7 @@ TEST length_null_string(void) {
 
 SUITE(suite_string_utils) {
     RUN_TEST(test_copy_empty_string);
+    RUN_TEST(test_copy_null_string);
     RUN_TEST(test_copy_literal_string);
     RUN_TEST(length_empty_string);
     RUN_TEST(length_literal_string);


### PR DESCRIPTION
## Goal
Passing a `NULL` source string to `bsg_strncpy` should still `\0` terminate the destination string if there is available space (`dst_size` > 0).

## Testing
A new unit test was added to cover the functionality