### PR TITLE
Fix MultiThreadedStartupScenario

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiThreadedStartupScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiThreadedStartupScenario.kt
@@ -13,12 +13,13 @@ class MultiThreadedStartupScenario(
     override fun startBugsnag(startBugsnagOnly: Boolean) {}
 
     override fun startScenario() {
-        // MIN_PRIORITY = trying our best to be slow without putting delays in place
-        val startThread = thread {
+        val startThread = thread(name = "AsyncStart") {
             Bugsnag.start(context, config)
         }
 
-        thread {
+        thread(name = "leaveBreadcrumb") {
+            // simulate the start of some startup work, but not enough for Bugsnag.start to complete
+            Thread.sleep(1L)
             try {
                 Bugsnag.leaveBreadcrumb("I'm leaving a breadcrumb on another thread")
             } catch (e: Exception) {


### PR DESCRIPTION
## Goal
Stop `MultiThreadedStartupScenario` from flaking.

## Design
Add a 1ms delay into the "leaveBreadcrumb" thread, simulating a small workload without being enough time for `Bugsnag.start` to have completed. This should stop the "leaveBreadcrumb" thread from acquiring the `lock` before `start` can.

## Testing
Will rerun the full test suite.