### PR TITLE
Trivial improvements to RootDetector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Added numeric range annotations to Configuration
   [#1808](https://github.com/bugsnag/bugsnag-android/pull/1808)
+* Small improvements to the root detection overhead
+  [#1815](https://github.com/bugsnag/bugsnag-android/pull/1815)
 
 ## 5.28.4 (2023-02-08)
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/RootDetectorTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/RootDetectorTest.kt
@@ -53,6 +53,18 @@ class RootDetectorTest {
     }
 
     /**
+     * The method returns false if 'which su' returns a blank string
+     */
+    @Test
+    fun checkSuNotFoundBlank() {
+        val emptyStream = ByteArrayInputStream("\n  \n".toByteArray())
+        `when`(process.inputStream).thenReturn(emptyStream)
+        assertFalse(rootDetector.checkSuExists(processBuilder))
+        verify(processBuilder, times(1)).command(listOf("which", "su"))
+        verify(process, times(1)).destroy()
+    }
+
+    /**
      * The method returns true if 'which su' returns a non-empty string
      */
     @Test


### PR DESCRIPTION
## Goal
Slightly improve the `RootDetector` overhead.

## Changeset

- Use `any` instead of `count() > 0` to early exit when checking the system build-props
- Use a `volatile boolean` instead of `AtomicBoolean` to check library-load (no CAS operations are used)
- Use a `Reader.isNotBlank` function instead of `Reader.readText().isNotBlank()`

## Testing
Modified the unit test, and added a new test for the `which su` check returning a blank (but not empty) string