### PR TITLE
e2e test improvements

### DIFF
--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -91,6 +91,11 @@ class MainActivity : Activity() {
         }
     }
 
+    // As per JSONObject.getString but returns and empty string rather than throwing if not present
+    private fun getStringSafely(jsonObject: JSONObject, key: String): String {
+        return if (jsonObject.has(key)) jsonObject.getString(key) else ""
+    }
+
     // Starts a thread to poll for Maze Runner actions to perform
     private fun startCommandRunner() {
         // Get the next maze runner command
@@ -111,16 +116,21 @@ class MainActivity : Activity() {
                     // Log the received command
                     log("Received command: $commandStr")
                     var command = JSONObject(commandStr)
-                    val action = command.getString("action")
-                    val scenarioName = command.getString("scenario_name")
-                    val scenarioMode = command.getString("scenario_mode")
-                    val sessionsUrl = command.getString("sessions_endpoint")
-                    val notifyUrl = command.getString("notify_endpoint")
+                    val action = getStringSafely(command, "action")
+                    val scenarioName = getStringSafely(command, "scenario_name")
+                    val scenarioMode = getStringSafely(command, "scenario_mode")
+                    val sessionsUrl = getStringSafely(command, "sessions_endpoint")
+                    val notifyUrl = getStringSafely(command, "notify_endpoint")
                     log("command.action: $action")
                     log("command.scenarioName: $scenarioName")
                     log("command.scenarioMode: $scenarioMode")
                     log("command.sessionsUrl: $sessionsUrl")
                     log("command.notifyUrl: $notifyUrl")
+
+                    // Stop polling once we have a scenario action
+                    if ("start_bugsnag".equals(action) || "run_scenario".equals(action)) {
+                        polling = false
+                    }
 
                     mainHandler.post {
                         // Display some feedback of the action being run on he UI
@@ -132,11 +142,9 @@ class MainActivity : Activity() {
                         // Perform the given action on the UI thread
                         when (action) {
                             "start_bugsnag" -> {
-                                polling = false
                                 startBugsnag(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
                             }
                             "run_scenario" -> {
-                                polling = false
                                 runScenario(scenarioName, scenarioMode, sessionsUrl, notifyUrl)
                             }
                             "clear_persistent_data" -> clearPersistentData()

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXBackgroundNotifyScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXBackgroundNotifyScenario.kt
@@ -6,7 +6,6 @@ import android.os.Handler
 import android.os.Looper
 import com.bugsnag.android.Configuration
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.concurrent.thread
 
 internal class CXXBackgroundNotifyScenario(
     config: Configuration,
@@ -36,5 +35,4 @@ internal class CXXBackgroundNotifyScenario(
             }
         }
     }
-
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXBackgroundNotifyScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXBackgroundNotifyScenario.kt
@@ -2,8 +2,11 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.app.Activity
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.bugsnag.android.Configuration
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 
 internal class CXXBackgroundNotifyScenario(
     config: Configuration,
@@ -26,9 +29,12 @@ internal class CXXBackgroundNotifyScenario(
     }
 
     override fun onActivityStopped(activity: Activity) {
-        // debounce so this can only ever occur once
-        if (!triggered.getAndSet(true)) {
-            activate()
+        Handler(Looper.getMainLooper()).post {
+            // debounce so this can only ever occur once
+            if (!triggered.getAndSet(true)) {
+                activate()
+            }
         }
     }
+
 }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.kt
@@ -1,6 +1,5 @@
 package com.bugsnag.android.mazerunner.scenarios
 
-import android.app.Activity
 import android.content.Context
 import android.os.Handler
 import android.os.Looper

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.kt
@@ -24,10 +24,8 @@ class CXXDelayedCrashScenario(
     override fun startScenario() {
         super.startScenario()
         registerActivityLifecycleCallbacks()
-    }
 
-    override fun onActivityStopped(activity: Activity) {
-        Handler(Looper.getMainLooper()).post {
+        onAppBackgrounded {
             log("App sent to background, triggering crash.")
             activate(405)
         }

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXDelayedCrashScenario.kt
@@ -25,9 +25,11 @@ class CXXDelayedCrashScenario(
         super.startScenario()
         registerActivityLifecycleCallbacks()
 
-        onAppBackgrounded {
-            log("App sent to background, triggering crash.")
-            activate(405)
+        Handler(Looper.getMainLooper()).post {
+            onAppBackgrounded {
+                log("App sent to background, triggering crash.")
+                activate(405)
+            }
         }
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InForegroundScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InForegroundScenario.kt
@@ -2,6 +2,8 @@ package com.bugsnag.android.mazerunner.scenarios
 
 import android.app.Activity
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import java.util.concurrent.atomic.AtomicBoolean
@@ -24,9 +26,11 @@ internal class InForegroundScenario(
     }
 
     override fun onActivityStopped(activity: Activity) {
-        // debounce so this can only ever occur once
-        if (!triggered.getAndSet(true)) {
-            Bugsnag.notify(generateException())
+        Handler(Looper.getMainLooper()).post {
+            // debounce so this can only ever occur once
+            if (!triggered.getAndSet(true)) {
+                Bugsnag.notify(generateException())
+            }
         }
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -3,8 +3,8 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.app.Activity
 import android.app.Application
 import android.content.BroadcastReceiver
-import android.content.Context
 import android.content.ComponentCallbacks2
+import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Application
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.ComponentCallbacks2
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
@@ -125,6 +126,22 @@ abstract class Scenario(
             dir.listFiles()?.forEach { println(it) }
             Thread.sleep(1000)
         }
+    }
+
+    protected fun onAppBackgrounded(listener: () -> Unit) {
+        (context.applicationContext as Application).registerComponentCallbacks(
+            object : ComponentCallbacks2 {
+                override fun onTrimMemory(level: Int) {
+                    if (level == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
+                        Handler(Looper.getMainLooper()).post(listener)
+                    }
+                }
+
+                override fun onConfigurationChanged(newConfig: android.content.res.Configuration) =
+                    Unit
+
+                override fun onLowMemory() = Unit
+            })
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}

--- a/features/full_tests/in_foreground.feature
+++ b/features/full_tests/in_foreground.feature
@@ -5,7 +5,7 @@ Feature: In foreground field populates correctly
 
   Scenario: Test handled exception in background
     When I run "InForegroundScenario"
-    And I send the app to the background for 1 seconds
+    And I send the app to the background for 5 seconds
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the event "app.inForeground" is false


### PR DESCRIPTION
## Goal

Fix a couple of test flakes and make the fixture output less noisy in some cases.

## Changeset

- Safely get JSON element values in the test fixture to avoid ugly stack traces (if Maze Runner were to change behaviour, for example).
- Trigger scenario actions on the main thread to make times more consistent and avoid flakes in 2 scenarios
- Stop the test fixture polling for commands as soon as a positive action is received, to avoid noisy output in the device log.

## Testing

Covered by a basic CI run, and I've rerun the flaky scenarios 100 times locally to verify they are fixed (except in the case of  
 CXXDelayedCrashScenario which needs more work, but is no worse than it was).