### PR TITLE
Fix generation of notifier size metrics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,14 +68,8 @@ steps:
   - label: ':android: Android size reporting'
     timeout_in_minutes: 10
     agents:
-      queue: macos-12-arm
-    commands:
-      - cd features/fixtures/minimalapp
-      - rm -rf .git
-      - ln -s ../../../.git
-      - bundle install
-      - bundle exec danger
-      - rm -f .git
+      queue: ms-arm-12-8
+    command: scripts/run-sizer.sh
 
   - label: ':android: JVM tests'
     timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,7 +68,7 @@ steps:
   - label: ':android: Android size reporting'
     timeout_in_minutes: 10
     agents:
-      queue: ms-arm-12-8
+      queue: macos-12-arm
     command: scripts/run-sizer.sh
 
   - label: ':android: JVM tests'

--- a/features/fixtures/minimalapp/Dangerfile
+++ b/features/fixtures/minimalapp/Dangerfile
@@ -22,7 +22,7 @@ def buildOutputs(bugsnag: false, minified: false)
   `./gradlew assembleRelease #{opts}`
   `./gradlew bundleRelease #{opts}`
 
-  `java -jar /sdk/bundletool.jar build-apks \
+  `bundletool build-apks \
     --bundle=#{BUNDLE_DIR + RELEASE_BUNDLE} \
     --output=#{BUNDLE_DIR + UNBUNDLED_RELEASE} \
     --ks=app/fakekeys.jks \
@@ -35,29 +35,29 @@ end
 
 buildOutputs(bugsnag: false, minified: false)
 
-apk_size = `stat --printf="%s" #{RELEASE_APK}`.to_i
-aab_size = `stat --printf="%s" #{STANDALONE_DIR + STANDALONE_HDPI_BASE}`.to_i
+apk_size = `stat -f "%z" #{RELEASE_APK}`.to_i
+aab_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_HDPI_BASE}`.to_i
 
 buildOutputs(bugsnag: false, minified: true)
 
-min_apk_size = `stat --printf="%s" #{RELEASE_APK}`.to_i
-min_aab_size = `stat --printf="%s" #{STANDALONE_DIR + STANDALONE_HDPI_BASE}`.to_i
+min_apk_size = `stat -f "%z" #{RELEASE_APK}`.to_i
+min_aab_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_HDPI_BASE}`.to_i
 
 buildOutputs(bugsnag: true, minified: false)
 
-apk_bugsnag_size = `stat --printf="%s" #{RELEASE_APK}`.to_i
-arm64_bugsnag_size = `stat --printf "%s" #{STANDALONE_DIR + STANDALONE_ARM64_V8A}`.to_i
-armeabi_v7a_bugsnag_size = `stat --printf "%s" #{STANDALONE_DIR + STANDALONE_ARMEABI_V7A}`.to_i
-x86_64_bugsnag_size = `stat --print "%s" #{STANDALONE_DIR + STANDALONE_X86_64}`.to_i
-x86_bugsnag_size = `stat --print "%s" #{STANDALONE_DIR + STANDALONE_X86}`.to_i
+apk_bugsnag_size = `stat -f "%z" #{RELEASE_APK}`.to_i
+arm64_bugsnag_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_ARM64_V8A}`.to_i
+armeabi_v7a_bugsnag_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_ARMEABI_V7A}`.to_i
+x86_64_bugsnag_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_X86_64}`.to_i
+x86_bugsnag_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_X86}`.to_i
 
 buildOutputs(bugsnag: true, minified: true)
 
-min_apk_bugsnag_size = `stat --printf="%s" #{RELEASE_APK}`.to_i
-min_arm64_bugsnag_size = `stat --printf "%s" #{STANDALONE_DIR + STANDALONE_ARM64_V8A}`.to_i
-min_armeabi_v7a_bugsnag_size = `stat --printf "%s" #{STANDALONE_DIR + STANDALONE_ARMEABI_V7A}`.to_i
-min_x86_64_bugsnag_size = `stat --print "%s" #{STANDALONE_DIR + STANDALONE_X86_64}`.to_i
-min_x86_bugsnag_size = `stat --print "%s" #{STANDALONE_DIR + STANDALONE_X86}`.to_i
+min_apk_bugsnag_size = `stat -f "%z" #{RELEASE_APK}`.to_i
+min_arm64_bugsnag_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_ARM64_V8A}`.to_i
+min_armeabi_v7a_bugsnag_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_ARMEABI_V7A}`.to_i
+min_x86_64_bugsnag_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_X86_64}`.to_i
+min_x86_bugsnag_size = `stat -f "%z" #{STANDALONE_DIR + STANDALONE_X86}`.to_i
 
 calculated_sizes = {
   :arm64 => arm64_bugsnag_size - aab_size,

--- a/scripts/run-sizer.sh
+++ b/scripts/run-sizer.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+cd features/fixtures/minimalapp
+rm -rf .git
+ln -s ../../../.git
+bundle install
+bundle exec danger
+rm -f .git


### PR DESCRIPTION
## Goal

Fixes the generation of notifier size metrics, which were recently broken after (incompletely) porting the build step from Linux to macOS.

## Changeset

Port `Dangerfile` to macOS, pushing the build commands into a script.

## Testing

By inspection of the comment on this PR.