### PR TITLE
Report the duration of Bugsnag.start calls in MazeRunner

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/Log.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android.mazerunner
 
+import android.os.SystemClock
 import android.util.Log
 
 fun log(msg: String) {
@@ -8,6 +9,16 @@ fun log(msg: String) {
 
 fun log(msg: String, e: Exception) {
     Log.e("BugsnagMazeRunner", msg, e)
+}
+
+inline fun <R> reportDuration(tag: String, block: () -> R): R {
+    val start = SystemClock.elapsedRealtime()
+    try {
+        return block()
+    } finally {
+        val end = SystemClock.elapsedRealtime()
+        Log.i("MazeDuration", "$tag - ${end - start}ms")
+    }
 }
 
 /**

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BugsnagInitScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/BugsnagInitScenario.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Client
 import com.bugsnag.android.Configuration
-import java.lang.RuntimeException
+import com.bugsnag.android.mazerunner.reportDuration
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 
@@ -23,9 +23,25 @@ internal class BugsnagInitScenario(
         val callables = mutableListOf<Callable<Client?>>()
 
         IntRange(1, 25).forEach {
-            callables.add(Callable { Bugsnag.start(context) })
-            callables.add(Callable { Bugsnag.start(context, config.apiKey) })
-            callables.add(Callable { Bugsnag.start(context, Configuration(config.apiKey)) })
+            callables.add(
+                Callable {
+                    reportDuration("Bugsnag.start") { Bugsnag.start(context) }
+                }
+            )
+
+            callables.add(
+                Callable {
+                    reportDuration("Bugsnag.start") { Bugsnag.start(context, config.apiKey) }
+                }
+            )
+
+            callables.add(
+                Callable {
+                    reportDuration("Bugsnag.start") {
+                        Bugsnag.start(context, Configuration(config.apiKey))
+                    }
+                }
+            )
         }
 
         val futures = threadPool.invokeAll(callables)

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationFromManifestScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationFromManifestScenario.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.OnErrorCallback
+import com.bugsnag.android.mazerunner.reportDuration
 import java.lang.RuntimeException
 
 internal class LoadConfigurationFromManifestScenario(
@@ -23,7 +24,7 @@ internal class LoadConfigurationFromManifestScenario(
             }
         )
 
-        Bugsnag.start(this.context, testConfig)
+        reportDuration("Bugsnag.start") { Bugsnag.start(this.context, testConfig) }
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
@@ -6,6 +6,7 @@ import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
 import com.bugsnag.android.OnErrorCallback
 import com.bugsnag.android.ThreadSendPolicy
+import com.bugsnag.android.mazerunner.reportDuration
 import java.lang.RuntimeException
 
 internal class LoadConfigurationKotlinScenario(
@@ -41,7 +42,7 @@ internal class LoadConfigurationKotlinScenario(
             }
         )
 
-        Bugsnag.start(this.context, testConfig)
+        reportDuration("Bugsnag.start") { Bugsnag.start(this.context, testConfig) }
     }
 
     override fun startScenario() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiThreadedStartupScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/MultiThreadedStartupScenario.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android.mazerunner.scenarios
 import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.reportDuration
 import kotlin.concurrent.thread
 
 class MultiThreadedStartupScenario(
@@ -14,7 +15,7 @@ class MultiThreadedStartupScenario(
 
     override fun startScenario() {
         val startThread = thread(name = "AsyncStart") {
-            Bugsnag.start(context, config)
+            reportDuration("Bugsnag.start") { Bugsnag.start(context, config) }
         }
 
         thread(name = "leaveBreadcrumb") {
@@ -24,7 +25,7 @@ class MultiThreadedStartupScenario(
                 Bugsnag.leaveBreadcrumb("I'm leaving a breadcrumb on another thread")
                 Bugsnag.notify(Exception("Scenario complete"))
             } catch (e: Exception) {
-                Bugsnag.start(context, config)
+                reportDuration("Bugsnag.start") { Bugsnag.start(context, config) }
                 Bugsnag.notify(e)
             }
         }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/Scenario.kt
@@ -17,6 +17,7 @@ import com.bugsnag.android.mazerunner.BugsnagIntentParams
 import com.bugsnag.android.mazerunner.log
 import com.bugsnag.android.mazerunner.multiprocess.MultiProcessService
 import com.bugsnag.android.mazerunner.multiprocess.findCurrentProcessName
+import com.bugsnag.android.mazerunner.reportDuration
 import java.io.File
 
 abstract class Scenario(
@@ -46,7 +47,7 @@ abstract class Scenario(
      */
     open fun startBugsnag(startBugsnagOnly: Boolean) {
         this.startBugsnagOnly = startBugsnagOnly
-        Bugsnag.start(context, config)
+        reportDuration("Bugsnag.start") { Bugsnag.start(context, config) }
     }
 
     /**


### PR DESCRIPTION
## Goal
Report the time taken calling `Bugsnag.start` within the MazeRunner test fixture, by logging the data to the device logs.

## Changelog
Introduced `reportDuration` to measure report the time taken by a tagged block of code. For now this is delivered in the device logs.

## Testing
Manually checked the reporting in the device logs