### PR TITLE
Sort received requests to avoid test flakes

### DIFF
--- a/features/full_tests/breadcrumb.feature
+++ b/features/full_tests/breadcrumb.feature
@@ -36,12 +36,9 @@ Feature: Reporting Breadcrumbs
     When I run "ErrorBreadcrumbsScenario" and relaunch the crashed app
     And I configure Bugsnag for "ErrorBreadcrumbsScenario"
     Then I wait to receive 2 errors
-    And the exception "errorClass" equals "java.lang.RuntimeException"
-    And the exception "message" equals "first error"
-    And the event "unhandled" is false
-    And the event has 0 breadcrumbs
-    Then I discard the oldest error
-    And the exception "errorClass" equals "java.lang.NullPointerException"
+    And I sort the errors by the payload field "events.0.exceptions.0.errorClass"
+
+    Then the exception "errorClass" equals "java.lang.NullPointerException"
     And the exception "message" equals "something broke"
     And the event "unhandled" is true
     And the event has 1 breadcrumbs
@@ -52,3 +49,9 @@ Feature: Reporting Breadcrumbs
     And the event "breadcrumbs.0.metaData.message" equals "first error"
     And the event "breadcrumbs.0.metaData.unhandled" equals "false"
     And the event "breadcrumbs.0.metaData.severity" equals "WARNING"
+
+    Then I discard the oldest error
+    And the exception "errorClass" equals "java.lang.RuntimeException"
+    And the exception "message" equals "first error"
+    And the event "unhandled" is false
+    And the event has 0 breadcrumbs

--- a/features/full_tests/multi_process.feature
+++ b/features/full_tests/multi_process.feature
@@ -6,7 +6,7 @@ Feature: Reporting errors in multi process apps
   Scenario: Handled JVM error
     When I run "MultiProcessHandledExceptionScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.app.processName"
+    And I sort the errors by the payload field "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
@@ -39,7 +39,7 @@ Feature: Reporting errors in multi process apps
     And I run "MultiProcessUnhandledExceptionScenario" and relaunch the crashed app
     And I run "MultiProcessUnhandledExceptionScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.app.processName"
+    And I sort the errors by the payload field "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
@@ -58,7 +58,7 @@ Feature: Reporting errors in multi process apps
   Scenario: Handled NDK error
     When I run "MultiProcessHandledCXXErrorScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.app.processName"
+    And I sort the errors by the payload field "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload contains a completed handled native report
     And the error payload field "events" is an array with 1 elements
@@ -89,7 +89,7 @@ Feature: Reporting errors in multi process apps
     And I run "MultiProcessUnhandledCXXErrorScenario" and relaunch the crashed app
     And I run "MultiProcessUnhandledCXXErrorScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.app.processName"
+    And I sort the errors by the payload field "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload contains a completed handled native report
     And the error payload field "events" is an array with 1 elements
@@ -118,7 +118,7 @@ Feature: Reporting errors in multi process apps
   Scenario: User/device information is migrated from SharedPreferences
     When I run "SharedPrefMigrationScenario"
     Then I wait to receive 2 errors
-    And I sort the errors by "events.0.metaData.app.processName"
+    And I sort the errors by the payload field "events.0.metaData.app.processName"
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -256,12 +256,6 @@ rescue Selenium::WebDriver::Error::UnknownError
   return false
 end
 
-Then("I sort the errors by {string}") do |comparator|
-  Maze::Server.errors.remaining.sort_by { |request|
-    Maze::Helper.read_key_path(request[:body], comparator)
-  }
-end
-
 Then("the exception stacktrace matches the thread stacktrace") do
   exc_trace = read_key_path(Server.current_request[:body], "events.0.exceptions.0.stacktrace")
   thread_trace = read_key_path(Server.current_request[:body], "events.0.threads.0.stacktrace")


### PR DESCRIPTION
## Goal

Avoids a flake in `ErrorBreadcrumbsScenario` where the errors can be received out of order.

## Changeset

Sorts the requests received in that scenario and refactors the existing scenarios that sort requests to use the step available in Maze runner.

## Testing

Covered by CI (once the device farm starts working again).