### PR TITLE
Avoid running over the end of the `maps` file buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fixed a rare race-condition in libunwindstack where reading memory-maps could buffer-overrun
+  [#1798](https://github.com/bugsnag/bugsnag-android/pull/1798)
+
 ## 5.28.3 (2022-11-16)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal
Avoid buffer overruns (and the resulting `SIGSEGV`) when parsing the `/proc/<pid>/maps` files.

## Changeset
Updated our internal `libunwindstack` to a version that checks the length of the buffer when parsing the file. If the end of the buffer is reached while parsing a line, the file is rejected as invalid data.

## Testing
Manual saturation testing