### PR TITLE
Correctly report native-lib filenames when still packed in APK files

### DIFF
--- a/features/fixtures/mazerunner/app/build.gradle
+++ b/features/fixtures/mazerunner/app/build.gradle
@@ -54,6 +54,7 @@ android {
     // picking SO file. see https://developer.android.com/studio/releases/gradle-plugin#cmake-imported-targets
     packagingOptions {
         pickFirst "**/*.so"
+        jniLibs.useLegacyPackaging = null
     }
     lintOptions {
         abortOnError false

--- a/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:gwpAsanMode="always"
         android:name=".MazerunnerApp"
+        android:extractNativeLibs="false"
         >
         <activity
             android:name=".MainActivity"

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -112,6 +112,9 @@ Feature: Native crash reporting
     And the event "severity" equals "error"
     And the event "unhandled" is true
 
+  # Android 6 dladdr does report .so files that are not extracted from their .apk file
+  # this test cannot pass on these devices with extractNativeLibs=false
+  @skip_android_6
   Scenario: Causing a crash in a separate library
     When I run "CXXExternalStackElementScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXExternalStackElementScenario"

--- a/features/steps/symbol_steps.rb
+++ b/features/steps/symbol_steps.rb
@@ -105,7 +105,7 @@ end
 # if the frame is not in project.
 def symbolicate arch, frame
   method = demangle(frame["method"])
-  binary_file = frame["file"]
+  binary_file = frame["file"]&.split('!')&.last
 
   return nil if is_out_of_project?(binary_file, method)
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -42,6 +42,10 @@ Before('@skip_android_10') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version == 10
 end
 
+Before('@skip_android_6') do |scenario|
+  skip_this_scenario("Skipping scenario") if Maze.config.os_version == 6
+end
+
 Before('@skip_samsung') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.driver.capabilities['device']&.downcase&.include? 'samsung'
 end


### PR DESCRIPTION
## Goal
Ensure that `.so` files are reported by name (where possible) when the native libraries are not extracted from the `.apk` file. When packaged correctly, the operating system may load the `.so` files from within the `.apk` file in order to save space and time (see [extractNativeLibs](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs) and [useLegacyPackaging](https://developer.android.com/studio/releases/gradle-plugin?buildsystem=ndk-build#compress-native-libs-dsl) for more information).

Symbols for these files were sometimes being reported as coming from `base.apk` instead of the expected `.so` file, and as a result were not displaying the correct symbols on the Dashboard.

## Changes

Updated the `dladdr` fallback logic in the stack unwinder to look for filenames ending in `.apk`. If these are found, the filename is either resolved from the `Elf.soname` (in the case of handled errors) or `dladdr` (in the case of signals).

## Testing
The test fixtures now use `extractNativeLibs=false` which previously would cause them to fail when the symbols could not be read. The `symbolicate` function used by Mazerunner now looks for the `!` indicator in filenames, and retrieves the correct filename when symbolicating native stack traces for tests.

### Notes
`dladdr` on Android 6 reports `base.apk` as the filename if the library has not been unpacked, so one of our existing scenarios (Causing a crash in a separate library / `CXXExternalStackElementScenario`) cannot correctly report its filename. This scenario is now skipped on Android 6.