### PR TITLE
Add telemetry for `attemptDeliveryOnCrash` config

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -105,6 +105,9 @@ internal class ConfigInternal(
     }
 
     fun getConfigDifferences(): Map<String, Any> {
+        // allocate a local ConfigInternal with all-defaults to compare against
+        val defaultConfig = ConfigInternal("")
+
         return listOfNotNull(
             if (plugins.count() > 0) "pluginCount" to plugins.count() else null,
             if (autoDetectErrors != defaultConfig.autoDetectErrors)
@@ -138,6 +141,8 @@ internal class ConfigInternal(
                 "persistenceDirectorySet" to true else null,
             if (sendThreads != defaultConfig.sendThreads)
                 "sendThreads" to sendThreads else null,
+            if (attemptDeliveryOnCrash != defaultConfig.attemptDeliveryOnCrash)
+                "attemptDeliveryOnCrash" to attemptDeliveryOnCrash else null
         ).toMap()
     }
 
@@ -155,7 +160,5 @@ internal class ConfigInternal(
         protected fun load(context: Context, apiKey: String?): Configuration {
             return ManifestConfigLoader().load(context, apiKey)
         }
-
-        private val defaultConfig = ConfigInternal("")
     }
 }

--- a/features/full_tests/crash_handler.feature
+++ b/features/full_tests/crash_handler.feature
@@ -20,3 +20,4 @@ Feature: Reporting with other exception handlers installed
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "DeliverOnCrashScenario"
+    And the event "usage.config.attemptDeliveryOnCrash" is true


### PR DESCRIPTION
## Goal
Telemetry to indicate if `attemptDeliveryOnCrash` is enabled (and telemetry is enabled).

## Testing
Added a step to the `DeliverOnCrashScenario`