### PR TITLE
Report "Build ID" as codeIdentifier in NDK stacktraces

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
@@ -26,6 +26,9 @@ typedef struct {
   jclass number;
   jmethodID number_double_value;
 
+  jclass Long;
+  jmethodID Long_valueOf;
+
   jclass String;
 
   jclass Map;
@@ -54,8 +57,8 @@ typedef struct {
   jmethodID NativeInterface_isDiscardErrorClass;
   jmethodID NativeInterface_deliverReport;
 
-  jclass StackTraceElement;
-  jmethodID StackTraceElement_constructor;
+  jclass NativeStackframe;
+  jmethodID NativeStackframe_constructor;
 
   jclass Severity;
 
@@ -63,6 +66,8 @@ typedef struct {
 
   jclass OpaqueValue;
   jmethodID OpaqueValue_getJson;
+
+  jobject ErrorType_C;
 } bsg_jni_cache_t;
 
 extern bsg_jni_cache_t *const bsg_jni_cache;

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -39,5 +39,5 @@ void bsg_hex_encode(char *dst, const void *src, size_t byte_count,
     *outCursor++ = hex[(*cursor++) & 0xF];
   }
 
-  *outCursor = 0;
+  *outCursor = '\0';
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -24,3 +24,20 @@ void bsg_strncpy(char *dst, const char *src, size_t dst_size) {
     strncat(dst, src, dst_size - 1);
   }
 }
+
+void bsg_hex_encode(char *dst, const void *src, size_t byte_count,
+                    size_t max_chars) __asyncsafe {
+  static const char *hex = "0123456789abcdef";
+
+  const size_t byte_copy_count =
+      (max_chars > byte_count * 2) ? byte_count : (max_chars - 1) / 2;
+
+  char *cursor = (char *)src;
+  char *outCursor = dst;
+  for (size_t i = 0; i < byte_copy_count; ++i) {
+    *outCursor++ = hex[(*cursor >> 4) & 0xF];
+    *outCursor++ = hex[(*cursor++) & 0xF];
+  }
+
+  *outCursor = 0;
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -23,6 +23,19 @@ size_t bsg_strlen(const char *str) __asyncsafe;
  */
 void bsg_strncpy(char *dst, const char *src, size_t len) __asyncsafe;
 
+/**
+ * Encode a number of bytes into dst while hex encoding the data.
+ *
+ * @param dst the destination buffer, which have enough space for at least
+ * max_chars
+ * @param src pointer to the first byte to encode
+ * @param byte_count the number of bytes to encode from src
+ * @param max_chars the maximum number of chars to encode (including a
+ * terminator)
+ */
+void bsg_hex_encode(char *dst, const void *src, size_t byte_count,
+                    size_t max_chars) __asyncsafe;
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
@@ -56,6 +56,41 @@ TEST length_null_string(void) {
     PASS();
 }
 
+TEST hex_encode(void) {
+    char out_buffer[16];
+    char *bytes = "bytes";
+    bsg_hex_encode(out_buffer, bytes, strlen(bytes), sizeof(out_buffer));
+    ASSERT_STR_EQ("6279746573", out_buffer);
+    PASS();
+}
+
+TEST hex_encode_zero(void) {
+    char out_buffer[256];
+    out_buffer[0] = '1';
+
+    bsg_hex_encode(out_buffer, NULL, 0, sizeof(out_buffer));
+    ASSERT_EQ(0, *out_buffer);
+    PASS();
+}
+
+TEST hex_encode_overflow(void) {
+    char out_buffer[7];
+    char *bytes = "bytes";
+    bsg_hex_encode(out_buffer, bytes, strlen(bytes), sizeof(out_buffer));
+    // the output must still be zero-terminated
+    ASSERT_STR_EQ("627974", out_buffer);
+    PASS();
+}
+
+TEST hex_encode_exact_length(void) {
+    char out_buffer[10];
+    char *bytes = "bytes";
+    bsg_hex_encode(out_buffer, bytes, strlen(bytes), sizeof(out_buffer));
+    // we expect the entire last byte of *input* to be dropped
+    ASSERT_STR_EQ("62797465", out_buffer);
+    PASS();
+}
+
 SUITE(suite_string_utils) {
     RUN_TEST(test_copy_empty_string);
     RUN_TEST(test_copy_null_string);
@@ -63,5 +98,9 @@ SUITE(suite_string_utils) {
     RUN_TEST(length_empty_string);
     RUN_TEST(length_literal_string);
     RUN_TEST(length_null_string);
+    RUN_TEST(hex_encode);
+    RUN_TEST(hex_encode_zero);
+    RUN_TEST(hex_encode_overflow);
+    RUN_TEST(hex_encode_exact_length);
 }
 

--- a/features/full_tests/native_context.feature
+++ b/features/full_tests/native_context.feature
@@ -18,3 +18,5 @@ Feature: Native Context API
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "message" equals "CXXAutoContextScenario"
     And the event "context" equals "SecondActivity"
+
+    And the "codeIdentifier" of stack frame 0 is not null

--- a/features/full_tests/native_context.feature
+++ b/features/full_tests/native_context.feature
@@ -18,5 +18,3 @@ Feature: Native Context API
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "message" equals "CXXAutoContextScenario"
     And the event "context" equals "SecondActivity"
-
-    And the "codeIdentifier" of stack frame 0 is not null

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -19,6 +19,7 @@ Feature: Native crash reporting
     And the error payload field "events.0.metaData.app.memoryLimit" is greater than 0
     And the first significant stack frames match:
       | get_the_null_value() | CXXDereferenceNullScenario.cpp | 7 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   # This scenario will not pass on API levels < 18, as stack corruption
   # is handled without calling atexit handlers, etc.
@@ -40,6 +41,7 @@ Feature: Native crash reporting
     And the event "unhandled" is true
     And the first significant stack frames match:
       | crash_stack_overflow | CXXStackoverflowScenario.cpp |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Program trap()
     When I run "CXXTrapScenario" and relaunch the crashed app
@@ -57,6 +59,7 @@ Feature: Native crash reporting
     And the event "unhandled" is true
     And the first significant stack frames match:
       | trap_it() | CXXTrapScenario.cpp | 12 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Write to read-only memory
     When I run "CXXWriteReadOnlyMemoryScenario" and relaunch the crashed app
@@ -70,6 +73,7 @@ Feature: Native crash reporting
     And the first significant stack frames match:
       | crash_write_read_only_mem(int)                                                     | CXXWriteReadOnlyMemoryScenario.cpp | 12 |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXWriteReadOnlyMemoryScenario_crash | CXXWriteReadOnlyMemoryScenario.cpp | 22 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Improper object type cast
     When I run "CXXImproperTypecastScenario" and relaunch the crashed app
@@ -83,6 +87,7 @@ Feature: Native crash reporting
     And the first significant stack frames match:
       | crash_improper_cast(void*)                                                      | CXXImproperTypecastScenario.cpp | 12 |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXImproperTypecastScenario_crash | CXXImproperTypecastScenario.cpp | 20 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Program abort()
     When I run "CXXAbortScenario" and relaunch the crashed app
@@ -101,6 +106,7 @@ Feature: Native crash reporting
     And the first significant stack frames match:
       | evictor::exit_with_style()                                           | CXXAbortScenario.cpp | 5  |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXAbortScenario_crash | CXXAbortScenario.cpp | 13 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Undefined JNI method
     When I run "UnsatisfiedLinkErrorScenario" and relaunch the crashed app

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -10,6 +10,7 @@ Feature: Synchronizing app/device metadata in the native layer
     And the event "app.inForeground" is true
     And the event "app.duration" is greater than 0
     And the event "unhandled" is false
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Capture foreground state while in the background
     When I run "CXXBackgroundNotifyScenario"
@@ -24,6 +25,7 @@ Feature: Synchronizing app/device metadata in the native layer
     # Appium 1.9.1 - 1.20.2 changes the orientation to landscape when foregrounding.
     # Return it to portrait to avoid impacting other scenarios.
     And I set the screen orientation to portrait
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Capture foreground state while in a foreground crash
     When I run "CXXTrapScenario" and relaunch the crashed app


### PR DESCRIPTION
## Goal
When reporting native stack traces, we need to include the "Build ID" as `codeIdentifier` for each stack frame (when it's available) so that we can later retrieve the correct symbol data.

## Changeset

- Add the "Build ID" to the stack-frames in the NDK event model during a crash
- Use `NativeStackframe` instead of `StackTraceElement` to relay `bugsnag_notify` events to the JVM layer

## Testing
New unit tests and additional checks on top of existing end-to-end testing