### PR TITLE
[PLAT-8191] Add Bugsnag.isStarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## TBD
 
+### Enhancements
+
+* Added `Bugsnag.isStarted()` to test whether the Bugsnag client is in the middle of initializing. This can be used to guard uses of the Bugsnag API that are either on separate threads early in the app's start-up and so not guaranteed to be executed after `Bugsnag.start` has completed, or where Bugsnag may not have been started at all due to some internal app logic.
+ [slack-jallen](https://github.com/slack-jallen):[#1621](https://github.com/bugsnag/bugsnag-android/pull/1621)
+ [#1640](https://github.com/bugsnag/bugsnag-android/pull/1640)
+
 ### Bug fixes
 
+* Fixed potentially [thread-unsafe access](https://github.com/bugsnag/bugsnag-android/issues/883) when invoking `Bugsnag` static methods across different threads whilst `Bugsnag.start` is still in-flight. It is now safe to call any `Bugsnag` static method once `Bugsnag.start` has _begun_ executing, as access to the client singleton is controlled by a lock, so the new `isStarted` method (see above) should only be required where it cannot be determined whether the call to `Bugsnag.start` has begun or you do not want to wait. [#1638](https://github.com/bugsnag/bugsnag-android/pull/1638)
 * Calling `bugsnag_event_set_context` with NULL `context` correctly clears the event context again
   [#1637](https://github.com/bugsnag/bugsnag-android/pull/1637)
-* `Bugsnag` methods are now [safe](https://github.com/bugsnag/bugsnag-android/issues/883) to invoke on different threads while `Bugsnag.start()` is still in-flight,
-  making multi-threaded application startup easier to implement
-  [#1638](https://github.com/bugsnag/bugsnag-android/pull/1638)
 
 ## 5.21.0 (2022-03-17)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -69,6 +69,15 @@ public final class Bugsnag {
         return client;
     }
 
+    /**
+     * Returns true if one of the <code>start</code> methods have been has been called and
+     * so Bugsnag is initialized; false if <code>start</code> has not been called and the
+     * other methods will throw IllegalStateException.
+     */
+    public static boolean isStarted() {
+        return client != null;
+    }
+
     private static void logClientInitWarning() {
         getClient().logger.w("Multiple Bugsnag.start calls detected. Ignoring.");
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagApiTest.kt
@@ -38,6 +38,17 @@ class BugsnagApiTest {
     }
 
     @Test
+    fun isStartedWhenStarted() {
+        assertEquals(true, Bugsnag.isStarted())
+    }
+
+    @Test
+    fun isStartedWhenNotStarted() {
+        Bugsnag.client = null
+        assertEquals(false, Bugsnag.isStarted())
+    }
+
+    @Test
     fun getUser() {
         Bugsnag.getUser()
         verify(client, times(1)).getUser()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagClientMirrorInterfaceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/BugsnagClientMirrorInterfaceTest.kt
@@ -9,13 +9,18 @@ import java.lang.reflect.Method
  * signatures, and fails if the two are out of sync.
  *
  * This is intended to catch the case where a new API is added to one class but not the other.
- * If a method genuinely only needs to be present on one of the classes, it can be added to a
- * blacklist via [bugsnagBlacklist] or [clientBlacklist].
+ * If a method genuinely only needs to be present on one of the classes, it should be added to
+ * [bugsnagAllowList] or [clientAllowList].
  */
 class BugsnagClientMirrorInterfaceTest {
 
-    private val bugsnagBlacklist = setOf("start", "getClient")
-    private val clientBlacklist = setOf(
+    private val bugsnagAllowList = setOf(
+        "start",
+        "getClient",
+        "isStarted"
+    )
+
+    private val clientAllowList = setOf(
         "update",
         "notifyObservers",
         "addObserver",
@@ -35,14 +40,14 @@ class BugsnagClientMirrorInterfaceTest {
     @Test
     fun bugsnagHasSameMethodsAsClient() {
         val methods = clientMethods.subtract(bugsnagMethods)
-            .filter { !clientBlacklist.contains(it.name) }
+            .filter { !clientAllowList.contains(it.name) }
         assertTrue("Bugsnag is missing the following methods: $methods", methods.isEmpty())
     }
 
     @Test
     fun clientHasSameMethodsAsBugsnag() {
         val methods = bugsnagMethods.subtract(clientMethods)
-            .filter { !bugsnagBlacklist.contains(it.name) }
+            .filter { !bugsnagAllowList.contains(it.name) }
         assertTrue("Client is missing the following methods: $methods", methods.isEmpty())
     }
 }


### PR DESCRIPTION
## Goal

From #1621:

> Add Bugsnag.isStarted so that it is possible to check whether it is safe to call the other methods. Currently to use Bugsnag safely you either have to keep track of this yourself or wrap calls in try/catch.

Raised internally for CI and merge purposes.