### PR TITLE
Preserve ordering of feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 
+* Feature flags are now kept in and trimmed in order of insertion or modification rather than in alphabetical order.
+  [#1718](https://github.com/bugsnag/bugsnag-android/pull/1718)
+
 * Complex metadata (nested structures such as maps & lists) added in Java/Kotlin is now fully preserved in NDK errors
   [#1715](https://github.com/bugsnag/bugsnag-android/pull/1715)
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/FeatureFlagsSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/FeatureFlagsSerializationTest.kt
@@ -17,14 +17,14 @@ internal class FeatureFlagsSerializationTest {
         )
 
         private fun basic() = FeatureFlags().apply {
-            addFeatureFlag("demo_mode")
             addFeatureFlag("sample_group", "a")
+            addFeatureFlag("demo_mode")
             addFeatureFlag("view_mode", "modern")
         }
 
         private fun overrideVariants() = FeatureFlags().apply {
-            addFeatureFlag("demo_mode")
             addFeatureFlag("sample_group", "a")
+            addFeatureFlag("demo_mode")
             addFeatureFlag("sample_group", "b")
         }
 

--- a/bugsnag-android-core/src/test/resources/feature_flags_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/feature_flags_serialization_0.json
@@ -4,10 +4,10 @@
     "variant": "a"
   },
   {
-    "featureFlag": "view_mode",
-    "variant": "modern"
+    "featureFlag": "demo_mode"
   },
   {
-    "featureFlag": "demo_mode"
+    "featureFlag": "view_mode",
+    "variant": "modern"
   }
 ]

--- a/bugsnag-android-core/src/test/resources/feature_flags_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/feature_flags_serialization_1.json
@@ -1,9 +1,9 @@
 [
   {
-    "featureFlag": "sample_group",
-    "variant": "b"
+    "featureFlag": "demo_mode"
   },
   {
-    "featureFlag": "demo_mode"
+    "featureFlag": "sample_group",
+    "variant": "b"
   }
 ]

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_featureflags.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_featureflags.c
@@ -6,19 +6,19 @@ TEST test_set_feature_flag(void) {
 
   bsg_set_feature_flag(event, "sample_group", "a");
   bsg_set_feature_flag(event, "demo_mode", NULL);
-  bsg_set_feature_flag(event, "demo_mode", "yes");
   bsg_set_feature_flag(event, "zzz", NULL);
+  bsg_set_feature_flag(event, "demo_mode", "yes");
 
   ASSERT_EQ(3, event->feature_flag_count);
 
-  ASSERT_STR_EQ("demo_mode", event->feature_flags[0].name);
-  ASSERT_STR_EQ("yes", event->feature_flags[0].variant);
+  ASSERT_STR_EQ("sample_group", event->feature_flags[0].name);
+  ASSERT_STR_EQ("a", event->feature_flags[0].variant);
 
-  ASSERT_STR_EQ("sample_group", event->feature_flags[1].name);
-  ASSERT_STR_EQ("a", event->feature_flags[1].variant);
+  ASSERT_STR_EQ("zzz", event->feature_flags[1].name);
+  ASSERT_EQ(NULL, event->feature_flags[1].variant);
 
-  ASSERT_STR_EQ("zzz", event->feature_flags[2].name);
-  ASSERT_EQ(NULL, event->feature_flags[2].variant);
+  ASSERT_STR_EQ("demo_mode", event->feature_flags[2].name);
+  ASSERT_STR_EQ("yes", event->feature_flags[2].variant);
 
   bsg_free_feature_flags(event);
   free(event);
@@ -38,12 +38,13 @@ TEST test_clear_feature_flag(void) {
   bsg_clear_feature_flag(event, "no_such_flag");
   ASSERT_EQ(3, event->feature_flag_count);
 
-  bsg_clear_feature_flag(event, "sample_group");
   bsg_clear_feature_flag(event, "demo_mode");
 
-  ASSERT_EQ(1, event->feature_flag_count);
-  ASSERT_STR_EQ("remaining", event->feature_flags[0].name);
-  ASSERT_STR_EQ("flag", event->feature_flags[0].variant);
+  ASSERT_EQ(2, event->feature_flag_count);
+  ASSERT_STR_EQ("sample_group", event->feature_flags[0].name);
+  ASSERT_STR_EQ("a", event->feature_flags[0].variant);
+  ASSERT_STR_EQ("remaining", event->feature_flags[1].name);
+  ASSERT_STR_EQ("flag", event->feature_flags[1].variant);
 
   bsg_free_feature_flags(event);
   free(event);


### PR DESCRIPTION
## Goal

PLAT-8682: Preserve the order of feature flags in the order they were added or modified.

## Design

The NDK implementation has been changed to use a linear search, and to do simple compaction when modifying or clearing a flag.

The JVM implementation simply changes to a LinkedHashMap, and synchronizes the public APIs.

## Testing

Updated the unit tests to verify the new behavior.
