### PR TITLE
e2e tests - use Maze Runner /command endpoint

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -416,7 +416,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[n-z].*.feature"
+          - "--exclude=features/full_tests/[^n-z].*.feature"
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_11_0"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -121,7 +121,6 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
-          - "--device=ANDROID_6_0_SAMSUNG_GALAXY_S7"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
           - "--fail-fast"
     env:
@@ -149,7 +148,6 @@ steps:
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
-          - "--device=ANDROID_6_0_SAMSUNG_GALAXY_S7"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
           - "--fail-fast"
     env:

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -17,7 +17,6 @@ steps:
         - "--app=/app/build/release/fixture-r16.apk"
         - "--farm=bs"
         - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
-        - "--device=ANDROID_6_0_SAMSUNG_GALAXY_S7"
         - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
         - "--fail-fast"
     concurrency: 9

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/Command.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/Command.kt
@@ -1,0 +1,8 @@
+/**
+ * A Maze Runner command.
+ */
+class Command {
+    var action: String = ""
+    var scenario_name: String = ""
+    var scenario_mode: String = ""
+}

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/Command.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/Command.kt
@@ -1,8 +1,0 @@
-/**
- * A Maze Runner command.
- */
-class Command {
-    var action: String = ""
-    var scenario_name: String = ""
-    var scenario_mode: String = ""
-}

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -56,7 +56,6 @@ class MainActivity : Activity() {
         findViewById<Button>(R.id.run_command).setOnClickListener {
             thread(start = true) {
                 // Get the next command from Maze Runner
-                log("Run command")
                 val commandUrl: String = "http://bs-local.com:9339/command"
                 var command: JSONObject
                 try {
@@ -72,15 +71,25 @@ class MainActivity : Activity() {
                     val commandStr = sb.toString()
                     log("Received command: " + commandStr)
                     command = JSONObject(commandStr)
-                    log("command.action: " + command.getString("action"))
-                    log("command.scenario_name: " + command.getString("scenario_name"))
-                    log("command.scenario_mode: " + command.getString("scenario_mode"))
+
+                    val action = command.getString("action")
+                    val scenarioName = command.getString("scenario_name")
+                    val scenarioMode = command.getString("scenario_mode")
+                    log("command.action: " + action)
+                    log("command.scenario_name: " + scenarioName)
+                    log("command.scenario_mode: " + scenarioMode)
+
+                    runOnUiThread {
+                        when (action) {
+                            "start_bugsnag" -> start_bugsnag(scenarioName, scenarioMode)
+                            "run_scenario" -> run_scenario(scenarioName, scenarioMode)
+                            else -> throw Exception("Unknown action: " + action)
+                        }
+                    }
+
                 } catch (e: Exception) {
                     log("Failed to fetch command from Maze Runner", e)
                 }
-
-                // command
-
             }
         }
 

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -44,14 +44,14 @@ class MainActivity : Activity() {
                     // Get the next command from Maze Runner
                     val commandUrl: String = "http://bs-local.com:9339/command"
                     val commandStr = URL(commandUrl).readText()
-                    log("Received command: " + commandStr)
+                    log("Received command: $commandStr")
                     var command = JSONObject(commandStr)
                     val action = command.getString("action")
                     val scenarioName = command.getString("scenario_name")
                     val scenarioMode = command.getString("scenario_mode")
-                    log("command.action: " + action)
-                    log("command.scenarioName: " + scenarioName)
-                    log("command.scenarioMode: " + scenarioMode)
+                    log("command.action: $action")
+                    log("command.scenarioName: $scenarioName")
+                    log("command.scenarioMode: $scenarioMode")
 
                     // Perform the given action on the UI thread
                     runOnUiThread {
@@ -59,7 +59,7 @@ class MainActivity : Activity() {
                             "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode)
                             "run_scenario" -> runScenario(scenarioName, scenarioMode)
                             "clear_persistent_data" -> clearPersistentData()
-                            else -> throw IllegalArgumentException("Unknown action: " + action)
+                            else -> throw IllegalArgumentException("Unknown action: $action")
                         }
                     }
                 } catch (e: Exception) {

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -38,6 +38,7 @@ class MainActivity : Activity() {
 
         // Get the next maze runner command
         findViewById<Button>(R.id.run_command).setOnClickListener {
+            log("run_command pressed")
             thread(start = true) {
                 try {
                     // Get the next command from Maze Runner

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -36,15 +36,6 @@ class MainActivity : Activity() {
             sendBroadcast(closeDialog)
         }
 
-        // Clear persistent data (used to stop scenarios bleeding into each other)
-        findViewById<Button>(R.id.clear_persistent_data).setOnClickListener {
-            clearFolder("last-run-info")
-            clearFolder("bugsnag-errors")
-            clearFolder("device-id")
-            clearFolder("user-info")
-            clearFolder("fake")
-        }
-
         // Get the next maze runner command
         findViewById<Button>(R.id.run_command).setOnClickListener {
             thread(start = true) {
@@ -65,6 +56,7 @@ class MainActivity : Activity() {
                     when (action) {
                         "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode)
                         "run_scenario" -> runScenario(scenarioName, scenarioMode)
+                        "clear_persistent_data" -> clear_persistent_data()
                         else -> throw IllegalArgumentException("Unknown action: " + action)
                     }
                 } catch (e: Exception) {
@@ -114,6 +106,16 @@ class MainActivity : Activity() {
             },
             1
         )
+    }
+
+    // Clear persistent data (used to stop scenarios bleeding into each other)
+    private fun clear_persistent_data() {
+        log("Clearing persistent data")
+        clearFolder("last-run-info")
+        clearFolder("bugsnag-errors")
+        clearFolder("device-id")
+        clearFolder("user-info")
+        clearFolder("fake")
     }
 
     private fun clearFolder(name: String) {

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
-import android.view.Window;
+import android.view.Window
 import android.widget.Button
 import android.widget.EditText
 import com.bugsnag.android.mazerunner.scenarios.Scenario
@@ -56,7 +56,7 @@ class MainActivity : Activity() {
                     when (action) {
                         "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode)
                         "run_scenario" -> runScenario(scenarioName, scenarioMode)
-                        "clear_persistent_data" -> clear_persistent_data()
+                        "clear_persistent_data" -> clearPersistentData()
                         else -> throw IllegalArgumentException("Unknown action: " + action)
                     }
                 } catch (e: Exception) {
@@ -109,7 +109,7 @@ class MainActivity : Activity() {
     }
 
     // Clear persistent data (used to stop scenarios bleeding into each other)
-    private fun clear_persistent_data() {
+    private fun clearPersistentData() {
         log("Clearing persistent data")
         clearFolder("last-run-info")
         clearFolder("bugsnag-errors")

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -52,12 +52,14 @@ class MainActivity : Activity() {
                     log("command.scenarioName: " + scenarioName)
                     log("command.scenarioMode: " + scenarioMode)
 
-                    // Perform the given action
-                    when (action) {
-                        "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode)
-                        "run_scenario" -> runScenario(scenarioName, scenarioMode)
-                        "clear_persistent_data" -> clearPersistentData()
-                        else -> throw IllegalArgumentException("Unknown action: " + action)
+                    // Perform the given action on the UI thread
+                    runOnUiThread {
+                        when (action) {
+                            "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode)
+                            "run_scenario" -> runScenario(scenarioName, scenarioMode)
+                            "clear_persistent_data" -> clearPersistentData()
+                            else -> throw IllegalArgumentException("Unknown action: " + action)
+                        }
                     }
                 } catch (e: Exception) {
                     log("Failed to fetch command from Maze Runner", e)

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -11,13 +11,6 @@
           android:layout_weight="4"
           android:text="Run command" />
 
-  <Button
-          android:id="@+id/clear_persistent_data"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_weight="0"
-          android:text="Clear app data" />
-
   <EditText
           android:id="@+id/notify_endpoint"
           android:layout_width="match_parent"

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -11,44 +11,12 @@
           android:layout_weight="0"
           android:text="Run command" />
 
-  <EditText
-          android:id="@+id/scenario_name"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_weight="0"
-          android:ems="10"
-          android:hint="Scenario name"
-          android:inputType="text" />
-
-  <EditText
-          android:id="@+id/scenario_mode"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_weight="0"
-          android:ems="10"
-          android:hint="Scenario mode"
-          android:inputType="text" />
-
   <Button
           android:id="@+id/clear_persistent_data"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_weight="0"
           android:text="Clear app data" />
-
-  <Button
-          android:id="@+id/start_bugsnag"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_weight="0"
-          android:text="Start Bugsnag" />
-
-  <Button
-          android:id="@+id/run_scenario"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_weight="0"
-          android:text="Execute" />
 
   <EditText
           android:id="@+id/notify_endpoint"

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
           android:id="@+id/run_command"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_weight="0"
+          android:layout_weight="4"
           android:text="Run command" />
 
   <Button
@@ -38,11 +38,6 @@
           android:inputType="text"
           android:text="http://bs-local.com:9339/sessions" />
 
-  <Space
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="1" />
-
   <TextView
     android:id="@+id/textView"
     android:layout_width="wrap_content"
@@ -69,10 +64,5 @@
     android:layout_height="wrap_content"
     android:layout_weight="0"
     android:text="Clear User data" />
-
-  <Space
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_weight="6" />
 
 </LinearLayout>

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -4,6 +4,13 @@
   android:layout_height="match_parent"
   android:orientation="vertical">
 
+  <Button
+          android:id="@+id/run_command"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_weight="0"
+          android:text="Run command" />
+
   <EditText
           android:id="@+id/scenario_name"
           android:layout_width="match_parent"
@@ -14,12 +21,12 @@
           android:inputType="text" />
 
   <EditText
-          android:id="@+id/scenario_metadata"
+          android:id="@+id/scenario_mode"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_weight="0"
           android:ems="10"
-          android:hint="Scenario metadata"
+          android:hint="Scenario mode"
           android:inputType="text" />
 
   <Button

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -10,6 +10,7 @@
     <ID>MagicNumber:DiscardBigEventsScenario.kt$DiscardBigEventsScenario$100</ID>
     <ID>MagicNumber:DiscardBigEventsScenario.kt$DiscardBigEventsScenario$1024</ID>
     <ID>MagicNumber:DiscardOldEventsScenario.kt$DiscardOldEventsScenario$100</ID>
+    <ID>MagicNumber:DiscardOldEventsScenario.kt$DiscardOldEventsScenario$2000</ID>
     <ID>MagicNumber:DiscardOldEventsScenario.kt$DiscardOldEventsScenario$60</ID>
     <ID>MagicNumber:DiscardOldSessionScenario.kt$DiscardOldSessionScenario$100</ID>
     <ID>MagicNumber:DiscardOldSessionScenario.kt$DiscardOldSessionScenario$35</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
@@ -6,6 +6,10 @@ fun log(msg: String) {
     Log.d("BugsnagMazeRunner", msg)
 }
 
+fun log(msg: String, e: Exception) {
+    Log.e("BugsnagMazeRunner", msg, e)
+}
+
 /**
  * Gets the log messages expected when zero events should be sent to Bugsnag.
  */

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
@@ -52,6 +52,8 @@ internal class DiscardOldEventsScenario(
         Bugsnag.notify(MyThrowable("DiscardOldEventsScenario"))
 
         waitForEventFile()
+        // Extra sleep needed on Android 10+
+        Thread.sleep(2000)
         oldifyEventFiles()
 
         Bugsnag.notify(MyThrowable("To keep maze-runner from shutting me down prematurely"))

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
@@ -52,7 +52,7 @@ internal class DiscardOldEventsScenario(
         Bugsnag.notify(MyThrowable("DiscardOldEventsScenario"))
 
         waitForEventFile()
-        // Extra sleep needed on Android 10+
+        // PLAT-8344 Determine why an extra sleep is needed on Android 10+
         Thread.sleep(2000)
         oldifyEventFiles()
 

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -1,5 +1,8 @@
 Feature: Discarding events
 
+  Background:
+    Given I clear all persistent data
+
   Scenario: Discard an on-disk error that failed to send and is too old
     # Fail to send initial handled error. Client stores it to disk.
     When I set the HTTP status code for the next request to 500

--- a/features/full_tests/discarded_session.feature
+++ b/features/full_tests/discarded_session.feature
@@ -1,5 +1,8 @@
 Feature: Discarding sessions
 
+  Background:
+    Given I clear all persistent data
+
   Scenario: Discard an on-disk session that failed to send and is too old
     # Part 1 sets a bogus session endpoint so that all attempts to send the session fail.
     # Note: The app will make two attempts.

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -21,6 +21,9 @@ Feature: Synchronizing app/device metadata in the native layer
     And the event "app.duration" is greater than 0
     And the event "context" string is empty
     And the event "unhandled" is false
+    # Appium 1.9.1 - 1.20.2 changes the orientation to landscape when foregrounding.
+    # Return it to portrait to avoid impacting other scenarios.
+    And I set the screen orientation to portrait
 
   Scenario: Capture foreground state while in a foreground crash
     When I run "CXXTrapScenario" and relaunch the crashed app
@@ -44,3 +47,6 @@ Feature: Synchronizing app/device metadata in the native layer
     And the event "app.duration" is greater than 0
     And the event "context" string is empty
     And the event "unhandled" is true
+    # Appium 1.9.1 - 1.20.2 changes the orientation to landscape when foregrounding.
+    # Return it to portrait to avoid impacting other scenarios.
+    And I set the screen orientation to portrait

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -27,8 +27,8 @@ def execute_command(action, scenario_name)
   command = { action: action, scenario_name: scenario_name, scenario_mode: $scenario_mode }
   Maze::Server.commands.add command
 
-  # TODO Consider tapping at an x,y to save time
-  Maze.driver.click_element 'run_command'
+  # Tapping saves a lot of time finding and clicking elements with Appium
+  tap_at 100, 100
   $scenario_mode = ''
   $reset_data = false
 
@@ -36,6 +36,12 @@ def execute_command(action, scenario_name)
   count = 100
   sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
   raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
+end
+
+def tap_at(x, y)
+  touch_action = Appium::TouchAction.new
+  touch_action.tap({:x => x, :y => y})
+  touch_action.perform
 end
 
 When("I clear any error dialogue") do
@@ -73,7 +79,7 @@ end
 When("I relaunch the app after a crash") do
   # This step should only be used when the app has crashed, but the notifier needs a little
   # time to write the crash report before being forced to reopen.  From trials, 2s was not enough.
-  # TODO: Consider checking when the app has closed using Appium app_state
+  # TODO Consider checking when the app has closed using Appium app_state
   sleep(5)
   Maze.driver.launch_app
 end
@@ -81,8 +87,7 @@ end
 When("I tap the screen {int} times") do |count|
   (1..count).each { |i|
     begin
-      touch_action = Appium::TouchAction.new
-      touch_action.tap({:x => 500, :y => 300})
+      tap_at 500, 300
       touch_action.perform
     rescue Selenium::WebDriver::Error::ElementNotInteractableError
       # Ignore it§

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -29,7 +29,7 @@ def execute_command(action, scenario_name)
 
   # TODO Consider tapping at an x,y to save time
   Maze.driver.click_element 'run_command'
-  $scenario_mode = nil
+  $scenario_mode = ''
   $reset_data = false
 
   # Ensure fixture has read the command
@@ -73,6 +73,7 @@ end
 When("I relaunch the app after a crash") do
   # This step should only be used when the app has crashed, but the notifier needs a little
   # time to write the crash report before being forced to reopen.  From trials, 2s was not enough.
+  # TODO: Consider checking when the app has closed using Appium app_state
   sleep(5)
   Maze.driver.launch_app
 end
@@ -91,7 +92,7 @@ When("I tap the screen {int} times") do |count|
 end
 
 When("I configure the app to run in the {string} state") do |scenario_mode|
-  $scenario_mode =  scenario_mode
+  $scenario_mode = scenario_mode
 end
 
 Then("the exception reflects a signal was raised") do

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -28,7 +28,7 @@ def execute_command(action, scenario_name)
   Maze::Server.commands.add command
 
   # Tapping saves a lot of time finding and clicking elements with Appium
-  tap_at 100, 100
+  tap_at 200, 200
   $scenario_mode = ''
   $reset_data = false
 
@@ -88,7 +88,6 @@ When("I tap the screen {int} times") do |count|
   (1..count).each { |i|
     begin
       tap_at 500, 300
-      touch_action.perform
     rescue Selenium::WebDriver::Error::ElementNotInteractableError
       # Ignore it§
     end

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -1,5 +1,5 @@
 When('I clear all persistent data') do
-  step 'I click the element "clear_persistent_data"'
+  execute_command :clear_persistent_data, ''
 end
 
 # Waits 5s for an element to be present.  If it isn't assume a system error dialog is

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -33,7 +33,7 @@ def execute_command(action, scenario_name)
   $reset_data = false
 
   # Ensure fixture has read the command
-  count = 100
+  count = 600
   sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
   raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,5 +1,6 @@
 BeforeAll do
   $api_key = "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  $scenario_mode = ''
   Maze.config.receive_no_requests_wait = 10
   Maze.config.receive_requests_wait = 60
 end


### PR DESCRIPTION
## Goal

Use Maze Runner's `/command` endpoint to fetch the next action to perform.  Also make various corrections and fixes some flakes.

## Design

Avoids the need for costly text entry/button presses by Appium by using a single button press to fetch the next "command" (JSON document) from Maze Runner.

## Changeset

- `run_command` button added to test fixture UI, redundant fields and buttons removed.
- Cucumber steps updated to drive tests using commands.
- Remove ARMv8 64 ABI device for NDK r16 tests as the relevant scenarios `.so`  is not included.
- Extra sleep added to `DiscardOldEventsScenario` as it was flaking heavily on Android 10+.
- Steps added to ensure device returns to portrait after being backgrounded (an Appium bug causes it to go landscape).

## Testing

Covered by a `[full ci]` run, performed before raising this PR.