### PR TITLE
Update test DiscardOldEventsScenario to check for Bugsnag log

### DIFF
--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -164,8 +164,11 @@ class MainActivity : Activity() {
             setStoredApiKey(apiKey)
         }
         val config = prepareConfig(apiKey, notifyUrl, sessionsUrl) {
+            var logMessage = it
             val interceptedLogMessages = scenario?.getInterceptedLogMessages()
-            interceptedLogMessages?.contains(it) ?: false
+            interceptedLogMessages?.any {
+                Regex(it).matches(logMessage)
+            } ?: false
         }
         return Scenario.load(this, config, eventType, mode)
     }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldEventsScenario.kt
@@ -45,4 +45,6 @@ internal class DiscardOldEventsScenario(
 
         Bugsnag.notify(MyThrowable("MazeRunner KeepAlive"))
     }
+
+    override fun getInterceptedLogMessages() = listOf("Discarding historical event \\(from .+\\) after failed delivery")
 }

--- a/features/full_tests/discarded_events.feature
+++ b/features/full_tests/discarded_events.feature
@@ -7,27 +7,29 @@ Feature: Discarding events
     # Fail to send initial handled error. Client stores it to disk.
     When I set the HTTP status code for the next request to 500
     And I run "DiscardOldEventsScenario"
-    And I wait to receive an error
+
+    # The second error to keeps maze-runner from shutting down the app prematurely.
+    And I wait to receive 2 errors
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "DiscardOldEventsScenario"
+    And I discard the oldest error
+
+    And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "MazeRunner KeepAlive"
+    And I discard the oldest error
 
     # Fail to send event that was reloaded from disk. Event is too old, so the client discards it.
-    Then I discard the oldest error
-    # We send another error to keep maze-runner from shutting down the app prematurely.
-    And I wait to receive an error
-    And I discard the oldest error
     And I set the HTTP status code for the next request to 500
     And I close and relaunch the app
     And I configure Bugsnag for "DiscardOldEventsScenario"
     And I wait to receive an error
-    # This allows for the response from MazeRunner to be processed.
-    And I wait for 5 seconds
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the exception "message" equals "DiscardOldEventsScenario"
 
-    # Now there is no event on disk, so there's nothing to send.
-    Then I discard the oldest error
-    And I close and relaunch the app
-    And I configure Bugsnag for "DiscardOldEventsScenario"
-    Then I should receive no requests
+    # Check that Bugsnag is discarding the event
+    And I wait to receive a log
+    And the log payload field "level" equals "warning"
+    And the log payload field "message" matches the regex "Discarding historical event \(from.*\) after failed delivery"
 
   Scenario: Discard an on-disk error that received 500 and is too big
     # Fail to send initial handled error due to 500 error. Client stores it to disk.


### PR DESCRIPTION
## Goal

Enhances the checks performed in `DiscardOldEventsScenario`, whilst also saving a relaunch of the app.

## Design

I've built slightly on the existing mechanism that allows us to capture and report specific log messages to Maze Runner.

## Changeset

Updates the log capture mechanism to allow logs that match a regex (rather than just a string) to be sent to Maze Runner.  The test scenario is then reworked to be more specific about the requests that are being received and to check for the log message (saving a relaunch of the app).

## Testing

Covered by CI and successfully run several times.