### PR TITLE
Avoid phantom values in NDK Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fixed Bugsnag interactions with the Google ANR handler on newer versions of Android
+  [#1699](https://github.com/bugsnag/bugsnag-android/pull/1699)
+* Overwriting & clearing event metadata in the NDK plugin will no longer leave phantom values
+  [#1700](https://github.com/bugsnag/bugsnag-android/pull/1700)
+
 ## 5.22.4 (2022-05-24)
 
 ### Bug fixes

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ fixture-r19: notifier
 	@ruby scripts/copy-build-files.rb release r19
 
 fixture-r21: notifier
-	# Build the minimal test fixture
+	# Build the r21 test fixture
 	@./gradlew -PTEST_FIXTURE_NDK_VERSION=21.4.7075529 \
                -PTEST_FIXTURE_NAME=fixture-r21.apk \
                -p=features/fixtures/mazerunner assembleRelease -x check

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXRemoveDataScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXRemoveDataScenario.java
@@ -29,8 +29,19 @@ public class CXXRemoveDataScenario extends Scenario {
     public void startScenario() {
         super.startScenario();
         Bugsnag.addMetadata("persist", "keep", "foo");
+        Bugsnag.addMetadata("persist", "remove", "not bar");
+        Bugsnag.addMetadata("persist", "overwrite", "value1");
+        Bugsnag.addMetadata("persist", "overwrite", "value2");
+
+        // repetatively overwrite the "remove" attribute enough times to cause the metadata
+        // to require cleaning, and ensure that the existing values are not dropped
+        for (int overload = 0; overload < 256; overload++) {
+            Bugsnag.addMetadata("persist", "remove", overload);
+        }
+
         Bugsnag.addMetadata("persist", "remove", "bar");
         Bugsnag.addMetadata("remove", "foo", "bar");
+
         activate();
         Handler main = new Handler(Looper.getMainLooper());
         main.postDelayed(new Runnable() {


### PR DESCRIPTION
## Goal
Fix a bug when overwriting of clearing metadata, the NDK did not always remove the value as expected leading to phantom metadata values in reports. For example:

```
addMetadata("section", "overwrite", "value1")
addMetadata("section", "overwrite", "value2")
clearMetadata("section", "overwrite")
```

Would typically result in the Event having `"value1"` in its reported metadata, instead of no value as expected.

## Design
Introduce a simple compacting function which will remove any duplicates and gaps in the metadata array and compact it.

This new function is used when either:
* an entry or entries are removed from the metadata
* the metadata array is full and a new value is being added

By retaining the insertion order of the metadata we introduce minimal additional overhead on the most common path: adding metadata. The correct values are retained as the most recent values are always the last in the array (effectively acting as a primitive journal).

### Designs considered but not used

* A linear scan to check for existing values in the `add` functions - this would have introduce unacceptable overheads
* A full hash-map style implementation - requires a significant rewrite of the entire metadata model

## Testing
Modified the existing end-to-end test which deletes metadata before a native crash