### PR TITLE
Fix placement of usage statistics so that they are all placed under "usage" in the payload

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -165,8 +165,14 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
         writer.name("device").value(device)
         writer.name("breadcrumbs").value(breadcrumbs)
         writer.name("groupingHash").value(groupingHash)
-        internalMetrics.toJsonableMap().forEach { entry ->
-            writer.name(entry.key).value(entry.value)
+        val usage = internalMetrics.toJsonableMap()
+        if (usage.isNotEmpty()) {
+            writer.name("usage")
+            writer.beginObject()
+            usage.forEach { entry ->
+                writer.name(entry.key).value(entry.value)
+            }
+            writer.endObject()
         }
 
         writer.name("threads")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/InternalMetricsImpl.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/InternalMetricsImpl.kt
@@ -7,16 +7,21 @@ class InternalMetricsImpl : InternalMetrics {
     private val callbackCounts = hashMapOf<String, Int>()
 
     override fun toJsonableMap(): Map<String, Any> {
-        return mapOf(
-            "config" to configDifferences,
-            "callbacks" to allCallbacks()
-        )
+        val callbacks = allCallbacks()
+
+        return listOfNotNull(
+            if (configDifferences.isNotEmpty()) "config" to configDifferences else null,
+            if (callbacks.isNotEmpty()) "callbacks" to callbacks else null,
+        ).toMap()
     }
 
     override fun setConfigDifferences(differences: Map<String, Any>) {
         configDifferences.clear()
         configDifferences.putAll(differences)
-        NdkPluginCaller.setStaticData(mapOf("config" to configDifferences))
+        // This is currently the only place where we set static data.
+        // When that changes in future, we'll need a StaticData object to properly merge data
+        // coming from multiple sources.
+        NdkPluginCaller.setStaticData(mapOf("usage" to mapOf("config" to configDifferences)))
     }
 
     override fun setCallbackCounts(newCallbackCounts: Map<String, Int>) {

--- a/features/full_tests/usage.feature
+++ b/features/full_tests/usage.feature
@@ -12,13 +12,13 @@ Feature: Reporting Errors with usage info
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "exceptions.0.message" equals "HandledExceptionWithUsageScenario"
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
-    And the event "config.maxBreadcrumbs" equals 10
-    And the event "config.autoTrackSessions" is false
-    And the event "callbacks.event_set_user" is true
-    And the event "callbacks.ndkOnError" equals 1
-    And the event "callbacks.onBreadcrumb" equals 1
-    And the event "callbacks.onError" equals 3
-    And the event "callbacks.onSession" equals 3
+    And the event "usage.config.maxBreadcrumbs" equals 10
+    And the event "usage.config.autoTrackSessions" is false
+    And the event "usage.callbacks.event_set_user" is true
+    And the event "usage.callbacks.ndkOnError" equals 1
+    And the event "usage.callbacks.onBreadcrumb" equals 1
+    And the event "usage.callbacks.onError" equals 3
+    And the event "usage.callbacks.onSession" equals 3
 
   Scenario: Report a handled exception with custom configuration and set callbacks, usage disabled
     When I configure the app to run in the "disable-usage" state
@@ -29,13 +29,13 @@ Feature: Reporting Errors with usage info
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "exceptions.0.message" equals "HandledExceptionWithUsageScenario"
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
-    And the event "config.maxBreadcrumbs" is null
-    And the event "config.autoTrackSessions" is null
-    And the event "callbacks.event_set_user" is null
-    And the event "callbacks.ndkOnError" is null
-    And the event "callbacks.onBreadcrumb" is null
-    And the event "callbacks.onError" is null
-    And the event "callbacks.onSession" is null
+    And the event "usage.config.maxBreadcrumbs" is null
+    And the event "usage.config.autoTrackSessions" is null
+    And the event "usage.callbacks.event_set_user" is null
+    And the event "usage.callbacks.ndkOnError" is null
+    And the event "usage.callbacks.onBreadcrumb" is null
+    And the event "usage.callbacks.onError" is null
+    And the event "usage.callbacks.onSession" is null
 
   Scenario: Report an unhandled exception with custom configuration and set callbacks
     When I configure the app to run in the "USAGE" state
@@ -47,13 +47,13 @@ Feature: Reporting Errors with usage info
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "exceptions.0.message" equals "UnhandledExceptionWithUsageScenario"
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
-    And the event "config.maxBreadcrumbs" equals 10
-    And the event "config.autoTrackSessions" is false
-    And the event "callbacks.event_set_user" is true
-    And the event "callbacks.ndkOnError" equals 1
-    And the event "callbacks.onBreadcrumb" equals 3
-    And the event "callbacks.onError" equals 2
-    And the event "callbacks.onSession" equals 2
+    And the event "usage.config.maxBreadcrumbs" equals 10
+    And the event "usage.config.autoTrackSessions" is false
+    And the event "usage.callbacks.event_set_user" is true
+    And the event "usage.callbacks.ndkOnError" equals 1
+    And the event "usage.callbacks.onBreadcrumb" equals 3
+    And the event "usage.callbacks.onError" equals 2
+    And the event "usage.callbacks.onSession" equals 2
 
   Scenario: Report an unhandled exception with custom configuration and set callbacks, usage disabled
     When I configure the app to run in the "disable-usage" state
@@ -65,13 +65,13 @@ Feature: Reporting Errors with usage info
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the event "exceptions.0.message" equals "UnhandledExceptionWithUsageScenario"
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
-    And the event "config.maxBreadcrumbs" is null
-    And the event "config.autoTrackSessions" is null
-    And the event "callbacks.event_set_user" is null
-    And the event "callbacks.ndkOnError" is null
-    And the event "callbacks.onBreadcrumb" is null
-    And the event "callbacks.onError" is null
-    And the event "callbacks.onSession" is null
+    And the event "usage.config.maxBreadcrumbs" is null
+    And the event "usage.config.autoTrackSessions" is null
+    And the event "usage.callbacks.event_set_user" is null
+    And the event "usage.callbacks.ndkOnError" is null
+    And the event "usage.callbacks.onBreadcrumb" is null
+    And the event "usage.callbacks.onError" is null
+    And the event "usage.callbacks.onSession" is null
 
   Scenario: Report a native exception with custom configuration and set callbacks
     When I configure the app to run in the "USAGE" state
@@ -81,13 +81,13 @@ Feature: Reporting Errors with usage info
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
-    And the event "config.maxBreadcrumbs" equals 10
-    And the event "config.autoTrackSessions" is false
-    And the event "config.discardClassesCount" equals 3
-    And the event "config.maxPersistedSessions" equals 1000
-    And the event "callbacks.onBreadcrumb" equals 1
-    And the event "callbacks.onError" equals 2
-    And the event "callbacks.onSession" equals 4
+    And the event "usage.config.maxBreadcrumbs" equals 10
+    And the event "usage.config.autoTrackSessions" is false
+    And the event "usage.config.discardClassesCount" equals 3
+    And the event "usage.config.maxPersistedSessions" equals 1000
+    And the event "usage.callbacks.onBreadcrumb" equals 1
+    And the event "usage.callbacks.onError" equals 2
+    And the event "usage.callbacks.onSession" equals 4
 
   Scenario: Report a native exception with custom configuration and set callbacks, usage disabled
     When I configure the app to run in the "disable-usage" state
@@ -97,13 +97,13 @@ Feature: Reporting Errors with usage info
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
-    And the event "config.maxBreadcrumbs" is null
-    And the event "config.autoTrackSessions" is null
-    And the event "config.discardClassesCount" is null
-    And the event "config.maxPersistedSessions" is null
-    And the event "callbacks.onBreadcrumb" is null
-    And the event "callbacks.onError" is null
-    And the event "callbacks.onSession" is null
+    And the event "usage.config.maxBreadcrumbs" is null
+    And the event "usage.config.autoTrackSessions" is null
+    And the event "usage.config.discardClassesCount" is null
+    And the event "usage.config.maxPersistedSessions" is null
+    And the event "usage.callbacks.onBreadcrumb" is null
+    And the event "usage.callbacks.onError" is null
+    And the event "usage.callbacks.onSession" is null
 
   Scenario: Report a native exception with custom configuration and set callbacks
     When I configure the app to run in the "USAGE" state
@@ -116,16 +116,16 @@ Feature: Reporting Errors with usage info
     And the event "exceptions.0.message" equals "Segmentation violation (invalid memory reference)"
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
     And the event "app.binaryArch" equals "something weird"
-    And the event "config.maxBreadcrumbs" equals 10
-    And the event "config.autoTrackSessions" is false
-    And the event "callbacks.ndkOnError" equals 1
-    And the event "callbacks.onBreadcrumb" equals 1
-    And the event "callbacks.onError" equals 2
-    And the event "callbacks.onSession" equals 4
-    And the event "callbacks.event_set_user" is true
-    And the event "callbacks.app_set_binary_arch" is true
-    And the event "callbacks.device_get_model" is true
-    And the event "callbacks.event_get_severity" is true
+    And the event "usage.config.maxBreadcrumbs" equals 10
+    And the event "usage.config.autoTrackSessions" is false
+    And the event "usage.callbacks.ndkOnError" equals 1
+    And the event "usage.callbacks.onBreadcrumb" equals 1
+    And the event "usage.callbacks.onError" equals 2
+    And the event "usage.callbacks.onSession" equals 4
+    And the event "usage.callbacks.event_set_user" is true
+    And the event "usage.callbacks.app_set_binary_arch" is true
+    And the event "usage.callbacks.device_get_model" is true
+    And the event "usage.callbacks.event_get_severity" is true
 
   Scenario: Report a native exception with custom configuration and set callbacks, usage disabled
     When I configure the app to run in the "disable-usage" state
@@ -138,13 +138,13 @@ Feature: Reporting Errors with usage info
     And the event "exceptions.0.message" equals "Segmentation violation (invalid memory reference)"
     And the error payload field "events.0.device.cpuAbi" is a non-empty array
     And the event "app.binaryArch" equals "something weird"
-    And the event "config.maxBreadcrumbs" is null
-    And the event "config.autoTrackSessions" is null
-    And the event "callbacks.ndkOnError" is null
-    And the event "callbacks.onBreadcrumb" is null
-    And the event "callbacks.onError" is null
-    And the event "callbacks.onSession" is null
-    And the event "callbacks.event_set_user" is null
-    And the event "callbacks.app_set_binary_arch" is null
-    And the event "callbacks.device_get_model" is null
-    And the event "callbacks.event_get_severity" is null
+    And the event "usage.config.maxBreadcrumbs" is null
+    And the event "usage.config.autoTrackSessions" is null
+    And the event "usage.callbacks.ndkOnError" is null
+    And the event "usage.callbacks.onBreadcrumb" is null
+    And the event "usage.callbacks.onError" is null
+    And the event "usage.callbacks.onSession" is null
+    And the event "usage.callbacks.event_set_user" is null
+    And the event "usage.callbacks.app_set_binary_arch" is null
+    And the event "usage.callbacks.device_get_model" is null
+    And the event "usage.callbacks.event_get_severity" is null


### PR DESCRIPTION
## Goal

The usage statistics were being put in the wrong place in the payload.

This PR moves the stats to their proper place under "usage".
