### PR TITLE
Do not run any ANR scenarios on Samsungs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on: [ push, pull_request ]
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false -Dorg.gradle.parallel=true"
+  ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 60
 
 jobs:
   android:

--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -19,8 +19,8 @@ Feature: Switching automatic error detection on/off for Unity
     And I configure Bugsnag for "UnhandledNdkAutoNotifyFalseScenario"
     Then Bugsnag confirms it has no errors to send
 
-  @skip_samsung
   @anr
+  @skip_samsung
   Scenario: ANR not captured with autoDetectAnrs=false
     When I run "AutoDetectAnrsFalseScenario"
     And I wait for 2 seconds
@@ -54,9 +54,8 @@ Feature: Switching automatic error detection on/off for Unity
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.unhandledOverridden" is false
 
-  # PLAT-6620
-  @skip_samsung
   @anr
+  @skip_samsung
   Scenario: ANR captured with autoDetectAnrs reenabled
     When I clear any error dialogue
     And I run "AutoDetectAnrsTrueScenario"

--- a/features/full_tests/detect_anr_cxx.feature
+++ b/features/full_tests/detect_anr_cxx.feature
@@ -4,6 +4,7 @@ Feature: ANRs triggered in CXX code are captured
     Given I clear all persistent data
 
   @anr
+  @skip_samsung
   Scenario: ANR triggered in CXX code is captured
     When I run "CXXAnrScenario"
     And I wait for 2 seconds
@@ -19,6 +20,7 @@ Feature: ANRs triggered in CXX code are captured
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
   @anr
+  @skip_samsung
   Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled
     When I run "CXXAnrNdkDisabledScenario"
     And I wait for 2 seconds

--- a/features/full_tests/detect_anr_jvm.feature
+++ b/features/full_tests/detect_anr_jvm.feature
@@ -4,6 +4,7 @@ Feature: ANRs triggered in JVM code are captured
     Given I clear all persistent data
 
   @anr
+  @skip_samsung
   Scenario: ANR triggered in JVM loop code is captured
     When I clear any error dialogue
     And I run "JvmAnrLoopScenario"
@@ -19,8 +20,8 @@ Feature: ANRs triggered in JVM code are captured
     And the error payload field "events.0.threads.0.type" equals "android"
     And the error payload field "events.0.threads.0.stacktrace.0.type" is null
 
-  @skip_samsung
   @anr
+  @skip_samsung
   Scenario: ANR triggered in JVM sleep code is captured
     When I clear any error dialogue
     And I run "JvmAnrSleepScenario"
@@ -34,6 +35,7 @@ Feature: ANRs triggered in JVM code are captured
     And the error payload field "events.0.exceptions.0.type" equals "android"
 
   @anr
+  @skip_samsung
   Scenario: ANR triggered in JVM code is not captured when detectAnrs = false
     When I run "JvmAnrDisabledScenario"
     And I wait for 2 seconds
@@ -45,6 +47,7 @@ Feature: ANRs triggered in JVM code are captured
     And the exception "message" equals "JvmAnrDisabledScenario"
 
   @anr
+  @skip_samsung
   Scenario: ANR triggered in JVM code is not captured when outside of release stage
     When I run "JvmAnrOutsideReleaseStagesScenario"
     And I wait for 2 seconds

--- a/features/minimal/detect_anr_minimal.feature
+++ b/features/minimal/detect_anr_minimal.feature
@@ -4,6 +4,7 @@ Feature: ANRs triggered in a fixture with only bugsnag-android-core are captured
     Given I clear all persistent data
 
   @anr
+  @skip_samsung
   Scenario: Triggering ANR does not crash the minimal app
     When I run "JvmAnrMinimalFixtureScenario"
     And I wait for 2 seconds

--- a/features/smoke_tests/01_anr.feature
+++ b/features/smoke_tests/01_anr.feature
@@ -1,8 +1,8 @@
 # This scenario is in its own file and folder so that it can be run first on Android 4
 Feature: ANR smoke test
 
-  @skip_samsung
   @anr
+  @skip_samsung
   Scenario: ANR detection
     When I set the screen orientation to portrait
     And I clear any error dialogue


### PR DESCRIPTION
## Goal

No not run any ANR scenarios on Samsungs.

## Design

Follow on to #1831, not all ANR scenarios were considered.

## Testing

Covered by CI.