### PR TITLE
Use step ‘Bugsnag confirms it has no errors to send’ where feasible

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkDisabledScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoDetectNdkDisabledScenario.java
@@ -1,11 +1,15 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
+import static com.bugsnag.android.mazerunner.LogKt.getZeroEventsLogMessages;
+
 import com.bugsnag.android.Configuration;
 
 import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.List;
 
 public class AutoDetectNdkDisabledScenario extends Scenario {
 
@@ -28,5 +32,10 @@ public class AutoDetectNdkDisabledScenario extends Scenario {
     public void startScenario() {
         super.startScenario();
         crash();
+    }
+
+    @Override
+    public List<String> getInterceptedLogMessages() {
+        return getZeroEventsLogMessages(getStartBugsnagOnly());
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardBigEventsScenario.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 
 internal class DiscardBigEventsScenario(
     config: Configuration,
@@ -36,5 +37,9 @@ internal class DiscardBigEventsScenario(
         super.startScenario()
         Bugsnag.markLaunchCompleted()
         Bugsnag.notify(MyThrowable("DiscardBigEventsScenario"))
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeFileUriExposeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeFileUriExposeScenario.kt
@@ -9,6 +9,7 @@ import android.os.StrictMode
 import android.os.StrictMode.VmPolicy
 import com.bugsnag.android.BugsnagVmViolationListener
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.getZeroEventsLogMessages
 import java.io.File
 
 /**
@@ -48,5 +49,9 @@ internal class StrictModeFileUriExposeScenario(
             policy.penaltyListener(context.mainExecutor, listener)
         }
         StrictMode.setVmPolicy(policy.build())
+    }
+
+    override fun getInterceptedLogMessages(): List<String> {
+        return getZeroEventsLogMessages(startBugsnagOnly)
     }
 }

--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -27,7 +27,6 @@ Feature: Switching automatic error detection on/off for Unity
     And I close and relaunch the app
     And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
     Then Bugsnag confirms it has no errors to send
-    And I should receive no requests
 
   Scenario: JVM exception captured with autoNotify reenabled
     When I run "UnhandledJvmAutoNotifyTrueScenario" and relaunch the crashed app

--- a/features/full_tests/detect_ndk_crashes.feature
+++ b/features/full_tests/detect_ndk_crashes.feature
@@ -6,4 +6,4 @@ Feature: Verifies autoDetectNdkCrashes controls when NDK crashes are reported
   Scenario: No crash reported when autoDetectNdkCrashes disabled
     When I run "AutoDetectNdkDisabledScenario" and relaunch the crashed app
     And I configure Bugsnag for "AutoDetectNdkDisabledScenario"
-    Then I should receive no requests
+    Then Bugsnag confirms it has no errors to send

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -69,4 +69,4 @@ Feature: Discarding events
     # Now there is no event on disk, so there's nothing to send.
     And I close and relaunch the app
     And I configure Bugsnag for "DiscardBigEventsScenario"
-    Then I should receive no requests
+    Then Bugsnag confirms it has no errors to send

--- a/features/full_tests/strict_mode_legacy.feature
+++ b/features/full_tests/strict_mode_legacy.feature
@@ -28,4 +28,4 @@ Feature: Reporting Strict Mode Violations
   Scenario: StrictMode Activity leak violation
     When I run "StrictModeFileUriExposeScenario" and relaunch the crashed app
     And I configure Bugsnag for "StrictModeFileUriExposeScenario"
-    Then I should receive no requests
+    Then Bugsnag confirms it has no errors to send


### PR DESCRIPTION
## Goal

Avoid some idle waiting time in e2e tests by checking for Bugsnag log messages rather than waiting for a set period of time for nothing to happen.

## Design

Follows the existing pattern for using the `Bugsnag confirms it has no errors to send` step, it just hasn't been employed uniformally.

## Changeset

Feature files updated to use the step where possible.  Scenario code updated to override `getInterceptedLogMessages`, which is needed so it knows what log messages to look out for.

## Testing

Covered by a full CI run.