### PR TITLE
Pull e2e test commands from Maze Runner

### DIFF
--- a/features/fixtures/mazerunner/app/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/app/detekt-baseline.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues></CurrentIssues>
+  <CurrentIssues>
+    <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
+  </CurrentIssues>
 </SmellBaseline>

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -36,15 +36,41 @@ class MainActivity : Activity() {
             sendBroadcast(closeDialog)
         }
 
+        val clearUserData = findViewById<Button>(R.id.clearUserData)
+
+        clearUserData.setOnClickListener {
+            clearStoredApiKey()
+            val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
+            apiKeyField.text.clear()
+            log("Cleared user data")
+        }
+
+        if (apiKeyStored()) {
+            val apiKey = getStoredApiKey()
+            val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
+            apiKeyField.text.clear()
+            apiKeyField.text.append(apiKey)
+        }
+
+        startCommandRunner()
+    }
+
+    // Starts a thread to poll for Maze Runner actions to perform
+    private fun startCommandRunner() {
         // Get the next maze runner command
-        findViewById<Button>(R.id.run_command).setOnClickListener {
-            log("run_command pressed")
-            thread(start = true) {
+        thread(start = true) {
+            while (true) {
+                Thread.sleep(1000)
                 try {
                     // Get the next command from Maze Runner
                     val commandUrl: String = "http://bs-local.com:9339/command"
                     val commandStr = URL(commandUrl).readText()
+                    if (commandStr == "null") {
+                        log("No Maze Runner commands queued")
+                        continue
+                    }
                     log("Received command: $commandStr")
+
                     var command = JSONObject(commandStr)
                     val action = command.getString("action")
                     val scenarioName = command.getString("scenario_name")
@@ -66,22 +92,6 @@ class MainActivity : Activity() {
                     log("Failed to fetch command from Maze Runner", e)
                 }
             }
-        }
-
-        val clearUserData = findViewById<Button>(R.id.clearUserData)
-
-        clearUserData.setOnClickListener {
-            clearStoredApiKey()
-            val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
-            apiKeyField.text.clear()
-            log("Cleared user data")
-        }
-
-        if (apiKeyStored()) {
-            val apiKey = getStoredApiKey()
-            val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
-            apiKeyField.text.clear()
-            apiKeyField.text.append(apiKey)
         }
     }
 

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -4,13 +4,6 @@
   android:layout_height="match_parent"
   android:orientation="vertical">
 
-  <Button
-          android:id="@+id/run_command"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:layout_weight="4"
-          android:text="Run command" />
-
   <EditText
           android:id="@+id/notify_endpoint"
           android:layout_width="match_parent"

--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -53,11 +53,10 @@ Feature: Switching automatic error detection on/off for Unity
 # PLAT-6620
   @skip_android_8_1
   Scenario: ANR captured with autoDetectAnrs reenabled
-    When I run "AutoDetectAnrsTrueScenario"
+    When I clear any error dialogue
+    And I run "AutoDetectAnrsTrueScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements

--- a/features/full_tests/detect_anr_jvm.feature
+++ b/features/full_tests/detect_anr_jvm.feature
@@ -4,7 +4,8 @@ Feature: ANRs triggered in JVM code are captured
     Given I clear all persistent data
 
   Scenario: ANR triggered in JVM loop code is captured
-    When I run "JvmAnrLoopScenario"
+    When I clear any error dialogue
+    And I run "JvmAnrLoopScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
     Then I wait to receive an error
@@ -21,11 +22,10 @@ Feature: ANRs triggered in JVM code are captured
 # on Samsung as it is explicitly design to test ANRs caused by a sleeping thread.
   @skip_samsung
   Scenario: ANR triggered in JVM sleep code is captured
-    When I run "JvmAnrSleepScenario"
+    When I clear any error dialogue
+    And I run "JvmAnrSleepScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"

--- a/features/full_tests/detect_ndk_crashes.feature
+++ b/features/full_tests/detect_ndk_crashes.feature
@@ -6,5 +6,4 @@ Feature: Verifies autoDetectNdkCrashes controls when NDK crashes are reported
   Scenario: No crash reported when autoDetectNdkCrashes disabled
     When I run "AutoDetectNdkDisabledScenario" and relaunch the crashed app
     And I configure Bugsnag for "AutoDetectNdkDisabledScenario"
-    And I wait for 2 seconds
     Then I should receive no requests

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -27,6 +27,8 @@ Feature: Discarding events
     And I configure Bugsnag for "DiscardOldEventsScenario"
     Then I should receive no requests
 
+  # Skip pending PLAT-8374
+  @skip
   Scenario: Discard an on-disk error that failed to send and is too big
     # Fail to send initial handled error. Client stores it to disk.
     Given I set the endpoints to the terminating server

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -38,7 +38,6 @@ Feature: Synchronizing app/device metadata in the native layer
   Scenario: Capture foreground state while in a background crash
     When I run "CXXDelayedCrashScenario"
     And I send the app to the background for 10 seconds
-    And I clear any error dialogue
     And I relaunch the app after a crash
     And I configure Bugsnag for "CXXDelayedCrashScenario"
     And I wait to receive an error

--- a/features/full_tests/startup_anr.feature
+++ b/features/full_tests/startup_anr.feature
@@ -8,9 +8,8 @@ Feature: onCreate ANR
 # fire at all). Since we can't cover a KILL signal in a test, we skip Android 10.
   @skip_android_10
   Scenario: onCreate ANR is reported
-    When I run "ConfigureStartupAnrScenario"
+    When I clear any error dialogue
+    And I run "ConfigureStartupAnrScenario"
     And I relaunch the app after a crash
-    And I wait for 30 seconds
-    And I clear any error dialogue
     Then I wait to receive an error
     And the exception "errorClass" equals "ANR"

--- a/features/full_tests/threaded_startup.feature
+++ b/features/full_tests/threaded_startup.feature
@@ -6,5 +6,4 @@ Feature: Switching automatic error detection on/off for Unity
   Scenario: Starting Bugsnag & calling it on separate threads
     When I run "MultiThreadedStartupScenario" and relaunch the crashed app
     And I configure Bugsnag for "MultiThreadedStartupScenario"
-    And I wait for 2 seconds
     Then I should receive no error

--- a/features/minimal/detect_anr_minimal.feature
+++ b/features/minimal/detect_anr_minimal.feature
@@ -8,7 +8,6 @@ Feature: ANRs triggered in a fixture with only bugsnag-android-core are captured
     And I wait for 2 seconds
     And I tap the screen 3 times
     And I wait for 4 seconds
-    And I clear any error dialogue
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "java.lang.RuntimeException"

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -263,11 +263,10 @@ Feature: Unhandled smoke tests
 
   @skip_android_8_1
   Scenario: ANR detection
-    When I run "JvmAnrLoopScenario"
+    When I clear any error dialogue
+    And I run "JvmAnrLoopScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I wait for 4 seconds
-    And I clear any error dialogue
     And I wait to receive an error
 
     # Exception details

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -1,5 +1,5 @@
 When('I clear all persistent data') do
-  execute_command :clear_persistent_data, ''
+  execute_command :clear_persistent_data
 end
 
 # Waits 5s for an element to be present.  If it isn't assume a system error dialog is
@@ -23,14 +23,11 @@ When('any dialog is cleared and the element {string} is present') do |element_id
   Maze.check.true(present, "The element #{element_id} could not be found")
 end
 
-def execute_command(action, scenario_name)
+def execute_command(action, scenario_name = '')
   command = { action: action, scenario_name: scenario_name, scenario_mode: $scenario_mode }
   Maze::Server.commands.add command
 
-  # Tapping saves a lot of time finding and clicking elements with Appium
-  tap_at 200, 200
   $scenario_mode = ''
-  $reset_data = false
 
   # Ensure fixture has read the command
   count = 600
@@ -51,7 +48,6 @@ When("I clear any error dialogue") do
 end
 
 When('I run {string}') do |scenario_name|
-  step 'I clear any error dialogue'
   execute_command :run_scenario, scenario_name
 end
 
@@ -63,7 +59,6 @@ When("I run {string} and relaunch the crashed app") do |event_type|
 end
 
 When("I configure Bugsnag for {string}") do |event_type|
-  step 'I clear any error dialogue'
   execute_command :start_bugsnag, event_type
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,8 +1,11 @@
 BeforeAll do
   $api_key = "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  $scenario_mode = ''
   Maze.config.receive_no_requests_wait = 10
   Maze.config.receive_requests_wait = 60
+end
+
+Before do
+  $scenario_mode = ''
 end
 
 Before('@skip') do |scenario|


### PR DESCRIPTION
## Goal

Reinstatement of #1651, having suffered what turned out to be a broken local repo.

Start a thread when the Test Fixture launches to poll Maze Runner for the next command action to perform.

## Design

Android likes to throw up system dialogs for crashy apps, which have needed to be closed so that Appium actions aren't blocked.  However, error dialogs aren't always shown and so we've been spending a lot of time trying to dismiss dialogs that are not present (around 4s each time).  With this change the runtime for each full set of e2e tests is reduced by around 10 minutes.

## Changeset

`run_command` button removed, being replaced by a polling thread.
Removal of error dialog closing calls in most situations (still needed for touch events so that ANR scenarios work reliably).

## Testing

Covered by a full CI run.