### PR TITLE
Set NDK lineNumber == frameAddress - loadAddress

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
@@ -144,8 +144,7 @@ ssize_t bsg_unwind_crash_stack(bugsnag_stackframe stack[BUGSNAG_FRAMES_MAX],
   int frame_count = 0;
   for (auto &frame : crash_time_unwinder->frames()) {
     auto &dst_frame = stack[frame_count];
-    dst_frame.frame_address =
-        frame.pc + (frame.map_exact_offset - frame.map_elf_start_offset);
+    dst_frame.frame_address = frame.map_start + frame.rel_pc;
     dst_frame.line_number = frame.rel_pc;
     dst_frame.load_address = frame.map_start;
     dst_frame.symbol_address = frame.pc - frame.function_offset;
@@ -182,9 +181,11 @@ bsg_unwind_concurrent_stack(bugsnag_stackframe stack[BUGSNAG_FRAMES_MAX],
   int frame_count = 0;
   for (auto &frame : frames) {
     bugsnag_stackframe &dst_frame = stack[frame_count];
-    dst_frame.frame_address = frame.pc + (frame.map_info->offset() -
-                                          frame.map_info->elf_start_offset());
+    dst_frame.frame_address = frame.pc;
     if (frame.map_info != nullptr) {
+      // if we have valid map info we overwrite the frame_address so that
+      // lineNumber == frameAddress - loadAddress
+      dst_frame.frame_address = frame.map_info->start() + frame.rel_pc;
       dst_frame.line_number = frame.rel_pc;
       dst_frame.load_address = frame.map_info->start();
       dst_frame.symbol_address = frame.pc - frame.map_info->offset();


### PR DESCRIPTION
## Goal
Ensure that the NDK line numbers, frame address and load address always line-up as expected by symbolication.

## Design
Set the `frameAddress` according to the expectations in symbolication to avoid the subtle differences that appear from platform-to-platform.

## Testing
Relied on the new end-to-end tests which enforce the `lineNumber == frameAddress - loadAddress` contract of all NDK reports.