### PR TITLE
Remove Motorola Moto X from e2e tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -102,7 +102,6 @@ steps:
           - "--app=/app/build/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
-          - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
@@ -128,7 +127,6 @@ steps:
           - "--app=/app/build/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
-          - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,7 +120,6 @@ steps:
           - "--app=/app/build/fixture-r16.apk"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
-          - "--device=ANDROID_6_0_MOTOROLA_MOTO_X_2ND_GEN"
           - "--fail-fast"
     concurrency: 24
     concurrency_group: 'browserstack-app'


### PR DESCRIPTION
## Goal

Remove Motorola Moto X from e2e tests.

## Design

BrowserStack have removed this device.

## Testing

Covered by CI.