### PR TITLE
Allow any Collection to be encoded as OPAQUE in NDK metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Non-List Collections are now correctly handled as OPAQUE values for NDK metadata
+  [#1728](https://github.com/bugsnag/bugsnag-android/pull/1728)
+
 ## 5.25.0 (2022-07-19)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/OpaqueValue.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/OpaqueValue.kt
@@ -41,7 +41,7 @@ internal class OpaqueValue(val json: String) {
             value is Boolean -> value
             value is Number -> value
             value is String && isStringNDKSupported(value) -> value
-            value is String || value is Map<*, *> || value is List<*> -> OpaqueValue(encode(value))
+            value is String || value is Map<*, *> || value is Collection<*> -> OpaqueValue(encode(value))
             else -> null
         }
     }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXConfigurationMetadataNativeCrashScenario.java
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXConfigurationMetadataNativeCrashScenario.java
@@ -11,7 +11,9 @@ import androidx.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class CXXConfigurationMetadataNativeCrashScenario extends Scenario {
 
@@ -54,6 +56,11 @@ public class CXXConfigurationMetadataNativeCrashScenario extends Scenario {
                     "spring",
                     "autumn"
             ));
+
+            Set<String> set = new LinkedHashSet<>();
+            set.add("value1");
+            set.add("2value");
+            config.addMetadata("complex", "set", set);
         }
     }
 

--- a/features/full_tests/native_metadata.feature
+++ b/features/full_tests/native_metadata.feature
@@ -25,6 +25,8 @@ Feature: Native Metadata API
     And the event "metaData.complex.list.1" equals "winter"
     And the event "metaData.complex.list.2" equals "spring"
     And the event "metaData.complex.list.3" equals "autumn"
+    And the event "metaData.complex.set.0" equals "value1"
+    And the event "metaData.complex.set.1" equals "2value"
     And the event "unhandled" is true
 
   Scenario: Remove MetaData from the NDK layer


### PR DESCRIPTION
## Goal
Allow any valid `Collection` to be encoded as OPAQUE NDK metadata

## Testing
Additional values in the end to end test