### PR TITLE
Move BackgroundTaskService to the internal package

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DataCollectorTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/DataCollectorTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
+import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -2,11 +2,13 @@ package com.bugsnag.android;
 
 import static com.bugsnag.android.SeverityReason.REASON_HANDLED_EXCEPTION;
 
+import com.bugsnag.android.internal.BackgroundTaskService;
 import com.bugsnag.android.internal.ImmutableConfig;
 import com.bugsnag.android.internal.InternalMetrics;
 import com.bugsnag.android.internal.InternalMetricsImpl;
 import com.bugsnag.android.internal.InternalMetricsNoop;
 import com.bugsnag.android.internal.StateObserver;
+import com.bugsnag.android.internal.TaskType;
 import com.bugsnag.android.internal.dag.ConfigModule;
 import com.bugsnag.android.internal.dag.ContextModule;
 import com.bugsnag.android.internal.dag.SystemServiceModule;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DataCollectionModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DataCollectionModule.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import android.os.Environment
+import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.dag.ConfigModule
 import com.bugsnag.android.internal.dag.ContextModule
 import com.bugsnag.android.internal.dag.DependencyModule

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java
@@ -2,7 +2,9 @@ package com.bugsnag.android;
 
 import static com.bugsnag.android.SeverityReason.REASON_PROMISE_REJECTION;
 
+import com.bugsnag.android.internal.BackgroundTaskService;
 import com.bugsnag.android.internal.ImmutableConfig;
+import com.bugsnag.android.internal.TaskType;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
@@ -11,6 +11,8 @@ import android.content.res.Resources
 import android.os.BatteryManager
 import android.os.Build
 import android.provider.Settings
+import com.bugsnag.android.internal.BackgroundTaskService
+import com.bugsnag.android.internal.TaskType
 import java.io.File
 import java.util.Date
 import java.util.Locale

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStorageModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStorageModule.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.dag.ConfigModule
 import com.bugsnag.android.internal.dag.ContextModule
 import com.bugsnag.android.internal.dag.DependencyModule

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.java
@@ -1,6 +1,8 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.BackgroundTaskService;
 import com.bugsnag.android.internal.ImmutableConfig;
+import com.bugsnag.android.internal.TaskType;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -3,8 +3,10 @@ package com.bugsnag.android;
 import static com.bugsnag.android.DeliveryHeadersKt.HEADER_INTERNAL_ERROR;
 import static com.bugsnag.android.SeverityReason.REASON_UNHANDLED_EXCEPTION;
 
+import com.bugsnag.android.internal.BackgroundTaskService;
 import com.bugsnag.android.internal.ImmutableConfig;
 import com.bugsnag.android.internal.JsonHelper;
+import com.bugsnag.android.internal.TaskType;
 
 import android.annotation.SuppressLint;
 import android.content.Context;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
@@ -1,5 +1,7 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.TaskType;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 
 class LibraryLoader {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -1,7 +1,9 @@
 package com.bugsnag.android;
 
+import com.bugsnag.android.internal.BackgroundTaskService;
 import com.bugsnag.android.internal.DateUtils;
 import com.bugsnag.android.internal.ImmutableConfig;
+import com.bugsnag.android.internal.TaskType;
 
 import android.os.SystemClock;
 
@@ -18,7 +20,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 class SessionTracker extends BaseObservable {
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/TrackerModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/TrackerModule.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.dag.ConfigModule
 import com.bugsnag.android.internal.dag.DependencyModule
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/BackgroundTaskService.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/BackgroundTaskService.kt
@@ -1,4 +1,4 @@
-package com.bugsnag.android
+package com.bugsnag.android.internal
 
 import androidx.annotation.VisibleForTesting
 import java.util.concurrent.BlockingQueue
@@ -18,7 +18,7 @@ import java.lang.Thread as JThread
  * The type of task which is being submitted. This determines which execution queue
  * the task will be added to.
  */
-internal enum class TaskType {
+enum class TaskType {
 
     /**
      * A task that sends an error request. Any filesystem operations
@@ -91,7 +91,7 @@ internal fun createExecutor(name: String, type: TaskType, keepAlive: Boolean): E
  * It also avoids short-running operations being held up by long-running operations submitted
  * to the same executor.
  */
-internal class BackgroundTaskService(
+class BackgroundTaskService(
     // these executors must remain single-threaded - the SDK makes assumptions
     // about synchronization based on this.
     @get:VisibleForTesting

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/dag/DependencyModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/dag/DependencyModule.kt
@@ -1,7 +1,7 @@
 package com.bugsnag.android.internal.dag
 
-import com.bugsnag.android.BackgroundTaskService
-import com.bugsnag.android.TaskType
+import com.bugsnag.android.internal.BackgroundTaskService
+import com.bugsnag.android.internal.TaskType
 
 internal abstract class DependencyModule {
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigChangeReceiverTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigChangeReceiverTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
+import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.StateObserver
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataCollectorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceDataCollectorSerializationTest.kt
@@ -6,6 +6,7 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.util.DisplayMetrics
 import com.bugsnag.android.BugsnagTestUtils.generateDeviceBuildInfo
+import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceMetadataSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeviceMetadataSerializationTest.kt
@@ -6,6 +6,7 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.util.DisplayMetrics
 import com.bugsnag.android.BugsnagTestUtils.generateDeviceBuildInfo
+import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.EventStore.EVENT_COMPARATOR
+import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateEvent
+import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.ImmutableConfig
 import com.bugsnag.android.internal.convertToImmutableConfig
 import org.junit.After

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/InternalEventPayloadDelegateTest.kt
@@ -5,6 +5,7 @@ import android.os.storage.StorageManager
 import com.bugsnag.android.BugsnagTestUtils.generateAppWithState
 import com.bugsnag.android.BugsnagTestUtils.generateDeviceWithState
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
+import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashDeliveryTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashDeliveryTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateEvent
+import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerPauseResumeTest.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.content.Context
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateDevice
+import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.ImmutableConfig
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTrackerTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
+import com.bugsnag.android.internal.BackgroundTaskService;
 import com.bugsnag.android.internal.ImmutableConfig;
 
 import android.app.ActivityManager;

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/BackgroundTaskServiceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/BackgroundTaskServiceTest.kt
@@ -1,4 +1,4 @@
-package com.bugsnag.android
+package com.bugsnag.android.internal
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull


### PR DESCRIPTION
## Goal
Allow first-party plugins to access the `BackgroundTaskService` and consider it stable internal API.

## Changeset
Moved the `BackgroundTaskService` to the `internal` package and made it `public` instead of `internal`. Updated use cases and tests.

## Testing
Relied on existing tests