### PR TITLE
Minor CI improvements

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -117,7 +117,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
@@ -144,7 +144,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
           - "--app=/app/build/release/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
@@ -172,7 +172,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_7_1_SAMSUNG_GALAXY_NOTE_8"
@@ -198,7 +198,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_7_1_SAMSUNG_GALAXY_NOTE_8"
@@ -225,7 +225,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
@@ -251,7 +251,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
           - "--app=/app/build/release/fixture-r19.apk"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
@@ -279,7 +279,7 @@ steps:
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
           - "features/smoke_tests"
           - "features/full_tests"
           - "--fail-fast"
@@ -304,7 +304,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
@@ -331,7 +331,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
@@ -358,7 +358,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
@@ -389,7 +389,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
@@ -416,7 +416,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
@@ -447,7 +447,7 @@ steps:
         command:
           - "features/smoke_tests"
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_12_0"
@@ -473,7 +473,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
           - "--app=/app/build/release/fixture-r21.apk"
           - "--farm=bs"
           - "--device=ANDROID_12_0"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -102,37 +102,19 @@ steps:
       TEST_FIXTURE_CONFIGURATION: "release"
       BUILD_TASK: "assembleRelease"
 
-  - label: ':android: Lint'
+  - label: ':android: Coding standards checks'
     depends_on: "android-ci"
     timeout_in_minutes: 10
     plugins:
       - docker-compose#v3.7.0:
           run: android-ci
-    command: './gradlew lint'
-
-  - label: ':android: Checkstyle'
-    depends_on: "android-ci"
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.7.0:
-          run: android-ci
-    command: './gradlew checkstyle'
-
-  - label: ':android: Detekt'
-    depends_on: "android-ci"
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.7.0:
-          run: android-ci
-    command: './gradlew detekt'
-
-  - label: ':android: Ktlint'
-    depends_on: "android-ci"
-    timeout_in_minutes: 10
-    plugins:
-      - docker-compose#v3.7.0:
-          run: android-ci
-    command: './gradlew ktlintCheck'
+    command: './gradlew --continue checkstyle detekt lint ktlintCheck'
+    artifact_paths:
+      - "./bugsnag-plugin-android-okhttp/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
+      - "./bugsnag-plugin-react-native/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
+      - "./bugsnag-plugin-android-ndk/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
+      - "./bugsnag-android-core/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
+      - "./bugsnag-plugin-android-anr/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
 
   - label: ':android: CppCheck'
     depends_on: "android-ci"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,12 +109,6 @@ steps:
       - docker-compose#v3.7.0:
           run: android-ci
     command: './gradlew --continue checkstyle detekt lint ktlintCheck'
-    artifact_paths:
-      - "./bugsnag-plugin-android-okhttp/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
-      - "./bugsnag-plugin-react-native/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
-      - "./bugsnag-plugin-android-ndk/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
-      - "./bugsnag-android-core/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
-      - "./bugsnag-plugin-android-anr/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt"
 
   - label: ':android: CppCheck'
     depends_on: "android-ci"


### PR DESCRIPTION
## Goal

Combine the coding standard check steps, making for a faster run.  Also try to balance the two batches of e2e tests so they take roughly the same amount of time.

## Testing

Combined steps covered by a standard CI run and I verified that the `--continue` did result in all checks being performed if one fails using a temporary commit.  

For balancing the batches, I ran a full build and whilst runtimes can always vary, the batches were pretty balanced - within a minute of each other.