### PR TITLE
Add the "dart" ErrorType

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorType.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorType.kt
@@ -18,9 +18,16 @@ enum class ErrorType(internal val desc: String) {
     /**
      * An error captured from Android's C layer
      */
-    C("c");
+    C("c"),
+
+    /**
+     * An error captured from a Dart / Flutter application
+     */
+    DART("dart");
 
     internal companion object {
+        @JvmStatic
+        @JvmName("fromDescriptor")
         internal fun fromDescriptor(desc: String) = values().find { it.desc == desc }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventErrorTypeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventErrorTypeTest.kt
@@ -121,7 +121,7 @@ class EventErrorTypeTest {
     fun verifyFileNameMixedTypes() {
         val config = convertToImmutableConfig(BugsnagTestUtils.generateConfiguration())
         val file =
-            File("1504255147933_0000111122223333aaaabbbbcccc9999_android,c,reactnativejs_my-uuid-123_.json")
+            File("1504255147933_0000111122223333aaaabbbbcccc9999_android,c,reactnativejs,dart_my-uuid-123_.json")
         val payload = EventPayload(config.apiKey, null, file, Notifier(), config)
         assertEquals(ErrorType.values().toSet(), payload.getErrorTypes())
     }


### PR DESCRIPTION
## Goal
Add `dart` to our available list of `ErrorType`s to support Flutter notifiers

## Testing
Added the new constant to existing tests.