### PR TITLE
Enable ANR test scenarios on BitBar

### DIFF
--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -20,6 +20,7 @@ Feature: Switching automatic error detection on/off for Unity
     Then Bugsnag confirms it has no errors to send
 
   @skip_android_8_1
+  @anr
   Scenario: ANR not captured with autoDetectAnrs=false
     When I run "AutoDetectAnrsFalseScenario"
     And I wait for 2 seconds
@@ -55,8 +56,7 @@ Feature: Switching automatic error detection on/off for Unity
 
   # PLAT-6620
   @skip_android_8_1
-  # PLAT-9580
-  @skip_bitbar
+  @anr
   Scenario: ANR captured with autoDetectAnrs reenabled
     When I clear any error dialogue
     And I run "AutoDetectAnrsTrueScenario"

--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -24,7 +24,7 @@ Feature: Switching automatic error detection on/off for Unity
   Scenario: ANR not captured with autoDetectAnrs=false
     When I run "AutoDetectAnrsFalseScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     And I close and relaunch the app
     And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
     Then Bugsnag confirms it has no errors to send
@@ -61,7 +61,7 @@ Feature: Switching automatic error detection on/off for Unity
     When I clear any error dialogue
     And I run "AutoDetectAnrsTrueScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements

--- a/features/full_tests/detect_anr_cxx.feature
+++ b/features/full_tests/detect_anr_cxx.feature
@@ -3,8 +3,7 @@ Feature: ANRs triggered in CXX code are captured
   Background:
     Given I clear all persistent data
 
-  # PLAT-9580
-  @skip_bitbar
+  @anr
   Scenario: ANR triggered in CXX code is captured
     When I run "CXXAnrScenario"
     And I wait for 2 seconds
@@ -19,8 +18,7 @@ Feature: ANRs triggered in CXX code are captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
-  # PLAT-9580
-  @skip_bitbar
+  @anr
   Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled
     When I run "CXXAnrNdkDisabledScenario"
     And I wait for 2 seconds

--- a/features/full_tests/detect_anr_cxx.feature
+++ b/features/full_tests/detect_anr_cxx.feature
@@ -7,7 +7,7 @@ Feature: ANRs triggered in CXX code are captured
   Scenario: ANR triggered in CXX code is captured
     When I run "CXXAnrScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -22,7 +22,7 @@ Feature: ANRs triggered in CXX code are captured
   Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled
     When I run "CXXAnrNdkDisabledScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"

--- a/features/full_tests/detect_anr_jvm.feature
+++ b/features/full_tests/detect_anr_jvm.feature
@@ -3,8 +3,7 @@ Feature: ANRs triggered in JVM code are captured
   Background:
     Given I clear all persistent data
 
-  # PLAT-9580
-  @skip_bitbar
+  @anr
   Scenario: ANR triggered in JVM loop code is captured
     When I clear any error dialogue
     And I run "JvmAnrLoopScenario"
@@ -23,8 +22,7 @@ Feature: ANRs triggered in JVM code are captured
 # Other scenarios use a deadlock to generate an ANR, which works on Samsung devices. This scenario remains skipped
 # on Samsung as it is explicitly designed to test ANRs caused by a sleeping thread.
   @skip_samsung
-  # PLAT-9580
-  @skip_bitbar
+  @anr
   Scenario: ANR triggered in JVM sleep code is captured
     When I clear any error dialogue
     And I run "JvmAnrSleepScenario"
@@ -37,6 +35,7 @@ Feature: ANRs triggered in JVM code are captured
     And the error "Bugsnag-Stacktrace-Types" header equals "android,c"
     And the error payload field "events.0.exceptions.0.type" equals "android"
 
+  @anr
   Scenario: ANR triggered in JVM code is not captured when detectAnrs = false
     When I run "JvmAnrDisabledScenario"
     And I wait for 2 seconds
@@ -47,6 +46,7 @@ Feature: ANRs triggered in JVM code are captured
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "JvmAnrDisabledScenario"
 
+  @anr
   Scenario: ANR triggered in JVM code is not captured when outside of release stage
     When I run "JvmAnrOutsideReleaseStagesScenario"
     And I wait for 2 seconds

--- a/features/full_tests/detect_anr_jvm.feature
+++ b/features/full_tests/detect_anr_jvm.feature
@@ -8,7 +8,7 @@ Feature: ANRs triggered in JVM code are captured
     When I clear any error dialogue
     And I run "JvmAnrLoopScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -27,7 +27,7 @@ Feature: ANRs triggered in JVM code are captured
     When I clear any error dialogue
     And I run "JvmAnrSleepScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -39,7 +39,7 @@ Feature: ANRs triggered in JVM code are captured
   Scenario: ANR triggered in JVM code is not captured when detectAnrs = false
     When I run "JvmAnrDisabledScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements
@@ -50,5 +50,5 @@ Feature: ANRs triggered in JVM code are captured
   Scenario: ANR triggered in JVM code is not captured when outside of release stage
     When I run "JvmAnrOutsideReleaseStagesScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     Then I should receive no requests

--- a/features/minimal/detect_anr_minimal.feature
+++ b/features/minimal/detect_anr_minimal.feature
@@ -7,7 +7,7 @@ Feature: ANRs triggered in a fixture with only bugsnag-android-core are captured
   Scenario: Triggering ANR does not crash the minimal app
     When I run "JvmAnrMinimalFixtureScenario"
     And I wait for 2 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     And I wait for 4 seconds
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/minimal/detect_anr_minimal.feature
+++ b/features/minimal/detect_anr_minimal.feature
@@ -3,6 +3,7 @@ Feature: ANRs triggered in a fixture with only bugsnag-android-core are captured
   Background:
     Given I clear all persistent data
 
+  @anr
   Scenario: Triggering ANR does not crash the minimal app
     When I run "JvmAnrMinimalFixtureScenario"
     And I wait for 2 seconds

--- a/features/smoke_tests/01_anr.feature
+++ b/features/smoke_tests/01_anr.feature
@@ -2,6 +2,7 @@
 Feature: ANR smoke test
 
   @skip_android_8_1
+  @anr
   Scenario: ANR detection
     When I set the screen orientation to portrait
     And I clear any error dialogue

--- a/features/smoke_tests/01_anr.feature
+++ b/features/smoke_tests/01_anr.feature
@@ -10,7 +10,7 @@ Feature: ANR smoke test
     And I wait for 1 seconds
     And I tap the screen 3 times
     And I wait for 5 seconds
-    And I tap the back-button 3 times
+    And I tap the screen 3 times
     And I wait to receive an error
 
     # Exception details

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,10 +24,6 @@ Before('@skip') do |scenario|
   skip_this_scenario("Skipping scenario")
 end
 
-Before('@skip_bitbar') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.farm == :bb
-end
-
 Before('@skip_above_android_8') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version >= 9
 end


### PR DESCRIPTION
## Goal

Enable ANR test scenarios on BitBar.

## Design

We discovered that the ANR scenarios were not working on BitBar due to the developer options.  They have now been updated and the ANR scenarios pass.

## Changeset

As part of the investigation, I changed the scenarios to go back to tapping the screen rather than pressing the back button.  I don't think it was strictly necessary, but have kept the change in having retested it like that.  I don't think there's really anything between tapping and using the back button anyhow. 

I've also tagged all the ANR scenarios with `@anr` for future convenience.

## Testing

Retested against BitBar on CI before raising this PR.