### PR TITLE
Fix memcpy error when removing or replacing feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## TBD
+
+* Fixed a bug that could sometimes cause native crashes when adding or clearing feature flags
+  [#1777](https://github.com/bugsnag/bugsnag-android/pull/1777)
+
 ## 5.28.1 (2022-10-19)
 
 ### Bug fixes

--- a/bugsnag-plugin-android-ndk/src/main/jni/featureflags.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/featureflags.c
@@ -42,8 +42,7 @@ static void remove_at_index_and_compact(bugsnag_event *const event,
                                         const int index) {
   if (event->feature_flag_count > 1 && index < event->feature_flag_count - 1) {
     memmove(&event->feature_flags[index], &event->feature_flags[index + 1],
-            (event->feature_flag_count - index) *
-                sizeof(event->feature_flags[0]));
+            (event->feature_flag_count - index - 1) * sizeof(bsg_feature_flag));
   }
 }
 


### PR DESCRIPTION
## Goal
Fix an off-by-one error in the `memmove` call of `remove_at_index_and_compact` (typically seen when calling `addFeatureFlag`).

## Testing
Relied on existing tests still working as expected