### PR TITLE
Event delivery with an event with setUnhandled(true) should behave as an unhandled event delivery

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -50,7 +50,7 @@ class DeliveryDelegate extends BaseObservable {
             }
         }
 
-        if (event.getImpl().getOriginalUnhandled()) {
+        if (event.isUnhandled() || event.getImpl().getOriginalUnhandled()) {
             // should only send unhandled errors if they don't terminate the process (i.e. ANRs)
             String severityReasonType = event.getImpl().getSeverityReasonType();
             boolean promiseRejection = REASON_PROMISE_REJECTION.equals(severityReasonType);


### PR DESCRIPTION
## Goal

In the case where client.notify is called and the event is modified to be treated as unhandled:
```java
client.notify(throwable, new OnErrorCallback() {
      @Override public boolean onError(@NonNull Event event) {
        event.setUnhandled(true);
       ...
      }
    });
```
we should cache the event, similar to how it is done for an unhandled exception. With an unhandled exception, the app's availability will cease - and if we are marking an event as unhandled, we are indicating this will be the case.

We use our own default exception handler which allows us to customize crash handling and send crashes to distinct destinations. Using the bugsnag client with client.notify with setUnhandled = true as part of that handler and being able to rely upon similar behavior as the bugsnag default exception handler rather than forward to the bugsnag exception handler would simplify the structure of our code. 

## Design

Change delivery logic to view events marked as unhandled to behave as a typical unhandled exception in bugsnag.

## Changeset

## Testing
