### PR TITLE
Encode line numbers as hex strings instead of numbers

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import androidx.test.filters.SmallTest
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
 import com.bugsnag.android.BugsnagTestUtils.streamableToJsonArray
+import com.bugsnag.android.internal.JsonHelper
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -141,7 +142,8 @@ class ThreadStateTest {
 
             expectedTrace.forEachIndexed { index, element ->
                 val jsonObject = serialisedTrace.getJSONObject(index + traceOffset)
-                assertEquals(element.lineNumber, jsonObject.getInt("lineNumber"))
+                val expectedLineNumber = JsonHelper.ulongToHex(element.lineNumber.toLong())
+                assertEquals(expectedLineNumber, jsonObject.getString("lineNumber"))
             }
         }
     }
@@ -178,7 +180,8 @@ class ThreadStateTest {
 
             expectedTrace.forEachIndexed { index, element ->
                 val jsonObject = serialisedTrace.getJSONObject(index)
-                assertEquals(element.lineNumber, jsonObject.getInt("lineNumber"))
+                val expectedLineNumber = JsonHelper.ulongToHex(element.lineNumber.toLong())
+                assertEquals(expectedLineNumber, jsonObject.getString("lineNumber"))
             }
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
@@ -123,7 +123,7 @@ class Stackframe : JsonStream.Streamable {
         writer.beginObject()
         writer.name("method").value(method)
         writer.name("file").value(file)
-        writer.name("lineNumber").value(lineNumber)
+        writer.name("lineNumber").value(lineNumber?.let { JsonHelper.ulongToHex(it.toLong()) })
 
         inProject?.let { writer.name("inProject").value(it) }
 

--- a/bugsnag-android-core/src/test/resources/error_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/error_serialization_1.json
@@ -6,7 +6,7 @@
     {
       "method": "foo()",
       "file": "Bar.kt",
-      "lineNumber": 55,
+      "lineNumber": "0x37",
       "inProject": true,
       "columnNumber": 99,
       "code": {

--- a/bugsnag-android-core/src/test/resources/error_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/error_serialization_2.json
@@ -6,13 +6,13 @@
     {
       "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.inProject",
       "file": "StacktraceSerializationTest.kt",
-      "lineNumber": 47,
+      "lineNumber": "0x2f",
       "inProject": true
     },
     {
       "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
       "file": "StacktraceSerializationTest.kt",
-      "lineNumber": 31,
+      "lineNumber": "0x1f",
       "inProject": true
     }
   ]

--- a/bugsnag-android-core/src/test/resources/stackframe_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/stackframe_serialization_0.json
@@ -1,7 +1,7 @@
 {
   "method": "foo",
   "file": "Bar",
-  "lineNumber": 55,
+  "lineNumber": "0x37",
   "inProject": true,
   "type": "android"
 }

--- a/bugsnag-android-core/src/test/resources/stackframe_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/stackframe_serialization_1.json
@@ -1,7 +1,7 @@
 {
   "method": "aMethod",
   "file": "aFile",
-  "lineNumber": 1,
+  "lineNumber": "0x1",
   "frameAddress": "0x2",
   "symbolAddress": "0x3",
   "loadAddress": "0x4",

--- a/bugsnag-android-core/src/test/resources/stackframe_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/stackframe_serialization_2.json
@@ -1,5 +1,5 @@
 {
   "method": "aMethod",
   "file": "aFile",
-  "lineNumber": 1
+  "lineNumber": "0x1"
 }

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_1.json
@@ -2,7 +2,7 @@
   {
     "method": "foo()",
     "file": "Bar.kt",
-    "lineNumber": 55,
+    "lineNumber": "0x37",
     "inProject": true,
     "columnNumber": 99,
     "code": {

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_2.json
@@ -2,11 +2,11 @@
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.basic",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": 41
+    "lineNumber": "0x29"
   },
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": 28
+    "lineNumber": "0x1c"
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_3.json
@@ -2,13 +2,13 @@
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.inProject",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": 47,
+    "lineNumber": "0x2f",
     "inProject": true
   },
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": 31,
+    "lineNumber": "0x1f",
     "inProject": true
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_4.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_4.json
@@ -2,1001 +2,1001 @@
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 0
+    "lineNumber": "0x0"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 1
+    "lineNumber": "0x1"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 2
+    "lineNumber": "0x2"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 3
+    "lineNumber": "0x3"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 4
+    "lineNumber": "0x4"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 5
+    "lineNumber": "0x5"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 6
+    "lineNumber": "0x6"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 7
+    "lineNumber": "0x7"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 8
+    "lineNumber": "0x8"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 9
+    "lineNumber": "0x9"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 10
+    "lineNumber": "0xa"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 11
+    "lineNumber": "0xb"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 12
+    "lineNumber": "0xc"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 13
+    "lineNumber": "0xd"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 14
+    "lineNumber": "0xe"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 15
+    "lineNumber": "0xf"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 16
+    "lineNumber": "0x10"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 17
+    "lineNumber": "0x11"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 18
+    "lineNumber": "0x12"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 19
+    "lineNumber": "0x13"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 20
+    "lineNumber": "0x14"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 21
+    "lineNumber": "0x15"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 22
+    "lineNumber": "0x16"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 23
+    "lineNumber": "0x17"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 24
+    "lineNumber": "0x18"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 25
+    "lineNumber": "0x19"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 26
+    "lineNumber": "0x1a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 27
+    "lineNumber": "0x1b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 28
+    "lineNumber": "0x1c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 29
+    "lineNumber": "0x1d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 30
+    "lineNumber": "0x1e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 31
+    "lineNumber": "0x1f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 32
+    "lineNumber": "0x20"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 33
+    "lineNumber": "0x21"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 34
+    "lineNumber": "0x22"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 35
+    "lineNumber": "0x23"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 36
+    "lineNumber": "0x24"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 37
+    "lineNumber": "0x25"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 38
+    "lineNumber": "0x26"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 39
+    "lineNumber": "0x27"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 40
+    "lineNumber": "0x28"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 41
+    "lineNumber": "0x29"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 42
+    "lineNumber": "0x2a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 43
+    "lineNumber": "0x2b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 44
+    "lineNumber": "0x2c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 45
+    "lineNumber": "0x2d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 46
+    "lineNumber": "0x2e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 47
+    "lineNumber": "0x2f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 48
+    "lineNumber": "0x30"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 49
+    "lineNumber": "0x31"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 50
+    "lineNumber": "0x32"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 51
+    "lineNumber": "0x33"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 52
+    "lineNumber": "0x34"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 53
+    "lineNumber": "0x35"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 54
+    "lineNumber": "0x36"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 55
+    "lineNumber": "0x37"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 56
+    "lineNumber": "0x38"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 57
+    "lineNumber": "0x39"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 58
+    "lineNumber": "0x3a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 59
+    "lineNumber": "0x3b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 60
+    "lineNumber": "0x3c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 61
+    "lineNumber": "0x3d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 62
+    "lineNumber": "0x3e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 63
+    "lineNumber": "0x3f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 64
+    "lineNumber": "0x40"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 65
+    "lineNumber": "0x41"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 66
+    "lineNumber": "0x42"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 67
+    "lineNumber": "0x43"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 68
+    "lineNumber": "0x44"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 69
+    "lineNumber": "0x45"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 70
+    "lineNumber": "0x46"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 71
+    "lineNumber": "0x47"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 72
+    "lineNumber": "0x48"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 73
+    "lineNumber": "0x49"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 74
+    "lineNumber": "0x4a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 75
+    "lineNumber": "0x4b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 76
+    "lineNumber": "0x4c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 77
+    "lineNumber": "0x4d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 78
+    "lineNumber": "0x4e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 79
+    "lineNumber": "0x4f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 80
+    "lineNumber": "0x50"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 81
+    "lineNumber": "0x51"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 82
+    "lineNumber": "0x52"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 83
+    "lineNumber": "0x53"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 84
+    "lineNumber": "0x54"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 85
+    "lineNumber": "0x55"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 86
+    "lineNumber": "0x56"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 87
+    "lineNumber": "0x57"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 88
+    "lineNumber": "0x58"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 89
+    "lineNumber": "0x59"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 90
+    "lineNumber": "0x5a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 91
+    "lineNumber": "0x5b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 92
+    "lineNumber": "0x5c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 93
+    "lineNumber": "0x5d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 94
+    "lineNumber": "0x5e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 95
+    "lineNumber": "0x5f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 96
+    "lineNumber": "0x60"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 97
+    "lineNumber": "0x61"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 98
+    "lineNumber": "0x62"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 99
+    "lineNumber": "0x63"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 100
+    "lineNumber": "0x64"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 101
+    "lineNumber": "0x65"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 102
+    "lineNumber": "0x66"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 103
+    "lineNumber": "0x67"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 104
+    "lineNumber": "0x68"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 105
+    "lineNumber": "0x69"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 106
+    "lineNumber": "0x6a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 107
+    "lineNumber": "0x6b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 108
+    "lineNumber": "0x6c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 109
+    "lineNumber": "0x6d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 110
+    "lineNumber": "0x6e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 111
+    "lineNumber": "0x6f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 112
+    "lineNumber": "0x70"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 113
+    "lineNumber": "0x71"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 114
+    "lineNumber": "0x72"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 115
+    "lineNumber": "0x73"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 116
+    "lineNumber": "0x74"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 117
+    "lineNumber": "0x75"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 118
+    "lineNumber": "0x76"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 119
+    "lineNumber": "0x77"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 120
+    "lineNumber": "0x78"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 121
+    "lineNumber": "0x79"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 122
+    "lineNumber": "0x7a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 123
+    "lineNumber": "0x7b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 124
+    "lineNumber": "0x7c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 125
+    "lineNumber": "0x7d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 126
+    "lineNumber": "0x7e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 127
+    "lineNumber": "0x7f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 128
+    "lineNumber": "0x80"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 129
+    "lineNumber": "0x81"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 130
+    "lineNumber": "0x82"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 131
+    "lineNumber": "0x83"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 132
+    "lineNumber": "0x84"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 133
+    "lineNumber": "0x85"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 134
+    "lineNumber": "0x86"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 135
+    "lineNumber": "0x87"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 136
+    "lineNumber": "0x88"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 137
+    "lineNumber": "0x89"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 138
+    "lineNumber": "0x8a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 139
+    "lineNumber": "0x8b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 140
+    "lineNumber": "0x8c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 141
+    "lineNumber": "0x8d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 142
+    "lineNumber": "0x8e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 143
+    "lineNumber": "0x8f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 144
+    "lineNumber": "0x90"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 145
+    "lineNumber": "0x91"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 146
+    "lineNumber": "0x92"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 147
+    "lineNumber": "0x93"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 148
+    "lineNumber": "0x94"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 149
+    "lineNumber": "0x95"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 150
+    "lineNumber": "0x96"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 151
+    "lineNumber": "0x97"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 152
+    "lineNumber": "0x98"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 153
+    "lineNumber": "0x99"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 154
+    "lineNumber": "0x9a"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 155
+    "lineNumber": "0x9b"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 156
+    "lineNumber": "0x9c"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 157
+    "lineNumber": "0x9d"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 158
+    "lineNumber": "0x9e"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 159
+    "lineNumber": "0x9f"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 160
+    "lineNumber": "0xa0"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 161
+    "lineNumber": "0xa1"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 162
+    "lineNumber": "0xa2"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 163
+    "lineNumber": "0xa3"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 164
+    "lineNumber": "0xa4"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 165
+    "lineNumber": "0xa5"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 166
+    "lineNumber": "0xa6"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 167
+    "lineNumber": "0xa7"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 168
+    "lineNumber": "0xa8"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 169
+    "lineNumber": "0xa9"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 170
+    "lineNumber": "0xaa"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 171
+    "lineNumber": "0xab"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 172
+    "lineNumber": "0xac"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 173
+    "lineNumber": "0xad"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 174
+    "lineNumber": "0xae"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 175
+    "lineNumber": "0xaf"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 176
+    "lineNumber": "0xb0"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 177
+    "lineNumber": "0xb1"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 178
+    "lineNumber": "0xb2"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 179
+    "lineNumber": "0xb3"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 180
+    "lineNumber": "0xb4"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 181
+    "lineNumber": "0xb5"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 182
+    "lineNumber": "0xb6"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 183
+    "lineNumber": "0xb7"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 184
+    "lineNumber": "0xb8"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 185
+    "lineNumber": "0xb9"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 186
+    "lineNumber": "0xba"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 187
+    "lineNumber": "0xbb"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 188
+    "lineNumber": "0xbc"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 189
+    "lineNumber": "0xbd"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 190
+    "lineNumber": "0xbe"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 191
+    "lineNumber": "0xbf"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 192
+    "lineNumber": "0xc0"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 193
+    "lineNumber": "0xc1"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 194
+    "lineNumber": "0xc2"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 195
+    "lineNumber": "0xc3"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 196
+    "lineNumber": "0xc4"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 197
+    "lineNumber": "0xc5"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 198
+    "lineNumber": "0xc6"
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": 199
+    "lineNumber": "0xc7"
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_5.json
@@ -2,1400 +2,1400 @@
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 0,
+    "lineNumber": "0x0",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 1,
+    "lineNumber": "0x1",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 2,
+    "lineNumber": "0x2",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 3,
+    "lineNumber": "0x3",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 4,
+    "lineNumber": "0x4",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 5,
+    "lineNumber": "0x5",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 6,
+    "lineNumber": "0x6",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 7,
+    "lineNumber": "0x7",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 8,
+    "lineNumber": "0x8",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 9,
+    "lineNumber": "0x9",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 10,
+    "lineNumber": "0xa",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 11,
+    "lineNumber": "0xb",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 12,
+    "lineNumber": "0xc",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 13,
+    "lineNumber": "0xd",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 14,
+    "lineNumber": "0xe",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 15,
+    "lineNumber": "0xf",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 16,
+    "lineNumber": "0x10",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 17,
+    "lineNumber": "0x11",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 18,
+    "lineNumber": "0x12",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 19,
+    "lineNumber": "0x13",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 20,
+    "lineNumber": "0x14",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 21,
+    "lineNumber": "0x15",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 22,
+    "lineNumber": "0x16",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 23,
+    "lineNumber": "0x17",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 24,
+    "lineNumber": "0x18",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 25,
+    "lineNumber": "0x19",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 26,
+    "lineNumber": "0x1a",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 27,
+    "lineNumber": "0x1b",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 28,
+    "lineNumber": "0x1c",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 29,
+    "lineNumber": "0x1d",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 30,
+    "lineNumber": "0x1e",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 31,
+    "lineNumber": "0x1f",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 32,
+    "lineNumber": "0x20",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 33,
+    "lineNumber": "0x21",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 34,
+    "lineNumber": "0x22",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 35,
+    "lineNumber": "0x23",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 36,
+    "lineNumber": "0x24",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 37,
+    "lineNumber": "0x25",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 38,
+    "lineNumber": "0x26",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 39,
+    "lineNumber": "0x27",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 40,
+    "lineNumber": "0x28",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 41,
+    "lineNumber": "0x29",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 42,
+    "lineNumber": "0x2a",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 43,
+    "lineNumber": "0x2b",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 44,
+    "lineNumber": "0x2c",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 45,
+    "lineNumber": "0x2d",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 46,
+    "lineNumber": "0x2e",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 47,
+    "lineNumber": "0x2f",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 48,
+    "lineNumber": "0x30",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 49,
+    "lineNumber": "0x31",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 50,
+    "lineNumber": "0x32",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 51,
+    "lineNumber": "0x33",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 52,
+    "lineNumber": "0x34",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 53,
+    "lineNumber": "0x35",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 54,
+    "lineNumber": "0x36",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 55,
+    "lineNumber": "0x37",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 56,
+    "lineNumber": "0x38",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 57,
+    "lineNumber": "0x39",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 58,
+    "lineNumber": "0x3a",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 59,
+    "lineNumber": "0x3b",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 60,
+    "lineNumber": "0x3c",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 61,
+    "lineNumber": "0x3d",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 62,
+    "lineNumber": "0x3e",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 63,
+    "lineNumber": "0x3f",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 64,
+    "lineNumber": "0x40",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 65,
+    "lineNumber": "0x41",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 66,
+    "lineNumber": "0x42",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 67,
+    "lineNumber": "0x43",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 68,
+    "lineNumber": "0x44",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 69,
+    "lineNumber": "0x45",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 70,
+    "lineNumber": "0x46",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 71,
+    "lineNumber": "0x47",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 72,
+    "lineNumber": "0x48",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 73,
+    "lineNumber": "0x49",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 74,
+    "lineNumber": "0x4a",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 75,
+    "lineNumber": "0x4b",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 76,
+    "lineNumber": "0x4c",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 77,
+    "lineNumber": "0x4d",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 78,
+    "lineNumber": "0x4e",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 79,
+    "lineNumber": "0x4f",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 80,
+    "lineNumber": "0x50",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 81,
+    "lineNumber": "0x51",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 82,
+    "lineNumber": "0x52",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 83,
+    "lineNumber": "0x53",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 84,
+    "lineNumber": "0x54",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 85,
+    "lineNumber": "0x55",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 86,
+    "lineNumber": "0x56",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 87,
+    "lineNumber": "0x57",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 88,
+    "lineNumber": "0x58",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 89,
+    "lineNumber": "0x59",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 90,
+    "lineNumber": "0x5a",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 91,
+    "lineNumber": "0x5b",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 92,
+    "lineNumber": "0x5c",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 93,
+    "lineNumber": "0x5d",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 94,
+    "lineNumber": "0x5e",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 95,
+    "lineNumber": "0x5f",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 96,
+    "lineNumber": "0x60",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 97,
+    "lineNumber": "0x61",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 98,
+    "lineNumber": "0x62",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 99,
+    "lineNumber": "0x63",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 100,
+    "lineNumber": "0x64",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 101,
+    "lineNumber": "0x65",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 102,
+    "lineNumber": "0x66",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 103,
+    "lineNumber": "0x67",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 104,
+    "lineNumber": "0x68",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 105,
+    "lineNumber": "0x69",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 106,
+    "lineNumber": "0x6a",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 107,
+    "lineNumber": "0x6b",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 108,
+    "lineNumber": "0x6c",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 109,
+    "lineNumber": "0x6d",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 110,
+    "lineNumber": "0x6e",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 111,
+    "lineNumber": "0x6f",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 112,
+    "lineNumber": "0x70",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 113,
+    "lineNumber": "0x71",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 114,
+    "lineNumber": "0x72",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 115,
+    "lineNumber": "0x73",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 116,
+    "lineNumber": "0x74",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 117,
+    "lineNumber": "0x75",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 118,
+    "lineNumber": "0x76",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 119,
+    "lineNumber": "0x77",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 120,
+    "lineNumber": "0x78",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 121,
+    "lineNumber": "0x79",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 122,
+    "lineNumber": "0x7a",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 123,
+    "lineNumber": "0x7b",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 124,
+    "lineNumber": "0x7c",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 125,
+    "lineNumber": "0x7d",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 126,
+    "lineNumber": "0x7e",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 127,
+    "lineNumber": "0x7f",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 128,
+    "lineNumber": "0x80",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 129,
+    "lineNumber": "0x81",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 130,
+    "lineNumber": "0x82",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 131,
+    "lineNumber": "0x83",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 132,
+    "lineNumber": "0x84",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 133,
+    "lineNumber": "0x85",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 134,
+    "lineNumber": "0x86",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 135,
+    "lineNumber": "0x87",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 136,
+    "lineNumber": "0x88",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 137,
+    "lineNumber": "0x89",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 138,
+    "lineNumber": "0x8a",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 139,
+    "lineNumber": "0x8b",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 140,
+    "lineNumber": "0x8c",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 141,
+    "lineNumber": "0x8d",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 142,
+    "lineNumber": "0x8e",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 143,
+    "lineNumber": "0x8f",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 144,
+    "lineNumber": "0x90",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 145,
+    "lineNumber": "0x91",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 146,
+    "lineNumber": "0x92",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 147,
+    "lineNumber": "0x93",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 148,
+    "lineNumber": "0x94",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 149,
+    "lineNumber": "0x95",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 150,
+    "lineNumber": "0x96",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 151,
+    "lineNumber": "0x97",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 152,
+    "lineNumber": "0x98",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 153,
+    "lineNumber": "0x99",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 154,
+    "lineNumber": "0x9a",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 155,
+    "lineNumber": "0x9b",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 156,
+    "lineNumber": "0x9c",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 157,
+    "lineNumber": "0x9d",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 158,
+    "lineNumber": "0x9e",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 159,
+    "lineNumber": "0x9f",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 160,
+    "lineNumber": "0xa0",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 161,
+    "lineNumber": "0xa1",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 162,
+    "lineNumber": "0xa2",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 163,
+    "lineNumber": "0xa3",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 164,
+    "lineNumber": "0xa4",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 165,
+    "lineNumber": "0xa5",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 166,
+    "lineNumber": "0xa6",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 167,
+    "lineNumber": "0xa7",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 168,
+    "lineNumber": "0xa8",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 169,
+    "lineNumber": "0xa9",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 170,
+    "lineNumber": "0xaa",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 171,
+    "lineNumber": "0xab",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 172,
+    "lineNumber": "0xac",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 173,
+    "lineNumber": "0xad",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 174,
+    "lineNumber": "0xae",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 175,
+    "lineNumber": "0xaf",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 176,
+    "lineNumber": "0xb0",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 177,
+    "lineNumber": "0xb1",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 178,
+    "lineNumber": "0xb2",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 179,
+    "lineNumber": "0xb3",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 180,
+    "lineNumber": "0xb4",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 181,
+    "lineNumber": "0xb5",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 182,
+    "lineNumber": "0xb6",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 183,
+    "lineNumber": "0xb7",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 184,
+    "lineNumber": "0xb8",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 185,
+    "lineNumber": "0xb9",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 186,
+    "lineNumber": "0xba",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 187,
+    "lineNumber": "0xbb",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 188,
+    "lineNumber": "0xbc",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 189,
+    "lineNumber": "0xbd",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 190,
+    "lineNumber": "0xbe",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 191,
+    "lineNumber": "0xbf",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 192,
+    "lineNumber": "0xc0",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 193,
+    "lineNumber": "0xc1",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 194,
+    "lineNumber": "0xc2",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 195,
+    "lineNumber": "0xc3",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 196,
+    "lineNumber": "0xc4",
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 197,
+    "lineNumber": "0xc5",
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 198,
+    "lineNumber": "0xc6",
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": 199,
+    "lineNumber": "0xc7",
     "inProject": true,
     "type": "android"
   }

--- a/bugsnag-android-core/src/test/resources/thread_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_0.json
@@ -7,17 +7,17 @@
     {
       "method": "run_func",
       "file": "librunner.so",
-      "lineNumber": 5038
+      "lineNumber": "0x13ae"
     },
     {
       "method": "Runner.runFunc",
       "file": "Runner.java",
-      "lineNumber": 14
+      "lineNumber": "0xe"
     },
     {
       "method": "App.launch",
       "file": "App.java",
-      "lineNumber": 70
+      "lineNumber": "0x46"
     }
   ],
   "errorReportingThread": true

--- a/bugsnag-android-core/src/test/resources/thread_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_1.json
@@ -7,17 +7,17 @@
     {
       "method": "run_func",
       "file": "librunner.so",
-      "lineNumber": 5038
+      "lineNumber": "0x13ae"
     },
     {
       "method": "Runner.runFunc",
       "file": "Runner.java",
-      "lineNumber": 14
+      "lineNumber": "0xe"
     },
     {
       "method": "App.launch",
       "file": "App.java",
-      "lineNumber": 70
+      "lineNumber": "0x46"
     }
   ]
 }

--- a/bugsnag-android-core/src/test/resources/thread_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_2.json
@@ -7,17 +7,17 @@
     {
       "method": "run_func",
       "file": "librunner.so",
-      "lineNumber": 5038
+      "lineNumber": "0x13ae"
     },
     {
       "method": "Runner.runFunc",
       "file": "Runner.java",
-      "lineNumber": 14
+      "lineNumber": "0xe"
     },
     {
       "method": "App.launch",
       "file": "App.java",
-      "lineNumber": 70
+      "lineNumber": "0x46"
     }
   ],
   "errorReportingThread": true

--- a/bugsnag-android-core/src/test/resources/thread_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_3.json
@@ -7,17 +7,17 @@
     {
       "method": "run_func",
       "file": "librunner.so",
-      "lineNumber": 5038
+      "lineNumber": "0x13ae"
     },
     {
       "method": "Runner.runFunc",
       "file": "Runner.java",
-      "lineNumber": 14
+      "lineNumber": "0xe"
     },
     {
       "method": "App.launch",
       "file": "App.java",
-      "lineNumber": 70
+      "lineNumber": "0x46"
     }
   ]
 }

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV10Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV10Tests.kt
@@ -136,7 +136,7 @@ class EventMigrationV10Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0xfffffffe",
-                            "lineNumber" to 4194967233L,
+                            "lineNumber" to "0xfa0a1ec1",
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -145,7 +145,7 @@ class EventMigrationV10Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0xb37a644b",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0xb37a644b" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV11Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV11Tests.kt
@@ -136,7 +136,7 @@ class EventMigrationV11Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0xfffffffe",
-                            "lineNumber" to 4194967233L,
+                            "lineNumber" to "0xfa0a1ec1",
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -145,7 +145,7 @@ class EventMigrationV11Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0xb37a644b",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0xb37a644b" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV4Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV4Tests.kt
@@ -119,7 +119,7 @@ class EventMigrationV4Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0x6eeeb",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -128,7 +128,7 @@ class EventMigrationV4Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0x5393e",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0x5393e" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV5Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV5Tests.kt
@@ -120,7 +120,7 @@ class EventMigrationV5Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0x6eeeb",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -129,7 +129,7 @@ class EventMigrationV5Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0x5393e",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0x5393e" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV6Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV6Tests.kt
@@ -119,7 +119,7 @@ class EventMigrationV6Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0x6eeeb",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -128,7 +128,7 @@ class EventMigrationV6Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0x5393e",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0x5393e" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV7Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV7Tests.kt
@@ -119,7 +119,7 @@ class EventMigrationV7Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0x6eeeb",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -128,7 +128,7 @@ class EventMigrationV7Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0x5393e",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0x5393e" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV8Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV8Tests.kt
@@ -136,7 +136,7 @@ class EventMigrationV8Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0xfffffffe",
-                            "lineNumber" to 4194967233L,
+                            "lineNumber" to "0xfa0a1ec1",
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -145,7 +145,7 @@ class EventMigrationV8Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0xb37a644b",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0xb37a644b" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV9Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV9Tests.kt
@@ -136,7 +136,7 @@ class EventMigrationV9Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0xfffffffe",
-                            "lineNumber" to 4194967233L,
+                            "lineNumber" to "0xfa0a1ec1",
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -145,7 +145,7 @@ class EventMigrationV9Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0xb37a644b",
-                            "lineNumber" to 0L,
+                            "lineNumber" to "0x0",
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0xb37a644b" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/exception_serialization.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/exception_serialization.json
@@ -1,1 +1,1 @@
-{"stacktrace":[{"frameAddress":"0x20000000","symbolAddress":"0x16000000","loadAddress":"0x12000000","lineNumber":52,"isPC":true,"file":"foo.c","method":"bar()"}],"errorClass":"signal","message":"whoops something went wrong","type":"c"}
+{"stacktrace":[{"frameAddress":"0x20000000","symbolAddress":"0x16000000","loadAddress":"0x12000000","lineNumber":"0x34","isPC":true,"file":"foo.c","method":"bar()"}],"errorClass":"signal","message":"whoops something went wrong","type":"c"}

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/stackframe_serialization.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/stackframe_serialization.json
@@ -1,1 +1,1 @@
-[{"frameAddress":"0x20000000","symbolAddress":"0x16000000","loadAddress":"0x12000000","lineNumber":52,"file":"foo.c","method":"bar()"}]
+[{"frameAddress":"0x20000000","symbolAddress":"0x16000000","loadAddress":"0x12000000","lineNumber":"0x34","file":"foo.c","method":"bar()"}]

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/json_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/json_writer.c
@@ -261,7 +261,7 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
   set_hex_number(frame, "frameAddress", (*stackframe).frame_address);
   set_hex_number(frame, "symbolAddress", (*stackframe).symbol_address);
   set_hex_number(frame, "loadAddress", (*stackframe).load_address);
-  json_object_set_number(frame, "lineNumber", (*stackframe).line_number);
+  set_hex_number(frame, "lineNumber", (*stackframe).line_number);
   if (is_pc) {
     // only necessary to set to true, false is the default value and omitting
     // the field keeps payload sizes smaller.

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -154,6 +154,6 @@ Feature: Native crash reporting
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the "method" of stack frame 0 equals "0x0"
-    And the "lineNumber" of stack frame 0 equals 0
+    And the "lineNumber" of stack frame 0 equals "0x0"
     And the first significant stack frames match:
       | dispatch::Handler::handle(_jobject*) | CXXCallNullFunctionPointerScenario.cpp | 9 |

--- a/features/smoke_tests/02_handled.feature
+++ b/features/smoke_tests/02_handled.feature
@@ -23,7 +23,7 @@ Feature: Handled smoke tests
     And the event "exceptions.0.stacktrace.0.method" ends with "HandledJavaSmokeScenario.startScenario"
     And the exception "stacktrace.0.file" equals "HandledJavaSmokeScenario.java"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 8
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals "0x8"
     And the event "exceptions.0.stacktrace.0.inProject" is true
     And the error payload field "events.0.projectPackages" is a non-empty array
     And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"
@@ -134,7 +134,7 @@ Feature: Handled smoke tests
     And the event "exceptions.0.stacktrace.0.method" ends with "generateException"
     And the exception "stacktrace.0.file" equals "Scenario.kt"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 1
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals "0x1"
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     # Overwritten App data

--- a/features/smoke_tests/04_unhandled.feature
+++ b/features/smoke_tests/04_unhandled.feature
@@ -26,7 +26,7 @@ Feature: Unhandled smoke tests
     And the event "exceptions.0.stacktrace.0.method" ends with "UnhandledJavaLoadedConfigScenario.startScenario"
     And the exception "stacktrace.0.file" equals "UnhandledJavaLoadedConfigScenario.java"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 7
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals "0x7"
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     And the thread with name "main" contains the error reporting flag

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -183,7 +183,7 @@ Then("the error payload contains a completed unhandled native report") do
 
       frameAddress = frame['frameAddress'].to_i(16)
       loadAddress = frame['loadAddress'].to_i(16)
-      Maze.check.equal(frame['lineNumber'],
+      Maze.check.equal(frame['lineNumber'].to_i(16),
                        frameAddress - loadAddress,
                         "lineNumber does not match frameAddress - loadAddress at frame #{index}")
     end

--- a/features/steps/symbol_steps.rb
+++ b/features/steps/symbol_steps.rb
@@ -88,7 +88,7 @@ def demangle symbol
 end
 
 def lookup_address binary, address
-  info = `addr2line --exe '#{binary}' --inlines --basenames --functions --demangle 0x#{address.to_s(16)}`.chomp
+  info = `addr2line --exe '#{binary}' --inlines --basenames --functions --demangle #{address}`.chomp
   return nil if info.start_with? '??' # failed to resolve
   # can return multiple if there are inlined frames
   frames = info.split("\n").each_slice(2).map do |function_name, location|


### PR DESCRIPTION
## Goal
Avoid potential overflow issues when storing addresses in the `lineNumber` property by encoding them as hex strings. When native crashes occur we store the relative PC in the `lineNumber` property, which may be larger than a JSON number can hold.

## Design
Encode all `lineNumber` values as hex strings instead of raw JSON numbers. These are automatically decoded again on the server-side and still present as decimal numbers in the dashboard.

## Testing
Altered all of the existing test fixtures that check line-numbers to use the hex-encoded string syntax