### PR TITLE
Upload e2e test fixtures just once

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -82,7 +82,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r16_url.txt"
+          - "build/fixture_r16_url.txt"
           - "build/fixture-r16/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -91,7 +91,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=@fixture_r16_url.txt"
+          - "--app=@/app/build/fixture_r16_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
           - "--appium-version=1.20.2"
@@ -108,7 +108,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r16_url.txt"
+          - "build/fixture_r16_url.txt"
           - "build/fixture-r16/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -117,7 +117,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@fixture_r16_url.txt"
+          - "--app=@/app/build/fixture_r16_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
           - "--appium-version=1.20.2"
@@ -134,7 +134,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r19_url.txt"
+          - "build/fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -143,7 +143,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=@fixture_r19_url.txt"
+          - "--app=@/app/build/fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
           - "--appium-version=1.20.2"
@@ -160,7 +160,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r19_url.txt"
+          - "build/fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -169,7 +169,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@fixture_r19_url.txt"
+          - "--app=@/app/build/fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
           - "--appium-version=1.20.2"
@@ -186,7 +186,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r19_url.txt"
+          - "build/fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -195,7 +195,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=@fixture_r19_url.txt"
+          - "--app=@/app/build/fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
           - "--appium-version=1.20.2"
@@ -212,7 +212,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r19_url.txt"
+          - "build/fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -221,7 +221,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@fixture_r19_url.txt"
+          - "--app=@/app/build/fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
           - "--appium-version=1.20.2"
@@ -238,14 +238,14 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: android-maze-runner
         run: android-maze-runner
         command:
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "--appium-version=1.20.2"
@@ -264,7 +264,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -273,7 +273,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "--appium-version=1.20.2"
@@ -290,7 +290,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -299,7 +299,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
           - "--appium-version=1.20.2"
@@ -316,7 +316,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -325,7 +325,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
           - "--appium-version=1.20.2"
@@ -346,7 +346,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -355,7 +355,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
           - "--appium-version=1.20.2"
@@ -372,7 +372,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -381,7 +381,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
           - "--appium-version=1.20.2"
@@ -398,7 +398,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -407,7 +407,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_13_0"
           - "--appium-version=1.20.2"
@@ -424,7 +424,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -433,7 +433,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_13_0"
           - "--appium-version=1.20.2"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -82,7 +82,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r16.apk"
+          - "fixture_r16_url.txt"
           - "build/fixture-r16/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -91,7 +91,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=/app/build/fixture-r16.apk"
+          - "--app=@fixture_r16_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
           - "--appium-version=1.20.2"
@@ -108,7 +108,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r16.apk"
+          - "fixture_r16_url.txt"
           - "build/fixture-r16/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -117,7 +117,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=/app/build/fixture-r16.apk"
+          - "--app=@fixture_r16_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
           - "--appium-version=1.20.2"
@@ -134,7 +134,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r19.apk"
+          - "fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -143,7 +143,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=/app/build/fixture-r19.apk"
+          - "--app=@fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
           - "--appium-version=1.20.2"
@@ -160,7 +160,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r19.apk"
+          - "fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -169,7 +169,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=/app/build/fixture-r19.apk"
+          - "--app=@fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
           - "--appium-version=1.20.2"
@@ -186,7 +186,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r19.apk"
+          - "fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -195,7 +195,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=/app/build/fixture-r19.apk"
+          - "--app=@fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
           - "--appium-version=1.20.2"
@@ -212,7 +212,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r19.apk"
+          - "fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -221,7 +221,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=/app/build/fixture-r19.apk"
+          - "--app=@fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
           - "--appium-version=1.20.2"
@@ -238,14 +238,14 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: android-maze-runner
         run: android-maze-runner
         command:
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "--appium-version=1.20.2"
@@ -264,7 +264,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -273,7 +273,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_9_0"
           - "--appium-version=1.20.2"
@@ -290,7 +290,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -299,7 +299,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
           - "--appium-version=1.20.2"
@@ -316,7 +316,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -325,7 +325,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
           - "--appium-version=1.20.2"
@@ -346,7 +346,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -355,7 +355,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
           - "--appium-version=1.20.2"
@@ -372,7 +372,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -381,7 +381,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
           - "--appium-version=1.20.2"
@@ -398,7 +398,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -407,7 +407,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_13_0"
           - "--appium-version=1.20.2"
@@ -424,7 +424,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -433,7 +433,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_13_0"
           - "--appium-version=1.20.2"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,12 +12,12 @@ steps:
     agents:
       queue: macos-12-arm
     artifact_paths:
-      - "fixture_r16_url.txt"
+      - "build/fixture_r16_url.txt"
       - "build/fixture-r16/*"
     commands:
       - bundle install
       - make fixture-r16
-      - bundle exec upload-app --app=./build/fixture-r16.apk --app-id-file=fixture_r16_url.txt
+      - bundle exec upload-app --app=./build/fixture-r16.apk --app-id-file=build/fixture_r16_url.txt
 
   - label: ':android: Build fixture APK r19'
     key: "fixture-r19"
@@ -25,12 +25,12 @@ steps:
     agents:
       queue: macos-12-arm
     artifact_paths:
-      - "fixture_r19_url.txt"
+      - "build/fixture_r19_url.txt"
       - "build/fixture-r19/*"
     commands:
       - bundle install
       - make fixture-r19
-      - bundle exec upload-app --app=./build/fixture-r19.apk --app-id-file=fixture_r19_url.txt
+      - bundle exec upload-app --app=./build/fixture-r19.apk --app-id-file=build/fixture_r19_url.txt
 
   - label: ':android: Build fixture APK r21'
     key: "fixture-r21"
@@ -43,7 +43,7 @@ steps:
     commands:
       - bundle install
       - make fixture-r21
-      - bundle exec upload-app --app=./build/fixture-r21.apk --app-id-file=fixture_r21_url.txt
+      - bundle exec upload-app --app=./build/fixture-r21.apk --app-id-file=build/fixture_r21_url.txt
 
   - label: ':android: Coding standards checks'
     timeout_in_minutes: 20
@@ -90,7 +90,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r16_url.txt"
+          - "build/fixture_r16_url.txt"
           - "build/fixture-r16/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -98,7 +98,7 @@ steps:
         run: android-maze-runner-legacy
         command:
           - "features/smoke_tests"
-          - "--app=@fixture_r16_url.txt"
+          - "--app=@/app/build/fixture_r16_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_4_4"
           - "--fail-fast"
@@ -115,7 +115,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r16_url.txt"
+          - "build/fixture_r16_url.txt"
           - "build/fixture-r16/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -123,7 +123,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=@fixture_r16_url.txt"
+          - "--app=@/app/build/fixture_r16_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
           - "--appium-version=1.20.2"
@@ -141,7 +141,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r19_url.txt"
+          - "build/fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -149,7 +149,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=@fixture_r19_url.txt"
+          - "--app=@/app/build/fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
           - "--appium-version=1.20.2"
@@ -167,7 +167,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r19_url.txt"
+          - "build/fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -175,7 +175,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=@fixture_r19_url.txt"
+          - "--app=@/app/build/fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
           - "--appium-version=1.20.2"
@@ -193,7 +193,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -201,7 +201,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
           - "--appium-version=1.20.2"
@@ -219,7 +219,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -227,7 +227,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
           - "--appium-version=1.20.2"
@@ -249,7 +249,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -258,7 +258,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_12_0"
           - "--appium-version=1.20.2"
@@ -276,7 +276,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "fixture_r21_url.txt"
+          - "build/fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -285,7 +285,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@fixture_r21_url.txt"
+          - "--app=@/app/build/fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_12_0"
           - "--appium-version=1.20.2"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
     agents:
       queue: macos-12-arm
     artifact_paths:
-      - "fixture_r121_url.txt"
+      - "build/fixture_r21_url.txt"
       - "build/fixture-r21/*"
     commands:
       - bundle install

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,10 +12,12 @@ steps:
     agents:
       queue: macos-12-arm
     artifact_paths:
-      - "build/fixture-r16.apk"
+      - "fixture_r16_url.txt"
       - "build/fixture-r16/*"
     commands:
+      - bundle install
       - make fixture-r16
+      - bundle exec upload-app --app=./build/fixture-r16.apk --app-id-file=fixture_r16_url.txt
 
   - label: ':android: Build fixture APK r19'
     key: "fixture-r19"
@@ -23,10 +25,12 @@ steps:
     agents:
       queue: macos-12-arm
     artifact_paths:
-      - "build/fixture-r19.apk"
+      - "fixture_r19_url.txt"
       - "build/fixture-r19/*"
     commands:
+      - bundle install
       - make fixture-r19
+      - bundle exec upload-app --app=./build/fixture-r19.apk --app-id-file=fixture_r19_url.txt
 
   - label: ':android: Build fixture APK r21'
     key: "fixture-r21"
@@ -34,10 +38,12 @@ steps:
     agents:
       queue: macos-12-arm
     artifact_paths:
-      - "build/fixture-r21.apk"
+      - "fixture_r121_url.txt"
       - "build/fixture-r21/*"
     commands:
+      - bundle install
       - make fixture-r21
+      - bundle exec upload-app --app=./build/fixture-r21.apk --app-id-file=fixture_r21_url.txt
 
   - label: ':android: Coding standards checks'
     timeout_in_minutes: 20
@@ -84,7 +90,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r16.apk"
+          - "fixture_r16_url.txt"
           - "build/fixture-r16/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -92,7 +98,7 @@ steps:
         run: android-maze-runner-legacy
         command:
           - "features/smoke_tests"
-          - "--app=/app/build/fixture-r16.apk"
+          - "--app=@fixture_r16_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_4_4"
           - "--fail-fast"
@@ -109,7 +115,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r16.apk"
+          - "fixture_r16_url.txt"
           - "build/fixture-r16/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -117,7 +123,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=/app/build/fixture-r16.apk"
+          - "--app=@fixture_r16_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
           - "--appium-version=1.20.2"
@@ -135,7 +141,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r19.apk"
+          - "fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -143,7 +149,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=/app/build/fixture-r19.apk"
+          - "--app=@fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_7_1"
           - "--appium-version=1.20.2"
@@ -161,7 +167,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r19.apk"
+          - "fixture_r19_url.txt"
           - "build/fixture-r19/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -169,7 +175,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=/app/build/fixture-r19.apk"
+          - "--app=@fixture_r19_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_8_1"
           - "--appium-version=1.20.2"
@@ -187,7 +193,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -195,7 +201,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_10_0"
           - "--appium-version=1.20.2"
@@ -213,7 +219,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -221,7 +227,7 @@ steps:
         run: android-maze-runner
         command:
           - "features/smoke_tests"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_11_0"
           - "--appium-version=1.20.2"
@@ -243,7 +249,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -252,7 +258,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_12_0"
           - "--appium-version=1.20.2"
@@ -270,7 +276,7 @@ steps:
     plugins:
       artifacts#v1.2.0:
         download:
-          - "build/fixture-r21.apk"
+          - "fixture_r21_url.txt"
           - "build/fixture-r21/*"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -279,7 +285,7 @@ steps:
         command:
           - "features/full_tests"
           - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=/app/build/fixture-r21.apk"
+          - "--app=@fixture_r21_url.txt"
           - "--farm=bs"
           - "--device=ANDROID_12_0"
           - "--appium-version=1.20.2"


### PR DESCRIPTION
## Goal

Upload each test fixture app to BrowserStack just once, saving time and reducing our exposure to any problems with the upload interface.

## Design

Follows the existing pattern on bugsnag-cocoa (and others).  Writing ids to files and uploading at Buildkite artifacts is a little clunky, but it's the nature of the tooling.

## Testing

Covered by a full CI run.