### PR TITLE
Check ConnectivityManager for network status

### DIFF
--- a/features/fixtures/mazerunner/app/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/app/detekt-baseline.xml
@@ -2,7 +2,8 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>MagicNumber:MainActivity.kt$MainActivity$250</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
+    <ID>MagicNumber:MainActivity.kt$MainActivity$250</ID>
+    <ID>SwallowedException:NetworkStatus.kt$catch (e: Exception) { NetworkStatus.NO_INTERNET }</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MainActivity.kt
@@ -107,14 +107,7 @@ class MainActivity : Activity() {
 
     // Checks general internet and secure tunnel connectivity
     private fun checkNetwork() {
-        log("Checking network connectivity")
-        try {
-            URL("https://www.google.com").readText()
-            log("Connection to www.google.com seems ok")
-        } catch (e: Exception) {
-            log("Connection to www.google.com FAILED", e)
-        }
-
+        log("Network connectivity: $networkStatus")
         try {
             URL("http://$mazeAddress").readText()
             log("Connection to Maze Runner seems ok")

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/NetworkStatus.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/NetworkStatus.kt
@@ -1,0 +1,43 @@
+package com.bugsnag.android.mazerunner
+
+import android.content.Context
+import android.content.Context.CONNECTIVITY_SERVICE
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import java.net.URL
+
+enum class NetworkStatus {
+    NO_NETWORK,
+    UNKNOWN_CAPABILITIES,
+    NO_INTERNET,
+    CONNECTED,
+    DISCONNECTED
+}
+
+val Context.networkStatus: NetworkStatus
+    get() {
+        val connectivityManager = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = connectivityManager.activeNetwork ?: return NetworkStatus.NO_NETWORK
+            val capabilities = connectivityManager.getNetworkCapabilities(network)
+                ?: return NetworkStatus.UNKNOWN_CAPABILITIES
+
+            return if (capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) NetworkStatus.CONNECTED
+            else NetworkStatus.NO_INTERNET
+        } else {
+            val networkInfo =
+                connectivityManager.activeNetworkInfo ?: return NetworkStatus.NO_NETWORK
+
+            if (networkInfo.isAvailable && networkInfo.isConnected) {
+                return try {
+                    URL("https://www.google.com").readText()
+                    NetworkStatus.CONNECTED
+                } catch (e: Exception) {
+                    NetworkStatus.NO_INTERNET
+                }
+            }
+
+            return NetworkStatus.DISCONNECTED
+        }
+    }


### PR DESCRIPTION
## Goal
Make MazeRunner slightly less network-chatty by checking with the `ConnectivityManager` for the current internet status instead of trying to ping external services.

## Testing
Relied on existing tests.