### PR TITLE
Relax checks on device orientation

### DIFF
--- a/features/full_tests/internal_error_reports.feature
+++ b/features/full_tests/internal_error_reports.feature
@@ -61,7 +61,7 @@ Feature: Cached Error Reports
     And the error payload field "events.0.device.totalMemory" is greater than 0
     And the error payload field "events.0.device.freeDisk" is greater than 0
     And the error payload field "events.0.device.freeMemory" is greater than 0
-    And the event "device.orientation" equals "portrait"
+    And the event "device.orientation" matches "(portrait|landscape)"
     And the event "device.time" is a timestamp
 
     # Threads validation

--- a/features/smoke_tests/01_anr.feature
+++ b/features/smoke_tests/01_anr.feature
@@ -59,7 +59,7 @@ Feature: ANR smoke test
     And the error payload field "events.0.device.totalMemory" is greater than 0
     And the error payload field "events.0.device.freeDisk" is greater than 0
     And the error payload field "events.0.device.freeMemory" is greater than 0
-    And the event "device.orientation" equals "portrait"
+    And the event "device.orientation" matches "(portrait|landscape)"
     And the event "device.time" is a timestamp
     And the event "metaData.device.locationStatus" is not null
     And the event "metaData.device.emulator" is false

--- a/features/smoke_tests/02_handled.feature
+++ b/features/smoke_tests/02_handled.feature
@@ -69,7 +69,7 @@ Feature: Handled smoke tests
     And the error payload field "events.0.device.totalMemory" is greater than 0
     And the error payload field "events.0.device.freeDisk" is greater than 0
     And the error payload field "events.0.device.freeMemory" is greater than 0
-    And the event "device.orientation" equals "portrait"
+    And the event "device.orientation" matches "(portrait|landscape)"
     And the event "device.time" is a timestamp
     And the event "metaData.device.locationStatus" is not null
     And the event "metaData.device.emulator" is false
@@ -218,7 +218,7 @@ Feature: Handled smoke tests
     And the error payload field "events.0.device.totalMemory" is greater than 0
     And the error payload field "events.0.device.freeDisk" is greater than 0
     And the error payload field "events.0.device.freeMemory" is greater than 0
-    And the event "device.orientation" equals "portrait"
+    And the event "device.orientation" matches "(portrait|landscape)"
     And the event "device.time" is a timestamp
 
     # User

--- a/features/smoke_tests/04_unhandled.feature
+++ b/features/smoke_tests/04_unhandled.feature
@@ -71,7 +71,7 @@ Feature: Unhandled smoke tests
     And the error payload field "events.0.device.totalMemory" is greater than 0
     And the error payload field "events.0.device.freeDisk" is greater than 0
     And the error payload field "events.0.device.freeMemory" is greater than 0
-    And the event "device.orientation" equals "portrait"
+    And the event "device.orientation" matches "(portrait|landscape)"
     And the event "device.time" is a timestamp
     And the event "metaData.device.locationStatus" is not null
     And the event "metaData.device.emulator" is false
@@ -158,7 +158,7 @@ Feature: Unhandled smoke tests
     And the event "device.runtimeVersions.androidApiLevel" is not null
     And the event "device.runtimeVersions.osBuild" is not null
     And the error payload field "events.0.device.totalMemory" is greater than 0
-    And the event "device.orientation" equals "portrait"
+    And the event "device.orientation" matches "(portrait|landscape)"
     And the event "device.time" is a timestamp
     And the event "metaData.device.locationStatus" is not null
     And the event "metaData.device.emulator" is false
@@ -266,7 +266,7 @@ Feature: Unhandled smoke tests
     And the event "device.runtimeVersions.androidApiLevel" is not null
     And the event "device.runtimeVersions.osBuild" is not null
     And the error payload field "events.0.device.totalMemory" is greater than 0
-    And the event "device.orientation" equals "portrait"
+    And the event "device.orientation" matches "(portrait|landscape)"
     And the event "device.time" is a timestamp
 
     # Metadata


### PR DESCRIPTION
## Goal

Relax checks on device orientation to avoid unnecessary flakes.

## Design

The device orientation in the test environment can be quite unreliable, as discussed here:
https://www.browserstack.com/docs/app-automate/appium/troubleshooting/app-orientation-issues

Rather rather battle against those factors, it seems more pragmatic to simply allow either portrait or landscape to be present in the field.

## Testing

Covered by a basic CI run.