### PR TITLE
Remove unnecessary toList() call that was slowing down initialization

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -37,7 +37,7 @@ class NativeBridge : StateObserver {
     private val is32bit: Boolean
         get() {
             val abis = NativeInterface.getCpuAbi()
-            return !abis.toList().any { it.contains("64") }
+            return !abis.any { it.contains("64") }
         }
 
     external fun install(


### PR DESCRIPTION
## Goal

`NativeBridge.is32Bit()` had an unnecessary `toList()` call that for some reason was adding 25ms to the startup time. Removing it brings the time back down to sub-millisecond.

## Testing

Manual testing, reran all tests.
