### PR TITLE
Temporary soft fail of tests on Android 6 and 7

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -101,6 +101,9 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
+    soft_fail:
+      - exit_status: 2
 
   - label: ':android: Android 6 NDK r16 end-to-end tests - batch 2'
     depends_on: "fixture-r16"
@@ -127,6 +130,9 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
+    soft_fail:
+      - exit_status: 2
 
   - label: ':android: Android 7 NDK r19 end-to-end tests - batch 1'
     depends_on: "fixture-r19"
@@ -153,6 +159,9 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
+    soft_fail:
+      - exit_status: 2
 
   - label: ':android: Android 7 NDK r19 end-to-end tests - batch 2'
     depends_on: "fixture-r19"
@@ -179,6 +188,9 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
+    soft_fail:
+      - exit_status: 2
 
   - label: ':android: Android 8.1 NDK r19 end-to-end tests - batch 1'
     depends_on: "fixture-r19"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,6 +127,9 @@ steps:
     concurrency_method: eager
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
+    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
+    soft_fail:
+      - exit_status: 2
 
   - label: ':android: Android 7 NDK r19 smoke tests'
     key: 'android-7-smoke'
@@ -153,6 +156,9 @@ steps:
     concurrency_method: eager
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
+    soft_fail:
+      - exit_status: 2
 
   - label: ':android: Android 8.1 NDK r19 smoke tests'
     key: 'android-8-1-smoke'


### PR DESCRIPTION
## Goal

A repeat of #976 .

Allows tests on Android 6 and 7 to soft fail whilst the secure tunnel outage at BrowserStack is resolved.

Once the outage is resolved and the jobs start running again we should remove the soft fails.

## Testing

Covered by CI.