### PR TITLE
Allow a single retry on flaky scenarios

### DIFF
--- a/features/full_tests/in_foreground.feature
+++ b/features/full_tests/in_foreground.feature
@@ -8,4 +8,5 @@ Feature: In foreground field populates correctly
     And I send the app to the background for 5 seconds
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
-    And the event "app.inForeground" is false
+    # PLAT-9155 Flaky: the event "app.inForeground" is false
+    And the error is correct for "InForegroundScenario" or I allow a retry

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -35,6 +35,8 @@ Feature: Synchronizing app/device metadata in the native layer
     And the event "app.duration" is not null
     And the event "unhandled" is true
 
+  # Skipped pending PLAT-9155
+  @skip
   Scenario: Capture foreground state while in a background crash
     When I run "CXXDelayedCrashScenario"
     And I send the app to the background for 10 seconds

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -17,7 +17,8 @@ Feature: Synchronizing app/device metadata in the native layer
     And I send the app to the background for 5 seconds
     And I wait to receive an error
     Then the error payload contains a completed handled native report
-    And the event "app.inForeground" is false
+    # PLAT-9155 Flaky: the event "app.inForeground" is false
+    And the error is correct for "CXXBackgroundNotifyScenario" or I allow a retry
     And the event "app.durationInForeground" equals 0
     And the event "app.duration" is greater than 0
     And the event "context" string is empty
@@ -34,8 +35,6 @@ Feature: Synchronizing app/device metadata in the native layer
     And the event "app.duration" is not null
     And the event "unhandled" is true
 
-  # Skipped pending PLAT-9155
-  @skip
   Scenario: Capture foreground state while in a background crash
     When I run "CXXDelayedCrashScenario"
     And I send the app to the background for 10 seconds
@@ -43,7 +42,8 @@ Feature: Synchronizing app/device metadata in the native layer
     And I configure Bugsnag for "CXXDelayedCrashScenario"
     And I wait to receive an error
     Then the error payload contains a completed handled native report
-    And the event "app.inForeground" is false
+    # PLAT-9155 Flaky: the event "app.inForeground" is false
+    And the error is correct for "CXXDelayedCrashScenario" or I allow a retry
     And the event "app.duration" is greater than 0
     And the event "context" string is empty
     And the event "unhandled" is true

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -261,5 +261,12 @@ Then("the error is correct for {string} or I allow a retry") do |scenario|
   when 'MultiThreadedStartupScenario'
     Maze.dynamic_retry = true if message == 'You must call Bugsnag.start before any other Bugsnag methods'
     Maze.check.equal 'Scenario complete', message
+  when 'InForegroundScenario', 'CXXBackgroundNotifyScenario', 'CXXDelayedCrashScenario'
+    begin
+      step 'the event "app.inForeground" is false'
+    rescue Test::Unit::AssertionFailedError
+      Maze.dynamic_retry = true
+      raise
+    end
   end
 end


### PR DESCRIPTION
## Goal

Allow a retry for some e2e scenarios in specific situations.

## Design

These scenarios are known to be flaky and a ticket exists to investigate further.  This PR uses a feature of Maze Runner to allow a single retry in a specific circumstance - in this case if `"app.inForeground"` is `true`.  If any other difference occurs or the request is not received, then the scenario will fail.

## Testing

Covered by CI and I ran a scenario multiple times locally to verify what happens on a retry.