### PR TITLE
Reduce flakes in StrictModeFileUriExposeScenario

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeFileUriExposeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/StrictModeFileUriExposeScenario.kt
@@ -28,11 +28,32 @@ internal class StrictModeFileUriExposeScenario(
 
         // expose a file URI to another app, triggering a StrictMode violation.
         // https://developer.android.com/reference/android/os/StrictMode.VmPolicy.Builder#detectFileUriExposure()
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            val fileUri = Uri.fromFile(File("/sdcard/bus.jpg"))
-            setDataAndType(fileUri, "image/jpeg")
-        }
+        val intents = arrayOf(
+            Intent(Intent.ACTION_VIEW).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                val fileUri = Uri.fromFile(File("/sdcard/bus.jpg"))
+                setDataAndType(fileUri, "image/jpeg")
+            },
+            Intent(Intent.ACTION_VIEW).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                val fileUri = Uri.fromFile(File("/sdcard/siren.wav"))
+                setDataAndType(fileUri, "audio/x-wav")
+            },
+            Intent(Intent.ACTION_VIEW).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                val fileUri = Uri.fromFile(File("/sdcard/siren.webm"))
+                setDataAndType(fileUri, "video/webm; codecs=\"vp8, vorbis\"")
+            },
+            Intent(Intent.ACTION_VIEW).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                val fileUri = Uri.fromFile(File("/sdcard/bus.pdf"))
+                setDataAndType(fileUri, "application/pdf")
+            }
+        )
+
+        val pm = context.packageManager
+        val intent = intents.firstOrNull { pm.queryIntentActivities(it, 0).isNotEmpty() }
+
         context.startActivity(intent)
     }
 


### PR DESCRIPTION
## Goal
Reduce the changes of flakes in the `StrictModeFileUriExposeScenario` test

## Design
Provide a list of "leaky" `Intent`s and attempt to find one that will resolve on the device before attempting to start it. These should reduce the chance that the scenario fails because the `Intent` cannot be resolved against an installed app (although it does not eliminate it entirely).

## Testing
Relied on existing tests.