### PR TITLE
Rollback hex line numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## TBD
-
-### Bug fixes
-
-* Fixed the offset of `frameAddress` in native crashes
-  [#1737](https://github.com/bugsnag/bugsnag-android/pull/1737)
-
 ## 5.26.0 (2022-08-18)
 
 ### Enhancements

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ThreadStateTest.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android
 import androidx.test.filters.SmallTest
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
 import com.bugsnag.android.BugsnagTestUtils.streamableToJsonArray
-import com.bugsnag.android.internal.JsonHelper
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
@@ -142,8 +141,7 @@ class ThreadStateTest {
 
             expectedTrace.forEachIndexed { index, element ->
                 val jsonObject = serialisedTrace.getJSONObject(index + traceOffset)
-                val expectedLineNumber = JsonHelper.ulongToHex(element.lineNumber.toLong())
-                assertEquals(expectedLineNumber, jsonObject.getString("lineNumber"))
+                assertEquals(element.lineNumber, jsonObject.getInt("lineNumber"))
             }
         }
     }
@@ -180,8 +178,7 @@ class ThreadStateTest {
 
             expectedTrace.forEachIndexed { index, element ->
                 val jsonObject = serialisedTrace.getJSONObject(index)
-                val expectedLineNumber = JsonHelper.ulongToHex(element.lineNumber.toLong())
-                assertEquals(expectedLineNumber, jsonObject.getString("lineNumber"))
+                assertEquals(element.lineNumber, jsonObject.getInt("lineNumber"))
             }
         }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stackframe.kt
@@ -123,7 +123,7 @@ class Stackframe : JsonStream.Streamable {
         writer.beginObject()
         writer.name("method").value(method)
         writer.name("file").value(file)
-        writer.name("lineNumber").value(lineNumber?.let { JsonHelper.ulongToHex(it.toLong()) })
+        writer.name("lineNumber").value(lineNumber)
 
         inProject?.let { writer.name("inProject").value(it) }
 

--- a/bugsnag-android-core/src/test/resources/error_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/error_serialization_1.json
@@ -6,7 +6,7 @@
     {
       "method": "foo()",
       "file": "Bar.kt",
-      "lineNumber": "0x37",
+      "lineNumber": 55,
       "inProject": true,
       "columnNumber": 99,
       "code": {

--- a/bugsnag-android-core/src/test/resources/error_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/error_serialization_2.json
@@ -6,13 +6,13 @@
     {
       "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.inProject",
       "file": "StacktraceSerializationTest.kt",
-      "lineNumber": "0x2f",
+      "lineNumber": 47,
       "inProject": true
     },
     {
       "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
       "file": "StacktraceSerializationTest.kt",
-      "lineNumber": "0x1f",
+      "lineNumber": 31,
       "inProject": true
     }
   ]

--- a/bugsnag-android-core/src/test/resources/stackframe_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/stackframe_serialization_0.json
@@ -1,7 +1,7 @@
 {
   "method": "foo",
   "file": "Bar",
-  "lineNumber": "0x37",
+  "lineNumber": 55,
   "inProject": true,
   "type": "android"
 }

--- a/bugsnag-android-core/src/test/resources/stackframe_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/stackframe_serialization_1.json
@@ -1,7 +1,7 @@
 {
   "method": "aMethod",
   "file": "aFile",
-  "lineNumber": "0x1",
+  "lineNumber": 1,
   "frameAddress": "0x2",
   "symbolAddress": "0x3",
   "loadAddress": "0x4",

--- a/bugsnag-android-core/src/test/resources/stackframe_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/stackframe_serialization_2.json
@@ -1,5 +1,5 @@
 {
   "method": "aMethod",
   "file": "aFile",
-  "lineNumber": "0x1"
+  "lineNumber": 1
 }

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_1.json
@@ -2,7 +2,7 @@
   {
     "method": "foo()",
     "file": "Bar.kt",
-    "lineNumber": "0x37",
+    "lineNumber": 55,
     "inProject": true,
     "columnNumber": 99,
     "code": {

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_2.json
@@ -2,11 +2,11 @@
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.basic",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": "0x29"
+    "lineNumber": 41
   },
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": "0x1c"
+    "lineNumber": 28
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_3.json
@@ -2,13 +2,13 @@
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.inProject",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": "0x2f",
+    "lineNumber": 47,
     "inProject": true
   },
   {
     "method": "com.bugsnag.android.StacktraceSerializationTest$Companion.testCases",
     "file": "StacktraceSerializationTest.kt",
-    "lineNumber": "0x1f",
+    "lineNumber": 31,
     "inProject": true
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_4.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_4.json
@@ -2,1001 +2,1001 @@
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x0"
+    "lineNumber": 0
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x1"
+    "lineNumber": 1
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x2"
+    "lineNumber": 2
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x3"
+    "lineNumber": 3
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x4"
+    "lineNumber": 4
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x5"
+    "lineNumber": 5
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x6"
+    "lineNumber": 6
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x7"
+    "lineNumber": 7
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x8"
+    "lineNumber": 8
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x9"
+    "lineNumber": 9
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa"
+    "lineNumber": 10
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb"
+    "lineNumber": 11
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc"
+    "lineNumber": 12
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xd"
+    "lineNumber": 13
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xe"
+    "lineNumber": 14
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xf"
+    "lineNumber": 15
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x10"
+    "lineNumber": 16
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x11"
+    "lineNumber": 17
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x12"
+    "lineNumber": 18
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x13"
+    "lineNumber": 19
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x14"
+    "lineNumber": 20
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x15"
+    "lineNumber": 21
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x16"
+    "lineNumber": 22
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x17"
+    "lineNumber": 23
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x18"
+    "lineNumber": 24
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x19"
+    "lineNumber": 25
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x1a"
+    "lineNumber": 26
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x1b"
+    "lineNumber": 27
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x1c"
+    "lineNumber": 28
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x1d"
+    "lineNumber": 29
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x1e"
+    "lineNumber": 30
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x1f"
+    "lineNumber": 31
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x20"
+    "lineNumber": 32
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x21"
+    "lineNumber": 33
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x22"
+    "lineNumber": 34
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x23"
+    "lineNumber": 35
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x24"
+    "lineNumber": 36
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x25"
+    "lineNumber": 37
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x26"
+    "lineNumber": 38
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x27"
+    "lineNumber": 39
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x28"
+    "lineNumber": 40
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x29"
+    "lineNumber": 41
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x2a"
+    "lineNumber": 42
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x2b"
+    "lineNumber": 43
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x2c"
+    "lineNumber": 44
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x2d"
+    "lineNumber": 45
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x2e"
+    "lineNumber": 46
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x2f"
+    "lineNumber": 47
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x30"
+    "lineNumber": 48
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x31"
+    "lineNumber": 49
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x32"
+    "lineNumber": 50
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x33"
+    "lineNumber": 51
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x34"
+    "lineNumber": 52
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x35"
+    "lineNumber": 53
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x36"
+    "lineNumber": 54
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x37"
+    "lineNumber": 55
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x38"
+    "lineNumber": 56
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x39"
+    "lineNumber": 57
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x3a"
+    "lineNumber": 58
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x3b"
+    "lineNumber": 59
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x3c"
+    "lineNumber": 60
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x3d"
+    "lineNumber": 61
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x3e"
+    "lineNumber": 62
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x3f"
+    "lineNumber": 63
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x40"
+    "lineNumber": 64
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x41"
+    "lineNumber": 65
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x42"
+    "lineNumber": 66
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x43"
+    "lineNumber": 67
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x44"
+    "lineNumber": 68
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x45"
+    "lineNumber": 69
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x46"
+    "lineNumber": 70
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x47"
+    "lineNumber": 71
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x48"
+    "lineNumber": 72
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x49"
+    "lineNumber": 73
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x4a"
+    "lineNumber": 74
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x4b"
+    "lineNumber": 75
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x4c"
+    "lineNumber": 76
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x4d"
+    "lineNumber": 77
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x4e"
+    "lineNumber": 78
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x4f"
+    "lineNumber": 79
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x50"
+    "lineNumber": 80
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x51"
+    "lineNumber": 81
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x52"
+    "lineNumber": 82
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x53"
+    "lineNumber": 83
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x54"
+    "lineNumber": 84
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x55"
+    "lineNumber": 85
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x56"
+    "lineNumber": 86
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x57"
+    "lineNumber": 87
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x58"
+    "lineNumber": 88
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x59"
+    "lineNumber": 89
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x5a"
+    "lineNumber": 90
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x5b"
+    "lineNumber": 91
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x5c"
+    "lineNumber": 92
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x5d"
+    "lineNumber": 93
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x5e"
+    "lineNumber": 94
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x5f"
+    "lineNumber": 95
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x60"
+    "lineNumber": 96
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x61"
+    "lineNumber": 97
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x62"
+    "lineNumber": 98
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x63"
+    "lineNumber": 99
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x64"
+    "lineNumber": 100
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x65"
+    "lineNumber": 101
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x66"
+    "lineNumber": 102
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x67"
+    "lineNumber": 103
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x68"
+    "lineNumber": 104
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x69"
+    "lineNumber": 105
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x6a"
+    "lineNumber": 106
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x6b"
+    "lineNumber": 107
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x6c"
+    "lineNumber": 108
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x6d"
+    "lineNumber": 109
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x6e"
+    "lineNumber": 110
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x6f"
+    "lineNumber": 111
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x70"
+    "lineNumber": 112
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x71"
+    "lineNumber": 113
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x72"
+    "lineNumber": 114
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x73"
+    "lineNumber": 115
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x74"
+    "lineNumber": 116
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x75"
+    "lineNumber": 117
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x76"
+    "lineNumber": 118
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x77"
+    "lineNumber": 119
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x78"
+    "lineNumber": 120
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x79"
+    "lineNumber": 121
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x7a"
+    "lineNumber": 122
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x7b"
+    "lineNumber": 123
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x7c"
+    "lineNumber": 124
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x7d"
+    "lineNumber": 125
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x7e"
+    "lineNumber": 126
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x7f"
+    "lineNumber": 127
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x80"
+    "lineNumber": 128
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x81"
+    "lineNumber": 129
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x82"
+    "lineNumber": 130
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x83"
+    "lineNumber": 131
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x84"
+    "lineNumber": 132
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x85"
+    "lineNumber": 133
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x86"
+    "lineNumber": 134
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x87"
+    "lineNumber": 135
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x88"
+    "lineNumber": 136
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x89"
+    "lineNumber": 137
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x8a"
+    "lineNumber": 138
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x8b"
+    "lineNumber": 139
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x8c"
+    "lineNumber": 140
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x8d"
+    "lineNumber": 141
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x8e"
+    "lineNumber": 142
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x8f"
+    "lineNumber": 143
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x90"
+    "lineNumber": 144
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x91"
+    "lineNumber": 145
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x92"
+    "lineNumber": 146
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x93"
+    "lineNumber": 147
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x94"
+    "lineNumber": 148
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x95"
+    "lineNumber": 149
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x96"
+    "lineNumber": 150
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x97"
+    "lineNumber": 151
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x98"
+    "lineNumber": 152
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x99"
+    "lineNumber": 153
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x9a"
+    "lineNumber": 154
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x9b"
+    "lineNumber": 155
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x9c"
+    "lineNumber": 156
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x9d"
+    "lineNumber": 157
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x9e"
+    "lineNumber": 158
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0x9f"
+    "lineNumber": 159
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa0"
+    "lineNumber": 160
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa1"
+    "lineNumber": 161
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa2"
+    "lineNumber": 162
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa3"
+    "lineNumber": 163
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa4"
+    "lineNumber": 164
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa5"
+    "lineNumber": 165
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa6"
+    "lineNumber": 166
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa7"
+    "lineNumber": 167
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa8"
+    "lineNumber": 168
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xa9"
+    "lineNumber": 169
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xaa"
+    "lineNumber": 170
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xab"
+    "lineNumber": 171
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xac"
+    "lineNumber": 172
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xad"
+    "lineNumber": 173
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xae"
+    "lineNumber": 174
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xaf"
+    "lineNumber": 175
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb0"
+    "lineNumber": 176
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb1"
+    "lineNumber": 177
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb2"
+    "lineNumber": 178
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb3"
+    "lineNumber": 179
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb4"
+    "lineNumber": 180
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb5"
+    "lineNumber": 181
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb6"
+    "lineNumber": 182
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb7"
+    "lineNumber": 183
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb8"
+    "lineNumber": 184
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xb9"
+    "lineNumber": 185
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xba"
+    "lineNumber": 186
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xbb"
+    "lineNumber": 187
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xbc"
+    "lineNumber": 188
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xbd"
+    "lineNumber": 189
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xbe"
+    "lineNumber": 190
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xbf"
+    "lineNumber": 191
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc0"
+    "lineNumber": 192
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc1"
+    "lineNumber": 193
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc2"
+    "lineNumber": 194
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc3"
+    "lineNumber": 195
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc4"
+    "lineNumber": 196
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc5"
+    "lineNumber": 197
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc6"
+    "lineNumber": 198
   },
   {
     "method": "SomeClass.someMethod",
     "file": "someFile",
-    "lineNumber": "0xc7"
+    "lineNumber": 199
   }
 ]

--- a/bugsnag-android-core/src/test/resources/stacktrace_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/stacktrace_serialization_5.json
@@ -2,1400 +2,1400 @@
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x0",
+    "lineNumber": 0,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x1",
+    "lineNumber": 1,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x2",
+    "lineNumber": 2,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x3",
+    "lineNumber": 3,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x4",
+    "lineNumber": 4,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x5",
+    "lineNumber": 5,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x6",
+    "lineNumber": 6,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x7",
+    "lineNumber": 7,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x8",
+    "lineNumber": 8,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x9",
+    "lineNumber": 9,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa",
+    "lineNumber": 10,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb",
+    "lineNumber": 11,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc",
+    "lineNumber": 12,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xd",
+    "lineNumber": 13,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xe",
+    "lineNumber": 14,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xf",
+    "lineNumber": 15,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x10",
+    "lineNumber": 16,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x11",
+    "lineNumber": 17,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x12",
+    "lineNumber": 18,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x13",
+    "lineNumber": 19,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x14",
+    "lineNumber": 20,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x15",
+    "lineNumber": 21,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x16",
+    "lineNumber": 22,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x17",
+    "lineNumber": 23,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x18",
+    "lineNumber": 24,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x19",
+    "lineNumber": 25,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x1a",
+    "lineNumber": 26,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x1b",
+    "lineNumber": 27,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x1c",
+    "lineNumber": 28,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x1d",
+    "lineNumber": 29,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x1e",
+    "lineNumber": 30,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x1f",
+    "lineNumber": 31,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x20",
+    "lineNumber": 32,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x21",
+    "lineNumber": 33,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x22",
+    "lineNumber": 34,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x23",
+    "lineNumber": 35,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x24",
+    "lineNumber": 36,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x25",
+    "lineNumber": 37,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x26",
+    "lineNumber": 38,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x27",
+    "lineNumber": 39,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x28",
+    "lineNumber": 40,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x29",
+    "lineNumber": 41,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x2a",
+    "lineNumber": 42,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x2b",
+    "lineNumber": 43,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x2c",
+    "lineNumber": 44,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x2d",
+    "lineNumber": 45,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x2e",
+    "lineNumber": 46,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x2f",
+    "lineNumber": 47,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x30",
+    "lineNumber": 48,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x31",
+    "lineNumber": 49,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x32",
+    "lineNumber": 50,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x33",
+    "lineNumber": 51,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x34",
+    "lineNumber": 52,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x35",
+    "lineNumber": 53,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x36",
+    "lineNumber": 54,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x37",
+    "lineNumber": 55,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x38",
+    "lineNumber": 56,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x39",
+    "lineNumber": 57,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x3a",
+    "lineNumber": 58,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x3b",
+    "lineNumber": 59,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x3c",
+    "lineNumber": 60,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x3d",
+    "lineNumber": 61,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x3e",
+    "lineNumber": 62,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x3f",
+    "lineNumber": 63,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x40",
+    "lineNumber": 64,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x41",
+    "lineNumber": 65,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x42",
+    "lineNumber": 66,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x43",
+    "lineNumber": 67,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x44",
+    "lineNumber": 68,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x45",
+    "lineNumber": 69,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x46",
+    "lineNumber": 70,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x47",
+    "lineNumber": 71,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x48",
+    "lineNumber": 72,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x49",
+    "lineNumber": 73,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x4a",
+    "lineNumber": 74,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x4b",
+    "lineNumber": 75,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x4c",
+    "lineNumber": 76,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x4d",
+    "lineNumber": 77,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x4e",
+    "lineNumber": 78,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x4f",
+    "lineNumber": 79,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x50",
+    "lineNumber": 80,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x51",
+    "lineNumber": 81,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x52",
+    "lineNumber": 82,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x53",
+    "lineNumber": 83,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x54",
+    "lineNumber": 84,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x55",
+    "lineNumber": 85,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x56",
+    "lineNumber": 86,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x57",
+    "lineNumber": 87,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x58",
+    "lineNumber": 88,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x59",
+    "lineNumber": 89,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x5a",
+    "lineNumber": 90,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x5b",
+    "lineNumber": 91,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x5c",
+    "lineNumber": 92,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x5d",
+    "lineNumber": 93,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x5e",
+    "lineNumber": 94,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x5f",
+    "lineNumber": 95,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x60",
+    "lineNumber": 96,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x61",
+    "lineNumber": 97,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x62",
+    "lineNumber": 98,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x63",
+    "lineNumber": 99,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x64",
+    "lineNumber": 100,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x65",
+    "lineNumber": 101,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x66",
+    "lineNumber": 102,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x67",
+    "lineNumber": 103,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x68",
+    "lineNumber": 104,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x69",
+    "lineNumber": 105,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x6a",
+    "lineNumber": 106,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x6b",
+    "lineNumber": 107,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x6c",
+    "lineNumber": 108,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x6d",
+    "lineNumber": 109,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x6e",
+    "lineNumber": 110,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x6f",
+    "lineNumber": 111,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x70",
+    "lineNumber": 112,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x71",
+    "lineNumber": 113,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x72",
+    "lineNumber": 114,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x73",
+    "lineNumber": 115,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x74",
+    "lineNumber": 116,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x75",
+    "lineNumber": 117,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x76",
+    "lineNumber": 118,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x77",
+    "lineNumber": 119,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x78",
+    "lineNumber": 120,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x79",
+    "lineNumber": 121,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x7a",
+    "lineNumber": 122,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x7b",
+    "lineNumber": 123,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x7c",
+    "lineNumber": 124,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x7d",
+    "lineNumber": 125,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x7e",
+    "lineNumber": 126,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x7f",
+    "lineNumber": 127,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x80",
+    "lineNumber": 128,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x81",
+    "lineNumber": 129,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x82",
+    "lineNumber": 130,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x83",
+    "lineNumber": 131,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x84",
+    "lineNumber": 132,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x85",
+    "lineNumber": 133,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x86",
+    "lineNumber": 134,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x87",
+    "lineNumber": 135,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x88",
+    "lineNumber": 136,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x89",
+    "lineNumber": 137,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x8a",
+    "lineNumber": 138,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x8b",
+    "lineNumber": 139,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x8c",
+    "lineNumber": 140,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x8d",
+    "lineNumber": 141,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x8e",
+    "lineNumber": 142,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x8f",
+    "lineNumber": 143,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x90",
+    "lineNumber": 144,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x91",
+    "lineNumber": 145,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x92",
+    "lineNumber": 146,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x93",
+    "lineNumber": 147,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x94",
+    "lineNumber": 148,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x95",
+    "lineNumber": 149,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x96",
+    "lineNumber": 150,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x97",
+    "lineNumber": 151,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x98",
+    "lineNumber": 152,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x99",
+    "lineNumber": 153,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x9a",
+    "lineNumber": 154,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x9b",
+    "lineNumber": 155,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x9c",
+    "lineNumber": 156,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x9d",
+    "lineNumber": 157,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x9e",
+    "lineNumber": 158,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0x9f",
+    "lineNumber": 159,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa0",
+    "lineNumber": 160,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa1",
+    "lineNumber": 161,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa2",
+    "lineNumber": 162,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa3",
+    "lineNumber": 163,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa4",
+    "lineNumber": 164,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa5",
+    "lineNumber": 165,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa6",
+    "lineNumber": 166,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa7",
+    "lineNumber": 167,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa8",
+    "lineNumber": 168,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xa9",
+    "lineNumber": 169,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xaa",
+    "lineNumber": 170,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xab",
+    "lineNumber": 171,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xac",
+    "lineNumber": 172,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xad",
+    "lineNumber": 173,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xae",
+    "lineNumber": 174,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xaf",
+    "lineNumber": 175,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb0",
+    "lineNumber": 176,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb1",
+    "lineNumber": 177,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb2",
+    "lineNumber": 178,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb3",
+    "lineNumber": 179,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb4",
+    "lineNumber": 180,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb5",
+    "lineNumber": 181,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb6",
+    "lineNumber": 182,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb7",
+    "lineNumber": 183,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb8",
+    "lineNumber": 184,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xb9",
+    "lineNumber": 185,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xba",
+    "lineNumber": 186,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xbb",
+    "lineNumber": 187,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xbc",
+    "lineNumber": 188,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xbd",
+    "lineNumber": 189,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xbe",
+    "lineNumber": 190,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xbf",
+    "lineNumber": 191,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc0",
+    "lineNumber": 192,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc1",
+    "lineNumber": 193,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc2",
+    "lineNumber": 194,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc3",
+    "lineNumber": 195,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc4",
+    "lineNumber": 196,
     "inProject": true,
     "type": "android"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc5",
+    "lineNumber": 197,
     "inProject": true,
     "type": "reactnativejs"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc6",
+    "lineNumber": 198,
     "inProject": true,
     "type": "c"
   },
   {
     "method": "Foo",
     "file": "Bar.kt",
-    "lineNumber": "0xc7",
+    "lineNumber": 199,
     "inProject": true,
     "type": "android"
   }

--- a/bugsnag-android-core/src/test/resources/thread_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_0.json
@@ -7,17 +7,17 @@
     {
       "method": "run_func",
       "file": "librunner.so",
-      "lineNumber": "0x13ae"
+      "lineNumber": 5038
     },
     {
       "method": "Runner.runFunc",
       "file": "Runner.java",
-      "lineNumber": "0xe"
+      "lineNumber": 14
     },
     {
       "method": "App.launch",
       "file": "App.java",
-      "lineNumber": "0x46"
+      "lineNumber": 70
     }
   ],
   "errorReportingThread": true

--- a/bugsnag-android-core/src/test/resources/thread_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_1.json
@@ -7,17 +7,17 @@
     {
       "method": "run_func",
       "file": "librunner.so",
-      "lineNumber": "0x13ae"
+      "lineNumber": 5038
     },
     {
       "method": "Runner.runFunc",
       "file": "Runner.java",
-      "lineNumber": "0xe"
+      "lineNumber": 14
     },
     {
       "method": "App.launch",
       "file": "App.java",
-      "lineNumber": "0x46"
+      "lineNumber": 70
     }
   ]
 }

--- a/bugsnag-android-core/src/test/resources/thread_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_2.json
@@ -7,17 +7,17 @@
     {
       "method": "run_func",
       "file": "librunner.so",
-      "lineNumber": "0x13ae"
+      "lineNumber": 5038
     },
     {
       "method": "Runner.runFunc",
       "file": "Runner.java",
-      "lineNumber": "0xe"
+      "lineNumber": 14
     },
     {
       "method": "App.launch",
       "file": "App.java",
-      "lineNumber": "0x46"
+      "lineNumber": 70
     }
   ],
   "errorReportingThread": true

--- a/bugsnag-android-core/src/test/resources/thread_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/thread_serialization_3.json
@@ -7,17 +7,17 @@
     {
       "method": "run_func",
       "file": "librunner.so",
-      "lineNumber": "0x13ae"
+      "lineNumber": 5038
     },
     {
       "method": "Runner.runFunc",
       "file": "Runner.java",
-      "lineNumber": "0xe"
+      "lineNumber": 14
     },
     {
       "method": "App.launch",
       "file": "App.java",
-      "lineNumber": "0x46"
+      "lineNumber": 70
     }
   ]
 }

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV10Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV10Tests.kt
@@ -136,7 +136,7 @@ class EventMigrationV10Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0xfffffffe",
-                            "lineNumber" to "0xfa0a1ec1",
+                            "lineNumber" to 4194967233L,
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -145,7 +145,7 @@ class EventMigrationV10Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0xb37a644b",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0xb37a644b" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV11Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV11Tests.kt
@@ -136,7 +136,7 @@ class EventMigrationV11Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0xfffffffe",
-                            "lineNumber" to "0xfa0a1ec1",
+                            "lineNumber" to 4194967233L,
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -145,7 +145,7 @@ class EventMigrationV11Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0xb37a644b",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0xb37a644b" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV4Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV4Tests.kt
@@ -119,7 +119,7 @@ class EventMigrationV4Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0x6eeeb",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -128,7 +128,7 @@ class EventMigrationV4Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0x5393e",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0x5393e" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV5Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV5Tests.kt
@@ -120,7 +120,7 @@ class EventMigrationV5Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0x6eeeb",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -129,7 +129,7 @@ class EventMigrationV5Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0x5393e",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0x5393e" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV6Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV6Tests.kt
@@ -119,7 +119,7 @@ class EventMigrationV6Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0x6eeeb",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -128,7 +128,7 @@ class EventMigrationV6Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0x5393e",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0x5393e" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV7Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV7Tests.kt
@@ -119,7 +119,7 @@ class EventMigrationV7Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0x6eeeb",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -128,7 +128,7 @@ class EventMigrationV7Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0x5393e",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0x5393e" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV8Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV8Tests.kt
@@ -136,7 +136,7 @@ class EventMigrationV8Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0xfffffffe",
-                            "lineNumber" to "0xfa0a1ec1",
+                            "lineNumber" to 4194967233L,
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -145,7 +145,7 @@ class EventMigrationV8Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0xb37a644b",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0xb37a644b" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV9Tests.kt
+++ b/bugsnag-plugin-android-ndk/src/androidTest/java/com/bugsnag/android/ndk/migrations/EventMigrationV9Tests.kt
@@ -136,7 +136,7 @@ class EventMigrationV9Tests : EventMigrationTest() {
                     "stacktrace" to listOf(
                         mapOf(
                             "frameAddress" to "0xfffffffe",
-                            "lineNumber" to "0xfa0a1ec1",
+                            "lineNumber" to 4194967233L,
                             "loadAddress" to "0x242023",
                             "symbolAddress" to "0x308",
                             "method" to "makinBacon",
@@ -145,7 +145,7 @@ class EventMigrationV9Tests : EventMigrationTest() {
                         ),
                         mapOf(
                             "frameAddress" to "0xb37a644b",
-                            "lineNumber" to "0x0",
+                            "lineNumber" to 0L,
                             "loadAddress" to "0x0",
                             "symbolAddress" to "0x0",
                             "method" to "0xb37a644b" // test address to method hex

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/exception_serialization.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/exception_serialization.json
@@ -1,1 +1,1 @@
-{"stacktrace":[{"frameAddress":"0x20000000","symbolAddress":"0x16000000","loadAddress":"0x12000000","lineNumber":"0x34","isPC":true,"file":"foo.c","method":"bar()"}],"errorClass":"signal","message":"whoops something went wrong","type":"c"}
+{"stacktrace":[{"frameAddress":"0x20000000","symbolAddress":"0x16000000","loadAddress":"0x12000000","lineNumber":52,"isPC":true,"file":"foo.c","method":"bar()"}],"errorClass":"signal","message":"whoops something went wrong","type":"c"}

--- a/bugsnag-plugin-android-ndk/src/androidTest/resources/stackframe_serialization.json
+++ b/bugsnag-plugin-android-ndk/src/androidTest/resources/stackframe_serialization.json
@@ -1,1 +1,1 @@
-[{"frameAddress":"0x20000000","symbolAddress":"0x16000000","loadAddress":"0x12000000","lineNumber":"0x34","file":"foo.c","method":"bar()"}]
+[{"frameAddress":"0x20000000","symbolAddress":"0x16000000","loadAddress":"0x12000000","lineNumber":52,"file":"foo.c","method":"bar()"}]

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/json_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/json_writer.c
@@ -261,7 +261,7 @@ void bsg_serialize_stackframe(bugsnag_stackframe *stackframe, bool is_pc,
   set_hex_number(frame, "frameAddress", (*stackframe).frame_address);
   set_hex_number(frame, "symbolAddress", (*stackframe).symbol_address);
   set_hex_number(frame, "loadAddress", (*stackframe).load_address);
-  set_hex_number(frame, "lineNumber", (*stackframe).line_number);
+  json_object_set_number(frame, "lineNumber", (*stackframe).line_number);
   if (is_pc) {
     // only necessary to set to true, false is the default value and omitting
     // the field keeps payload sizes smaller.

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
@@ -144,8 +144,7 @@ ssize_t bsg_unwind_crash_stack(bugsnag_stackframe stack[BUGSNAG_FRAMES_MAX],
   int frame_count = 0;
   for (auto &frame : crash_time_unwinder->frames()) {
     auto &dst_frame = stack[frame_count];
-    dst_frame.frame_address =
-        frame.pc + (frame.map_exact_offset - frame.map_elf_start_offset);
+    dst_frame.frame_address = frame.pc;
     dst_frame.line_number = frame.rel_pc;
     dst_frame.load_address = frame.map_start;
     dst_frame.symbol_address = frame.pc - frame.function_offset;
@@ -182,8 +181,7 @@ bsg_unwind_concurrent_stack(bugsnag_stackframe stack[BUGSNAG_FRAMES_MAX],
   int frame_count = 0;
   for (auto &frame : frames) {
     bugsnag_stackframe &dst_frame = stack[frame_count];
-    dst_frame.frame_address = frame.pc + (frame.map_info->offset() -
-                                          frame.map_info->elf_start_offset());
+    dst_frame.frame_address = frame.pc;
     if (frame.map_info != nullptr) {
       dst_frame.line_number = frame.rel_pc;
       dst_frame.load_address = frame.map_info->start();

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -154,6 +154,6 @@ Feature: Native crash reporting
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the "method" of stack frame 0 equals "0x0"
-    And the "lineNumber" of stack frame 0 equals "0x0"
+    And the "lineNumber" of stack frame 0 equals 0
     And the first significant stack frames match:
       | dispatch::Handler::handle(_jobject*) | CXXCallNullFunctionPointerScenario.cpp | 9 |

--- a/features/smoke_tests/02_handled.feature
+++ b/features/smoke_tests/02_handled.feature
@@ -23,7 +23,7 @@ Feature: Handled smoke tests
     And the event "exceptions.0.stacktrace.0.method" ends with "HandledJavaSmokeScenario.startScenario"
     And the exception "stacktrace.0.file" equals "HandledJavaSmokeScenario.java"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals "0x8"
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 8
     And the event "exceptions.0.stacktrace.0.inProject" is true
     And the error payload field "events.0.projectPackages" is a non-empty array
     And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"
@@ -134,7 +134,7 @@ Feature: Handled smoke tests
     And the event "exceptions.0.stacktrace.0.method" ends with "generateException"
     And the exception "stacktrace.0.file" equals "Scenario.kt"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals "0x1"
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 1
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     # Overwritten App data

--- a/features/smoke_tests/04_unhandled.feature
+++ b/features/smoke_tests/04_unhandled.feature
@@ -26,7 +26,7 @@ Feature: Unhandled smoke tests
     And the event "exceptions.0.stacktrace.0.method" ends with "UnhandledJavaLoadedConfigScenario.startScenario"
     And the exception "stacktrace.0.file" equals "UnhandledJavaLoadedConfigScenario.java"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals "0x7"
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 7
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     And the thread with name "main" contains the error reporting flag

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -180,12 +180,6 @@ Then("the error payload contains a completed unhandled native report") do
       Maze.check.not_nil(frame['symbolAddress'], "The symbolAddress of frame #{index} is nil")
       Maze.check.not_nil(frame['frameAddress'], "The frameAddress of frame #{index} is nil")
       Maze.check.not_nil(frame['loadAddress'], "The loadAddress of frame #{index} is nil")
-
-      frameAddress = frame['frameAddress'].to_i(16)
-      loadAddress = frame['loadAddress'].to_i(16)
-      Maze.check.equal(frame['lineNumber'],
-                       frameAddress - loadAddress,
-                        "lineNumber does not match frameAddress - loadAddress at frame #{index}")
     end
 end
 

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -183,7 +183,7 @@ Then("the error payload contains a completed unhandled native report") do
 
       frameAddress = frame['frameAddress'].to_i(16)
       loadAddress = frame['loadAddress'].to_i(16)
-      Maze.check.equal(frame['lineNumber'].to_i(16),
+      Maze.check.equal(frame['lineNumber'],
                        frameAddress - loadAddress,
                         "lineNumber does not match frameAddress - loadAddress at frame #{index}")
     end

--- a/features/steps/symbol_steps.rb
+++ b/features/steps/symbol_steps.rb
@@ -88,7 +88,7 @@ def demangle symbol
 end
 
 def lookup_address binary, address
-  info = `addr2line --exe '#{binary}' --inlines --basenames --functions --demangle #{address}`.chomp
+  info = `addr2line --exe '#{binary}' --inlines --basenames --functions --demangle 0x#{address.to_s(16)}`.chomp
   return nil if info.start_with? '??' # failed to resolve
   # can return multiple if there are inlined frames
   frames = info.split("\n").each_slice(2).map do |function_name, location|


### PR DESCRIPTION
## Goal
Rollback the changes to `lineNumber`:
- do not encode `lineNumber` as hex strings
- rollback the PC address changes that were stored in `lineNumber`

## Testing
Relied on existing tests.