### PR TITLE
Add tests for Android 13 to Full CI

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -388,6 +388,56 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
+  - label: ':android: Android 13 Beta NDK r21 end-to-end tests - batch 1'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - "build/fixture-r21.apk"
+          - "build/fixture-r21/*"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: android-maze-runner
+        run: android-maze-runner
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
+          - "--app=/app/build/fixture-r21.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_13_0_BETA"
+          - "--fail-fast"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 24
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: ':android: Android 13 Beta NDK r21 end-to-end tests - batch 2'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.2.0:
+        download:
+          - "build/fixture-r21.apk"
+          - "build/fixture-r21/*"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: android-maze-runner
+        run: android-maze-runner
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
+          - "--app=/app/build/fixture-r21.apk"
+          - "--farm=bs"
+          - "--device=ANDROID_13_0_BETA"
+          - "--fail-fast"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 24
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
   # If there is a tag present activate a manual publishing step
 
   - block: 'Trigger package publish'


### PR DESCRIPTION
## Goal

Add tests against Android 13 Beta to CI.

## Design

For now I have just added this to the full CI run.  Once 13 comes out for real (and is available on BrowserStack) we'll put it into the basic CI and push 12 into full.

## Changeset

New pipeline steps for Android 13 Beta.

## Testing

Covered by a Full CI run.