### PR TITLE
Use the DexBuildIdGenerator when no `BUILD_UUID` is present

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -48,6 +48,7 @@
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get battery status") }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get locationStatus") }</ID>
     <ID>SwallowedException:DeviceIdFilePersistence.kt$DeviceIdFilePersistence$catch (exc: OverlappingFileLockException) { Thread.sleep(FILE_LOCK_WAIT_MS) }</ID>
+    <ID>SwallowedException:ImmutableConfig.kt$catch (e: Exception) { null }</ID>
     <ID>SwallowedException:JsonHelperTest.kt$JsonHelperTest$catch (e: IllegalArgumentException) { didThrow = true }</ID>
     <ID>SwallowedException:PluginClient.kt$PluginClient$catch (exc: ClassNotFoundException) { logger.d("Plugin '$clz' is not on the classpath - functionality will not be enabled.") null }</ID>
     <ID>ThrowsCount:JsonHelper.kt$JsonHelper$ fun jsonToLong(value: Any?): Long?</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -143,7 +143,13 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         });
 
         // set sensible defaults for delivery/project packages etc if not set
-        ConfigModule configModule = new ConfigModule(contextModule, configuration, connectivity);
+        ConfigModule configModule = new ConfigModule(
+                contextModule,
+                configuration,
+                connectivity,
+                bgTaskService
+        );
+
         immutableConfig = configModule.getConfig();
         logger = immutableConfig.getLogger();
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/dag/ConfigModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/dag/ConfigModule.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android.internal.dag
 
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.Connectivity
+import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.sanitiseConfiguration
 
 /**
@@ -11,8 +12,9 @@ import com.bugsnag.android.internal.sanitiseConfiguration
 internal class ConfigModule(
     contextModule: ContextModule,
     configuration: Configuration,
-    connectivity: Connectivity
+    connectivity: Connectivity,
+    bgTaskExecutor: BackgroundTaskService
 ) : DependencyModule() {
 
-    val config = sanitiseConfiguration(contextModule.ctx, configuration, connectivity)
+    val config = sanitiseConfiguration(contextModule.ctx, configuration, connectivity, bgTaskExecutor)
 }


### PR DESCRIPTION
## Goal
Fallback to using the `dex` signature derived `buildId` when no `BUILD_UUID` metadata is present.

## Design
If no `BUILD_UUID` metadata is present when constructing the `ImmutableConfig` we fallback to building the `buildUuid` using the new `DexBuildIdGenerator` class. If for any reason that fails we revert to `null`.

The retrieval of the `dex` signatures is run on the `BackgroundTaskService` IO thread in order to avoid StrictMode violations.

## Testing
Tested manually with the example app.