### PR TITLE
Add Error support to BugsnagMapper

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
@@ -89,7 +89,11 @@ internal class BugsnagEventMapper(
         return event
     }
 
-    internal fun convertErrorInternal(error: Map<String, Any?>): ErrorInternal {
+    internal fun convertError(error: Map<in String, Any?>): Error {
+        return Error(convertErrorInternal(error), logger)
+    }
+
+    internal fun convertErrorInternal(error: Map<in String, Any?>): ErrorInternal {
         return ErrorInternal(
             error.readEntry("errorClass"),
             error["message"] as? String,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/BugsnagMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/BugsnagMapper.kt
@@ -5,6 +5,7 @@ import com.bugsnag.android.Event
 import com.bugsnag.android.JsonStream
 import com.bugsnag.android.Logger
 import java.io.ByteArrayOutputStream
+import com.bugsnag.android.Error as BugsnagError
 
 class BugsnagMapper(logger: Logger) {
     private val eventMapper = BugsnagEventMapper(logger)
@@ -17,15 +18,27 @@ class BugsnagMapper(logger: Logger) {
     }
 
     /**
+     * Convert the given `Map` of data to an `Error` object
+     */
+    fun convertToError(data: Map<in String, Any?>): BugsnagError {
+        return eventMapper.convertError(data)
+    }
+
+    /**
      * Convert a given `Event` object to a `Map<String, Any?>`
      */
     fun convertToMap(event: Event): Map<in String, Any?> {
         val byteStream = ByteArrayOutputStream()
+        byteStream.writer().use { writer -> JsonStream(writer).value(event) }
+        return JsonHelper.deserialize(byteStream.toByteArray())
+    }
 
-        byteStream.writer().use { writer ->
-            JsonStream(writer).value(event)
-        }
-
+    /**
+     * Convert a given `Error` object to a `Map<String, Any?>`
+     */
+    fun convertToMap(error: BugsnagError): Map<in String, Any?> {
+        val byteStream = ByteArrayOutputStream()
+        byteStream.writer().use { writer -> JsonStream(writer).value(error) }
         return JsonHelper.deserialize(byteStream.toByteArray())
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
@@ -14,7 +14,49 @@ internal class ErrorSerializationTest {
         @Parameters
         fun testCases() = generateSerializationTestCases(
             "error",
-            Error(ErrorInternal("foo", "bar", Stacktrace(listOf())), NoopLogger)
+            Error(ErrorInternal("foo", "bar", Stacktrace(listOf())), NoopLogger),
+            Error(
+                ErrorInternal(
+                    "foo",
+                    "bar",
+                    Stacktrace(
+                        listOf(
+                            Stackframe(
+                                method = "foo()",
+                                file = "Bar.kt",
+                                lineNumber = 55,
+                                inProject = true,
+                                columnNumber = 99,
+                                code = mapOf("54" to "invoke()")
+                            ),
+                        )
+                    )
+                ),
+                NoopLogger
+            ),
+            Error(
+                ErrorInternal(
+                    "com.bugsnag.android.StacktraceSerializationTest",
+                    "bar",
+                    Stacktrace(
+                        listOf(
+                            Stackframe(
+                                method = "com.bugsnag.android.StacktraceSerializationTest\$Companion.inProject",
+                                file = "StacktraceSerializationTest.kt",
+                                lineNumber = 47,
+                                inProject = true,
+                            ),
+                            Stackframe(
+                                method = "com.bugsnag.android.StacktraceSerializationTest\$Companion.testCases",
+                                file = "StacktraceSerializationTest.kt",
+                                lineNumber = 31,
+                                inProject = true,
+                            )
+                        )
+                    )
+                ),
+                NoopLogger
+            )
         )
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/BugsnagMapperTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/BugsnagMapperTest.kt
@@ -3,37 +3,35 @@ package com.bugsnag.android.internal
 import com.bugsnag.android.NoopLogger
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
-@RunWith(Parameterized::class)
 internal class BugsnagMapperTest {
-    companion object {
-        @JvmStatic
-        @Parameterized.Parameters
-        fun testCases(): Collection<String> = listOf(
-            "event_serialization_0.json",
-            "event_serialization_1.json",
-            "event_serialization_2.json",
-            "event_serialization_3.json",
-            "event_serialization_4.json",
-            "event_serialization_5.json",
-            "event_serialization_6.json",
-            "event_serialization_7.json"
-        )
-    }
-
-    @Parameterized.Parameter
-    lateinit var serializedEventName: String
-
     private val bugsnagMapper = BugsnagMapper(NoopLogger)
 
     @Test
-    fun mapsBidirectionally() {
-        val contentMap = JsonHelper.deserialize(this.javaClass.getResourceAsStream("/$serializedEventName")!!)
-        val event = bugsnagMapper.convertToEvent(contentMap, "abc123")
-        val mappedEvent = bugsnagMapper.convertToMap(event)
+    fun mapsEventsBidirectionally() {
+        repeat(8) { index ->
+            val contentMap = JsonHelper.deserialize(
+                this.javaClass.getResourceAsStream("/event_serialization_$index.json")!!
+            )
 
-        assertEquals(contentMap, mappedEvent)
+            val event = bugsnagMapper.convertToEvent(contentMap, "abc123")
+            val mappedEvent = bugsnagMapper.convertToMap(event)
+
+            assertEquals("event_serialization_$index.json", contentMap, mappedEvent)
+        }
+    }
+
+    @Test
+    fun mapsErrorsBidirectionally() {
+        repeat(3) { index ->
+            val contentMap = JsonHelper.deserialize(
+                this.javaClass.getResourceAsStream("/error_serialization_$index.json")!!
+            )
+
+            val error = bugsnagMapper.convertToError(contentMap)
+            val mappedError = bugsnagMapper.convertToMap(error)
+
+            assertEquals("error_serialization_$index.json", contentMap, mappedError)
+        }
     }
 }

--- a/bugsnag-android-core/src/test/resources/error_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/error_serialization_1.json
@@ -1,0 +1,17 @@
+{
+  "errorClass": "foo",
+  "message": "bar",
+  "type": "android",
+  "stacktrace": [
+    {
+      "method": "foo()",
+      "file": "Bar.kt",
+      "lineNumber": 55,
+      "inProject": true,
+      "columnNumber": 99,
+      "code": {
+        "54": "invoke()"
+      }
+    }
+  ]
+}

--- a/bugsnag-android-core/src/test/resources/error_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/error_serialization_2.json
@@ -1,0 +1,19 @@
+{
+  "errorClass": "com.bugsnag.android.StacktraceSerializationTest",
+  "message": "bar",
+  "type": "android",
+  "stacktrace": [
+    {
+      "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.inProject",
+      "file": "StacktraceSerializationTest.kt",
+      "lineNumber": 47,
+      "inProject": true
+    },
+    {
+      "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
+      "file": "StacktraceSerializationTest.kt",
+      "lineNumber": 31,
+      "inProject": true
+    }
+  ]
+}


### PR DESCRIPTION
## Goal
Allow cross-platform notifiers to level JSON-like encoding & decoding of Bugsnag `Error` objects.

## Testing
Additional unit tests to cover the new logic. Also expanded our existing `Error` serialization tests.