### PR TITLE
Consistently fail fast in e2e tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -98,13 +98,13 @@ steps:
         run: android-maze-runner-bitbar
         service-ports: true
         command:
+          - "features/full_tests"
           - "--app=build/fixture-r19.apk"
           - "--farm=bb"
           - "--device=ANDROID_7"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "features/full_tests"
           - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
@@ -154,13 +154,13 @@ steps:
         run: android-maze-runner-bitbar
         service-ports: true
         command:
+          - "features/full_tests"
           - "--app=build/fixture-r21.apk"
           - "--farm=bb"
           - "--device=ANDROID_9"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "features/full_tests"
           - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
@@ -217,6 +217,7 @@ steps:
           - "--device=ANDROID_10"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -244,6 +245,7 @@ steps:
           - "--device=ANDROID_10"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -331,6 +333,7 @@ steps:
           - "--device=ANDROID_13"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -358,6 +361,7 @@ steps:
           - "--device=ANDROID_13"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -109,6 +109,7 @@ steps:
           - "--device=ANDROID_7"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -135,6 +136,7 @@ steps:
           - "--device=ANDROID_9"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -161,6 +163,7 @@ steps:
           - "--device=ANDROID_10"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -277,6 +280,7 @@ steps:
           - "--device=ANDROID_13"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--fail-fast"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25


### PR DESCRIPTION
## Goal

Make sure all Maze Runner CI jobs are consistently set to `--fail-fast`.

## Testing

Covered by a full CI run.