### PR TITLE
Avoid thread-starvation in BackgroundTaskService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fixed rare thread-starvation issue where some internal failures could lead to deadlocks. This was most noticeable
+  when attempting to call Bugsnag.start on an architecture (ABI) that was not packaged in the APK, and lead to an
+  ANR instead of an error report.
+  [#1768](https://github.com/bugsnag/bugsnag-android/pull/1768)
+
 ## 5.28.0 (2022-10-13)
 
 ### Enhancements


### PR DESCRIPTION
## Goal
Avoid possible thread starvation when submitting tasks to the `BackgroundTaskService`.

## Design
Changed the `BackgroundTaskService` to internally be able to identify its threads. When the result of a `Future` is queried it will first check to see if the task is incomplete `&&` is queued to be executed on the current thread. If so the task is run immediately and the result is returned.

## Testing
A new unit test was added that causes thread starvation by adding a task to each queue, which then adds a task to the same queue and then blocks on both tasks to await their completion. This triggers a deadlock as the first task waits for itself to complete.