### PR TITLE
Rename Cucumber step for consistency with Cocoa

### DIFF
--- a/features/full_tests/async_error_flush.feature
+++ b/features/full_tests/async_error_flush.feature
@@ -4,7 +4,7 @@ Feature: Flushing errors does not send duplicates
 # Disabled until PLAT-5869 can be actioned to convert these to unit tests.
 
 #Scenario: Only 1 request sent if connectivity change occurs before launch
-#    When I run "AsyncErrorConnectivityScenario" and relaunch the app
+#    When I run "AsyncErrorConnectivityScenario" and relaunch the crashed app
 #    And I configure Bugsnag for "AsyncErrorConnectivityScenario"
 #    Then I wait to receive an error
 #    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -10,23 +10,23 @@ Feature: Switching automatic error detection on/off for Unity
     And the exception "message" equals "HandledJvmAutoNotifyFalseScenario"
 
   Scenario: JVM exception not captured with autoNotify=false
-    When I run "UnhandledJvmAutoNotifyFalseScenario" and relaunch the app
+    When I run "UnhandledJvmAutoNotifyFalseScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledJvmAutoNotifyFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
   Scenario: NDK signal not captured with autoNotify=false
-    When I run "UnhandledNdkAutoNotifyFalseScenario" and relaunch the app
+    When I run "UnhandledNdkAutoNotifyFalseScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledNdkAutoNotifyFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
   @skip_android_8_1
   Scenario: ANR not captured with autoDetectAnrs=false
-    When I run "AutoDetectAnrsFalseScenario" and relaunch the app
+    When I run "AutoDetectAnrsFalseScenario" and relaunch the crashed app
     And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
   Scenario: JVM exception captured with autoNotify reenabled
-    When I run "UnhandledJvmAutoNotifyTrueScenario" and relaunch the app
+    When I run "UnhandledJvmAutoNotifyTrueScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledJvmAutoNotifyTrueScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -38,7 +38,7 @@ Feature: Switching automatic error detection on/off for Unity
     And the event "severity" equals "error"
 
   Scenario: NDK signal captured with autoNotify reenabled
-    When I run "UnhandledNdkAutoNotifyTrueScenario" and relaunch the app
+    When I run "UnhandledNdkAutoNotifyTrueScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledNdkAutoNotifyTrueScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/breadcrumb.feature
+++ b/features/full_tests/breadcrumb.feature
@@ -33,7 +33,7 @@ Feature: Reporting Breadcrumbs
     And the event has a "state" breadcrumb with the message "Bugsnag loaded"
 
   Scenario: Error Breadcrumbs appear in subsequent events
-    When I run "ErrorBreadcrumbsScenario" and relaunch the app
+    When I run "ErrorBreadcrumbsScenario" and relaunch the crashed app
     And I configure Bugsnag for "ErrorBreadcrumbsScenario"
     Then I wait to receive 2 errors
     And the exception "errorClass" equals "java.lang.RuntimeException"

--- a/features/full_tests/crash_handler.feature
+++ b/features/full_tests/crash_handler.feature
@@ -4,7 +4,7 @@ Feature: Reporting with other exception handlers installed
     Given I clear all persistent data
 
   Scenario: Other uncaught exception handler installed
-    When I run "CrashHandlerScenario" and relaunch the app
+    When I run "CrashHandlerScenario" and relaunch the crashed app
     And I configure Bugsnag for "CrashHandlerScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/custom_http_client.feature
+++ b/features/full_tests/custom_http_client.feature
@@ -5,7 +5,7 @@ Feature: Using custom API clients for reporting errors
 
   Scenario: Set a custom HTTP client and flush a stored error + session
     When I configure the app to run in the "offline" state
-    And I run "CustomHttpClientFlushScenario" and relaunch the app
+    And I run "CustomHttpClientFlushScenario" and relaunch the crashed app
     And I configure Bugsnag for "CustomHttpClientFlushScenario"
 
     # error received

--- a/features/full_tests/detect_ndk_crashes.feature
+++ b/features/full_tests/detect_ndk_crashes.feature
@@ -4,7 +4,7 @@ Feature: Verifies autoDetectNdkCrashes controls when NDK crashes are reported
     Given I clear all persistent data
 
   Scenario: No crash reported when autoDetectNdkCrashes disabled
-    When I run "AutoDetectNdkDisabledScenario" and relaunch the app
+    When I run "AutoDetectNdkDisabledScenario" and relaunch the crashed app
     And I configure Bugsnag for "AutoDetectNdkDisabledScenario"
     And I wait for 2 seconds
     Then I should receive no requests

--- a/features/full_tests/event_callback_alters_api_key.feature
+++ b/features/full_tests/event_callback_alters_api_key.feature
@@ -12,7 +12,7 @@ Feature: When the api key is altered in an Event the JSON payload reflects this
     And the error "Bugsnag-Api-Key" header equals "0000111122223333aaaabbbbcccc9999"
 
   Scenario: Unhandled exception with altered API key
-    When I run "UnhandledExceptionApiKeyChangeScenario" and relaunch the app
+    When I run "UnhandledExceptionApiKeyChangeScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledExceptionApiKeyChangeScenario"
     And I wait to receive an error
     And the error payload field "events" is an array with 1 elements

--- a/features/full_tests/feature_flags.feature
+++ b/features/full_tests/feature_flags.feature
@@ -27,7 +27,7 @@ Feature: Reporting with feature flags
 
   Scenario: Sends unhandled exception which includes feature flags added in the notify callback
     When I configure the app to run in the "unhandled callback" state
-    And I run "FeatureFlagScenario" and relaunch the app
+    And I run "FeatureFlagScenario" and relaunch the crashed app
     And I configure Bugsnag for "FeatureFlagScenario"
     Then I wait to receive an error
     And the exception "errorClass" equals "java.lang.RuntimeException"
@@ -48,7 +48,7 @@ Feature: Reporting with feature flags
 
   Scenario: Sends feature flags added in OnSend Callbacks
     When I configure the app to run in the "onsend" state
-    And I run "FeatureFlagScenario" and relaunch the app
+    And I run "FeatureFlagScenario" and relaunch the crashed app
     And I configure Bugsnag for "FeatureFlagScenario"
     Then I wait to receive an error
     And the exception "errorClass" equals "java.lang.RuntimeException"

--- a/features/full_tests/identify_crashes_on_launch.feature
+++ b/features/full_tests/identify_crashes_on_launch.feature
@@ -15,7 +15,7 @@ Feature: Identifying crashes on launch
     And the event "app.isLaunching" is false
 
   Scenario: An NDK error captured after the launch period is false for app.isLaunching
-    When I run "CXXDelayedErrorScenario" and relaunch the app
+    When I run "CXXDelayedErrorScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXDelayedErrorScenario"
     Then I wait to receive 2 errors
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -38,7 +38,7 @@ Feature: Identifying crashes on launch
     And the event "app.isLaunching" is false
 
   Scenario: An NDK error captured after markLaunchComplete() is false for app.isLaunching
-    When I run "CXXMarkLaunchCompletedScenario" and relaunch the app
+    When I run "CXXMarkLaunchCompletedScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXMarkLaunchCompletedScenario"
     Then I wait to receive 2 errors
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -50,8 +50,8 @@ Feature: Identifying crashes on launch
     And the event "app.isLaunching" is false
 
   Scenario: Escaping from a crash loop by reading LastRunInfo in a JVM error
-    When I run "JvmCrashLoopScenario" and relaunch the app
-    When I run "JvmCrashLoopScenario" and relaunch the app
+    When I run "JvmCrashLoopScenario" and relaunch the crashed app
+    When I run "JvmCrashLoopScenario" and relaunch the crashed app
     When I run "JvmCrashLoopScenario"
     And I wait to receive 3 errors
 
@@ -79,8 +79,8 @@ Feature: Identifying crashes on launch
     And the event "metaData.LastRunInfo.consecutiveLaunchCrashes" equals 2
 
   Scenario: Escaping from a crash loop by reading LastRunInfo in an NDK error
-    When I run "CXXCrashLoopScenario" and relaunch the app
-    When I run "CXXCrashLoopScenario" and relaunch the app
+    When I run "CXXCrashLoopScenario" and relaunch the crashed app
+    When I run "CXXCrashLoopScenario" and relaunch the crashed app
     When I run "CXXCrashLoopScenario"
     And I wait to receive 3 errors
 

--- a/features/full_tests/ignored_reports.feature
+++ b/features/full_tests/ignored_reports.feature
@@ -12,16 +12,16 @@ Feature: Reports are ignored
     And the event "unhandled" is false
 
   Scenario: Disabled Exception Handler
-    When I run "DisableAutoDetectErrorsScenario" and relaunch the app
+    When I run "DisableAutoDetectErrorsScenario" and relaunch the crashed app
     And I configure Bugsnag for "DisableAutoDetectErrorsScenario"
     Then Bugsnag confirms it has no errors to send
 
   Scenario: Changing release stage to exclude the current stage settings before a POSIX signal
-    When I run "CXXTrapOutsideReleaseStagesScenario" and relaunch the app
+    When I run "CXXTrapOutsideReleaseStagesScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXTrapOutsideReleaseStagesScenario"
     Then Bugsnag confirms it has no errors to send
 
   Scenario: Changing release stage settings to exclude the current stage before a native C++ crash
-    When I run "CXXThrowSomethingOutsideReleaseStagesScenario" and relaunch the app
+    When I run "CXXThrowSomethingOutsideReleaseStagesScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXThrowSomethingOutsideReleaseStagesScenario"
     Then Bugsnag confirms it has no errors to send

--- a/features/full_tests/max_reported_threads.feature
+++ b/features/full_tests/max_reported_threads.feature
@@ -4,7 +4,7 @@ Feature: Reporting with other exception handlers installed
     Given I clear all persistent data
 
   Scenario: Unhandled exception with max threads set
-    When I run "UnhandledExceptionMaxThreadsScenario" and relaunch the app
+    When I run "UnhandledExceptionMaxThreadsScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledExceptionMaxThreadsScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -16,7 +16,7 @@ Feature: Reporting with other exception handlers installed
     And the error payload field "events.0.threads.2.name" ends with "threads omitted as the maxReportedThreads limit (2) was exceeded]"
 
   Scenario: Handled exception with max threads set
-    When I run "HandledExceptionMaxThreadsScenario" and relaunch the app
+    When I run "HandledExceptionMaxThreadsScenario" and relaunch the crashed app
     And I configure Bugsnag for "HandledExceptionMaxThreadsScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/multi_process.feature
+++ b/features/full_tests/multi_process.feature
@@ -34,9 +34,9 @@ Feature: Reporting errors in multi process apps
 
   Scenario: Unhandled JVM error
     And I configure the app to run in the "main-activity" state
-    When I run "MultiProcessUnhandledExceptionScenario" and relaunch the app
+    When I run "MultiProcessUnhandledExceptionScenario" and relaunch the crashed app
     And I configure the app to run in the "multi-process-service" state
-    And I run "MultiProcessUnhandledExceptionScenario" and relaunch the app
+    And I run "MultiProcessUnhandledExceptionScenario" and relaunch the crashed app
     And I run "MultiProcessUnhandledExceptionScenario"
     Then I wait to receive 2 errors
     And I sort the errors by "events.0.metaData.app.processName"
@@ -84,9 +84,9 @@ Feature: Reporting errors in multi process apps
 
   Scenario: Unhandled NDK error
     And I configure the app to run in the "main-activity" state
-    When I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the app
+    When I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the crashed app
     And I configure the app to run in the "multi-process-service" state
-    And I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the app
+    And I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the crashed app
     And I run "MultiProcessUnhandledCXXErrorScenario"
     Then I wait to receive 2 errors
     And I sort the errors by "events.0.metaData.app.processName"

--- a/features/full_tests/native_api.feature
+++ b/features/full_tests/native_api.feature
@@ -4,7 +4,7 @@ Feature: Native API
     Given I clear all persistent data
 
   Scenario: Set extraordinarily long app information
-    When I run "CXXExtraordinaryLongStringScenario" and relaunch the app
+    When I run "CXXExtraordinaryLongStringScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXExtraordinaryLongStringScenario"
     And I wait to receive an error
     And the error payload contains a completed handled native report

--- a/features/full_tests/native_breadcrumbs.feature
+++ b/features/full_tests/native_breadcrumbs.feature
@@ -4,7 +4,7 @@ Feature: Native Breadcrumbs API
     Given I clear all persistent data
 
   Scenario: Leaving breadcrumbs in C followed by a Java crash
-    When I run "CXXNativeBreadcrumbJavaCrashScenario" and relaunch the app
+    When I run "CXXNativeBreadcrumbJavaCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXNativeBreadcrumbJavaCrashScenario"
     And I wait to receive an error
     And the error payload contains a completed handled native report

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -4,7 +4,7 @@ Feature: Native crash reporting
     Given I clear all persistent data
 
   Scenario: Dereference a null pointer
-    When I run "CXXDereferenceNullScenario" and relaunch the app
+    When I run "CXXDereferenceNullScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXDereferenceNullScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -30,7 +30,7 @@ Feature: Native crash reporting
   # https://android.googlesource.com/platform/bionic/+/fb7eb5e07f43587c2bedf2aaa53b21fa002417bb
   @skip_below_api18
   Scenario: Stack buffer overflow
-    When I run "CXXStackoverflowScenario" and relaunch the app
+    When I run "CXXStackoverflowScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXStackoverflowScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -42,7 +42,7 @@ Feature: Native crash reporting
       | crash_stack_overflow | CXXStackoverflowScenario.cpp |
 
   Scenario: Program trap()
-    When I run "CXXTrapScenario" and relaunch the app
+    When I run "CXXTrapScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXTrapScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -59,7 +59,7 @@ Feature: Native crash reporting
       | trap_it() | CXXTrapScenario.cpp | 10 |
 
   Scenario: Write to read-only memory
-    When I run "CXXWriteReadOnlyMemoryScenario" and relaunch the app
+    When I run "CXXWriteReadOnlyMemoryScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXWriteReadOnlyMemoryScenario"
     And I wait to receive an error
     And the exception "errorClass" equals "SIGSEGV"
@@ -72,7 +72,7 @@ Feature: Native crash reporting
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXWriteReadOnlyMemoryScenario_crash | CXXWriteReadOnlyMemoryScenario.cpp | 22 |
 
   Scenario: Improper object type cast
-    When I run "CXXImproperTypecastScenario" and relaunch the app
+    When I run "CXXImproperTypecastScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXImproperTypecastScenario"
     And I wait to receive an error
     And the exception "errorClass" equals "SIGSEGV"
@@ -85,7 +85,7 @@ Feature: Native crash reporting
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXImproperTypecastScenario_crash | CXXImproperTypecastScenario.cpp | 20 |
 
   Scenario: Program abort()
-    When I run "CXXAbortScenario" and relaunch the app
+    When I run "CXXAbortScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXAbortScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -103,7 +103,7 @@ Feature: Native crash reporting
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXAbortScenario_crash | CXXAbortScenario.cpp | 13 |
 
   Scenario: Undefined JNI method
-    When I run "UnsatisfiedLinkErrorScenario" and relaunch the app
+    When I run "UnsatisfiedLinkErrorScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnsatisfiedLinkErrorScenario"
     And I wait to receive an error
     And the report contains the required fields
@@ -113,7 +113,7 @@ Feature: Native crash reporting
     And the event "unhandled" is true
 
   Scenario: Causing a crash in a separate library
-    When I run "CXXExternalStackElementScenario" and relaunch the app
+    When I run "CXXExternalStackElementScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXExternalStackElementScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -134,7 +134,7 @@ Feature: Native crash reporting
   A null pointer should be the first element of a stack trace,
   followed by the calling function
 
-    When I run "CXXCallNullFunctionPointerScenario" and relaunch the app
+    When I run "CXXCallNullFunctionPointerScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXCallNullFunctionPointerScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -23,7 +23,7 @@ Feature: Synchronizing app/device metadata in the native layer
     And the event "unhandled" is false
 
   Scenario: Capture foreground state while in a foreground crash
-    When I run "CXXTrapScenario" and relaunch the app
+    When I run "CXXTrapScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXStartSessionScenario"
     And I wait to receive an error
     Then the error payload contains a completed handled native report

--- a/features/full_tests/native_feature_flags.feature
+++ b/features/full_tests/native_feature_flags.feature
@@ -4,7 +4,7 @@ Feature: Synchronizing feature flags to the native layer
     Given I clear all persistent data
 
   Scenario: Feature flags are synchronized to the native layer
-    When I run "CXXFeatureFlagNativeCrashScenario" and relaunch the app
+    When I run "CXXFeatureFlagNativeCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -19,7 +19,7 @@ Feature: Synchronizing feature flags to the native layer
 
   Scenario: clearFeatureFlags() is synchronized to the native layer
     When I configure the app to run in the "cleared" state
-    And I run "CXXFeatureFlagNativeCrashScenario" and relaunch the app
+    And I run "CXXFeatureFlagNativeCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXFeatureFlagNativeCrashScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report

--- a/features/full_tests/native_metadata.feature
+++ b/features/full_tests/native_metadata.feature
@@ -4,7 +4,7 @@ Feature: Native Metadata API
     Given I clear all persistent data
 
   Scenario: Add custom metadata to configuration followed by a C crash
-    When I run "CXXConfigurationMetadataNativeCrashScenario" and relaunch the app
+    When I run "CXXConfigurationMetadataNativeCrashScenario" and relaunch the crashed app
     And I configure the app to run in the "non-metadata" state
     And I configure Bugsnag for "CXXConfigurationMetadataNativeCrashScenario"
     And I wait to receive an error
@@ -39,7 +39,7 @@ Feature: Native Metadata API
     And the event "metaData.remove" is null
 
   Scenario: Get Java data in the Native layer
-    When I run "CXXGetJavaDataScenario" and relaunch the app
+    When I run "CXXGetJavaDataScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXGetJavaDataScenario"
     And I wait to receive an error
     Then the error payload contains a completed unhandled native report

--- a/features/full_tests/native_on_error.feature
+++ b/features/full_tests/native_on_error.feature
@@ -4,17 +4,17 @@ Feature: Native on error callbacks are invoked
     Given I clear all persistent data
 
   Scenario: on_error returning false prevents C signal being reported
-    When I run "CXXSignalOnErrorFalseScenario" and relaunch the app
+    When I run "CXXSignalOnErrorFalseScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSignalOnErrorFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
   Scenario: on_error returning false prevents C++ exception being reported
-    When I run "CXXExceptionOnErrorFalseScenario" and relaunch the app
+    When I run "CXXExceptionOnErrorFalseScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXExceptionOnErrorFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
   Scenario: Removing on_error callback
-    When I run "CXXRemoveOnErrorScenario" and relaunch the app
+    When I run "CXXRemoveOnErrorScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXRemoveOnErrorScenario"
     And I wait to receive an error
     Then the error payload contains a completed handled native report

--- a/features/full_tests/native_session_tracking.feature
+++ b/features/full_tests/native_session_tracking.feature
@@ -4,7 +4,7 @@ Feature: NDK Session Tracking
     Given I clear all persistent data
 
   Scenario: Paused session is not in payload of unhandled NDK error
-    And I run "CXXPausedSessionScenario" and relaunch the app
+    And I run "CXXPausedSessionScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXPausedSessionScenario"
     And I wait to receive a session
     Then the session is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
@@ -14,7 +14,7 @@ Feature: NDK Session Tracking
     And the error payload field "events.0.session" is null
 
   Scenario: Started session is in payload of unhandled NDK error
-    And I run "CXXStartSessionScenario" and relaunch the app
+    And I run "CXXStartSessionScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXStartSessionScenario"
     And I wait to receive a session
     Then the session is valid for the session reporting API version "1.0" for the "Android Bugsnag Notifier" notifier
@@ -24,7 +24,7 @@ Feature: NDK Session Tracking
     And the error payload field "events.0.session.events.unhandled" equals 1
 
   Scenario: Starting a session, notifying, followed by a C crash
-    When I run "CXXSessionInfoCrashScenario" and relaunch the app
+    When I run "CXXSessionInfoCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSessionInfoCrashScenario"
     And I wait to receive a session
     And I wait to receive 3 errors

--- a/features/full_tests/native_signal_raise.feature
+++ b/features/full_tests/native_signal_raise.feature
@@ -4,7 +4,7 @@ Feature: Raising native signals
     Given I clear all persistent data
 
   Scenario: Raise SIGILL
-    When I run "CXXSigillScenario" and relaunch the app
+    When I run "CXXSigillScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSigillScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -17,7 +17,7 @@ Feature: Raising native signals
     And the event "unhandled" is true
 
   Scenario: Raise SIGSEGV
-    When I run "CXXSigsegvScenario" and relaunch the app
+    When I run "CXXSigsegvScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSigsegvScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -28,7 +28,7 @@ Feature: Raising native signals
     And the event "unhandled" is true
 
   Scenario: Raise SIGABRT
-    When I run "CXXSigabrtScenario" and relaunch the app
+    When I run "CXXSigabrtScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSigabrtScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -39,7 +39,7 @@ Feature: Raising native signals
     And the event "unhandled" is true
 
   Scenario: Raise SIGBUS
-    When I run "CXXSigbusScenario" and relaunch the app
+    When I run "CXXSigbusScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSigbusScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -50,7 +50,7 @@ Feature: Raising native signals
     And the event "unhandled" is true
 
   Scenario: Raise SIGFPE
-    When I run "CXXSigfpeScenario" and relaunch the app
+    When I run "CXXSigfpeScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSigfpeScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -61,7 +61,7 @@ Feature: Raising native signals
     And the event "unhandled" is true
 
   Scenario: Raise SIGTRAP
-    When I run "CXXSigtrapScenario" and relaunch the app
+    When I run "CXXSigtrapScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSigtrapScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report

--- a/features/full_tests/native_threads.feature
+++ b/features/full_tests/native_threads.feature
@@ -4,7 +4,7 @@ Feature: Capture native threads
     Given I clear all persistent data
 
   Scenario: Reports native threads for Unhandled errors
-    When I run "CXXCaptureThreadsScenario" and relaunch the app
+    When I run "CXXCaptureThreadsScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXCaptureThreadsScenario"
     And I wait to receive an error
     Then the error payload contains a completed unhandled native report
@@ -15,7 +15,7 @@ Feature: Capture native threads
 
   Scenario: Reports native threads for Unhandled errors where sendThreads is UNHANDLED_ONLY
     When I configure the app to run in the "UNHANDLED_ONLY" state
-    And I run "CXXCaptureThreadsScenario" and relaunch the app
+    And I run "CXXCaptureThreadsScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXCaptureThreadsScenario"
     And I wait to receive an error
     Then the error payload contains a completed unhandled native report
@@ -26,7 +26,7 @@ Feature: Capture native threads
 
   Scenario: No threads are reported when sendThreads is NEVER
     When I configure the app to run in the "NEVER" state
-    And I run "CXXCaptureThreadsScenario" and relaunch the app
+    And I run "CXXCaptureThreadsScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXCaptureThreadsScenario"
     And I wait to receive an error
     Then the error payload contains a completed handled native report

--- a/features/full_tests/native_throw_crash.feature
+++ b/features/full_tests/native_throw_crash.feature
@@ -4,7 +4,7 @@ Feature: Native crash reporting with thrown objects
     Given I clear all persistent data
 
   Scenario: Throwing an exception in C++
-    When I run "CXXExceptionScenario" and relaunch the app
+    When I run "CXXExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXExceptionScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -14,7 +14,7 @@ Feature: Native crash reporting with thrown objects
     And the exception "message" equals "Abort program"
 
   Scenario: Throwing an object in C++
-    When I run "CXXThrowSomethingScenario" and relaunch the app
+    When I run "CXXThrowSomethingScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXThrowSomethingScenario"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -24,7 +24,7 @@ Feature: Native crash reporting with thrown objects
     And the exception "message" equals "Abort program"
 
   Scenario: Rethrow in C++ without initial exception
-    When I run "CXXInvalidRethrow" and relaunch the app
+    When I run "CXXInvalidRethrow" and relaunch the crashed app
     And I configure Bugsnag for "CXXInvalidRethrow"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
@@ -36,7 +36,7 @@ Feature: Native crash reporting with thrown objects
       | print_last_exception() | CXXInvalidRethrow.cpp | 7 |
 
   Scenario: Throw from C++ noexcept function
-    When I run "CXXThrowFromNoexcept" and relaunch the app
+    When I run "CXXThrowFromNoexcept" and relaunch the crashed app
     And I configure Bugsnag for "CXXThrowFromNoexcept"
     And I wait to receive an error
     And the error payload contains a completed unhandled native report

--- a/features/full_tests/native_user.feature
+++ b/features/full_tests/native_user.feature
@@ -4,7 +4,7 @@ Feature: Native User API
     Given I clear all persistent data
 
   Scenario: Adding user information in Java followed by a C crash
-    And I run "CXXJavaUserInfoNativeCrashScenario" and relaunch the app
+    And I run "CXXJavaUserInfoNativeCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXJavaUserInfoNativeCrashScenario"
     And I wait to receive an error
     Then the error payload contains a completed handled native report
@@ -18,7 +18,7 @@ Feature: Native User API
     And the event "unhandled" is true
 
   Scenario: Set user in Native layer followed by a Java crash
-    When I run "CXXNativeUserInfoJavaCrashScenario" and relaunch the app
+    When I run "CXXNativeUserInfoJavaCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXNativeUserInfoJavaCrashScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/naughty_strings.feature
+++ b/features/full_tests/naughty_strings.feature
@@ -29,7 +29,7 @@ Feature: The notifier handles user data containing unusual strings
 # commented out some failing unicode assertions and skipped Android <6 until PLAT-5606 is addressed
   @skip_below_android_6
   Scenario: Test unhandled NDK error
-    When I run "CXXNaughtyStringsScenario" and relaunch the app
+    When I run "CXXNaughtyStringsScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXNaughtyStringsScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/onsend_callback.feature
+++ b/features/full_tests/onsend_callback.feature
@@ -4,7 +4,7 @@ Feature: OnSend Callbacks can alter Events before upload
     Given I clear all persistent data
 
   Scenario: Unhandled exception altered by OnSendCallback
-    When I run "OnSendCallbackScenario" and relaunch the app
+    When I run "OnSendCallbackScenario" and relaunch the crashed app
     And I configure the app to run in the "start-only" state
     And I configure Bugsnag for "OnSendCallbackScenario"
     Then I wait to receive an error

--- a/features/full_tests/oom.feature
+++ b/features/full_tests/oom.feature
@@ -4,7 +4,7 @@ Feature: Reporting OOMs
     Given I clear all persistent data
 
   Scenario: Out of Memory Error captured
-    When I run "OomScenario" and relaunch the app
+    When I run "OomScenario" and relaunch the crashed app
     And I configure Bugsnag for "OomScenario"
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/override_unhandled.feature
+++ b/features/full_tests/override_unhandled.feature
@@ -18,7 +18,7 @@ Feature: Overriding unhandled state
     And the event "session.events.unhandled" equals 1
 
   Scenario: Fatal exception overridden to handled
-    When I run "OverrideToHandledExceptionScenario" and relaunch the app
+    When I run "OverrideToHandledExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "OverrideToHandledExceptionScenario"
     And I wait to receive an error
     And I wait to receive a session
@@ -33,7 +33,7 @@ Feature: Overriding unhandled state
     And the event "session.events.unhandled" equals 0
 
   Scenario: CXX error overridden to handled
-    When I run "CXXHandledOverrideScenario" and relaunch the app
+    When I run "CXXHandledOverrideScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXHandledOverrideScenario"
     And I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/stackoverflow.feature
+++ b/features/full_tests/stackoverflow.feature
@@ -4,7 +4,7 @@ Feature: Reporting Stack overflow
     Given I clear all persistent data
 
   Scenario: Stack Overflow sends
-    When I run "StackOverflowScenario" and relaunch the app
+    When I run "StackOverflowScenario" and relaunch the crashed app
     And I configure Bugsnag for "StackOverflowScenario"
     And I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/full_tests/strict_mode_legacy.feature
+++ b/features/full_tests/strict_mode_legacy.feature
@@ -5,7 +5,7 @@ Feature: Reporting Strict Mode Violations
 
   @skip_above_android_8
   Scenario: StrictMode DiscWrite violation
-    When I run "StrictModeDiscScenario" and relaunch the app
+    When I run "StrictModeDiscScenario" and relaunch the crashed app
     And I configure Bugsnag for "StrictModeDiscScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -15,7 +15,7 @@ Feature: Reporting Strict Mode Violations
 
   @skip_above_android_8
   Scenario: StrictMode Network on Main Thread violation
-    When I run "StrictModeNetworkScenario" and relaunch the app
+    When I run "StrictModeNetworkScenario" and relaunch the crashed app
     And I configure Bugsnag for "StrictModeNetworkScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -26,6 +26,6 @@ Feature: Reporting Strict Mode Violations
 # In Android <9 StrictMode kills VM policy violations with SIGKILL, so no requests are received.
   @skip_above_android_8
   Scenario: StrictMode Activity leak violation
-    When I run "StrictModeFileUriExposeScenario" and relaunch the app
+    When I run "StrictModeFileUriExposeScenario" and relaunch the crashed app
     And I configure Bugsnag for "StrictModeFileUriExposeScenario"
     Then I should receive no requests

--- a/features/full_tests/strict_mode_violations.feature
+++ b/features/full_tests/strict_mode_violations.feature
@@ -5,7 +5,7 @@ Feature: Reporting Strict Mode Violations
 
   @skip_below_android_9
   Scenario: StrictMode Exposed File URI violation
-    When I run "StrictModeFileUriExposeScenario" and relaunch the app
+    When I run "StrictModeFileUriExposeScenario" and relaunch the crashed app
     And I configure Bugsnag for "StrictModeFileUriExposeScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -20,7 +20,7 @@ Feature: Reporting Strict Mode Violations
 
   @skip_below_android_9
   Scenario: StrictMode DiscWrite violation
-    When I run "StrictModeDiscScenario" and relaunch the app
+    When I run "StrictModeDiscScenario" and relaunch the crashed app
     And I configure Bugsnag for "StrictModeDiscScenario"
     And I wait to receive 2 errors
 

--- a/features/full_tests/threaded_startup.feature
+++ b/features/full_tests/threaded_startup.feature
@@ -4,7 +4,7 @@ Feature: Switching automatic error detection on/off for Unity
     Given I clear all persistent data
 
   Scenario: Starting Bugsnag & calling it on separate threads
-    When I run "MultiThreadedStartupScenario" and relaunch the app
+    When I run "MultiThreadedStartupScenario" and relaunch the crashed app
     And I configure Bugsnag for "MultiThreadedStartupScenario"
     And I wait for 2 seconds
     Then I should receive no error

--- a/features/smoke_tests/sessions.feature
+++ b/features/smoke_tests/sessions.feature
@@ -57,7 +57,7 @@ Feature: Session functionality smoke tests
 
   @debug-safe
   Scenario: Manual session control works
-    When I run "ManualSessionSmokeScenario" and relaunch the app
+    When I run "ManualSessionSmokeScenario" and relaunch the crashed app
     And I configure Bugsnag for "ManualSessionSmokeScenario"
     And I wait to receive a session
 

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -4,7 +4,7 @@ Feature: Unhandled smoke tests
     Given I clear all persistent data
 
   Scenario: Unhandled Java Exception with loaded configuration
-    When I run "UnhandledJavaLoadedConfigScenario" and relaunch the app
+    When I run "UnhandledJavaLoadedConfigScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledJavaLoadedConfigScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -99,7 +99,7 @@ Feature: Unhandled smoke tests
     And the event "threads.0.stacktrace.0.lineNumber" is not null
 
   Scenario: Signal raised with overwritten config
-    When I run "CXXSignalSmokeScenario" and relaunch the app
+    When I run "CXXSignalSmokeScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXSignalSmokeScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
@@ -186,7 +186,7 @@ Feature: Unhandled smoke tests
 
   @debug-safe
   Scenario: C++ exception thrown with overwritten config
-    When I run "CXXExceptionSmokeScenario" and relaunch the app
+    When I run "CXXExceptionSmokeScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXExceptionSmokeScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -31,7 +31,7 @@ When("I run {string}") do |event_type|
   }
 end
 
-When("I run {string} and relaunch the app") do |event_type|
+When("I run {string} and relaunch the crashed app") do |event_type|
   steps %Q{
     When I run "#{event_type}"
     And I relaunch the app after a crash


### PR DESCRIPTION
## Goal

Renames a single Cucumber step for consistency with the tests for bugsnag-cocoa.

## Changeset

Changes `I run {string} and relaunch the app` to `I run {string} and relaunch the crashed app`.

## Testing

Covered by a quick CI run (that includes a full set of e2e tests).