### PR TITLE
Ensure handling_crash flag is atomic

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -4,6 +4,7 @@
 #ifndef BUGSNAG_NDK_H
 #define BUGSNAG_NDK_H
 
+#include <stdatomic.h>
 #include <stdbool.h>
 
 #include "../assets/include/bugsnag.h"
@@ -53,7 +54,7 @@ typedef struct {
    * true if a crash is currently being handled. Disallows multiple crashes
    * from being processed simultaneously
    */
-  bool handling_crash;
+  _Atomic bool handling_crash;
   /**
    * true if a handler has completed crash handling
    */
@@ -77,6 +78,22 @@ typedef struct {
  * discarded
  */
 bool bsg_run_on_error();
+
+/**
+ * This must be called before handling a native crash to ensure that two crash
+ * handlers don't run simultaneously. If this function returns falls, DO NOT
+ * PROCEED WITH CRASH HANDLING!
+ *
+ * When done handling the crash, you must call bsg_finish_handling_crash()
+ *
+ * @return true if no other crash handler is already running.
+ */
+bool bsg_begin_handling_crash();
+
+/**
+ * Let the system know that you've finished handling the crash.
+ */
+void bsg_finish_handling_crash();
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -47,7 +47,10 @@ void bsg_handle_cpp_terminate() {
   if (bsg_global_env == NULL || bsg_global_env->handling_crash)
     return;
 
-  bsg_global_env->handling_crash = true;
+  if (!bsg_begin_handling_crash()) {
+    return;
+  }
+
   bsg_populate_event_as(bsg_global_env);
   bsg_global_env->next_event.unhandled = true;
   bsg_global_env->next_event.error.frame_count = bsg_unwind_crash_stack(
@@ -72,7 +75,8 @@ void bsg_handle_cpp_terminate() {
     bsg_serialize_event_to_file(bsg_global_env);
     bsg_serialize_last_run_info_to_file(bsg_global_env);
   }
-  bsg_global_env->crash_handled = true;
+
+  bsg_finish_handling_crash();
   bsg_handler_uninstall_cpp();
   if (bsg_global_terminate_previous != NULL) {
     bsg_global_terminate_previous();


### PR DESCRIPTION
## Goal

The flag to mark that a native crash is being handled was not atomic, leaving room for a race condition should two threads trigger a native crash at the same time.

## Design

Use atomics to ensure that no race condition is possible.

## Testing

Reran all tests.
