### PR TITLE
Reduce flakes in the ANR Smoke Test on Android 4

### DIFF
--- a/features/smoke_tests/01_anr.feature
+++ b/features/smoke_tests/01_anr.feature
@@ -5,7 +5,9 @@ Feature: ANR smoke test
   Scenario: ANR detection
     When I clear any error dialogue
     And I run "JvmAnrLoopScenario"
-    And I wait for 2 seconds
+    And I wait for 1 seconds
+    And I tap the screen 3 times
+    And I wait for 5 seconds
     And I tap the back-button 3 times
     And I wait to receive an error
 


### PR DESCRIPTION
## Goal
Attempt to reduce flakes in the ANR Smoke Test on Android 4 devices.

## Design
The test scenario now taps the screen, then waits 5 seconds, and finally uses the back button to try force an ANR. While this takes a little longer than previously, it more closely mimics expected user behaviour.

## Testing
Reran the test scenario several times without the ANR scenario flaking.