### PR TITLE
Only update session tracking after Activities have changed state

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionLifecycleCallback.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionLifecycleCallback.kt
@@ -2,17 +2,32 @@ package com.bugsnag.android
 
 import android.app.Activity
 import android.app.Application
+import android.os.Build
 import android.os.Bundle
 
 internal class SessionLifecycleCallback(
     private val sessionTracker: SessionTracker
 ) : Application.ActivityLifecycleCallbacks {
 
-    override fun onActivityStarted(activity: Activity) =
-        sessionTracker.onActivityStarted(activity.javaClass.simpleName)
+    override fun onActivityStarted(activity: Activity) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            sessionTracker.onActivityStarted(activity.javaClass.simpleName)
+        }
+    }
 
-    override fun onActivityStopped(activity: Activity) =
+    override fun onActivityPostStarted(activity: Activity) {
+        sessionTracker.onActivityStarted(activity.javaClass.simpleName)
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            sessionTracker.onActivityStopped(activity.javaClass.simpleName)
+        }
+    }
+
+    override fun onActivityPostStopped(activity: Activity) {
         sessionTracker.onActivityStopped(activity.javaClass.simpleName)
+    }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
     override fun onActivityResumed(activity: Activity) {}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionLifecycleCallbackTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionLifecycleCallbackTest.kt
@@ -32,8 +32,20 @@ internal class SessionLifecycleCallbackTest {
     }
 
     @Test
+    fun onActivityPostStarted() {
+        callbacks.onActivityPostStarted(activity)
+        verify(tracker, times(1)).onActivityStarted("Activity")
+    }
+
+    @Test
     fun onActivityStopped() {
         callbacks.onActivityStopped(activity)
+        verify(tracker, times(1)).onActivityStopped("Activity")
+    }
+
+    @Test
+    fun onActivityPostStopped() {
+        callbacks.onActivityPostStopped(activity)
         verify(tracker, times(1)).onActivityStopped("Activity")
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAutoContextScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXAutoContextScenario.java
@@ -33,7 +33,7 @@ public class CXXAutoContextScenario extends Scenario {
     }
 
     @Override
-    public void onActivityStarted(@NonNull Activity activity) {
+    public void onActivityResumed(@NonNull Activity activity) {
         activate();
         Bugsnag.notify(generateException());
     }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.kt
@@ -2,6 +2,8 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.app.Activity
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.mazerunner.log
 
@@ -25,8 +27,9 @@ class CXXDelayedCrashScenario(
     }
 
     override fun onActivityStopped(activity: Activity) {
-        super.onActivityStopped(activity)
-        log("App sent to background, triggering crash.")
-        activate(405)
+        Handler(Looper.getMainLooper()).post {
+            log("App sent to background, triggering crash.")
+            activate(405)
+        }
     }
 }


### PR DESCRIPTION
## Goal
On SDK 29 and higher use the `onActivityPostStarted` and `onActivityPostStopped` to update the session tracking, ensuring the `Activity` has finished changing state before we fetch new session state attributes.

## Design
When the foreground activities are started and stopped we capture flags such as context and `inForeground` and send them to observing layers (such as ReactNative and NDK). By capturing them after the `onStart`/`onStop` methods have returned we ensure that these attributes are properly up-to-date.

## Testing
TBD