### PR TITLE
Offset `frameAddress` by the map base offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fixed the offset of `frameAddress` in native crashes
+  [#1737](https://github.com/bugsnag/bugsnag-android/pull/1737)
+
 ## 5.26.0 (2022-08-18)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
@@ -144,7 +144,8 @@ ssize_t bsg_unwind_crash_stack(bugsnag_stackframe stack[BUGSNAG_FRAMES_MAX],
   int frame_count = 0;
   for (auto &frame : crash_time_unwinder->frames()) {
     auto &dst_frame = stack[frame_count];
-    dst_frame.frame_address = frame.pc;
+    dst_frame.frame_address =
+        frame.pc + (frame.map_exact_offset - frame.map_elf_start_offset);
     dst_frame.line_number = frame.rel_pc;
     dst_frame.load_address = frame.map_start;
     dst_frame.symbol_address = frame.pc - frame.function_offset;
@@ -181,7 +182,8 @@ bsg_unwind_concurrent_stack(bugsnag_stackframe stack[BUGSNAG_FRAMES_MAX],
   int frame_count = 0;
   for (auto &frame : frames) {
     bugsnag_stackframe &dst_frame = stack[frame_count];
-    dst_frame.frame_address = frame.pc;
+    dst_frame.frame_address = frame.pc + (frame.map_info->offset() -
+                                          frame.map_info->elf_start_offset());
     if (frame.map_info != nullptr) {
       dst_frame.line_number = frame.rel_pc;
       dst_frame.load_address = frame.map_info->start();

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -180,6 +180,12 @@ Then("the error payload contains a completed unhandled native report") do
       Maze.check.not_nil(frame['symbolAddress'], "The symbolAddress of frame #{index} is nil")
       Maze.check.not_nil(frame['frameAddress'], "The frameAddress of frame #{index} is nil")
       Maze.check.not_nil(frame['loadAddress'], "The loadAddress of frame #{index} is nil")
+
+      frameAddress = frame['frameAddress'].to_i(16)
+      loadAddress = frame['loadAddress'].to_i(16)
+      Maze.check.equal(frame['lineNumber'],
+                       frameAddress - loadAddress,
+                        "lineNumber does not match frameAddress - loadAddress at frame #{index}")
     end
 end
 


### PR DESCRIPTION
## Goal
Correct the `frameAddress` to take into account code mapped in with non-zero base offsets, or mapped in from an `apk` file (without extracting the `.so` file).

## Testing
Additional check in all native mazerunner tests to ensure that the expected contract is being followed.