### PR TITLE
Rework test DiscardBigEventsScenario

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXExceptionSmokeScenario.kt
@@ -8,6 +8,7 @@ import com.bugsnag.android.Configuration
 import com.bugsnag.android.OnBreadcrumbCallback
 import com.bugsnag.android.OnErrorCallback
 import com.bugsnag.android.Severity
+import com.bugsnag.android.mazerunner.disableSessionDelivery
 
 class CXXExceptionSmokeScenario(
     config: Configuration,

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalSmokeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalSmokeScenario.java
@@ -7,6 +7,7 @@ import com.bugsnag.android.Event;
 import com.bugsnag.android.OnBreadcrumbCallback;
 import com.bugsnag.android.OnErrorCallback;
 import com.bugsnag.android.Severity;
+import com.bugsnag.android.mazerunner.BugsnagConfigKt;
 
 import android.content.Context;
 import android.os.Handler;
@@ -18,6 +19,7 @@ import androidx.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 
 public class CXXSignalSmokeScenario extends Scenario {
 
@@ -66,7 +68,7 @@ public class CXXSignalSmokeScenario extends Scenario {
                 return true;
             }
         });
-        disableSessionDelivery(config);
+        BugsnagConfigKt.disableSessionDelivery(config);
 
         config.addMetadata("fruit", "counters", 47);
         config.addMetadata("fruit", "ripe", true);

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -7,9 +7,7 @@
     <ID>MagicNumber:AutoDetectAnrsFalseScenario.kt$AutoDetectAnrsFalseScenario$100000</ID>
     <ID>MagicNumber:AutoDetectAnrsTrueScenario.kt$AutoDetectAnrsTrueScenario$100000</ID>
     <ID>MagicNumber:BugsnagInitScenario.kt$BugsnagInitScenario$25</ID>
-    <ID>MagicNumber:DiscardBigEventsScenario.kt$DiscardBigEventsScenario$100</ID>
     <ID>MagicNumber:DiscardBigEventsScenario.kt$DiscardBigEventsScenario$1024</ID>
-    <ID>MagicNumber:DiscardOldEventsScenario.kt$DiscardOldEventsScenario$100</ID>
     <ID>MagicNumber:DiscardOldEventsScenario.kt$DiscardOldEventsScenario$2000</ID>
     <ID>MagicNumber:DiscardOldEventsScenario.kt$DiscardOldEventsScenario$60</ID>
     <ID>MagicNumber:DiscardOldSessionScenario.kt$DiscardOldSessionScenario$100</ID>
@@ -22,6 +20,8 @@
     <ID>MagicNumber:LoadConfigurationKotlinScenario.kt$LoadConfigurationKotlinScenario$10000</ID>
     <ID>MagicNumber:LoadConfigurationKotlinScenario.kt$LoadConfigurationKotlinScenario$98</ID>
     <ID>MagicNumber:ManualSessionSmokeScenario.kt$ManualSessionSmokeScenario$3</ID>
+    <ID>MagicNumber:Scenario.kt$Scenario$100</ID>
+    <ID>MagicNumber:Scenario.kt$Scenario$1000</ID>
     <ID>MagicNumber:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$6000</ID>
     <ID>MagicNumber:TestHarnessHooks.kt$&lt;no name provided&gt;$500</ID>
     <ID>MagicNumber:TrimmedStacktraceScenario.kt$TrimmedStacktraceScenario$100000</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomHttpClientFlushScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CustomHttpClientFlushScenario.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.createCustomHeaderDelivery
+import com.bugsnag.android.mazerunner.disableAllDelivery
 
 /**
  * Sends an unhandled exception and sessions which is cached on disk to Bugsnag,

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
@@ -22,6 +22,16 @@ internal class DiscardBigEventsScenario(
         return "*".repeat(1024 * 1024)
     }
 
+    override fun startBugsnag(startBugsnagOnly: Boolean) {
+        super.startBugsnag(startBugsnagOnly)
+
+        // Wait and signal to Maze that the error has been deleted
+        if (eventMetadata == "delete-wait") {
+            waitForNoEventFiles()
+            Bugsnag.notify(MyThrowable("ErrorsDirectoryEmpty"))
+        }
+    }
+
     override fun startScenario() {
         super.startScenario()
         Bugsnag.markLaunchCompleted()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
@@ -23,17 +23,6 @@ internal class DiscardOldEventsScenario(
         assert(file.renameTo(dstFile))
     }
 
-    fun errorsDir(): File {
-        return File(context.cacheDir, "bugsnag-errors")
-    }
-
-    fun waitForEventFile() {
-        val dir = errorsDir()
-        while (dir.listFiles()!!.isEmpty()) {
-            Thread.sleep(100)
-        }
-    }
-
     fun oldifyEventFiles() {
         val cal = Calendar.getInstance()
         cal.add(Calendar.DATE, -60)

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ReportCacheScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/ReportCacheScenario.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.disableAllDelivery
 
 /**
  * Sends an unhandled exception which is cached on disk to Bugsnag, then sent on a separate launch.

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -12,12 +12,6 @@ import android.os.HandlerThread
 import android.os.Looper
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
-import com.bugsnag.android.Delivery
-import com.bugsnag.android.DeliveryParams
-import com.bugsnag.android.DeliveryStatus
-import com.bugsnag.android.EventPayload
-import com.bugsnag.android.Session
-import com.bugsnag.android.createDefaultDelivery
 import com.bugsnag.android.mazerunner.BugsnagIntentParams
 import com.bugsnag.android.mazerunner.log
 import com.bugsnag.android.mazerunner.multiprocess.MultiProcessService
@@ -59,50 +53,6 @@ abstract class Scenario(
      */
     open fun startScenario() {
         startBugsnagOnly = false
-    }
-
-    /**
-     * Sets a NOP implementation for the Session Tracking API, preventing delivery
-     */
-    protected fun disableSessionDelivery(config: Configuration) {
-        val baseDelivery = createDefaultDelivery()
-        config.delivery = object : Delivery {
-            override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
-                return baseDelivery.deliver(payload, deliveryParams)
-            }
-
-            override fun deliver(payload: Session, deliveryParams: DeliveryParams): DeliveryStatus {
-                return DeliveryStatus.UNDELIVERED
-            }
-        }
-    }
-
-    /**
-     * Sets a NOP implementation for the Error Tracking API, preventing delivery
-     */
-    protected fun disableReportDelivery(config: Configuration) {
-        val baseDelivery = createDefaultDelivery()
-        config.delivery = object : Delivery {
-            override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
-                return DeliveryStatus.UNDELIVERED
-            }
-
-            override fun deliver(payload: Session, deliveryParams: DeliveryParams): DeliveryStatus {
-                return baseDelivery.deliver(payload, deliveryParams)
-            }
-        }
-    }
-
-    protected fun disableAllDelivery(config: Configuration) {
-        config.delivery = object : Delivery {
-            override fun deliver(payload: EventPayload, deliveryParams: DeliveryParams): DeliveryStatus {
-                return DeliveryStatus.UNDELIVERED
-            }
-
-            override fun deliver(payload: Session, deliveryParams: DeliveryParams): DeliveryStatus {
-                return DeliveryStatus.UNDELIVERED
-            }
-        }
     }
 
     /**

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -22,6 +22,7 @@ import com.bugsnag.android.mazerunner.BugsnagIntentParams
 import com.bugsnag.android.mazerunner.log
 import com.bugsnag.android.mazerunner.multiprocess.MultiProcessService
 import com.bugsnag.android.mazerunner.multiprocess.findCurrentProcessName
+import java.io.File
 
 abstract class Scenario(
     protected val config: Configuration,
@@ -154,6 +155,26 @@ abstract class Scenario(
         val handlerThread = HandlerThread("bg-thread")
         handlerThread.start()
         Handler(handlerThread.looper).post(block)
+    }
+
+    protected fun errorsDir(): File {
+        return File(context.cacheDir, "bugsnag-errors")
+    }
+
+    protected fun waitForEventFile() {
+        val dir = errorsDir()
+        while (dir.listFiles()!!.isEmpty()) {
+            dir.listFiles().forEach { println(it) }
+            Thread.sleep(100)
+        }
+    }
+
+    protected fun waitForNoEventFiles() {
+        val dir = errorsDir()
+        while (!dir.listFiles()!!.isEmpty()) {
+            dir.listFiles().forEach { println(it) }
+            Thread.sleep(1000)
+        }
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionCacheScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/SessionCacheScenario.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.disableAllDelivery
 
 /**
  * Sends a session which is cached on disk to Bugsnag, then sent on a separate launch.

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StartupCrashFlushScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StartupCrashFlushScenario.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import android.os.Handler
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.disableAllDelivery
 
 /**
  * Generates an uncaught exception, catches it, and persists it to disc, preventing any delivery.

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -38,7 +38,30 @@ Feature: Discarding events
     # Fail to send event that was reloaded from disk. Event is too big, so the client discards it.
     And I set the HTTP status code for the next request to 500
     And I close and relaunch the app
+
+    And I configure the app to run in the "delete-wait" state
     And I configure Bugsnag for "DiscardBigEventsScenario"
+
+    And I wait to receive 2 errors
+
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "DiscardBigEventsScenario"
+
+    And I discard the oldest error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "ErrorsDirectoryEmpty"
+
+    And I discard the oldest error
+
+    # Now there is no event on disk, so there's nothing to send.
+    And I close and relaunch the app
+    And I configure Bugsnag for "DiscardBigEventsScenario"
+    Then I should receive no requests
+
+  Scenario: Discard an on-disk error that received 400 and is too big
+    # Fail to send initial handled error due to 400 error. Client discards it immediately.
+    When I set the HTTP status code for the next request to 400
+    And I run "DiscardBigEventsScenario"
     And I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And I discard the oldest error

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -27,17 +27,23 @@ Feature: Discarding events
     And I configure Bugsnag for "DiscardOldEventsScenario"
     Then I should receive no requests
 
-  # Skip pending PLAT-8374
-  @skip
-  Scenario: Discard an on-disk error that failed to send and is too big
-    # Fail to send initial handled error. Client stores it to disk.
-    Given I set the endpoints to the terminating server
-    And I start the terminating server
-    When I run "DiscardBigEventsScenario"
-    And I wait for 2 seconds
-    And the terminating server has received 1 requests
+  Scenario: Discard an on-disk error that received 500 and is too big
+    # Fail to send initial handled error due to 500 error. Client stores it to disk.
+    When I set the HTTP status code for the next request to 500
+    And I run "DiscardBigEventsScenario"
+    And I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And I discard the oldest error
 
-    # The event should have been deleted, so we should receive nothing
-    Then I close and relaunch the app
+    # Fail to send event that was reloaded from disk. Event is too big, so the client discards it.
+    And I set the HTTP status code for the next request to 500
+    And I close and relaunch the app
     And I configure Bugsnag for "DiscardBigEventsScenario"
-    And I should receive no requests
+    And I wait to receive an error
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And I discard the oldest error
+
+    # Now there is no event on disk, so there's nothing to send.
+    And I close and relaunch the app
+    And I configure Bugsnag for "DiscardBigEventsScenario"
+    Then I should receive no requests


### PR DESCRIPTION
## Goal

Reinstate and rework e2e test scenario DiscardBigEventsScenario.

## Design

This scenario was using the Maze Runner `TerminatingServer` to prematurely terminate big requests (like the real Bugsnag does), but the network doesn't behave consistently with the BrowserStack secure tunnel involved.

## Changeset

Reverts to using the classic Maze mock server, returning a 500 (and 400 in a separate scenario) to test the different code paths.

## Testing

Covered by CI and I have run it several times (40) locally to gain a good level of confidence in it being flake-free.