### PR TITLE
Correctly truncate long strings from nested metadata structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## TBD
 
+### Bug fixes
+
 * Fixed a bug that could sometimes cause native crashes when adding or clearing feature flags
   [#1777](https://github.com/bugsnag/bugsnag-android/pull/1777)
+* Nested metadata is now correctly subject to the `Configuration.setMaxStringValueLength` setting
+  [#1778](https://github.com/bugsnag/bugsnag-android/pull/1778)
 
 ## 5.28.1 (2022-10-19)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbInternal.kt
@@ -26,7 +26,7 @@ internal class BreadcrumbInternal internal constructor(
 
     internal fun trimMetadataStringsTo(maxStringLength: Int): TrimMetrics {
         val metadata = this.metadata ?: return TrimMetrics(0, 0)
-        return StringUtils.trimNullableStringValuesTo(maxStringLength, metadata)
+        return StringUtils.trimStringValuesTo(maxStringLength, metadata)
     }
 
     @Throws(IOException::class)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Metadata.kt
@@ -144,7 +144,11 @@ internal data class Metadata @JvmOverloads constructor(
         var stringCount = 0
         var charCount = 0
         store.forEach { entry ->
-            val stringAndCharCounts = StringUtils.trimStringValuesTo(maxStringLength, entry.value)
+            val stringAndCharCounts = StringUtils.trimStringValuesTo(
+                maxStringLength,
+                entry.value as MutableMap<String, Any?>
+            )
+
             stringCount += stringAndCharCounts.itemsTrimmed
             charCount += stringAndCharCounts.dataTrimmed
         }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/StringUtils.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/StringUtils.kt
@@ -1,7 +1,17 @@
 package com.bugsnag.android.internal
 
+import java.util.EnumMap
+import java.util.Hashtable
+import java.util.LinkedList
+import java.util.TreeMap
+import java.util.Vector
+import java.util.WeakHashMap
+import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.CopyOnWriteArrayList
+
 internal object StringUtils {
-    val trimMessageLength = "***<9> CHARS TRUNCATED***".length
+    private const val trimMessageLength = "***<9> CHARS TRUNCATED***".length
+
     fun stringTrimmedTo(maxLength: Int, str: String): String {
         val excessCharCount = str.length - maxLength
         return when {
@@ -10,33 +20,88 @@ internal object StringUtils {
         }
     }
 
-    fun trimNullableStringValuesTo(maxStringLength: Int, map: MutableMap<String, Any?>): TrimMetrics {
+    @Suppress("unchecked_cast")
+    fun trimStringValuesTo(maxStringLength: Int, list: MutableList<Any?>): TrimMetrics {
         var stringCount = 0
         var charCount = 0
-        for (entry in map.entries) {
-            val value = entry.value
-            if (value is String && value.length > maxStringLength) {
-                entry.setValue(stringTrimmedTo(maxStringLength, value))
-                charCount += value.length - maxStringLength
-                stringCount++
+
+        repeat(list.size) { index ->
+            trimValue(maxStringLength, list[index]) { newValue, stringTrimmed, charsTrimmed ->
+                list[index] = newValue
+                stringCount += stringTrimmed
+                charCount += charsTrimmed
             }
         }
 
         return TrimMetrics(stringCount, charCount)
     }
 
-    fun trimStringValuesTo(maxStringLength: Int, map: MutableMap<String, Any>): TrimMetrics {
+    @Suppress("unchecked_cast")
+    fun trimStringValuesTo(maxStringLength: Int, map: MutableMap<String, Any?>): TrimMetrics {
         var stringCount = 0
         var charCount = 0
-        for (entry in map.entries) {
-            val value = entry.value
-            if (value is String && value.length > maxStringLength) {
-                entry.setValue(stringTrimmedTo(maxStringLength, value))
-                charCount += value.length - maxStringLength
-                stringCount++
+        map.entries.forEach { entry ->
+            trimValue(maxStringLength, entry.value) { newValue, stringTrimmed, charsTrimmed ->
+                entry.setValue(newValue)
+                stringCount += stringTrimmed
+                charCount += charsTrimmed
             }
         }
 
         return TrimMetrics(stringCount, charCount)
     }
+
+    @Suppress("unchecked_cast")
+    private inline fun trimValue(
+        maxStringLength: Int,
+        value: Any?,
+        update: (newValue: Any, stringTrimmed: Int, charsTrimmed: Int) -> Unit
+    ) {
+        if (value is String && value.length > maxStringLength) {
+            update(stringTrimmedTo(maxStringLength, value), 1, value.length - maxStringLength)
+        } else if (value.isDefinitelyMutableMap()) {
+            val (innerStringCount, innerCharCount) = trimStringValuesTo(
+                maxStringLength,
+                value as MutableMap<String, Any?>
+            )
+
+            update(value, innerStringCount, innerCharCount)
+        } else if (value.isDefinitelyMutableList()) {
+            val (innerStringCount, innerCharCount) = trimStringValuesTo(
+                maxStringLength,
+                value as MutableList<Any?>
+            )
+
+            update(value, innerStringCount, innerCharCount)
+        } else if (value is Map<*, *>) {
+            val newValue = value.toMutableMap() as MutableMap<String, Any?>
+            val (innerStringCount, innerCharCount) = trimStringValuesTo(maxStringLength, newValue)
+            update(newValue, innerStringCount, innerCharCount)
+        } else if (value is Collection<*>) {
+            val newValue = value.toMutableList()
+            val (innerStringCount, innerCharCount) = trimStringValuesTo(maxStringLength, newValue)
+            update(newValue, innerStringCount, innerCharCount)
+        }
+    }
+
+    /**
+     * In order to avoid surprises we have a small list of commonly used Map types that are known
+     * to be mutable (avoiding issues around Kotlin trying to determine whether
+     * `Collections.singletonMap` (and such) is mutable or not).
+     *
+     * It is technically possible that a HashMap was extended to be immutable, but it's unlikely.
+     */
+    private fun Any?.isDefinitelyMutableMap() =
+        this is HashMap<*, *> ||
+            this is TreeMap<*, *> ||
+            this is ConcurrentMap<*, *> || // concurrent automatically implies mutability
+            this is EnumMap<*, *> ||
+            this is Hashtable<*, *> ||
+            this is WeakHashMap<*, *>
+
+    private fun Any?.isDefinitelyMutableList() =
+        this is ArrayList<*> ||
+            this is LinkedList<*> ||
+            this is CopyOnWriteArrayList<*> ||
+            this is Vector<*>
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/StringUtilsTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/StringUtilsTest.kt
@@ -1,0 +1,96 @@
+package com.bugsnag.android.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Collections
+
+class StringUtilsTest {
+    private val shortString = "this is a short string"
+    private val longString =
+        "this is a really long string with lots of words, words are made out of characters... " +
+            "we have a lot of character"
+    private val trimmedLongString = "this is a really***<95> CHARS TRUNCATED***"
+
+    /**
+     * Check that StringUtils doesn't trim strings where the trim message would overflow the
+     * maximum string length (ie: trimming would make the string > max)
+     */
+    @Test
+    fun testTrimOverflow() {
+        assertEquals(shortString, StringUtils.stringTrimmedTo(9, shortString))
+        assertEquals(longString, StringUtils.stringTrimmedTo(longString.length - 8, longString))
+    }
+
+    @Test
+    fun testTrim() {
+        assertEquals(
+            trimmedLongString,
+            StringUtils.stringTrimmedTo(16, longString)
+        )
+    }
+
+    @Test
+    fun testTrimMap() {
+        val map = mutableMapOf(
+            "short" to shortString,
+            "long" to longString,
+            "null" to null,
+            "number" to 54321,
+            "boolean" to false,
+            "nested" to mutableMapOf(
+                "short" to shortString,
+                "long" to longString
+            ),
+            "list" to mutableListOf(
+                shortString,
+                longString
+            ),
+            "singleton" to Collections.singleton(longString),
+            "immutableList" to Collections.unmodifiableList(
+                listOf(
+                    shortString,
+                    longString,
+                    12345
+                )
+            ),
+            "immutableMap" to Collections.unmodifiableMap(
+                mapOf(
+                    "short" to shortString,
+                    "long" to longString,
+                )
+            )
+        )
+
+        StringUtils.trimStringValuesTo(
+            16, map
+        )
+
+        assertEquals(shortString, map["short"])
+        assertEquals(trimmedLongString, map["long"])
+        assertNull(map["null"])
+        assertEquals(54321, map["number"])
+        assertEquals(false, map["boolean"])
+
+        val nested = map["nested"] as Map<*, *>
+        assertEquals(shortString, nested["short"])
+        assertEquals(trimmedLongString, nested["long"])
+        assertNull(nested["null"])
+
+        val list = map["list"] as List<*>
+        assertEquals(shortString, list[0])
+        assertEquals(trimmedLongString, list[1])
+
+        val singleton = map["singleton"] as List<*>
+        assertEquals(trimmedLongString, singleton[0])
+
+        val immutableList = map["immutableList"] as List<*>
+        assertEquals(shortString, immutableList[0])
+        assertEquals(trimmedLongString, immutableList[1])
+        assertEquals(12345, immutableList[2])
+
+        val immutableMap = map["immutableMap"] as Map<*, *>
+        assertEquals(shortString, immutableMap["short"])
+        assertEquals(trimmedLongString, immutableMap["long"])
+    }
+}


### PR DESCRIPTION
## Goal
Trim strings nested in complex metadata (nested lists, maps or other collections) when they are over the configured "maximum length".

## Testing
Introduced a new unit test for `StringUtils` to ensure all the string trimming code is properly covered