### PR TITLE
Installer package name visible on dashboard

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -41,6 +41,7 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityReason(@SeverityReason.SeverityReasonType reason: String)</ID>
     <ID>RethrowCaughtException:JsonHelper.kt$JsonHelper$throw ex</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, json: ByteArray, headers: Map&lt;String, String?> ): DeliveryStatus</ID>
+    <ID>SwallowedException:AppDataCollector.kt$AppDataCollector$catch (e: Exception) { return null }</ID>
     <ID>SwallowedException:BugsnagEventMapper.kt$BugsnagEventMapper$catch (pe: IllegalArgumentException) { ndkDateFormatHolder.get()!!.parse(this) ?: throw IllegalArgumentException("cannot parse date $this") }</ID>
     <ID>SwallowedException:ConnectivityCompat.kt$ConnectivityLegacy$catch (e: NullPointerException) { // in some rare cases we get a remote NullPointerException via Parcel.readException null }</ID>
     <ID>SwallowedException:ContextExtensions.kt$catch (exc: RuntimeException) { null }</ID>

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
@@ -2,6 +2,7 @@ package com.bugsnag.android
 
 import android.app.ActivityManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
@@ -10,7 +11,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 
@@ -52,6 +55,7 @@ class AppDataCollectorTest {
         )
         val app = collector.getAppDataMetadata()
         assertNull(app["backgroundWorkRestricted"])
+        assertTrue(app.containsKey("installerPackage"))
         assertEquals("com.bugsnag.android.core.test", app["processName"] as String)
     }
 
@@ -99,5 +103,27 @@ class AppDataCollectorTest {
         } else {
             assertNull(app["backgroundWorkRestricted"])
         }
+    }
+
+    @Test
+    fun testGetInstallerPackageName() = withBuildSdkInt(Build.VERSION_CODES.Q) {
+        val packageManager = mock(PackageManager::class.java)
+        `when`(packageManager.getApplicationLabel(any())).thenReturn("Test App name")
+
+        val collector = AppDataCollector(
+            context,
+            packageManager,
+            client.immutableConfig,
+            client.sessionTracker,
+            am,
+            client.launchCrashTracker,
+            client.memoryTrimState
+        )
+
+        @Suppress("DEPRECATION")
+        `when`(packageManager.getInstallerPackageName(any())).thenReturn("Test Installer name")
+
+        val result = collector.getInstallerPackageName()
+        assertEquals("Test Installer name", result)
     }
 }

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagKotlinTestUtils.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/BugsnagKotlinTestUtils.kt
@@ -1,0 +1,17 @@
+package com.bugsnag.android
+
+import android.os.Build
+
+inline fun <R> withBuildSdkInt(sdk: Int, block: () -> R): R {
+    val build = Build.VERSION::class.java
+    val sdkInt = build.getDeclaredField("SDK_INT")
+        .apply { isAccessible = true }
+
+    val oldSdkInt = sdkInt.get(null)
+    sdkInt.set(null, sdk)
+    try {
+        return block()
+    } finally {
+        sdkInt.set(null, oldSdkInt)
+    }
+}

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -171,11 +171,12 @@ public class ClientTest {
     public void testAppDataMetadata() {
         client = generateClient();
         Map<String, Object> app = client.getAppDataCollector().getAppDataMetadata();
-        assertEquals(9, app.size());
+        assertEquals(10, app.size());
         assertEquals("Bugsnag Android Tests", app.get("name"));
         assertEquals("com.bugsnag.android.core.test", app.get("processName"));
         assertNotNull(app.get("memoryUsage"));
         assertTrue(app.containsKey("activeScreen"));
+        assertTrue(app.containsKey("installerPackage"));
         assertNotNull(app.get("lowMemory"));
         assertNotNull(app.get("memoryTrimLevel"));
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -33,6 +33,7 @@ internal class AppDataCollector(
     private val processName = findProcessName()
     private val releaseStage = config.releaseStage
     private val versionName = config.appVersion ?: config.packageInfo?.versionName
+    private val installerPackage = getInstallerPackageName()
 
     fun generateApp(): App =
         App(config, binaryArch, packageName, releaseStage, versionName, codeBundleId)
@@ -74,6 +75,7 @@ internal class AppDataCollector(
         map["totalMemory"] = totalMemory
         map["freeMemory"] = freeMemory
         map["memoryLimit"] = runtime.maxMemory()
+        map["installerPackage"] = installerPackage
     }
 
     /**
@@ -127,6 +129,20 @@ internal class AppDataCollector(
                 packageManager.getApplicationLabel(copy).toString()
             }
             else -> null
+        }
+    }
+
+    /**
+     * The name of installer / vendor package of the app
+     */
+    fun getInstallerPackageName(): String? {
+        try {
+            if (VERSION.SDK_INT >= VERSION_CODES.R)
+                return packageManager?.getInstallSourceInfo(packageName)?.installingPackageName
+            @Suppress("DEPRECATION")
+            return packageManager?.getInstallerPackageName(packageName)
+        } catch (e: Exception) {
+            return null
         }
     }
 


### PR DESCRIPTION
## Goal

Name of installer / vendor package of the app casing the crash/exception can be viewed in the app metadata 

## Changeset

Add Installer package name in the payload and using packageManager to get InstallerPackageName

## Testing

Unit tests