### PR TITLE
Encode opaque metadata into JSON events to be delivered

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/OpaqueValue.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/OpaqueValue.kt
@@ -26,8 +26,11 @@ internal class OpaqueValue(val json: String) {
             return value.toByteArray().size < MAX_NDK_STRING_LENGTH
         }
 
-        private fun encode(value: Any): String =
-            StringWriter().use { JsonStream(it).value(value, true) }.toString()
+        private fun encode(value: Any): String {
+            val writer = StringWriter()
+            writer.use { JsonStream(it).value(value, true) }
+            return writer.toString()
+        }
 
         /**
          * Ensure that the given `value` is compatible with the Bugsnag C layer by ensuring it

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <utils/memory.h>
 
 #include "event.h"
 #include "featureflags.h"
@@ -176,6 +177,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
                                     last_run_info_path);
 
   if ((bool)auto_detect_ndk_crashes) {
+    bsg_init_memory(bugsnag_env);
     bsg_handler_install_signal(bugsnag_env);
     bsg_handler_install_cpp(bugsnag_env);
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/memory.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/memory.c
@@ -1,6 +1,5 @@
 #include <malloc.h>
 
-#include "bugsnag_ndk.h"
 #include "memory.h"
 
 #ifdef __cplusplus
@@ -11,6 +10,8 @@ extern "C" {
  * Global shared context for Bugsnag reports
  */
 static bsg_environment *bsg_global_env;
+
+void bsg_init_memory(bsg_environment *env) { bsg_global_env = env; }
 
 void bsg_free(void *ptr) {
   /*

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/memory.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/memory.h
@@ -1,6 +1,8 @@
 #ifndef BUGSNAG_ANDROID_MEMORY_H
 #define BUGSNAG_ANDROID_MEMORY_H
 
+#include "bugsnag_ndk.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -10,6 +12,8 @@ extern "C" {
  * @param ptr
  */
 void bsg_free(void *ptr);
+
+void bsg_init_memory(bsg_environment *env);
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_reader.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_reader.c
@@ -973,6 +973,6 @@ void bsg_read_opaque_breadcrumb_metadata(int fd,
   for (int breadcrumb_index = 0; breadcrumb_index < crumb_count;
        breadcrumb_index++) {
 
-    bsg_read_opaque_metadata(fd, &breadcrumbs->metadata);
+    bsg_read_opaque_metadata(fd, &(breadcrumbs[breadcrumb_index].metadata));
   }
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_writer.c
@@ -95,7 +95,7 @@ static bool bsg_write_opaque_metadata_unit(bugsnag_metadata *metadata,
     uint32_t value_size = metadata->values[index].opaque_value_size;
     if (metadata->values[index].type == BSG_METADATA_OPAQUE_VALUE &&
         value_size > 0) {
-      if (!writer->write(writer, &(metadata->values[index].opaque_value),
+      if (!writer->write(writer, metadata->values[index].opaque_value,
                          value_size)) {
         return false;
       }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/json_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/json_writer.c
@@ -138,6 +138,13 @@ void bsg_serialize_device(const bsg_device_info device,
 void bsg_serialize_device_metadata(const bsg_device_info device,
                                    JSON_Object *event_obj) {}
 
+static JSON_Value *
+bsg_json_for_opaque_metadata(const bsg_metadata_value *metadata) {
+  return (metadata->opaque_value_size > 0)
+             ? json_parse_string(metadata->opaque_value)
+             : NULL;
+}
+
 void bsg_serialize_custom_metadata(const bugsnag_metadata metadata,
                                    JSON_Object *event_obj) {
   for (int i = 0; i < metadata.value_count; i++) {
@@ -156,6 +163,11 @@ void bsg_serialize_custom_metadata(const bugsnag_metadata metadata,
     case BSG_METADATA_NUMBER_VALUE:
       sprintf(format, "metaData.%s.%s", value.section, value.name);
       json_object_dotset_number(event_obj, format, value.double_value);
+      break;
+    case BSG_METADATA_OPAQUE_VALUE:
+      sprintf(format, "metaData.%s.%s", value.section, value.name);
+      JSON_Value *metadata_json_value = bsg_json_for_opaque_metadata(&value);
+      json_object_dotset_value(event_obj, format, metadata_json_value);
       break;
     default:
       break;
@@ -182,6 +194,11 @@ void bsg_serialize_breadcrumb_metadata(const bugsnag_metadata metadata,
     case BSG_METADATA_NUMBER_VALUE:
       sprintf(format, "metaData.%s", value.name);
       json_object_dotset_number(event_obj, format, value.double_value);
+      break;
+    case BSG_METADATA_OPAQUE_VALUE:
+      sprintf(format, "metaData.%s", value.name);
+      JSON_Value *metadata_json_value = bsg_json_for_opaque_metadata(&value);
+      json_object_dotset_value(event_obj, format, metadata_json_value);
       break;
     default:
       break;

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
@@ -17,6 +17,7 @@ bool __attribute__((noinline)) make_dirty_stack() {
 }
 
 bool on_err_true(void *event_ptr) {
+  bugsnag_event_clear_metadata_section(event_ptr, "removeMe");
   bugsnag_event_set_context(event_ptr, (char *) "Some custom context");
   return true;
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalSmokeScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXSignalSmokeScenario.java
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
 import com.bugsnag.android.Breadcrumb;
+import com.bugsnag.android.BreadcrumbType;
 import com.bugsnag.android.Bugsnag;
 import com.bugsnag.android.Configuration;
 import com.bugsnag.android.Event;
@@ -12,10 +13,13 @@ import com.bugsnag.android.mazerunner.BugsnagConfigKt;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -85,8 +89,16 @@ public class CXXSignalSmokeScenario extends Scenario {
                 + "it at you instead of them.");
         Bugsnag.addMetadata("fruit", "apple", "gala");
 
+        Bugsnag.addMetadata("opaque", createComplexMetadata());
+        Bugsnag.addMetadata("removeMe", createComplexMetadata());
+
         Bugsnag.startSession();
-        Bugsnag.leaveBreadcrumb("CXXSignalSmokeScenario");
+        Bugsnag.leaveBreadcrumb(
+                "CXXSignalSmokeScenario",
+                createComplexMetadata(),
+                BreadcrumbType.MANUAL
+        );
+
         Handler main = new Handler(Looper.getMainLooper());
         main.postDelayed(new Runnable() {
             @Override
@@ -94,5 +106,20 @@ public class CXXSignalSmokeScenario extends Scenario {
                 crash(2726);
             }
         }, 500);
+    }
+
+    private Map<String, Object> createComplexMetadata() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("number", 12345);
+        metadata.put("boolean", true);
+        metadata.put("list", Arrays.asList(1, 2, 3, 4, "five"));
+
+        Map<String, Object> nestedMap = new HashMap<>();
+        nestedMap.put("nestedMapKey", "this is valuable data");
+        metadata.put("nestedList", Arrays.asList(nestedMap, "one", "two", "three"));
+
+        metadata.put("nestedMap", nestedMap);
+
+        return metadata;
     }
 }

--- a/features/full_tests/native_metadata.feature
+++ b/features/full_tests/native_metadata.feature
@@ -16,10 +16,15 @@ Feature: Native Metadata API
     And the event "metaData.fruit.apple" equals "gala"
     And the event "metaData.fruit.ripe" is true
     And the event "metaData.fruit.counters" equals 47
-    And the event "metaData.complex.message" is null
-    And the event "metaData.complex.maps.location" is null
-    And the event "metaData.complex.maps.inventory" is null
-    And the event "metaData.complex.list" is null
+    And the event "metaData.complex.message" equals "That might've been one of the shortest assignments in the history of Starfleet. The Enterprise computer system is controlled by three primary main processor cores, cross-linked with a redundant melacortz ramistat, fourteen kiloquad interface modules."
+    And the event "metaData.complex.maps.location" equals "you are here"
+    And the event "metaData.complex.maps.inventory.0" equals "lots of string"
+    And the error payload field "events.0.metaData.complex.maps.inventory.1" is a number
+    And the error payload field "events.0.metaData.complex.maps.inventory.2" is true
+    And the event "metaData.complex.list.0" equals "summer"
+    And the event "metaData.complex.list.1" equals "winter"
+    And the event "metaData.complex.list.2" equals "spring"
+    And the event "metaData.complex.list.3" equals "autumn"
     And the event "unhandled" is true
 
   Scenario: Remove MetaData from the NDK layer

--- a/features/smoke_tests/unhandled.feature
+++ b/features/smoke_tests/unhandled.feature
@@ -174,16 +174,40 @@ Feature: Unhandled smoke tests
     # Breadcrumbs
     And the event has a "manual" breadcrumb named "CXXSignalSmokeScenario"
     And the event has a "request" breadcrumb named "Substandard nacho error"
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.number" equal to 12345
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.boolean" is true
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.list.0" equal to 1
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.list.1" equal to 2
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.list.2" equal to 3
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.list.3" equal to 4
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.list.4" equal to "five"
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.nestedMap.nestedMapKey" equal to "this is valuable data"
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.nestedList.0.nestedMapKey" equal to "this is valuable data"
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.nestedList.1" equal to "one"
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.nestedList.2" equal to "two"
+    And the breadcrumb named "CXXSignalSmokeScenario" has "metaData.nestedList.3" equal to "three"
 
     # Native context override
     And the event "context" equals "Some custom context"
 
     # Metadata
-    # Riker Ipsum is null until PLAT-8581 (store / load opaque metadata) is complete
-    And the event "metaData.Riker Ipsum.examples" is null
+    And the event "metaData.Riker Ipsum.examples" equals "I'll be sure to note that in my log. You enjoyed that. They were just sucked into space. How long can two people talk about nothing? I've had twelve years to think about it. And if I had it to do over again, I would have grabbed the phaser and pointed it at you instead of them."
     And the event "metaData.fruit.apple" equals "gala"
     And the event "metaData.fruit.ripe" is true
     And the event "metaData.fruit.counters" equals 47
+    And the event "metaData.removeMe" is null
+    And the event "metaData.opaque.number" equals 12345
+    And the event "metaData.opaque.boolean" is true
+    And the event "metaData.opaque.list.0" equals 1
+    And the event "metaData.opaque.list.1" equals 2
+    And the event "metaData.opaque.list.2" equals 3
+    And the event "metaData.opaque.list.3" equals 4
+    And the event "metaData.opaque.list.4" equals "five"
+    And the event "metaData.opaque.nestedMap.nestedMapKey" equals "this is valuable data"
+    And the event "metaData.opaque.nestedList.0.nestedMapKey" equals "this is valuable data"
+    And the event "metaData.opaque.nestedList.1" equals "one"
+    And the event "metaData.opaque.nestedList.2" equals "two"
+    And the event "metaData.opaque.nestedList.3" equals "three"
 
   @debug-safe
   Scenario: C++ exception thrown with overwritten config

--- a/features/steps/breadcrumb_metadata_steps.rb
+++ b/features/steps/breadcrumb_metadata_steps.rb
@@ -1,0 +1,28 @@
+Then("the breadcrumb named {string} has {string} equal to {string}") do |message, path, expected_value|
+  match_breadcrumb_metadata(message, path) { |v| Maze.check.equal(expected_value, v) }
+end
+
+Then("the breadcrumb named {string} has {string} equal to {int}") do |message, path, expected_value|
+  match_breadcrumb_metadata(message, path) { |v| Maze.check.equal(expected_value, v) }
+end
+
+Then("the breadcrumb named {string} has {string} is true") do |message, path|
+  match_breadcrumb_metadata(message, path) { |v| assert_true(v) }
+end
+
+Then("the breadcrumb named {string} has {string} is false") do |message, path|
+  match_breadcrumb_metadata(message, path) { |v| assert_false(v) }
+end
+
+def match_breadcrumb_metadata message, path
+  value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.breadcrumbs")
+  found = false
+  value.each do |crumb|
+    if crumb["name"] == message
+      value = Maze::Helper.read_key_path(crumb, path)
+      yield value
+      found = true
+    end
+  end
+  fail("No breadcrumb matched: #{value}") unless found
+end


### PR DESCRIPTION
## Goal
Encode the opaque JSON values into the Parson JSON model so that they are delivered with the event.

## Changeset

- When not in a signal handler: `free` any opaque values that cannot be referenced
  - clear metadata
  - clear metadata section
  - clear breadcrumbs
  - add breadcrumb (when overriding an existing breadcrumb)
- end-to-end tests covering opaque metadata in events and breadcrumbs
  - clearing opaque metadata in a C `on_error` callback to ensure we don't deadlock within a signal handler
- small fixes for bugs picked up in end-to-end testing
- new Mazerunner steps to cover metadata within breadcrumbs
  - searching breadcrumbs by name instead of index makes the tests more robust

## Testing
Modified the existing `CXXSignalSmokeScenario` to include a large amount of opaque metadata at both the event level, and within breadcrumbs. Some of this data is cleared out as part of the C crash handler to ensure out opaque metadata logic remains async safe.