### PR TITLE
Report the Build ID in codeIdentifier

### DIFF
--- a/bugsnag-plugin-android-ndk/detekt-baseline.xml
+++ b/bugsnag-plugin-android-ndk/detekt-baseline.xml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>ComplexMethod:NativeBridge.kt$NativeBridge$override fun onStateChange(event: StateEvent)</ID>
+    <ID>LongMethod:EventMigrationV10Tests.kt$EventMigrationV10Tests$@Test fun testMigrateEventToLatest()</ID>
     <ID>LongMethod:EventMigrationV4Tests.kt$EventMigrationV4Tests$@Test fun testMigrateEventToLatest()</ID>
     <ID>LongMethod:EventMigrationV5Tests.kt$EventMigrationV5Tests$@Test fun testMigrateEventToLatest()</ID>
     <ID>LongMethod:EventMigrationV6Tests.kt$EventMigrationV6Tests$@Test fun testMigrateEventToLatest()</ID>

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV10Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV10Tests.kt
@@ -5,8 +5,8 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.fail
 import org.junit.Test
 
-/** Migration v9 added opaque metadata */
-class EventMigrationV9Tests : EventMigrationTest() {
+/** Migration v10 added codeIdentifier to stack frames */
+class EventMigrationV10Tests : EventMigrationTest() {
 
     @Test
     /** check notifier and api key, since they aren't included in event JSON */

--- a/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/assets/include/event.h
@@ -72,6 +72,7 @@ typedef struct {
 
   char filename[256];
   char method[256];
+  char code_identifier[65];
 } bugsnag_stackframe;
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -34,7 +34,7 @@
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
-#define BUGSNAG_EVENT_VERSION 9
+#define BUGSNAG_EVENT_VERSION 10
 
 #ifdef __cplusplus
 extern "C" {

--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
@@ -26,6 +26,9 @@ typedef struct {
   jclass number;
   jmethodID number_double_value;
 
+  jclass Long;
+  jmethodID Long_valueOf;
+
   jclass String;
 
   jclass Map;
@@ -54,8 +57,8 @@ typedef struct {
   jmethodID NativeInterface_isDiscardErrorClass;
   jmethodID NativeInterface_deliverReport;
 
-  jclass StackTraceElement;
-  jmethodID StackTraceElement_constructor;
+  jclass NativeStackframe;
+  jmethodID NativeStackframe_constructor;
 
   jclass Severity;
 
@@ -63,6 +66,8 @@ typedef struct {
 
   jclass OpaqueValue;
   jmethodID OpaqueValue_getJson;
+
+  jobject ErrorType_C;
 } bsg_jni_cache_t;
 
 extern bsg_jni_cache_t *const bsg_jni_cache;

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/json_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/json_writer.c
@@ -275,6 +275,15 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
     json_object_set_string(frame, "method", (*stackframe).method);
   }
 
+  if (*stackframe->code_identifier != 0) {
+    char code_identifier[sizeof(stackframe->code_identifier) + 1];
+    code_identifier[sizeof(stackframe->code_identifier)] =
+        0; // force zero terminator
+    strncpy(code_identifier, stackframe->code_identifier,
+            sizeof(stackframe->code_identifier));
+    json_object_set_string(frame, "codeIdentifier", code_identifier);
+  }
+
   json_array_append_value(stacktrace, frame_val);
 }
 
@@ -287,6 +296,7 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
 #define TIMESTAMP_DECODE atol
 #define TIMESTAMP_MILLIS_FORMAT "%s.%03ldZ"
 #endif
+
 /**
  * Convert a string representing the number of milliseconds since the epoch
  * into the date format "yyyy-MM-ddTHH:mm:ss.SSSZ". Safe for all dates earlier
@@ -322,6 +332,7 @@ static bool timestamp_to_iso8601_millis(const char *source, char *dest) {
   }
   return false;
 }
+
 #undef TIMESTAMP_T
 #undef TIMESTAMP_DECODE
 #undef TIMESTAMP_MILLIS_FORMAT

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/migrate.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/migrate.h
@@ -34,6 +34,16 @@ typedef struct {
   char url[64];
 } bsg_library;
 
+typedef struct {
+  uintptr_t frame_address;
+  uintptr_t symbol_address;
+  uintptr_t load_address;
+  uintptr_t line_number;
+
+  char filename[256];
+  char method[256];
+} bugsnag_stackframe_v1;
+
 /** a Bugsnag exception */
 typedef struct {
   /** The exception name or stringified code */
@@ -51,8 +61,28 @@ typedef struct {
   /**
    * An ordered list of stack frames from the oldest to the most recent
    */
-  bugsnag_stackframe stacktrace[BUGSNAG_FRAMES_MAX];
+  bugsnag_stackframe_v1 stacktrace[BUGSNAG_FRAMES_MAX];
 } bsg_exception;
+
+/** a Bugsnag exception */
+typedef struct {
+  /** The exception name or stringified code */
+  char errorClass[64];
+  /** A description of what went wrong */
+  char errorMessage[256];
+  /** The variety of exception which needs to be processed by the pipeline */
+  char type[32];
+
+  /**
+   * The number of frames used in the stacktrace. Must be less than
+   * BUGSNAG_FRAMES_MAX.
+   */
+  ssize_t frame_count;
+  /**
+   * An ordered list of stack frames from the oldest to the most recent
+   */
+  bugsnag_stackframe_v1 stacktrace[BUGSNAG_FRAMES_MAX];
+} bsg_error_v1;
 
 typedef struct {
   char key[64];
@@ -236,7 +266,7 @@ typedef struct {
   bsg_app_info_v2 app;
   bsg_device_info_v2 device;
   bugsnag_user user;
-  bsg_error error;
+  bsg_error_v1 error;
   bugsnag_metadata_v1 metadata;
 
   int crumb_count;
@@ -261,7 +291,7 @@ typedef struct {
   bsg_app_info_v2 app;
   bsg_device_info_v2 device;
   bugsnag_user user;
-  bsg_error error;
+  bsg_error_v1 error;
   bugsnag_metadata_v1 metadata;
 
   int crumb_count;
@@ -287,7 +317,7 @@ typedef struct {
   bsg_app_info_v3 app;
   bsg_device_info_v2 device;
   bugsnag_user user;
-  bsg_error error;
+  bsg_error_v1 error;
   bugsnag_metadata_v1 metadata;
 
   int crumb_count;
@@ -313,7 +343,7 @@ typedef struct {
   bsg_app_info_v3 app;
   bsg_device_info_v2 device;
   bugsnag_user user;
-  bsg_error error;
+  bsg_error_v1 error;
   bugsnag_metadata_v1 metadata;
 
   int crumb_count;
@@ -339,7 +369,7 @@ typedef struct {
   bsg_app_info_v3 app;
   bsg_device_info_v2 device;
   bugsnag_user user;
-  bsg_error error;
+  bsg_error_v1 error;
   bugsnag_metadata_v1 metadata;
 
   int crumb_count;
@@ -368,7 +398,7 @@ typedef struct {
   bsg_app_info app;
   bsg_device_info device;
   bugsnag_user user;
-  bsg_error error;
+  bsg_error_v1 error;
   bugsnag_metadata_v1 metadata;
 
   int crumb_count;
@@ -394,6 +424,46 @@ typedef struct {
   size_t feature_flag_count;
   bsg_feature_flag *feature_flags;
 } bugsnag_report_v8;
+
+typedef struct {
+  bsg_notifier notifier;
+  bsg_app_info app;
+  bsg_device_info device;
+  bugsnag_user user;
+  bsg_error_v1 error;
+  bugsnag_metadata metadata;
+
+  int crumb_count;
+  // Breadcrumbs are a ring; the first index moves as the
+  // structure is filled and replaced.
+  int crumb_first_index;
+  bugsnag_breadcrumb breadcrumbs[BUGSNAG_CRUMBS_MAX];
+
+  char context[64];
+  bugsnag_severity severity;
+
+  char session_id[33];
+  char session_start[33];
+  int handled_events;
+  int unhandled_events;
+  char grouping_hash[64];
+  bool unhandled;
+  char api_key[64];
+
+  int thread_count;
+  bsg_thread threads[BUGSNAG_THREADS_MAX];
+
+  /**
+   * The number of feature flags currently specified.
+   */
+  size_t feature_flag_count;
+
+  /**
+   * Pointer to the current feature flags. This is dynamically allocated and
+   * serialized/deserialized separately to the rest of the struct.
+   */
+  bsg_feature_flag *feature_flags;
+} bugsnag_report_v9;
 
 #ifdef __cplusplus
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.c
@@ -24,3 +24,20 @@ void bsg_strncpy(char *dst, const char *src, size_t dst_size) {
     strncat(dst, src, dst_size - 1);
   }
 }
+
+void bsg_hex_encode(char *dst, const void *src, size_t byte_count,
+                    size_t max_chars) __asyncsafe {
+  static const char *hex = "0123456789abcdef";
+
+  const size_t byte_copy_count =
+      (max_chars > byte_count * 2) ? byte_count : (max_chars - 1) / 2;
+
+  char *cursor = (char *)src;
+  char *outCursor = dst;
+  for (size_t i = 0; i < byte_copy_count; ++i) {
+    *outCursor++ = hex[(*cursor >> 4) & 0xF];
+    *outCursor++ = hex[(*cursor++) & 0xF];
+  }
+
+  *outCursor = '\0';
+}

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/string.h
@@ -23,6 +23,19 @@ size_t bsg_strlen(const char *str) __asyncsafe;
  */
 void bsg_strncpy(char *dst, const char *src, size_t len) __asyncsafe;
 
+/**
+ * Encode a number of bytes into dst while hex encoding the data.
+ *
+ * @param dst the destination buffer, which have enough space for at least
+ * max_chars
+ * @param src pointer to the first byte to encode
+ * @param byte_count the number of bytes to encode from src
+ * @param max_chars the maximum number of chars to encode (including a
+ * terminator)
+ */
+void bsg_hex_encode(char *dst, const void *src, size_t byte_count,
+                    size_t max_chars) __asyncsafe;
+
 #ifdef __cplusplus
 }
 #endif

--- a/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/test/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(bugsnag-ndk-test SHARED
     cpp/migrations/EventMigrationV7Tests.cpp
     cpp/migrations/EventMigrationV8Tests.cpp
     cpp/migrations/EventMigrationV9Tests.cpp
+    cpp/migrations/EventMigrationV10Tests.cpp
     cpp/UnwindTest.cpp
 )
 target_link_libraries(bugsnag-ndk-test bugsnag-ndk)

--- a/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV10Tests.cpp
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventMigrationV10Tests.cpp
@@ -1,12 +1,11 @@
 #include <cstring>
 
 #include <parson/parson.h>
-#include <utils/serializer/buffered_writer.h>
 
 #include "utils.hpp"
 
 static void *create_payload_info_event() {
-  auto event = (bugsnag_report_v9 *)calloc(1, sizeof(bugsnag_report_v9));
+  auto event = (bugsnag_event *)calloc(1, sizeof(bugsnag_event));
 
   strcpy(event->api_key, "5d1e5fbd39a74caa1200142706a90b20");
   strcpy(event->notifier.name, "Test Library");
@@ -20,7 +19,7 @@ static void *create_payload_info_event() {
  * Create a new event in v9 format
  */
 static void *create_full_event() {
-  auto event = (bugsnag_report_v9 *)calloc(1, sizeof(bugsnag_report_v9));
+  auto event = (bugsnag_event *)calloc(1, sizeof(bugsnag_event));
 
   strcpy(event->context,
          "00000000000m0r3.61ee9e6e099d3dd7448f740d395768da6b2df55d5.m4g1c");
@@ -103,10 +102,10 @@ static void *create_full_event() {
 
   // metadata
   strcpy(event->app.active_screen, "Menu");
-  bsg_add_metadata_value_bool(&event->metadata, "metrics", "experimentX", false);
-  bsg_add_metadata_value_str(&event->metadata, "metrics", "subject", "percy");
-  bsg_add_metadata_value_str(&event->metadata, "app", "weather", "rain");
-  bsg_add_metadata_value_double(&event->metadata, "metrics", "counter", 47.5);
+  bugsnag_event_add_metadata_bool(event, "metrics", "experimentX", false);
+  bugsnag_event_add_metadata_string(event, "metrics", "subject", "percy");
+  bugsnag_event_add_metadata_string(event, "app", "weather", "rain");
+  bugsnag_event_add_metadata_double(event, "metrics", "counter", 47.5);
 
   // session info
   event->handled_events = 5;
@@ -130,112 +129,22 @@ static void *create_full_event() {
   return event;
 }
 
-static bool write_feature_flag(bsg_buffered_writer *writer,
-                               bsg_feature_flag *flag) {
-  if (!writer->write_string(writer, flag->name)) {
-    return false;
-  }
-
-  if (flag->variant) {
-    if (!writer->write_byte(writer, 1)) {
-      return false;
-    }
-
-    if (!writer->write_string(writer, flag->variant)) {
-      return false;
-    }
-  } else {
-    if (!writer->write_byte(writer, 0)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-static bool bsg_write_feature_flags(bugsnag_report_v9 *event,
-                                    bsg_buffered_writer *writer) {
-  const uint32_t feature_flag_count = event->feature_flag_count;
-  if (!writer->write(writer, &feature_flag_count, sizeof(feature_flag_count))) {
-    return false;
-  }
-
-  for (uint32_t index = 0; index < feature_flag_count; index++) {
-    if (!write_feature_flag(writer, &event->feature_flags[index])) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-static bool bsg_write_opaque_metadata_unit(bugsnag_metadata *metadata,
-                                           bsg_buffered_writer *writer) {
-
-  for (size_t index = 0; index < metadata->value_count; index++) {
-    uint32_t value_size = metadata->values[index].opaque_value_size;
-    if (metadata->values[index].type == BSG_METADATA_OPAQUE_VALUE &&
-        value_size > 0) {
-      if (!writer->write(writer, metadata->values[index].opaque_value,
-                         value_size)) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
-
-bool bsg_write_opaque_metadata(bugsnag_report_v9 *event,
-                               bsg_buffered_writer *writer) {
-
-  if (!bsg_write_opaque_metadata_unit(&event->metadata, writer)) {
-    return false;
-  }
-
-  for (int breadcrumb_index = 0; breadcrumb_index < event->crumb_count;
-       breadcrumb_index++) {
-    if (!bsg_write_opaque_metadata_unit(
-        &event->breadcrumbs[breadcrumb_index].metadata, writer)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-bool bsg_event_write_v9(bsg_environment *env) {
-  bsg_buffered_writer writer;
-  if (!bsg_buffered_writer_open(&writer, env->next_event_path)) {
-    return false;
-  }
-
-  bool result =
-      // write header - determines format version, etc
-      bsg_report_header_write(&env->report_header, writer.fd) &&
-      // add cached event info
-      writer.write(&writer, &env->next_event, sizeof(bugsnag_report_v9)) &&
-      // append feature flags after event structure
-      bsg_write_feature_flags((bugsnag_report_v9*)(&env->next_event), &writer) &&
-      // append opaque metadata after the feature flags
-      bsg_write_opaque_metadata((bugsnag_report_v9*)(&env->next_event), &writer);
-
-  writer.dispose(&writer);
-  return result;
-}
-
 static const char *write_event_v9(JNIEnv *env, jstring temp_file,
                                   void *(event_generator)()) {
   auto event_ctx = (bsg_environment *)calloc(1, sizeof(bsg_environment));
-  event_ctx->report_header.version = 9;
+  event_ctx->report_header.version = 10;
   const char *path = (*env).GetStringUTFChars(temp_file, nullptr);
   sprintf(event_ctx->next_event_path, "%s", path);
 
   // (old format) event struct -> file on disk
   void *old_event = event_generator();
-  memcpy(&event_ctx->next_event, old_event, sizeof(bugsnag_report_v9));
+  memcpy(&event_ctx->next_event, old_event, sizeof(bugsnag_event));
   free(old_event);
-  bsg_event_write_v9(event_ctx);
+  // FUTURE(df): whenever migration v11 rolls around, the v10 version of
+  // bsg_serialize_event_to_file() function should be moved into this file to
+  // preserve the migration test behavior. The good news is—if this doesn't
+  // happen—the test will probably start failing loudly.
+  bsg_serialize_event_to_file(event_ctx);
   free(event_ctx);
   return path;
 }
@@ -245,7 +154,7 @@ extern "C" {
 #endif
 
 JNIEXPORT jstring JNICALL
-Java_com_bugsnag_android_ndk_migrations_EventMigrationV9Tests_migratePayloadInfo(
+Java_com_bugsnag_android_ndk_migrations_EventMigrationV10Tests_migratePayloadInfo(
     JNIEnv *env, jobject _this, jstring temp_file) {
   const char *path = write_event_v9(env, temp_file, create_payload_info_event);
 
@@ -269,7 +178,7 @@ Java_com_bugsnag_android_ndk_migrations_EventMigrationV9Tests_migratePayloadInfo
 }
 
 JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_migrations_EventMigrationV9Tests_migrateEvent(
+Java_com_bugsnag_android_ndk_migrations_EventMigrationV10Tests_migrateEvent(
     JNIEnv *env, jobject _this, jstring temp_file) {
   const char *path = write_event_v9(env, temp_file, create_full_event);
 

--- a/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/test_utils_string.c
@@ -56,6 +56,41 @@ TEST length_null_string(void) {
     PASS();
 }
 
+TEST hex_encode(void) {
+    char out_buffer[16];
+    char *bytes = "bytes";
+    bsg_hex_encode(out_buffer, bytes, strlen(bytes), sizeof(out_buffer));
+    ASSERT_STR_EQ("6279746573", out_buffer);
+    PASS();
+}
+
+TEST hex_encode_zero(void) {
+    char out_buffer[256];
+    out_buffer[0] = '1';
+
+    bsg_hex_encode(out_buffer, NULL, 0, sizeof(out_buffer));
+    ASSERT_EQ(0, *out_buffer);
+    PASS();
+}
+
+TEST hex_encode_overflow(void) {
+    char out_buffer[7];
+    char *bytes = "bytes";
+    bsg_hex_encode(out_buffer, bytes, strlen(bytes), sizeof(out_buffer));
+    // the output must still be zero-terminated
+    ASSERT_STR_EQ("627974", out_buffer);
+    PASS();
+}
+
+TEST hex_encode_exact_length(void) {
+    char out_buffer[10];
+    char *bytes = "bytes";
+    bsg_hex_encode(out_buffer, bytes, strlen(bytes), sizeof(out_buffer));
+    // we expect the entire last byte of *input* to be dropped
+    ASSERT_STR_EQ("62797465", out_buffer);
+    PASS();
+}
+
 SUITE(suite_string_utils) {
     RUN_TEST(test_copy_empty_string);
     RUN_TEST(test_copy_null_string);
@@ -63,5 +98,9 @@ SUITE(suite_string_utils) {
     RUN_TEST(length_empty_string);
     RUN_TEST(length_literal_string);
     RUN_TEST(length_null_string);
+    RUN_TEST(hex_encode);
+    RUN_TEST(hex_encode_zero);
+    RUN_TEST(hex_encode_overflow);
+    RUN_TEST(hex_encode_exact_length);
 }
 

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -19,6 +19,7 @@ Feature: Native crash reporting
     And the error payload field "events.0.metaData.app.memoryLimit" is greater than 0
     And the first significant stack frames match:
       | get_the_null_value() | CXXDereferenceNullScenario.cpp | 7 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   # This scenario will not pass on API levels < 18, as stack corruption
   # is handled without calling atexit handlers, etc.
@@ -40,6 +41,7 @@ Feature: Native crash reporting
     And the event "unhandled" is true
     And the first significant stack frames match:
       | crash_stack_overflow | CXXStackoverflowScenario.cpp |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Program trap()
     When I run "CXXTrapScenario" and relaunch the crashed app
@@ -57,6 +59,7 @@ Feature: Native crash reporting
     And the event "unhandled" is true
     And the first significant stack frames match:
       | trap_it() | CXXTrapScenario.cpp | 12 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Write to read-only memory
     When I run "CXXWriteReadOnlyMemoryScenario" and relaunch the crashed app
@@ -70,6 +73,7 @@ Feature: Native crash reporting
     And the first significant stack frames match:
       | crash_write_read_only_mem(int)                                                     | CXXWriteReadOnlyMemoryScenario.cpp | 12 |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXWriteReadOnlyMemoryScenario_crash | CXXWriteReadOnlyMemoryScenario.cpp | 22 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Improper object type cast
     When I run "CXXImproperTypecastScenario" and relaunch the crashed app
@@ -83,6 +87,7 @@ Feature: Native crash reporting
     And the first significant stack frames match:
       | crash_improper_cast(void*)                                                      | CXXImproperTypecastScenario.cpp | 12 |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXImproperTypecastScenario_crash | CXXImproperTypecastScenario.cpp | 20 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Program abort()
     When I run "CXXAbortScenario" and relaunch the crashed app
@@ -101,6 +106,7 @@ Feature: Native crash reporting
     And the first significant stack frames match:
       | evictor::exit_with_style()                                           | CXXAbortScenario.cpp | 5  |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXAbortScenario_crash | CXXAbortScenario.cpp | 13 |
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Undefined JNI method
     When I run "UnsatisfiedLinkErrorScenario" and relaunch the crashed app

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -10,6 +10,7 @@ Feature: Synchronizing app/device metadata in the native layer
     And the event "app.inForeground" is true
     And the event "app.duration" is greater than 0
     And the event "unhandled" is false
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Capture foreground state while in the background
     When I run "CXXBackgroundNotifyScenario"
@@ -24,6 +25,7 @@ Feature: Synchronizing app/device metadata in the native layer
     # Appium 1.9.1 - 1.20.2 changes the orientation to landscape when foregrounding.
     # Return it to portrait to avoid impacting other scenarios.
     And I set the screen orientation to portrait
+    And the "codeIdentifier" of stack frame 0 is not null
 
   Scenario: Capture foreground state while in a foreground crash
     When I run "CXXTrapScenario" and relaunch the crashed app


### PR DESCRIPTION
## Goal
Report the "BuildID" of `.so` files for each frame where it can be identified.

## Design
After unwinding the stack, attempt to identify the "Build ID" from `MapInfo` for each frame. The Build ID or MapInfo will be empty if the frame is not backed by a `.so` file (such as Dex frames) or if the module has no `.note.gnu.build-id`. In these cases the `codeIdentifier` will be left as `null`.

## Testing
New unit tests to cover the new structure and migration, additions to the end-to-end tests.