### PR TITLE
Update payload too large test to be less flakey

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,9 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.3'
+# gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.3'
 
 # Or follow master:
-#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'terminating-server'
 
 gem "license_finder", "~> 6.13"

--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,9 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-# gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.3'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.10.0'
 
 # Or follow master:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'terminating-server'
+# gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'
 
 gem "license_finder", "~> 6.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: d7b74e6c06ab00144620544ea5ff0556068b5c65
-  branch: terminating-server
+  revision: 50e354dd25d96291796ed333be0e32ba37240107
+  tag: v6.10.0
   specs:
     bugsnag-maze-runner (6.10.0)
       appium_lib (~> 11.2.0)
@@ -82,10 +82,10 @@ GEM
     mime-types-data (3.2022.0105)
     mini_portile2 (2.8.0)
     multi_test (0.1.2)
-    nokogiri (1.13.3)
+    nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-darwin)
+    nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 3230db9009a6f5ee9d8beac07deb0d87658521ea
-  tag: v6.9.3
+  revision: d7b74e6c06ab00144620544ea5ff0556068b5c65
+  branch: terminating-server
   specs:
-    bugsnag-maze-runner (6.9.3)
+    bugsnag-maze-runner (6.10.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -31,7 +31,7 @@ GEM
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cucumber (7.1.0)
       builder (~> 3.2, >= 3.2.4)
       cucumber-core (~> 10.1, >= 10.1.0)
@@ -80,8 +80,12 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
+    mini_portile2 (2.8.0)
     multi_test (0.1.2)
-    nokogiri (1.13.1-x86_64-darwin)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:terminating-server-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v6-cli
     environment:
       DEBUG:
       BUILDKITE:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:terminating-server-ci-ruby-3
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:terminating-server-cli
     environment:
       DEBUG:
       BUILDKITE:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       BUILDKITE_REPO:
 
   android-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v6-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:terminating-server-ci-ruby-3
     environment:
       DEBUG:
       BUILDKITE:

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
@@ -23,13 +23,6 @@ internal class DiscardBigEventsScenario(
         return "*".repeat(1024 * 1024)
     }
 
-    fun waitForEventFile() {
-        val dir = File(context.cacheDir, "bugsnag-errors")
-        while (dir.listFiles()!!.isEmpty()) {
-            Thread.sleep(100)
-        }
-    }
-
     override fun startScenario() {
         super.startScenario()
         Bugsnag.markLaunchCompleted()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
@@ -34,9 +34,5 @@ internal class DiscardBigEventsScenario(
         super.startScenario()
         Bugsnag.markLaunchCompleted()
         Bugsnag.notify(MyThrowable("DiscardBigEventsScenario"))
-
-        waitForEventFile()
-
-        Bugsnag.notify(MyThrowable("To keep maze-runner from shutting me down prematurely"))
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import java.io.File
 
 internal class DiscardBigEventsScenario(
     config: Configuration,

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -27,7 +27,7 @@ Feature: Discarding events
     And I configure Bugsnag for "DiscardOldEventsScenario"
     Then I should receive no requests
 
-    Scenario: Discard an on-disk error that failed to send and is too big
+  Scenario: Discard an on-disk error that failed to send and is too big
     # Fail to send initial handled error. Client stores it to disk.
     Given I set the endpoints to the terminating server
     And I start the terminating server

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -35,13 +35,6 @@ Feature: Discarding events
     And I wait for 2 seconds
     And the terminating server has received 1 requests
 
-    # Relaunch, failing again by targetting the terminating server.
-    Then I close and relaunch the app
-    And I set the endpoints to the terminating server
-    And I configure Bugsnag for "DiscardBigEventsScenario"
-    And I wait for 2 seconds
-    And the terminating server has received 1 requests
-
     # The event should have been deleted, so we should receive nothing
     Then I close and relaunch the app
     And I configure Bugsnag for "DiscardBigEventsScenario"

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -67,6 +67,15 @@ When("I configure Bugsnag for {string}") do |event_type|
   execute_command :start_bugsnag, event_type
 end
 
+When("I set the endpoints to the terminating server") do
+  steps %Q{
+    Given any dialog is cleared and the element "notify_endpoint" is present
+    And any dialog is cleared and the element "session_endpoint" is present
+    When I send the keys "http://bs-local.com:9341" to the element "notify_endpoint"
+    And I send the keys "http://bs-local.com:9341" to the element "session_endpoint"
+  }
+end
+
 When("I close and relaunch the app") do
   Maze.driver.close_app
   Maze.driver.launch_app


### PR DESCRIPTION
## Goal

Due to potential flakiness, and to more accurately reflect the processes involved, use the terminating server for testing how the Android notifier handles situations where the payload is rejected by the pipeline due to being too large.