### PR TITLE
Handle dirty folder and leave it clean

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,9 +71,11 @@ steps:
       queue: macos-12-arm
     commands:
       - cd features/fixtures/minimalapp
-      - cp -r ../../../.git .
+      - rm -rf .git
+      - ln -s ../../../.git
       - bundle install
       - bundle exec danger
+      - rm -f .git
 
   - label: ':android: JVM tests'
     timeout_in_minutes: 10


### PR DESCRIPTION
## Goal

Ensure the Android Sizer step can handle a `.git` folder of symlink already being present in the tree.

## Design

#1678 was incomplete.  `.git` folders are not removed either by `git clean -xfd` (not surprising on reflection), so I have reverted to the cheaper symlink operation, but ensured it can handle a dirty folder and attempt to leave it clean.

## Testing

I pushed a temporary commit prior to raising this PR with the step duplicated several times to force it to run all all our servers (including two that were previously broken).  