### PR TITLE
Reconcile Cucumber steps

### DIFF
--- a/features/full_tests/breadcrumb.feature
+++ b/features/full_tests/breadcrumb.feature
@@ -30,7 +30,7 @@ Feature: Reporting Breadcrumbs
     When I run "BreadcrumbAutoScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-    And the event has a "state" breadcrumb with message "Bugsnag loaded"
+    And the event has a "state" breadcrumb named "Bugsnag loaded"
 
   Scenario: Error Breadcrumbs appear in subsequent events
     When I run "ErrorBreadcrumbsScenario" and relaunch the crashed app

--- a/features/full_tests/breadcrumb.feature
+++ b/features/full_tests/breadcrumb.feature
@@ -30,7 +30,7 @@ Feature: Reporting Breadcrumbs
     When I run "BreadcrumbAutoScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-    And the event has a "state" breadcrumb with the message "Bugsnag loaded"
+    And the event has a "state" breadcrumb with message "Bugsnag loaded"
 
   Scenario: Error Breadcrumbs appear in subsequent events
     When I run "ErrorBreadcrumbsScenario" and relaunch the crashed app

--- a/features/smoke_tests/02_handled.feature
+++ b/features/smoke_tests/02_handled.feature
@@ -226,8 +226,8 @@ Feature: Handled smoke tests
     And the event "user.name" equals "Jack Mill"
 
     # Breadcrumbs
-    And the event has a "manual" breadcrumb with message "Initiate lift"
-    And the event has a "manual" breadcrumb with message "Disable lift"
+    And the event has a "manual" breadcrumb named "Initiate lift"
+    And the event has a "manual" breadcrumb named "Disable lift"
     And the event has a "log" breadcrumb named "Cold beans detected"
 
     # Context

--- a/features/smoke_tests/02_handled.feature
+++ b/features/smoke_tests/02_handled.feature
@@ -226,8 +226,8 @@ Feature: Handled smoke tests
     And the event "user.name" equals "Jack Mill"
 
     # Breadcrumbs
-    And the event has a "manual" breadcrumb with the message "Initiate lift"
-    And the event has a "manual" breadcrumb with the message "Disable lift"
+    And the event has a "manual" breadcrumb with message "Initiate lift"
+    And the event has a "manual" breadcrumb with message "Disable lift"
     And the event has a "log" breadcrumb named "Cold beans detected"
 
     # Context

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -218,19 +218,6 @@ Then("the stacktrace contains native frame information") do
   end
 end
 
-Then("the exception stacktrace matches the thread stacktrace") do
-  exc_trace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.stacktrace")
-  thread_trace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.threads.0.stacktrace")
-  Maze.check.equal(exc_trace.length(),
-                   thread_trace.length(),
-                   "Exception and thread stacktraces are different lengths.")
-
-  thread_trace.each_with_index do |thread_frame, index|
-    exc_frame = exc_trace[index]
-    Maze.check.equal(exc_frame, thread_frame)
-  end
-end
-
 def click_if_present(element)
   return false unless Maze.driver.wait_for_element(element, 1)
 
@@ -238,19 +225,6 @@ def click_if_present(element)
 rescue Selenium::WebDriver::Error::UnknownError
   # Ignore Appium errors (e.g. during an ANR)
   return false
-end
-
-Then("the exception stacktrace matches the thread stacktrace") do
-  exc_trace = read_key_path(Server.current_request[:body], "events.0.exceptions.0.stacktrace")
-  thread_trace = read_key_path(Server.current_request[:body], "events.0.threads.0.stacktrace")
-  Maze.check.equal(exc_trace.length(),
-                   thread_trace.length(),
-                   "Exception and thread stacktraces are different lengths.")
-
-  thread_trace.each_with_index do |thread_frame, index|
-    exc_frame = exc_trace[index]
-    Maze.check.equal(exc_frame, thread_frame)
-  end
 end
 
 Then("the event binary arch field is valid") do

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -223,17 +223,6 @@ Then("the event has {int} breadcrumbs") do |expected_count|
   fail("Incorrect number of breadcrumbs found: #{value.length()}, expected: #{expected_count}") if value.length() != expected_count.to_i
 end
 
-Then("the event has a {string} breadcrumb with the message {string}") do |type, message|
-  value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.breadcrumbs")
-  found = false
-  value.each do |crumb|
-    if crumb["type"] == type and crumb["name"] == message
-      found = true
-    end
-  end
-  fail("No breadcrumb matched: #{value}") unless found
-end
-
 Then("the exception stacktrace matches the thread stacktrace") do
   exc_trace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.stacktrace")
   thread_trace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.threads.0.stacktrace")

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -218,11 +218,6 @@ Then("the stacktrace contains native frame information") do
   end
 end
 
-Then("the event has {int} breadcrumbs") do |expected_count|
-  value = Maze::Server.errors.current[:body]["events"].first["breadcrumbs"]
-  fail("Incorrect number of breadcrumbs found: #{value.length()}, expected: #{expected_count}") if value.length() != expected_count.to_i
-end
-
 Then("the exception stacktrace matches the thread stacktrace") do
   exc_trace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.stacktrace")
   thread_trace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.threads.0.stacktrace")


### PR DESCRIPTION
## Goal

Fixes the build after `the event has {int} breadcrumbs` was added to Maze Runner, causing a Cucumber ambiguous step error.

Also takes the opportunity to remove `the event has a {string} breadcrumb with the message {string}` in favour of `the event has a {string} breadcrumb name {string}` (no "the"), also already defined in Maze Runner.

## Testing

Covered by a basic CI run.