### PR TITLE
add addMetadata overload to allow Unity to pass metadata as a hashmap

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -266,6 +266,13 @@ public class NativeInterface {
     }
 
     /**
+     * Add metadata to subsequent exception reports with a Hashmap
+     */
+    public static void addMetadata(@NonNull final String tab, HashMap<String, Object> metadata) {
+        getClient().addMetadata(tab, metadata);
+    }
+
+    /**
      * Return the client report release stage
      */
     @Nullable


### PR DESCRIPTION
add addMetadata overload to nativeInterface.java to allow Unity to pass metadata as a hashmap
