### PR TITLE
Improve CI stability

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -101,8 +101,8 @@ steps:
           - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--app=/app/build/fixture-r16.apk"
           - "--farm=bs"
-          - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
+          - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
@@ -127,8 +127,8 @@ steps:
           - "--exclude=features/full_tests/[^l-z].*.feature"
           - "--app=/app/build/fixture-r16.apk"
           - "--farm=bs"
-          - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
+            - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -119,8 +119,8 @@ steps:
           - "features/smoke_tests"
           - "--app=/app/build/fixture-r16.apk"
           - "--farm=bs"
-          - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
+          - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--fail-fast"
     concurrency: 24
     concurrency_group: 'browserstack-app'

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -67,7 +67,7 @@ class MainActivity : Activity() {
         log("MainActivity.onResume complete")
     }
 
-        // Checks general internet and secure tunnel connectivity
+    // Checks general internet and secure tunnel connectivity
     private fun checkNetwork() {
         log("Checking network connectivity")
         try {

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -22,10 +22,11 @@ class MainActivity : Activity() {
     lateinit var prefs: SharedPreferences
 
     var scenario: Scenario? = null
+    var polling = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        log("MainActivity.onCreate started")
+        log("MainActivity.onCreate called")
         requestWindowFeature(Window.FEATURE_NO_TITLE)
         setContentView(R.layout.activity_main)
         prefs = getPreferences(Context.MODE_PRIVATE)
@@ -53,13 +54,20 @@ class MainActivity : Activity() {
             apiKeyField.text.clear()
             apiKeyField.text.append(apiKey)
         }
-
-        log("startCommandRunner")
-        startCommandRunner()
         log("MainActivity.onCreate complete")
     }
 
-    // Checks general internet and secure tunnel connectivity
+    override fun onResume() {
+        super.onResume()
+        log("MainActivity.onResume called")
+
+        if (!polling) {
+            startCommandRunner()
+        }
+        log("MainActivity.onResume complete")
+    }
+
+        // Checks general internet and secure tunnel connectivity
     private fun checkNetwork() {
         log("Checking network connectivity")
         try {
@@ -80,7 +88,7 @@ class MainActivity : Activity() {
     // Starts a thread to poll for Maze Runner actions to perform
     private fun startCommandRunner() {
         // Get the next maze runner command
-        var polling = true
+        polling = true
         thread(start = true) {
             checkNetwork()
 

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -284,6 +284,6 @@ Then("the error is correct for {string} or I allow a retry") do |scenario|
   case scenario
   when 'MultiThreadedStartupScenario'
     Maze.dynamic_retry = true if message == 'You must call Bugsnag.start before any other Bugsnag methods'
-    assert_equal 'Scenario complete', message
+    Maze.check.equal 'Scenario complete', message
   end
 end


### PR DESCRIPTION
## Goal

Attempts to improve CI stability.

## Changeset

- Use Google Nexus 6 in preference, as a higher tier device on BrowserStack
- Move the starting of the thread the polls for test Command to `onResume`, in the hope that the app is "more ready"
- USe `Maze.check.equal` rather than `assert_equal`

## Testing

Ran a full batch of e2e tests on Android 6 twenty times with no failures due to how the polling started (some other flakes do still exist).