### PR TITLE
Stop test fixture from polling once a command is received

### DIFF
--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -58,8 +58,9 @@ class MainActivity : Activity() {
     // Starts a thread to poll for Maze Runner actions to perform
     private fun startCommandRunner() {
         // Get the next maze runner command
+        var polling = true
         thread(start = true) {
-            while (true) {
+            while (polling) {
                 Thread.sleep(1000)
                 try {
                     // Get the next command from Maze Runner
@@ -93,8 +94,14 @@ class MainActivity : Activity() {
 
                         // Perform the given action on the UI thread
                         when (action) {
-                            "start_bugsnag" -> startBugsnag(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
-                            "run_scenario" -> runScenario(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
+                            "start_bugsnag" -> {
+                                polling = false
+                                startBugsnag(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
+                            }
+                            "run_scenario" -> {
+                                polling = false
+                                runScenario(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
+                            }
                             "clear_persistent_data" -> clearPersistentData()
                             else -> throw IllegalArgumentException("Unknown action: $action")
                         }


### PR DESCRIPTION
## Goal

Avoid Maze Runner commands from being lost by stopping polling for commands once one is received.  

## Design

We have seen commands "go missing" in some test runs, causing them to flake.  The Cucumber step includes a check that queued commands are fetched, suggesting they are somehow lost in the test fixture.  The theory behind this change is that it's possible for the fixture to fetch another command before the app crashes (and before the response to the request is received and processed, so there is not sign of it in the logs).

## Changeset

Stop polling after a run_scenario or start_bugsnag command is received.

## Testing

Covered by a basic CI run.