### PR TITLE
Do not symlink folders during a CI build

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -84,16 +84,6 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android size reporting'
-    timeout_in_minutes: 10
-    agents:
-      queue: macos-12-arm
-    commands:
-      - cd features/fixtures/minimalapp
-      - ln -s ../../../.git
-      - bundle install
-      - bundle exec danger
-
   - label: ':android: Android 6 NDK r16 end-to-end tests - batch 1'
     depends_on: "fixture-r16"
     timeout_in_minutes: 90

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,16 @@ steps:
       - cd features/fixtures/mazerunner
       - ./gradlew ktlintCheck detekt checkstyle
 
+  - label: ':android: Android size reporting'
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-12-arm
+    commands:
+      - cd features/fixtures/minimalapp
+      - cp -r ../../../.git .
+      - bundle install
+      - bundle exec danger
+
   - label: ':android: JVM tests'
     timeout_in_minutes: 10
     agents:


### PR DESCRIPTION
## Goal

`cp` the `.git` folder needed by Danger, rather than symlinking to it, as Buildkite won't remove the symlink - causing later builds on the same server to fail.  This was introduced in #1674.

## Changeset

I've also moved the size step to the main pipeline, as Danger only runs its checks for PRs - most of which will not run a full build.

## Testing

Covered by CI.