### PR TITLE
Remove trigger of RN tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,14 +1,4 @@
 steps:
-  - label: 'Trigger RN tests for all builds of our next branch'
-    if: build.branch == "next"
-    trigger: 'bugsnag-js'
-    build:
-      branch: 'next'
-      message: 'Run RN tests with latest Android next branch'
-      env:
-        BUILD_RN_WITH_LATEST_NATIVES: "true"
-    async: true
-
   - label: ':android: Build minimal fixture APK'
     key: "fixture-minimal"
     timeout_in_minutes: 30


### PR DESCRIPTION
## Goal

Remove trigger of RN tests in the build.

## Design

A new mechanism for testing our cross-platform notifiers is being developed and the older mechanism has already been removed from bugsnag-js.

## Testing

Covered by CI.