### PR TITLE
Visual feedback for e2e tests being run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.10.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.11.1'
 
 # Or follow master:
 # gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 50e354dd25d96291796ed333be0e32ba37240107
-  tag: v6.10.0
+  revision: b7012344cc0c7081f54bfefe6d9356e3629d2b37
+  tag: v6.11.1
   specs:
-    bugsnag-maze-runner (6.10.0)
+    bugsnag-maze-runner (6.11.1)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -80,11 +80,7 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
-    mini_portile2 (2.8.0)
     multi_test (0.1.2)
-    nokogiri (1.13.4)
-      mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -75,15 +75,19 @@ class MainActivity : Activity() {
                     val action = command.getString("action")
                     val scenarioName = command.getString("scenario_name")
                     val scenarioMode = command.getString("scenario_mode")
+                    val sessionsUrl = command.getString("sessions_endpoint")
+                    val notifyUrl = command.getString("notify_endpoint")
                     log("command.action: $action")
                     log("command.scenarioName: $scenarioName")
                     log("command.scenarioMode: $scenarioMode")
+                    log("command.sessionsUrl: $sessionsUrl")
+                    log("command.notifyUrl: $notifyUrl")
 
                     // Perform the given action on the UI thread
                     runOnUiThread {
                         when (action) {
-                            "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode)
-                            "run_scenario" -> runScenario(scenarioName, scenarioMode)
+                            "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
+                            "run_scenario" -> runScenario(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
                             "clear_persistent_data" -> clearPersistentData()
                             else -> throw IllegalArgumentException("Unknown action: $action")
                         }
@@ -96,15 +100,15 @@ class MainActivity : Activity() {
     }
 
     // load the scenario first, which initialises bugsnag without running any crashy code
-    private fun startBugsnag(eventType: String, mode: String) {
-        scenario = loadScenario(eventType, mode)
+    private fun startBugsnag(eventType: String, mode: String, sessionsUrl: String, notifyUrl: String) {
+        scenario = loadScenario(eventType, mode, sessionsUrl, notifyUrl)
         scenario?.startBugsnag(true)
     }
 
     // execute the pre-loaded scenario, or load it then execute it if needed
-    private fun runScenario(eventType: String, mode: String) {
+    private fun runScenario(eventType: String, mode: String, sessionsUrl: String, notifyUrl: String) {
         if (scenario == null) {
-            scenario = loadScenario(eventType, mode)
+            scenario = loadScenario(eventType, mode, sessionsUrl, notifyUrl)
             scenario?.startBugsnag(false)
         }
 
@@ -138,11 +142,9 @@ class MainActivity : Activity() {
         folder.deleteRecursively()
     }
 
-    private fun loadScenario(eventType: String, mode: String): Scenario {
+    private fun loadScenario(eventType: String, mode: String, sessionsUrl: String, notifyUrl: String): Scenario {
 
         val apiKeyField = findViewById<EditText>(R.id.manualApiKey)
-        val notifyEndpointField = findViewById<EditText>(R.id.notify_endpoint)
-        val sessionEndpointField = findViewById<EditText>(R.id.session_endpoint)
 
         val manualMode = apiKeyField.text.isNotEmpty()
         val apiKey = when {
@@ -154,9 +156,7 @@ class MainActivity : Activity() {
             log("Running in manual mode with API key: $apiKey")
             setStoredApiKey(apiKey)
         }
-        val notify = notifyEndpointField.text.toString()
-        val sessions = sessionEndpointField.text.toString()
-        val config = prepareConfig(apiKey, notify, sessions) {
+        val config = prepareConfig(apiKey, notifyUrl, sessionsUrl) {
             val interceptedLogMessages = scenario?.getInterceptedLogMessages()
             interceptedLogMessages?.contains(it) ?: false
         }

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -69,8 +69,9 @@ class MainActivity : Activity() {
                         log("No Maze Runner commands queued")
                         continue
                     }
-                    log("Received command: $commandStr")
 
+                    // Log the received command
+                    log("Received command: $commandStr")
                     var command = JSONObject(commandStr)
                     val action = command.getString("action")
                     val scenarioName = command.getString("scenario_name")
@@ -83,8 +84,14 @@ class MainActivity : Activity() {
                     log("command.sessionsUrl: $sessionsUrl")
                     log("command.notifyUrl: $notifyUrl")
 
-                    // Perform the given action on the UI thread
                     runOnUiThread {
+                        // Display some feedback of the action being run on he UI
+                        val actionField = findViewById<EditText>(R.id.command_action)
+                        val scenarioField = findViewById<EditText>(R.id.command_scenario)
+                        actionField.setText(action)
+                        scenarioField.setText(scenarioName)
+
+                        // Perform the given action on the UI thread
                         when (action) {
                             "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
                             "run_scenario" -> runScenario(scenarioName, scenarioMode, sessionsUrl, notifyUrl)

--- a/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
+++ b/features/fixtures/mazerunner/app/src/main/res/layout/activity_main.xml
@@ -5,24 +5,22 @@
   android:orientation="vertical">
 
   <EditText
-          android:id="@+id/notify_endpoint"
+          android:id="@+id/command_action"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_weight="0"
           android:ems="10"
-          android:hint="Notify endpoint"
-          android:inputType="text"
-          android:text="http://bs-local.com:9339/notify" />
+          android:text=""
+          android:inputType="text" />
 
   <EditText
-          android:id="@+id/session_endpoint"
+          android:id="@+id/command_scenario"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_weight="0"
           android:ems="10"
-          android:hint="Session endpoint"
-          android:inputType="text"
-          android:text="http://bs-local.com:9339/sessions" />
+          android:text=""
+          android:inputType="text" />
 
   <TextView
     android:id="@+id/textView"

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -3,10 +3,19 @@ When('I clear all persistent data') do
 end
 
 def execute_command(action, scenario_name = '')
-  command = { action: action, scenario_name: scenario_name, scenario_mode: $scenario_mode }
+  command = {
+    action: action,
+    scenario_name: scenario_name,
+    scenario_mode: $scenario_mode,
+    sessions_endpoint: $sessions_endpoint,
+    notify_endpoint: $notify_endpoint
+  }
   Maze::Server.commands.add command
 
+  # Reset values to defaults
   $scenario_mode = ''
+  $sessions_endpoint = 'http://bs-local.com:9339/sessions'
+  $notify_endpoint = 'http://bs-local.com:9339/notify'
 
   # Ensure fixture has read the command
   count = 600
@@ -47,12 +56,8 @@ When("I configure Bugsnag for {string}") do |event_type|
 end
 
 When("I set the endpoints to the terminating server") do
-  steps %Q{
-    Given any dialog is cleared and the element "notify_endpoint" is present
-    And any dialog is cleared and the element "session_endpoint" is present
-    When I send the keys "http://bs-local.com:9341" to the element "notify_endpoint"
-    And I send the keys "http://bs-local.com:9341" to the element "session_endpoint"
-  }
+  $notify_endpoint = 'http://bs-local.com:9341'
+  $sessions_endpoint = 'http://bs-local.com:9341'
 end
 
 When("I close and relaunch the app") do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,8 @@ end
 
 Before do
   $scenario_mode = ''
+  $sessions_endpoint = 'http://bs-local.com:9339/sessions'
+  $notify_endpoint = 'http://bs-local.com:9339/notify'
 end
 
 Before('@skip') do |scenario|


### PR DESCRIPTION
## Goal

Provide some visual feedback for the current e2e scenario being run.

## Design

When a Command is received from Maze Runner, the action and scenario name are displayed in the UI fields.  This can help if a test run goes wrong - to see if something like a popup appears as the scenario is being run.

## Changeset

Instead of adding additional field to the fixture's UI, I've pushed the endpoints into the Command itself and reused the existing fields.  Their presence on the UI was a bit of a hangover and there's no specific need for them to be on the UI.

## Testing

Covered by a basic CI run.  I've also watched a video back to verify that the values appear and are generally useful.