### PR TITLE
Skip flaky test "StrictMode Exposed File URI violation"

### DIFF
--- a/features/full_tests/strict_mode_violations.feature
+++ b/features/full_tests/strict_mode_violations.feature
@@ -3,7 +3,7 @@ Feature: Reporting Strict Mode Violations
   Background:
     Given I clear all persistent data
 
-  # TODO: Skipped pending PLAT-10003
+  # TODO: Skipped pending PLAT-9675
   @skip
   @skip_below_android_9
   Scenario: StrictMode Exposed File URI violation

--- a/features/full_tests/strict_mode_violations.feature
+++ b/features/full_tests/strict_mode_violations.feature
@@ -3,6 +3,8 @@ Feature: Reporting Strict Mode Violations
   Background:
     Given I clear all persistent data
 
+  # TODO: Skipped pending PLAT-10003
+  @skip
   @skip_below_android_9
   Scenario: StrictMode Exposed File URI violation
     When I run "StrictModeFileUriExposeScenario" and relaunch the crashed app


### PR DESCRIPTION
## Goal

Reduce CI noise by skipping a known-flaky test pending further investigation.

## Testing

Covered by CI.