### PR TITLE
[PLAT-8704] Allow feature flags to be accessed from the event object during callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-* Feature flags can now be accessed in the onSend callbacks.
+* Feature flags can now be accessed in the onSend and onError callbacks.
   [#1720](https://github.com/bugsnag/bugsnag-android/pull/1720)
 
 ## 5.24.0 (2022-06-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Feature flags can now be accessed in the onSend callbacks.
+  [#1720](https://github.com/bugsnag/bugsnag-android/pull/1720)
+
 ## 5.24.0 (2022-06-30)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -92,6 +92,15 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     }
 
     /**
+     * A list of feature flags active at the time of the event.
+     * See {@link FeatureFlag} for details of the data available.
+     */
+    @NonNull
+    public List<FeatureFlag> getFeatureFlags() {
+        return impl.getFeatureFlags().toList();
+    }
+
+    /**
      * Information set by the notifier about your app can be found in this field. These values
      * can be accessed and amended if necessary.
      */

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OnSendCallbackScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OnSendCallbackScenario.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
+import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.OnSendCallback
 import java.lang.RuntimeException
@@ -14,6 +15,8 @@ internal class OnSendCallbackScenario(
     init {
         config.addOnSend(
             OnSendCallback { event ->
+                event.clearFeatureFlag("deleteMe")
+                event.addFeatureFlag(event.featureFlags[0].name, "b")
                 event.addMetadata("mazerunner", "onSendCallback", "true")
                 event.apiKey = "99999999999999909999999999999999"
                 true
@@ -23,6 +26,9 @@ internal class OnSendCallbackScenario(
 
     override fun startScenario() {
         super.startScenario()
+
+        Bugsnag.addFeatureFlag("fromStartup", "a")
+        Bugsnag.addFeatureFlag("deleteMe")
 
         if (eventMetadata != "start-only") {
             throw RuntimeException("Unhandled Error")

--- a/features/full_tests/onsend_callback.feature
+++ b/features/full_tests/onsend_callback.feature
@@ -12,6 +12,8 @@ Feature: OnSend Callbacks can alter Events before upload
     And the error payload field "apiKey" equals "99999999999999909999999999999999"
     And the exception "message" equals "Unhandled Error"
     And the event "metaData.mazerunner.onSendCallback" equals "true"
+    And the event "featureFlags.0.featureFlag" equals "fromStartup"
+    And the event "featureFlags.0.variant" equals "b"
 
   Scenario: Handled exception altered by OnSendCallback
     When I run "HandledOnSendCallbackScenario"


### PR DESCRIPTION
## Goal

Allow feature flags to be accessed from the event object during OnSend callbacks

## Testing

Updated e2e tests to check accessing the feature flags from OnSend
