### PR TITLE
Attempt delivery on crash if configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Setting `Configuration.attemptDeliveryOnCrash` will cause Bugsnag to attempt error delivery during some crashes.
+  Use of this feature is discouraged, see the method JavaDoc for more information.
+  [#1749](https://github.com/bugsnag/bugsnag-android/pull/1749)
+
 ## 5.26.0 (2022-08-18)
 
 ### Enhancements

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -92,6 +92,7 @@ class ManifestConfigLoaderTest {
             putBoolean("com.bugsnag.android.SEND_LAUNCH_CRASHES_SYNCHRONOUSLY", false)
             putString("com.bugsnag.android.APP_TYPE", "react-native")
             putString("com.bugsnag.android.CODE_BUNDLE_ID", "123")
+            putBoolean("com.bugsnag.android.ATTEMPT_DELIVERY_ON_CRASH", true)
         }
 
         val config = configLoader.load(data, null)
@@ -128,6 +129,7 @@ class ManifestConfigLoaderTest {
             assertEquals(launchDurationMillis, 7000)
             assertFalse(sendLaunchCrashesSynchronously)
             assertEquals("react-native", appType)
+            assertTrue(isAttemptDeliveryOnCrash)
         }
     }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -57,6 +57,8 @@ internal class ConfigInternal(
     var projectPackages: Set<String> = emptySet()
     var persistenceDirectory: File? = null
 
+    var attemptDeliveryOnCrash: Boolean = false
+
     val notifier: Notifier = Notifier()
 
     protected val plugins = HashSet<Plugin>()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -7,7 +7,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import java.io.File;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -1110,6 +1109,39 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
         } else {
             logNull("addPlugin");
         }
+    }
+
+    /**
+     * Whether Bugsnag should try to send crashing errors prior to app termination.
+     *
+     * Delivery will only be attempted for uncaught Java / Kotlin exceptions or errors, and
+     * while in progress will block the crashing thread for up to 3 seconds.
+     *
+     * Delivery on crash should be considered unreliable due to the necessary short timeout and
+     * potential for generating "errors on errors".
+     *
+     * Use of this feature is discouraged because it:
+     * - may cause Application Not Responding (ANR) errors on-top of existing crashes
+     * - will result in duplicate errors in your Dashboard when errors are not detected as sent
+     *   before termination
+     * - may prevent other error handlers from detecting or reporting a crash
+     *
+     * By default this value is {@code false}.
+     *
+     * @param attemptDeliveryOnCrash {@code true} if Bugsnag should try to send crashing errors
+     *                               prior to app termination
+     */
+    public void setAttemptDeliveryOnCrash(boolean attemptDeliveryOnCrash) {
+        impl.setAttemptDeliveryOnCrash(attemptDeliveryOnCrash);
+    }
+
+    /**
+     * Whether Bugsnag should try to send crashing errors prior to app termination.
+     * 
+     * @see #setAttemptDeliveryOnCrash(boolean)
+     */
+    public boolean isAttemptDeliveryOnCrash() {
+        return impl.getAttemptDeliveryOnCrash();
     }
 
     Set<Plugin> getPlugins() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -42,6 +42,7 @@ internal class ManifestConfigLoader {
         private const val LAUNCH_DURATION_MILLIS = "$BUGSNAG_NS.LAUNCH_DURATION_MILLIS"
         private const val SEND_LAUNCH_CRASHES_SYNCHRONOUSLY = "$BUGSNAG_NS.SEND_LAUNCH_CRASHES_SYNCHRONOUSLY"
         private const val APP_TYPE = "$BUGSNAG_NS.APP_TYPE"
+        private const val ATTEMPT_DELIVERY_ON_CRASH = "$BUGSNAG_NS.ATTEMPT_DELIVERY_ON_CRASH"
     }
 
     fun load(ctx: Context, userSuppliedApiKey: String?): Configuration {
@@ -90,6 +91,10 @@ internal class ManifestConfigLoader {
                 sendLaunchCrashesSynchronously = data.getBoolean(
                     SEND_LAUNCH_CRASHES_SYNCHRONOUSLY,
                     sendLaunchCrashesSynchronously
+                )
+                isAttemptDeliveryOnCrash = data.getBoolean(
+                    ATTEMPT_DELIVERY_ON_CRASH,
+                    isAttemptDeliveryOnCrash
                 )
             }
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
@@ -52,6 +52,7 @@ data class ImmutableConfig(
     val maxReportedThreads: Int,
     val persistenceDirectory: Lazy<File>,
     val sendLaunchCrashesSynchronously: Boolean,
+    val attemptDeliveryOnCrash: Boolean,
 
     // results cached here to avoid unnecessary lookups in Client.
     val packageInfo: PackageInfo?,
@@ -167,6 +168,7 @@ internal fun convertToImmutableConfig(
         telemetry = config.telemetry.toSet(),
         persistenceDirectory = persistenceDir,
         sendLaunchCrashesSynchronously = config.sendLaunchCrashesSynchronously,
+        attemptDeliveryOnCrash = config.isAttemptDeliveryOnCrash,
         packageInfo = packageInfo,
         appInfo = appInfo,
         redactedKeys = config.redactedKeys.toSet()

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestData.java
@@ -51,6 +51,7 @@ class TestData {
                     }
                 }),
                 true,
+                true,
                 null,
                 null,
                 Collections.singleton("password")

--- a/features/fixtures/mazerunner/app/proguard-rules.pro
+++ b/features/fixtures/mazerunner/app/proguard-rules.pro
@@ -1,1 +1,2 @@
 -keep class com.bugsnag.android.mazerunner.** {*;}
+-keep class com.bugsnag.android.DeliveryDelegate {*;}

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -31,6 +31,7 @@
     <ID>ThrowingExceptionsWithoutMessageOrCause:TrimmedStacktraceScenario.kt$TrimmedStacktraceScenario$RuntimeException()</ID>
     <ID>TooGenericExceptionThrown:CrashHandlerScenario.kt$CrashHandlerScenario$throw RuntimeException("CrashHandlerScenario")</ID>
     <ID>TooGenericExceptionThrown:CustomHttpClientFlushScenario.kt$CustomHttpClientFlushScenario$throw RuntimeException("ReportCacheScenario")</ID>
+    <ID>TooGenericExceptionThrown:DeliverOnCrashScenario.kt$DeliverOnCrashScenario$throw RuntimeException("DeliverOnCrashScenario")</ID>
     <ID>TooGenericExceptionThrown:DisableAutoDetectErrorsScenario.kt$DisableAutoDetectErrorsScenario$throw RuntimeException("Should never appear")</ID>
     <ID>TooGenericExceptionThrown:FeatureFlagScenario.kt$FeatureFlagScenario$throw RuntimeException("FeatureFlagScenario unhandled")</ID>
     <ID>TooGenericExceptionThrown:OnSendCallbackScenario.kt$OnSendCallbackScenario$throw RuntimeException("Unhandled Error")</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeliverOnCrashScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DeliverOnCrashScenario.kt
@@ -1,0 +1,27 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+
+private const val TIMEOUT = 15_000L
+
+internal class DeliverOnCrashScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String
+) : Scenario(config, context, eventMetadata) {
+
+    init {
+        config.isAttemptDeliveryOnCrash = true
+        val deliveryDelegate = Class.forName("com.bugsnag.android.DeliveryDelegate")
+        deliveryDelegate.getDeclaredField("DELIVERY_TIMEOUT").apply {
+            isAccessible = true
+            set(null, TIMEOUT)
+        }
+    }
+
+    override fun startScenario() {
+        super.startScenario()
+        throw RuntimeException("DeliverOnCrashScenario")
+    }
+}

--- a/features/full_tests/crash_handler.feature
+++ b/features/full_tests/crash_handler.feature
@@ -12,3 +12,11 @@ Feature: Reporting with other exception handlers installed
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "CrashHandlerScenario"
     And the event "metaData.customHandler.invoked" is true
+
+  Scenario: Delivers crashes synchronously when configured
+    When I run "DeliverOnCrashScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the exception "message" equals "DeliverOnCrashScenario"


### PR DESCRIPTION
## Goal
Attempt to deliver crashes when they happen if configured.

## Design
The `DeliveryDelegate.cacheEvent` flag for `attemptSent` now attempts immediate delivery of just that single event

## Testing
A new test scenario was introduced to test that a crash can be delivered without a fixture restart.