### PR TITLE
DiscardOldEventsScenario Flake

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
@@ -31,6 +31,7 @@ internal class DiscardOldEventsScenario(
 
         val files = errorsDir().listFiles()
         for (file in files!!) {
+            println("Josh here is a file: ${file}")
             setEventFileTimestamp(file, timestamp)
         }
     }
@@ -41,10 +42,8 @@ internal class DiscardOldEventsScenario(
         Bugsnag.notify(MyThrowable("DiscardOldEventsScenario"))
 
         waitForEventFile()
-        // PLAT-8344 Determine why an extra sleep is needed on Android 10+
-        Thread.sleep(2000)
         oldifyEventFiles()
 
-        Bugsnag.notify(MyThrowable("To keep maze-runner from shutting me down prematurely"))
+        Bugsnag.notify(MyThrowable("MazeRunner KeepAlive"))
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
@@ -31,7 +31,6 @@ internal class DiscardOldEventsScenario(
 
         val files = errorsDir().listFiles()
         for (file in files!!) {
-            println("Josh here is a file: ${file}")
             setEventFileTimestamp(file, timestamp)
         }
     }

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -19,7 +19,7 @@ Feature: Discarding events
     And I close and relaunch the app
     And I configure Bugsnag for "DiscardOldEventsScenario"
     And I wait to receive an error
-    # This allows for the request from MazeRunner to be processed.
+    # This allows for the response from MazeRunner to be processed.
     And I wait for 5 seconds
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
 

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -19,6 +19,8 @@ Feature: Discarding events
     And I close and relaunch the app
     And I configure Bugsnag for "DiscardOldEventsScenario"
     And I wait to receive an error
+    # This allows for the request from MazeRunner to be processed.
+    And I wait for 5 seconds
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
 
     # Now there is no event on disk, so there's nothing to send.


### PR DESCRIPTION
## Goal

Remove the sleep from `DiscardOldEventsScenario` and adjust the `DiscardOldEventsScenario` tests to remove flakeyness

## Design

`Wait for 5 seconds` added to cucumber test to allow for the request to be sent and processed to properly remove he old event.

## Changeset

Sleep removed from `DiscardOldEventsScenario.kt`
`And I wait for 5 seconds` added to `discarded_events.feature` 

## Testing

Battery of tests run locally and covered by a full CI