### PR TITLE
Remove Android 6 from BrowserStack

### DIFF
--- a/.buildkite/pipeline.bb.yml
+++ b/.buildkite/pipeline.bb.yml
@@ -3,6 +3,62 @@ steps:
   #
   # BitBar PoC
   #
+  - label: ':android: BitBar Poc - Android 6 - batch 1'
+    soft_fail: true
+    depends_on: "fixture-r16"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r16.apk"
+          - "build/fixture-r16/*"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
+          - "--app=build/fixture-r16.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_6"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
+    concurrency: 2
+    concurrency_group: 'bitbar-android-6'
+    concurrency_method: eager
+
+  - label: ':android: BitBar Poc - Android 6 - batch 2'
+    soft_fail: true
+    depends_on: "fixture-r16"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r16.apk"
+          - "build/fixture-r16/*"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: android-maze-runner-bitbar
+        run: android-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
+          - "--app=build/fixture-r16.apk"
+          - "--farm=bb"
+          - "--device=ANDROID_6"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
+    concurrency: 2
+    concurrency_group: 'bitbar-android-6'
+    concurrency_method: eager
+
   - label: ':android: BitBar Poc - Android 10 - batch 1'
     depends_on: "fixture-r21"
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.bs.yml
+++ b/.buildkite/pipeline.bs.yml
@@ -25,32 +25,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 6 NDK r16 smoke tests'
-    skip: Not sufficiently available on BrowserStack currently
-    key: 'android-6-smoke'
-    depends_on: "fixture-r16"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture_r16_url.txt"
-          - "build/fixture-r16/*"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: android-maze-runner
-        run: android-maze-runner
-        command:
-          - "features/smoke_tests"
-          - "--app=@/app/build/fixture_r16_url.txt"
-          - "--farm=bs"
-          - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
-          - "--appium-version=1.20.2"
-          - "--fail-fast"
-    concurrency: 24
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
+  # No Android 6 devices available on BrowserStack
 
   - label: ':android: Android 7 NDK r19 smoke tests'
     key: 'android-7-smoke'

--- a/.buildkite/pipeline.bs.yml
+++ b/.buildkite/pipeline.bs.yml
@@ -26,6 +26,7 @@ steps:
     concurrency_method: eager
 
   - label: ':android: Android 6 NDK r16 smoke tests'
+    skip: Not sufficiently available on BrowserStack currently
     key: 'android-6-smoke'
     depends_on: "fixture-r16"
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -89,6 +89,7 @@ steps:
         pull: android-maze-runner
         run: android-maze-runner
         command:
+          - "features/smoke_tests"
           - "features/full_tests"
           - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--app=@/app/build/fixture_r16_url.txt"

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -76,58 +76,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 6 NDK r16 end-to-end tests - batch 1'
-    depends_on: "fixture-r16"
-    timeout_in_minutes: 90
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture_r16_url.txt"
-          - "build/fixture-r16/*"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: android-maze-runner
-        run: android-maze-runner
-        command:
-          - "features/smoke_tests"
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--app=@/app/build/fixture_r16_url.txt"
-          - "--farm=bs"
-          - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
-          - "--appium-version=1.20.2"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
-    concurrency: 24
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':android: Android 6 NDK r16 end-to-end tests - batch 2'
-    depends_on: "fixture-r16"
-    timeout_in_minutes: 90
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture_r16_url.txt"
-          - "build/fixture-r16/*"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: android-maze-runner
-        run: android-maze-runner
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--app=@/app/build/fixture_r16_url.txt"
-          - "--farm=bs"
-          - "--device=ANDROID_6_0_GOOGLE_NEXUS_6"
-          - "--appium-version=1.20.2"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r16"
-    concurrency: 24
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
+  # No Android 6 devices available on BrowserStack
 
   - label: ':android: Android 7 NDK r19 end-to-end tests - batch 1'
     depends_on: "fixture-r19"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ steps:
     agents:
       queue: macos-12-arm
     artifact_paths:
+      - "build/fixture-r16.apk"
       - "build/fixture_r16_url.txt"
       - "build/fixture-r16/*"
     commands:
@@ -25,6 +26,7 @@ steps:
     agents:
       queue: macos-12-arm
     artifact_paths:
+      - "build/fixture-r19.apk"
       - "build/fixture_r19_url.txt"
       - "build/fixture-r19/*"
     commands:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - ./maze_output:/app/maze_output
 
   android-maze-runner-bitbar:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v7-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:integration-bitbar-improvements-cli
     environment:
       DEBUG:
       BUILDKITE:


### PR DESCRIPTION
## Goal

Do not attempt to run tests on Android 6 devices on BrowserStack, as they have deprecated them.

## Design

BrowserStack have made it clear that they do not intend on maintaining support for Android 6.  I've completely removed the Buildkite steps that run on BrowserStack, but added them to the BitBar pipeline steps with a `soft_fail` so that we can start experimenting with it.

## Changeset

I've also changed the docker-compose service for BitBar to pick up the integration branch on Maze Runner for making BitBar improvements.

## Testing

Covered by CI and an intermediate build for BitBar.