### PR TITLE
Allow retry for specific failure in MultiThreadedStartupScenario

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 #gem 'bugsnag-maze-runner', path: '../maze-runner'
 
 # Or a specific release:
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.11.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.15.0'
 
 # Or follow master:
 # gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b7012344cc0c7081f54bfefe6d9356e3629d2b37
-  tag: v6.11.1
+  revision: d71ba8a1b770e86800b4e9f6782a63fef019a989
+  tag: v6.15.0
   specs:
-    bugsnag-maze-runner (6.11.1)
+    bugsnag-maze-runner (6.15.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -81,7 +81,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     multi_test (0.1.2)
-    nokogiri (1.13.4-x86_64-darwin)
+    nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
     os (1.0.1)

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiThreadedStartupScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiThreadedStartupScenario.kt
@@ -22,6 +22,7 @@ class MultiThreadedStartupScenario(
             Thread.sleep(1L)
             try {
                 Bugsnag.leaveBreadcrumb("I'm leaving a breadcrumb on another thread")
+                Bugsnag.notify(Exception("Scenario complete"))
             } catch (e: Exception) {
                 Bugsnag.start(context, config)
                 Bugsnag.notify(e)

--- a/features/full_tests/threaded_startup.feature
+++ b/features/full_tests/threaded_startup.feature
@@ -6,4 +6,5 @@ Feature: Switching automatic error detection on/off for Unity
   Scenario: Starting Bugsnag & calling it on separate threads
     When I run "MultiThreadedStartupScenario" and relaunch the crashed app
     And I configure Bugsnag for "MultiThreadedStartupScenario"
-    Then I should receive no error
+    Then I wait to receive an error
+    And the error is correct for "MultiThreadedStartupScenario" or I allow a retry

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -277,3 +277,13 @@ Then("Bugsnag confirms it has no errors to send") do
     Then the "debug" level log message equals "No regular events to flush to Bugsnag."
   }
 end
+
+Then("the error is correct for {string} or I allow a retry") do |scenario|
+  error = Maze::Server.errors.current[:body]
+  message = Maze::Helper.read_key_path(error, 'events.0.exceptions.0.message')
+  case scenario
+  when 'MultiThreadedStartupScenario'
+    Maze.dynamic_retry = true if message == 'You must call Bugsnag.start before any other Bugsnag methods'
+    assert_equal 'Scenario complete', message
+  end
+end


### PR DESCRIPTION
## Goal

Avoid test flake in `MultiThreadedStartupScenario`.

## Design

`MultiThreadedStartupScenario` is designed to verify that calling Bugsnag methods while it is being started on another thread does not raise an exception.  The scenario can occasionally flake if the OS end up starting the `leaveBreadcrumb` thread first (which we cannot control completely, even by setting thread priorities).  If that happens that Bugsnag raises an exception stating that `Bugsnag.start` must be called first.

## Changeset

This change allow a retry in the specific case that the exception is raised because the threads started in reverse order.

## Testing

Covered by CI and I saw the retry take affect once during development (it's not that easy to reproduce).