### PR TITLE
OkHttp Plugin - Allow filtering sensitive query params

### DIFF
--- a/bugsnag-plugin-android-okhttp/src/main/java/com/bugsnag/android/okhttp/BugsnagOkHttpPlugin.kt
+++ b/bugsnag-plugin-android-okhttp/src/main/java/com/bugsnag/android/okhttp/BugsnagOkHttpPlugin.kt
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentHashMap
  * https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/#the-response-body-must-be-closed
  */
 class BugsnagOkHttpPlugin @JvmOverloads constructor(
+    val sensitiveQueryParamList: List<String> = emptyList(),
     internal val timeProvider: () -> Long = { System.currentTimeMillis() }
 ) : Plugin, EventListener() {
 
@@ -112,10 +113,12 @@ class BugsnagOkHttpPlugin @JvmOverloads constructor(
         val params = mutableMapOf<String, Any?>()
 
         url.queryParameterNames.forEach { name ->
-            val values = url.queryParameterValues(name)
-            when (values.size) {
-                1 -> params[name] = values.first()
-                else -> params[name] = url.queryParameterValues(name)
+            if (name !in sensitiveQueryParamList) {
+                val values = url.queryParameterValues(name)
+                when (values.size) {
+                    1 -> params[name] = values.first()
+                    else -> params[name] = url.queryParameterValues(name)
+                }
             }
         }
         return params

--- a/bugsnag-plugin-android-okhttp/src/main/java/com/bugsnag/android/okhttp/BugsnagOkHttpPlugin.kt
+++ b/bugsnag-plugin-android-okhttp/src/main/java/com/bugsnag/android/okhttp/BugsnagOkHttpPlugin.kt
@@ -23,6 +23,8 @@ import java.util.concurrent.ConcurrentHashMap
  * You *must* close the [Response] body as documented by OkHttp. Failing to do so will leak the
  * OkHttp connection and prevent breadcrumbs from being collected. For further information, see:
  * https://square.github.io/okhttp/4.x/okhttp/okhttp3/-response-body/#the-response-body-must-be-closed
+ *
+ * @param sensitiveQueryParamList a list of sensitive query params that shouldn't be captured
  */
 class BugsnagOkHttpPlugin @JvmOverloads constructor(
     val sensitiveQueryParamList: List<String> = emptyList(),

--- a/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/BugsnagOkHttpPluginTest.kt
+++ b/bugsnag-plugin-android-okhttp/src/test/java/com/bugsnag/android/BugsnagOkHttpPluginTest.kt
@@ -108,11 +108,15 @@ class BugsnagOkHttpPluginTest {
      */
     @Test
     fun loadedClientCallEnd() {
-        val request = Request.Builder().url("https://example.com?debug=true").build()
+        val request = Request.Builder().url(
+            "https://example.com?debug=true&latitude=10.55&longitude=11.33"
+        ).build()
         `when`(call.request()).thenReturn(request)
 
         val duration = AtomicLong()
-        val plugin = BugsnagOkHttpPlugin { duration.incrementAndGet() }.apply {
+        val plugin = BugsnagOkHttpPlugin(
+            sensitiveQueryParamList = listOf("latitude", "longitude")
+        ) { duration.incrementAndGet() }.apply {
             load(client)
             callStart(call)
             callEnd(call)


### PR DESCRIPTION
## Goal

Allow filtering sensitive query params. Some of our requests contains sensitive information, such as latitude and longitude and we don't want Bugsnag to store that information.

## Design

I thought about receiving a function as constructor parameter, but that could harm the library behavior, so I opted to a more simple approach which is receiving a list os Strings and filtering the terms inside the Plugin. I think this approach makes it clear the intention of the new constructor parameter.

## Changeset

- BugsnagOkHttpPlugin
  - Receiving a new constructor parameter `sensitiveQueryParamList` to allow clients of bugsnag to tell the SDK which query param should be filtered.
  - Updated the `buildQueryParams` function to not add the query params that are in the `sensitiveQueryParamList` list.
## Testing

- BugsnagOkHttpPluginTest
  - Updated the `loadedClientCallEnd` test to guarantee the new logic.

I tried to run the tests locally, but I had a hard time configuring the CMake. Help registered here: https://github.com/bugsnag/bugsnag-android/issues/1741