### PR TITLE
Avoid race conditions in refreshSymbolTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fixed a very rare race-condition in refreshSymbolTable that could lead to empty native stack traces being reported
+  [#1781](https://github.com/bugsnag/bugsnag-android/pull/1781)
+
 ## 5.28.2 (2022-11-08)
 
 ### Bug fixes

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/cpp/cxx-scenarios-bugsnag.cpp
@@ -404,4 +404,19 @@ Java_com_bugsnag_android_mazerunner_scenarios_MetadataStringsTooLargeScenario_na
     return value / x / 8;
 }
 
+static volatile int *the_value;
+
+int __attribute__((optnone)) get_the_null_value() {
+  // assume this function is very interesting
+  return *the_value;
+}
+
+extern "C"
+JNIEXPORT jint JNICALL
+Java_com_bugsnag_android_mazerunner_scenarios_CXXRefreshSymbolTableDuringCrashScenario_activate(
+    JNIEnv *env, jobject thiz) {
+
+  return get_the_null_value();
+}
+
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXRefreshSymbolTableDuringCrashScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXRefreshSymbolTableDuringCrashScenario.kt
@@ -1,0 +1,35 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import com.bugsnag.android.Configuration
+import com.bugsnag.android.ndk.BugsnagNDK
+import kotlin.concurrent.thread
+
+class CXXRefreshSymbolTableDuringCrashScenario(
+    config: Configuration,
+    context: Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+
+    companion object {
+        init {
+            System.loadLibrary("bugsnag-ndk")
+            System.loadLibrary("cxx-scenarios-bugsnag")
+        }
+    }
+
+    external fun activate(): Int
+
+    override fun startScenario() {
+        super.startScenario()
+
+        thread {
+            while (true) {
+                BugsnagNDK.refreshSymbolTable()
+            }
+        }
+
+        Thread.sleep(1L)
+        activate()
+    }
+}

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/cxx-scenarios.cpp
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/cpp/cxx-scenarios.cpp
@@ -275,3 +275,4 @@ Java_com_bugsnag_android_mazerunner_scenarios_UnhandledNdkAutoNotifyFalseScenari
 }
 
 }
+

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -157,3 +157,18 @@ Feature: Native crash reporting
     And the "lineNumber" of stack frame 0 equals 0
     And the first significant stack frames match:
       | dispatch::Handler::handle(_jobject*) | CXXCallNullFunctionPointerScenario.cpp | 9 |
+
+  Scenario: Refresh symbol table during a crash
+    When I run "CXXRefreshSymbolTableDuringCrashScenario" and relaunch the crashed app
+    And I configure Bugsnag for "CXXRefreshSymbolTableDuringCrashScenario"
+    And I wait to receive an error
+    Then the error payload contains a completed unhandled native report
+    And the exception "errorClass" equals one of:
+      | SIGABRT |
+      | SIGSEGV |
+    And the exception "message" equals one of:
+      | Abort program                                     |
+      | Segmentation violation (invalid memory reference) |
+    And the exception "type" equals "c"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true


### PR DESCRIPTION
## Goal
Avoid race conditions between the refreshing of the crash-time stack unwinder in the NDK module, and the `refreshSymbolTable` functions.

## Changelog

- `bsg_unwinder_refresh` now completely rebuilds the crash-time stack unwinder and only updates the pointer once the new unwinder is fully initialised.
- `bsg_unwind_crash_stack` localises its reference to the crash-time unwinder upon entry to keep the reference stable.
- `unwinding_crash_stack` is used to ensure that the unwinder used by `bsg_unwind_crash_stack` is not destroyed by a concurrent `bsg_unwinder_refresh`

## Testing
A new mazerunner scenario was introduced that crashes the app while repeatedly rebuilding the unwinder. This scenario will break (most of the time) if the refresh interferes with the stack unwind. Under manual testing this break happens for almost every test, but given the race-condition nature of this we can expect some fakes (but only on regression).