### PR TITLE
Don't rely on reflection to construct DefaultDelivery in Maze Runner tests

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/JavaHooks.java
@@ -50,4 +50,9 @@ public class JavaHooks {
             }
         };
     }
+
+    @NonNull
+    public static Delivery createDefaultDelivery() {
+        return new DefaultDelivery(null, NoopLogger.INSTANCE);
+    }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/TestHarnessHooks.kt
@@ -57,22 +57,7 @@ internal fun createCustomHeaderDelivery(): Delivery {
     }
 }
 
-fun createDefaultDelivery(): Delivery { // use reflection as DefaultDelivery is internal
-    val clz = Class.forName("com.bugsnag.android.DefaultDelivery")
-    return clz.constructors[0].newInstance(
-        null,
-        object : Logger {
-            override fun e(msg: String) = Unit
-            override fun e(msg: String, throwable: Throwable) = Unit
-            override fun w(msg: String) = Unit
-            override fun w(msg: String, throwable: Throwable) = Unit
-            override fun i(msg: String) = Unit
-            override fun i(msg: String, throwable: Throwable) = Unit
-            override fun d(msg: String) = Unit
-            override fun d(msg: String, throwable: Throwable) = Unit
-        }
-    ) as Delivery
-}
+fun createDefaultDelivery(): Delivery = JavaHooks.createDefaultDelivery()
 
 internal fun writeErrorToStore(client: Client, event: Event) {
     client.eventStore.write(event)


### PR DESCRIPTION
## Goal
Avoid reflection in `createDefaultDelivery` in the Maze Runner fixture, as it's fragile and the order of constructors is subject to change.

## Design
`DefaultDelivery` is `internal` and so can be accessed directly by Java code (although with a warning). 

## Testing
This change would fail the Maze Runners compile instead of at runtime, so makes tests more robust.