### PR TITLE
Add `BugsnagMapper` to the `internal` package

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
@@ -11,6 +11,10 @@ internal class BugsnagEventMapper(
     private val logger: Logger
 ) {
 
+    internal fun convertToEvent(map: Map<in String, Any?>, apiKey: String): Event {
+        return Event(convertToEventImpl(map, apiKey), logger)
+    }
+
     @Suppress("UNCHECKED_CAST")
     internal fun convertToEventImpl(map: Map<in String, Any?>, apiKey: String): EventInternal {
         val event = EventInternal(apiKey)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/BugsnagMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/BugsnagMapper.kt
@@ -1,0 +1,31 @@
+package com.bugsnag.android.internal
+
+import com.bugsnag.android.BugsnagEventMapper
+import com.bugsnag.android.Event
+import com.bugsnag.android.JsonStream
+import com.bugsnag.android.Logger
+import java.io.ByteArrayOutputStream
+
+class BugsnagMapper(logger: Logger) {
+    private val eventMapper = BugsnagEventMapper(logger)
+
+    /**
+     * Convert the given `Map` of data to an `Event` object
+     */
+    fun convertToEvent(data: Map<in String, Any?>, fallbackApiKey: String): Event {
+        return eventMapper.convertToEvent(data, fallbackApiKey)
+    }
+
+    /**
+     * Convert a given `Event` object to a `Map<String, Any?>`
+     */
+    fun convertToMap(event: Event): Map<in String, Any?> {
+        val byteStream = ByteArrayOutputStream()
+
+        byteStream.writer().use { writer ->
+            JsonStream(writer).value(event)
+        }
+
+        return JsonHelper.deserialize(byteStream.toByteArray())
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/BugsnagMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/BugsnagMapperTest.kt
@@ -1,0 +1,39 @@
+package com.bugsnag.android.internal
+
+import com.bugsnag.android.NoopLogger
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class BugsnagMapperTest {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun testCases(): Collection<String> = listOf(
+            "event_serialization_0.json",
+            "event_serialization_1.json",
+            "event_serialization_2.json",
+            "event_serialization_3.json",
+            "event_serialization_4.json",
+            "event_serialization_5.json",
+            "event_serialization_6.json",
+            "event_serialization_7.json"
+        )
+    }
+
+    @Parameterized.Parameter
+    lateinit var serializedEventName: String
+
+    private val bugsnagMapper = BugsnagMapper(NoopLogger)
+
+    @Test
+    fun mapsBidirectionally() {
+        val contentMap = JsonHelper.deserialize(this.javaClass.getResourceAsStream("/$serializedEventName")!!)
+        val event = bugsnagMapper.convertToEvent(contentMap, "abc123")
+        val mappedEvent = bugsnagMapper.convertToMap(event)
+
+        assertEquals(contentMap, mappedEvent)
+    }
+}


### PR DESCRIPTION
## Goal
Expose the existing `BugsnagEventMapper` logic as an internal API for cross-platform notifiers to use, rather than having to re-invent the JSON serialization & deserialization logic.

## Design
Create a new `BugsnagMapper` public class as a member of the `internal` package so that we don't conflict with the existing Java or Kotlin name-spaces.

The class exposes 2 functions:
- `convertToEvent` converts JSON-like `Map` objects to an `Event` if possible
- `convertToMap` converts `Event` object to JSON-like `Map` objects compatible with `convertToEvent`

## Testing
Added a new unit test which uses existing event JSON fixtures.