### PR TITLE
Add null-check to native setStaticJsonData

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -907,6 +907,10 @@ JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_setStaticJsonData(JNIEnv *env,
                                                             jobject thiz,
                                                             jstring data_) {
+  if (bsg_global_env == NULL) {
+    return;
+  }
+
   const char *data = bsg_safe_get_string_utf_chars(env, data_);
   if (data == NULL) {
     return;

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/FeatureFlagScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/FeatureFlagScenario.kt
@@ -18,12 +18,12 @@ class FeatureFlagScenario(
                 return@addOnSend true
             }
         }
+
+        config.addFeatureFlag("demo_mode")
     }
 
     override fun startScenario() {
         super.startScenario()
-
-        Bugsnag.addFeatureFlag("demo_mode")
 
         Bugsnag.addFeatureFlags(
             listOf(


### PR DESCRIPTION
## Goal
Add a safety null-check to `setStaticJsonData` to avoid a null-deref of `bsg_global_env`.

## Notes
While it should not be possible based on our standard initialisation path, the additional check aligns the function with our other functions in this path.

## Testing
Relied on existing tests