### PR TITLE
Improve reliability of EventStoreConfinementTest

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventStoreConfinementTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/EventStoreConfinementTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
@@ -74,9 +75,13 @@ internal class EventStoreConfinementTest {
         assertEquals(EVENT_CONFINEMENT_ATTEMPTS, filenames.size)
         assertEquals(EVENT_CONFINEMENT_ATTEMPTS, filenames.toSet().size)
 
+        val remainingExpectedApiKeys = filenames.indices.mapTo(hashSetOf()) { "$it" }
         retainingDelivery.files.forEachIndexed { index, file ->
             val eventInfo = EventFilenameInfo.fromFile(file, client.immutableConfig)
-            assertEquals("$index", eventInfo.apiKey)
+            assertTrue(
+                "unexpected file: $file ($index), expected one of $remainingExpectedApiKeys",
+                remainingExpectedApiKeys.remove(eventInfo.apiKey)
+            )
         }
     }
 


### PR DESCRIPTION
## Goal
Lower the probability that `EventStoreConfinementTest` fails due to over-strict verification.

## Design
`EventStoreConfinementTest` silently relies on the order of files being listed (due to the way `EventStore.flushAsync` works). As a result the assertions sometimes fail when files are not returned in the expected order.

The test does not need to depend on the file order however, and instead is attempting to ensure no unexpected files are being delivered.

## Changeset
Change the `flushAsyncIsThreadConfined` assertion to check each file against a list of "expected" files, and report if an unexpected file is being delivered.

The report will now include the index of the file being checked, alongside the list of files it still expects to see (to aid future debugging).

## Testing
Rerun the test many times locally without it breaking.