### PR TITLE
Relaunch test fixture based on app_state

### DIFF
--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -21,9 +21,13 @@ Feature: Switching automatic error detection on/off for Unity
 
   @skip_android_8_1
   Scenario: ANR not captured with autoDetectAnrs=false
-    When I run "AutoDetectAnrsFalseScenario" and relaunch the crashed app
+    When I run "AutoDetectAnrsFalseScenario"
+    And I wait for 2 seconds
+    And I tap the screen 3 times
+    And I close and relaunch the app
     And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
     Then Bugsnag confirms it has no errors to send
+    And I should receive no requests
 
   Scenario: JVM exception captured with autoNotify reenabled
     When I run "UnhandledJvmAutoNotifyTrueScenario" and relaunch the crashed app

--- a/features/full_tests/feature_flags.feature
+++ b/features/full_tests/feature_flags.feature
@@ -48,8 +48,7 @@ Feature: Reporting with feature flags
 
   Scenario: Sends feature flags added in OnSend Callbacks
     When I configure the app to run in the "onsend" state
-    And I run "FeatureFlagScenario" and relaunch the crashed app
-    And I configure Bugsnag for "FeatureFlagScenario"
+    And I run "FeatureFlagScenario"
     Then I wait to receive an error
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "unhandled" is false

--- a/features/full_tests/max_reported_threads.feature
+++ b/features/full_tests/max_reported_threads.feature
@@ -16,8 +16,7 @@ Feature: Reporting with other exception handlers installed
     And the error payload field "events.0.threads.2.name" ends with "threads omitted as the maxReportedThreads limit (2) was exceeded]"
 
   Scenario: Handled exception with max threads set
-    When I run "HandledExceptionMaxThreadsScenario" and relaunch the crashed app
-    And I configure Bugsnag for "HandledExceptionMaxThreadsScenario"
+    When I run "HandledExceptionMaxThreadsScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -64,11 +64,34 @@ When('I set the screen orientation to portrait') do
   Maze.driver.set_rotation(:portrait)
 end
 
+# Waits for the given block to yield true
+#
+# @return [Float] Number of seconds it took for the condition to yield true
+# @raise [StandardError] If the condition is not met
+def wait_for_true
+  max_attempts = 300
+  attempts = 0
+  assertion_passed = false
+  until (attempts >= max_attempts) || assertion_passed
+    attempts += 1
+    assertion_passed = yield
+    sleep 0.1
+  end
+  raise 'Assertion not passed in 30s' unless assertion_passed
+  attempts / 10
+end
+
+When('the app is not running') do
+  time = wait_for_true do
+    state = Maze.driver.app_state('com.bugsnag.android.mazerunner')
+    $logger.info "app_state: #{state}"
+    state == :not_running
+  end
+  $logger.info "Waited #{time} seconds for the app to stop running"
+end
+
 When("I relaunch the app after a crash") do
-  # This step should only be used when the app has crashed, but the notifier needs a little
-  # time to write the crash report before being forced to reopen.  From trials, 2s was not enough.
-  # TODO Consider checking when the app has closed using Appium app_state
-  sleep(5)
+  step 'the app is not running'
   Maze.driver.launch_app
 end
 


### PR DESCRIPTION
## Goal

Use a more sophisticated approach to relaunching the test fixture after a crash, rather than a simple sleep.

## Design

If a slow device takes longer than the 5s currently allowed to write reports to file, flakes can occur.  Conversely, the app normally closes down far faster and so 5s on every crash is a waste of time.

## Changeset

Uses Appium's `app_state` to try and determine when the app has stopped running.  This identified some non-crashy scenarios that needed changing to avoid using the relaunch step, although there are still some scenarios for which the state still doesn't end in `not_running`.  While this is investigated further the step will simply log a warning and carry one regardless (just as it did with a simple sleep).

## Testing

Covered by a `[full ci]` run.