### PR TITLE
Correct skips for ANR scenarios

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -29,6 +29,10 @@ steps:
       queue: macos-12-arm
     command: './gradlew clean assembleRelease check --scan'
 
+  #
+  # BitBar steps
+  #
+
   - label: ':bitbar: Minimal fixture end-to-end tests'
     depends_on: "fixture-minimal"
     timeout_in_minutes: 30
@@ -80,9 +84,6 @@ steps:
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
-  #
-  # BitBar steps
-  #
   - label: ':bitbar: Android 9 NDK r21 end-to-end tests - batch 1'
     depends_on: "fixture-r21"
     timeout_in_minutes: 60
@@ -139,7 +140,7 @@ steps:
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
-  - label: ':android: Android 10 NDK r21 end-to-end tests - batch 1'
+  - label: ':bitbar: Android 10 NDK r21 end-to-end tests - batch 1'
     depends_on: "fixture-r21"
     timeout_in_minutes: 60
     plugins:
@@ -166,7 +167,7 @@ steps:
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
-  - label: ':android: Android 10 NDK r21 end-to-end tests - batch 2'
+  - label: ':bitbar: Android 10 NDK r21 end-to-end tests - batch 2'
     depends_on: "fixture-r21"
     timeout_in_minutes: 60
     plugins:
@@ -311,7 +312,7 @@ steps:
   # BrowserStack steps
   #
 
-  - label: ':android: Android 7 NDK r19 end-to-end tests - batch 1'
+  - label: ':browserstack: Android 7 NDK r19 end-to-end tests - batch 1'
     depends_on: "fixture-r19"
     timeout_in_minutes: 60
     plugins:
@@ -337,7 +338,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 7 NDK r19 end-to-end tests - batch 2'
+  - label: ':browserstack: Android 7 NDK r19 end-to-end tests - batch 2'
     depends_on: "fixture-r19"
     timeout_in_minutes: 60
     plugins:
@@ -363,7 +364,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 8.1 NDK r19 end-to-end tests - batch 1'
+  - label: ':browserstack: Android 8.1 NDK r19 end-to-end tests - batch 1'
     depends_on: "fixture-r19"
     timeout_in_minutes: 60
     plugins:
@@ -389,7 +390,7 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-  - label: ':android: Android 8.1 NDK r19 end-to-end tests - batch 2'
+  - label: ':browserstack: Android 8.1 NDK r19 end-to-end tests - batch 2'
     depends_on: "fixture-r19"
     timeout_in_minutes: 60
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -174,7 +174,7 @@ steps:
   # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
   # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
   # by inspecting the devices logs.
-  - label: ':android: Android 12 NDK r21 end-to-end tests - batch 1'
+  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
     depends_on:
       - "fixture-r21"
     timeout_in_minutes: 60
@@ -203,7 +203,7 @@ steps:
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
-  - label: ':android: Android 12 NDK r21 end-to-end tests - batch 2'
+  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
     depends_on:
       - "fixture-r21"
     timeout_in_minutes: 60
@@ -232,7 +232,7 @@ steps:
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
-  - label: ':android: Android 13 NDK r21 smoke tests'
+  - label: ':bitbar: Android 13 NDK r21 smoke tests'
     depends_on: "fixture-r21"
     timeout_in_minutes: 60
     plugins:
@@ -261,7 +261,7 @@ steps:
   #
   # BrowserStack steps
   #
-  - label: ':android: Android 7 NDK r19 smoke tests'
+  - label: ':browserstack: Android 7 NDK r19 smoke tests'
     key: 'android-7-smoke'
     depends_on: "fixture-r19"
     timeout_in_minutes: 60
@@ -287,7 +287,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
 
-  - label: ':android: Android 8.1 NDK r19 smoke tests'
+  - label: ':browserstack: Android 8.1 NDK r19 smoke tests'
     key: 'android-8-1-smoke'
     depends_on: "fixture-r19"
     timeout_in_minutes: 60

--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -19,7 +19,7 @@ Feature: Switching automatic error detection on/off for Unity
     And I configure Bugsnag for "UnhandledNdkAutoNotifyFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
-  @skip_android_8_1
+  @skip_samsung
   @anr
   Scenario: ANR not captured with autoDetectAnrs=false
     When I run "AutoDetectAnrsFalseScenario"
@@ -55,7 +55,7 @@ Feature: Switching automatic error detection on/off for Unity
     And the event "severityReason.unhandledOverridden" is false
 
   # PLAT-6620
-  @skip_android_8_1
+  @skip_samsung
   @anr
   Scenario: ANR captured with autoDetectAnrs reenabled
     When I clear any error dialogue

--- a/features/full_tests/detect_anr_jvm.feature
+++ b/features/full_tests/detect_anr_jvm.feature
@@ -19,8 +19,6 @@ Feature: ANRs triggered in JVM code are captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
-# Other scenarios use a deadlock to generate an ANR, which works on Samsung devices. This scenario remains skipped
-# on Samsung as it is explicitly designed to test ANRs caused by a sleeping thread.
   @skip_samsung
   @anr
   Scenario: ANR triggered in JVM sleep code is captured

--- a/features/smoke_tests/01_anr.feature
+++ b/features/smoke_tests/01_anr.feature
@@ -1,7 +1,7 @@
 # This scenario is in its own file and folder so that it can be run first on Android 4
 Feature: ANR smoke test
 
-  @skip_android_8_1
+  @skip_samsung
   @anr
   Scenario: ANR detection
     When I set the screen orientation to portrait

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -65,9 +65,6 @@ Before('@skip_android_6') do |scenario|
 end
 
 Before('@skip_samsung') do |scenario|
-
-  $logger.info "Checking: #{Maze.driver.capabilities}"
-
   caps = Maze.driver.capabilities
   options_cap = 'bitbar:options'
   device_cap = 'device'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -65,6 +65,19 @@ Before('@skip_android_6') do |scenario|
 end
 
 Before('@skip_samsung') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.driver.capabilities['device']&.downcase&.include? 'samsung'
+
+  $logger.info "Checking: #{Maze.driver.capabilities}"
+
+  caps = Maze.driver.capabilities
+  options_cap = 'bitbar:options'
+  device_cap = 'device'
+
+  device = if caps.has_key?(options_cap)
+             caps[options_cap][device_cap]
+           else
+             caps[device_cap]
+           end
+
+  skip_this_scenario("Skipping scenario") if device&.downcase&.include? 'samsung'
 end
 


### PR DESCRIPTION
## Goal

Skip ANR scenarios on Samsung devices.

## Design

Samsung devices behave different in the ANR scenarios and for the time being it's easier to skip those specific scenarios.  We've done that before by skipping "Android 8.1", but that's just because the BS device we used for 8.1 happened to be a Samsung.  This change means we're more intelligent about it.

## Changeset

I've also tweaked the Buildkite labels to better discern between BitBar and BrowserStack steps.

## Testing

Covered by CI.