### PR TITLE
Mutability of metadata in initial client with breacrumb

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SmallTest;
 
@@ -287,10 +288,16 @@ public class ClientTest {
 
     @Test
     public void testClientCanAddMetadataToBreadCrumb() {
-        client = generateClient();
-        client.breadcrumbState.copy().get(0).getMetadata().put("test", 0);
-        assertEquals(1, client.getBreadcrumbs().size());
-        client.leaveBreadcrumb("test2");
-        assertEquals(2, client.getBreadcrumbs().size());
+        Configuration config = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
+        config.addOnBreadcrumb(new OnBreadcrumbCallback() {
+            @Override
+            public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
+                breadcrumb.getMetadata().put("Test",1);
+                return true;
+            }
+        });
+        client = BugsnagTestUtils.generateClient(config);
+        client.leaveBreadcrumb("Test2");
+        assertTrue( client.getBreadcrumbs().get(0).getMetadata().containsKey("Test"));
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -293,7 +293,7 @@ public class ClientTest {
             @Override
             public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 Map<String, Object> metadata = breadcrumb.getMetadata();
-                metadata.put("Test",1);
+                metadata.put("Test", 1);
                 metadata.put("Test2", 2);
                 metadata.remove("Test");
                 metadata.clear();
@@ -302,6 +302,10 @@ public class ClientTest {
             }
         });
         client = BugsnagTestUtils.generateClient(config);
-        assertTrue( client.getBreadcrumbs().get(0).getMetadata().containsKey("Test3"));
+
+        List<Breadcrumb> breadcrumbs = client.getBreadcrumbs();
+        assertEquals(1, breadcrumbs.size());
+        Integer testMetadataValue = (Integer) breadcrumbs.get(0).getMetadata().get("Test3");
+        assertEquals(Integer.valueOf(3), testMetadataValue);
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -287,17 +287,20 @@ public class ClientTest {
     }
 
     @Test
-    public void testClientCanAddMetadataToBreadCrumb() {
-        Configuration config = new Configuration("5d1ec5bd39a74caa1267142706a7fb21");
+    public void testMetadataIsMutableInBreadCrumb() {
+        Configuration config = new Configuration("api keys");
         config.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
             public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
                 breadcrumb.getMetadata().put("Test",1);
+                breadcrumb.getMetadata().put("Test2", 2);
+                breadcrumb.getMetadata().remove("Test");
+                breadcrumb.getMetadata().clear();
+                breadcrumb.getMetadata().put("Test3", 3);
                 return true;
             }
         });
         client = BugsnagTestUtils.generateClient(config);
-        client.leaveBreadcrumb("Test2");
-        assertTrue( client.getBreadcrumbs().get(0).getMetadata().containsKey("Test"));
+        assertTrue( client.getBreadcrumbs().get(0).getMetadata().containsKey("Test3"));
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -292,11 +292,12 @@ public class ClientTest {
         config.addOnBreadcrumb(new OnBreadcrumbCallback() {
             @Override
             public boolean onBreadcrumb(@NonNull Breadcrumb breadcrumb) {
-                breadcrumb.getMetadata().put("Test",1);
-                breadcrumb.getMetadata().put("Test2", 2);
-                breadcrumb.getMetadata().remove("Test");
-                breadcrumb.getMetadata().clear();
-                breadcrumb.getMetadata().put("Test3", 3);
+                Map<String, Object> metadata = breadcrumb.getMetadata();
+                metadata.put("Test",1);
+                metadata.put("Test2", 2);
+                metadata.remove("Test");
+                metadata.clear();
+                metadata.put("Test3", 3);
                 return true;
             }
         });

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -305,7 +305,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         registerListenersInBackground();
 
         // Leave auto breadcrumb
-        Map<String, Object> data = Collections.emptyMap();
+        Map<String, Object> data = new HashMap<>();
         leaveAutoBreadcrumb("Bugsnag loaded", BreadcrumbType.STATE, data);
 
         logger.d("Bugsnag loaded");


### PR DESCRIPTION
## Goal
Metadata is mutable in initial breadcrumb

## Changeset
Metadata is mutable when initialising a client with breadcrumb

## Testing
A unit test for metadata mutability 