### PR TITLE
Read mazerunner address from config file

### DIFF
--- a/docs/MAZERUNNER.md
+++ b/docs/MAZERUNNER.md
@@ -28,7 +28,7 @@ Remote tests can be run against real devices provided by BrowserStack. In order 
     bundle exec maze-runner --app=build/fixture-r21.apk                 \
                             --farm=bs                               \
                             --device=ANDROID_9_0                    \
-                            features/smoke_tests/unhandled.feature
+                            features/smoke_tests/04_unhandled.feature
     ```
 1. To run all features, omit the final argument, but be wary of how many tests you run locally as we have a limited number of parallel tests and local running subverts the controls we have in place.  For a full test run it is generally best to push your branch to Github and let CI run them.
 1. Maze Runner also supports all options that Cucumber does.  Run `bundle exec maze-runner --help` for full details.

--- a/features/fixtures/mazerunner/app/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/app/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>MagicNumber:MainActivity.kt$MainActivity$250</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -125,7 +125,7 @@ class MainActivity : Activity() {
 
     // As per JSONObject.getString but returns and empty string rather than throwing if not present
     private fun getStringSafely(jsonObject: JSONObject?, key: String): String {
-        return if (jsonObject!!.has(key)) jsonObject.getString(key) else ""
+        return jsonObject?.optString(key) ?: ""
     }
 
     // Starts a thread to poll for Maze Runner actions to perform

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -20,6 +20,8 @@ import java.net.URL
 import kotlin.concurrent.thread
 import kotlin.math.max
 
+const val CONFIG_FILE_TIMEOUT = 5000
+
 class MainActivity : Activity() {
 
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -29,6 +31,7 @@ class MainActivity : Activity() {
 
     var scenario: Scenario? = null
     var polling = false
+    var mazeAddress: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -73,6 +76,33 @@ class MainActivity : Activity() {
         log("MainActivity.onResume complete")
     }
 
+    private fun setMazeRunnerAddress() {
+        val context = MazerunnerApp.applicationContext()
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val configFile = File(externalFilesDir, "fixture_config.json")
+        log("Attempting to read Maze Runner address from config file ${configFile.path}")
+
+        // Poll for the fixture config file
+        val pollStart = System.currentTimeMillis()
+        while (System.currentTimeMillis() - pollStart < CONFIG_FILE_TIMEOUT) {
+            if (configFile.exists()) {
+                val fileContents = configFile.inputStream().use { it.reader().readText() }
+                val fixtureConfig = JSONObject(fileContents)
+                mazeAddress = getStringSafely(fixtureConfig, "maze_address")
+                log("Maze Runner address set from config file: $mazeAddress")
+                break
+            }
+
+            Thread.sleep(250)
+        }
+
+        // Assume we are running in legacy mode on BrowserStack
+        if (mazeAddress == null) {
+            log("Failed to read Maze Runner address from config file, reverting to legacy BrowserStack address")
+            mazeAddress = "bs-local.com:9339"
+        }
+    }
+
     // Checks general internet and secure tunnel connectivity
     private fun checkNetwork() {
         log("Checking network connectivity")
@@ -84,7 +114,7 @@ class MainActivity : Activity() {
         }
 
         try {
-            URL("http://bs-local.com:9339").readText()
+            URL("http://$mazeAddress").readText()
             log("Connection to Maze Runner seems ok")
         } catch (e: Exception) {
             log("Connection to Maze Runner FAILED", e)
@@ -101,6 +131,7 @@ class MainActivity : Activity() {
         // Get the next maze runner command
         polling = true
         thread(start = true) {
+            if (mazeAddress == null) setMazeRunnerAddress()
             checkNetwork()
 
             while (polling) {
@@ -162,7 +193,7 @@ class MainActivity : Activity() {
     }
 
     private fun readCommand(): String {
-        val commandUrl = "http://bs-local.com:9339/command"
+        val commandUrl = "http://$mazeAddress/command"
         val urlConnection = URL(commandUrl).openConnection() as HttpURLConnection
         try {
             return urlConnection.inputStream.use { it.reader().readText() }


### PR DESCRIPTION
## Goal

The test fixture is currently hard-coded to reach Maze Runner on [bs-local.com:9339](http://bs-local.com:9339/).  We’re moving to BitBar, so that address will need to change - but also we’re going to use public IP address that we’ll need to determine dynamically.

Maze Runner is being updated to write its address to a “Fixture config” (json) file and push this to the app using Appium.  

This PR updates the fixture app to poll/watch for the arrival of the file and read the Maze Runner address before it continues with what it normally does (poll the command endpoint for stuff to do).

The file is called `fixture_config.json` and will be located in `/sdcard/Android/data/<app package>/files` .  Contents is a simple JSON object:
```
{
  "maze_address": "bs-local.com:9339"
}
```

If the config file is not found within 5 seconds the fixture app will revert back to the current address.