### PR TITLE
Remove soft fails for Android 6 and 7 e2e tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -101,9 +101,6 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
-    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
-    soft_fail:
-      - exit_status: 2
 
   - label: ':android: Android 6 NDK r16 end-to-end tests - batch 2'
     depends_on: "fixture-r16"
@@ -130,9 +127,6 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
-    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
-    soft_fail:
-      - exit_status: 2
 
   - label: ':android: Android 7 NDK r19 end-to-end tests - batch 1'
     depends_on: "fixture-r19"
@@ -159,9 +153,6 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
-    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
-    soft_fail:
-      - exit_status: 2
 
   - label: ':android: Android 7 NDK r19 end-to-end tests - batch 2'
     depends_on: "fixture-r19"
@@ -188,9 +179,6 @@ steps:
     concurrency: 24
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
-    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
-    soft_fail:
-      - exit_status: 2
 
   - label: ':android: Android 8.1 NDK r19 end-to-end tests - batch 1'
     depends_on: "fixture-r19"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,9 +127,6 @@ steps:
     concurrency_method: eager
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
-    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
-    soft_fail:
-      - exit_status: 2
 
   - label: ':android: Android 7 NDK r19 smoke tests'
     key: 'android-7-smoke'
@@ -156,9 +153,6 @@ steps:
     concurrency_method: eager
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    # PLAT-9240: Soft fail pending resolution of BrowserStack secure tunnel outage
-    soft_fail:
-      - exit_status: 2
 
   - label: ':android: Android 8.1 NDK r19 smoke tests'
     key: 'android-8-1-smoke'


### PR DESCRIPTION
## Goal

Remove soft fails for Android 6 and 7 e2e tests.

## Design

A persistent problem with the BrowserStack secure tunnel meant that these tests were consistently failing for a number of days.  The problem is now confirmed as fixed and so these soft_fails can now be removed.

## Testing

Covered by CI.