### PR TITLE
Make telemetry an EnumSet so that it can be modified

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import android.content.Context
 import java.io.File
+import java.util.EnumSet
 
 internal class ConfigInternal(
     var apiKey: String
@@ -52,7 +53,7 @@ internal class ConfigInternal(
     var discardClasses: Set<String> = emptySet()
     var enabledReleaseStages: Set<String>? = null
     var enabledBreadcrumbTypes: Set<BreadcrumbType>? = null
-    var telemetry: Set<Telemetry> = setOf(Telemetry.INTERNAL_ERRORS)
+    var telemetry: Set<Telemetry> = EnumSet.of(Telemetry.INTERNAL_ERRORS)
     var projectPackages: Set<String> = emptySet()
     var persistenceDirectory: File? = null
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -759,7 +759,11 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * - internal errors: Errors in the Bugsnag SDK itself.
      */
     public void setTelemetry(@NonNull Set<Telemetry> telemetry) {
-        impl.setTelemetry(telemetry);
+        if (telemetry != null) {
+            impl.setTelemetry(telemetry);
+        } else {
+            logNull("telemetry");
+        }
     }
 
     /**


### PR DESCRIPTION
This allows users to do:

```kotlin
config.telemetry.remove(Telemetry.INTERNAL_ERRORS)
```
instead of having to make a copy first (which is ugly in Java).
