### PR TITLE
[PLAT-8520] Better heuristics for detecting the signal catcher thread

### DIFF
--- a/bugsnag-plugin-android-anr/src/main/jni/anr_google.c
+++ b/bugsnag-plugin-android-anr/src/main/jni/anr_google.c
@@ -96,8 +96,11 @@ static bool is_thread_named_signal_catcher(pid_t tid) {
   return success;
 }
 
+static inline uint64_t sigmask_for_signal(uint64_t sig) {
+  return (((uint64_t)1) << (sig - 1));
+}
+
 static bool is_thread_signal_catcher_sigblk(pid_t tid) {
-  static const uint64_t SIGNAL_CATCHER_THREAD_SIGBLK = 0x1000;
   static const char *SIGBLK_HEADER = "SigBlk:\t";
   const size_t SIGBLK_HEADER_LENGTH = strlen(SIGBLK_HEADER);
 
@@ -117,7 +120,9 @@ static bool is_thread_signal_catcher_sigblk(pid_t tid) {
     }
   }
   fclose(fp);
-  return sigblk == SIGNAL_CATCHER_THREAD_SIGBLK;
+
+  // The signal catcher thread will not have SIGQUIT blocked
+  return (sigblk & sigmask_for_signal(SIGQUIT)) == 0;
 }
 
 bool bsg_google_anr_init() {


### PR DESCRIPTION
## Goal

The Google signal catcher thread detection heuristic that used the blocked signals mask was too naive, and checked for a specific value (0x1000), which is fragile and broke when the block mask changed to 0x5000 in Android 12.

## Design

Instead, change the heuristic to check only that the `SIGQUIT` signal is unblocked, since that's the only signal we actually care about (all other threads default to blocking SIGQUIT).

On very old versions of Android the normal sigblk of a thread is 0x0000000000001204, and the signal catcher has 0x0000000000001000.

On more recent Android versions, the normal sigblk is 0x0000000080001204, and the signal catcher has 0x0000000000001000.

On Android 12, the normal sigblk is 0x0000000080005204, and the signal catcher has 0x0000000000005000.

In all cases, we only need to mask against the SIGQUIT signal (which is mask 0x0000000000000004).

## Testing

Tested manually on Android from API 18 to 31 (Android 12).
