### PR TITLE
Rare app crash in shared preferences migrator 

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -51,6 +51,7 @@
     <ID>SwallowedException:DeviceIdFilePersistence.kt$DeviceIdFilePersistence$catch (exc: OverlappingFileLockException) { Thread.sleep(FILE_LOCK_WAIT_MS) }</ID>
     <ID>SwallowedException:JsonHelperTest.kt$JsonHelperTest$catch (e: IllegalArgumentException) { didThrow = true }</ID>
     <ID>SwallowedException:PluginClient.kt$PluginClient$catch (exc: ClassNotFoundException) { if (isWarningEnabled) { logger.d("Plugin '$clz' is not on the classpath - functionality will not be enabled.") } null }</ID>
+    <ID>SwallowedException:SharedPrefMigrator.kt$SharedPrefMigrator$catch (e: RuntimeException) { null }</ID>
     <ID>ThrowsCount:JsonHelper.kt$JsonHelper$ fun jsonToLong(value: Any?): Long?</ID>
     <ID>TooManyFunctions:ConfigInternal.kt$ConfigInternal : CallbackAwareMetadataAwareUserAwareFeatureFlagAware</ID>
     <ID>TooManyFunctions:DeviceDataCollector.kt$DeviceDataCollector</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SharedPrefMigrator.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SharedPrefMigrator.kt
@@ -2,32 +2,38 @@ package com.bugsnag.android
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.SharedPreferences
 
 /**
  * Reads legacy information left in SharedPreferences and migrates it to the new location.
  */
 internal class SharedPrefMigrator(context: Context) : DeviceIdPersistence {
 
-    private val prefs = context
-        .getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE)
+    private val prefs: SharedPreferences? =
+        try {
+            context.getSharedPreferences("com.bugsnag.android", Context.MODE_PRIVATE)
+        } catch (e: RuntimeException) {
+            null
+        }
 
     /**
      * This implementation will never create an ID; it will only fetch one if present.
      */
-    override fun loadDeviceId(requestCreateIfDoesNotExist: Boolean) = prefs.getString(INSTALL_ID_KEY, null)
+    override fun loadDeviceId(requestCreateIfDoesNotExist: Boolean) =
+        prefs?.getString(INSTALL_ID_KEY, null)
 
     fun loadUser(deviceId: String?) = User(
-        prefs.getString(USER_ID_KEY, deviceId),
-        prefs.getString(USER_EMAIL_KEY, null),
-        prefs.getString(USER_NAME_KEY, null)
+        prefs?.getString(USER_ID_KEY, deviceId),
+        prefs?.getString(USER_EMAIL_KEY, null),
+        prefs?.getString(USER_NAME_KEY, null)
     )
 
-    fun hasPrefs() = prefs.contains(INSTALL_ID_KEY)
+    fun hasPrefs() = prefs?.contains(INSTALL_ID_KEY) == true
 
     @SuppressLint("ApplySharedPref")
     fun deleteLegacyPrefs() {
         if (hasPrefs()) {
-            prefs.edit().clear().commit()
+            prefs?.edit()?.clear()?.commit()
         }
     }
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SharedPrefMigratorTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SharedPrefMigratorTest.kt
@@ -37,6 +37,20 @@ internal class SharedPrefMigratorTest {
     }
 
     @Test
+    fun nullSharedPreferences() {
+        `when`(context.getSharedPreferences(eq("com.bugsnag.android"), eq(0))).thenReturn(null)
+        prefMigrator = SharedPrefMigrator(context)
+        assertFalse(prefMigrator.hasPrefs())
+    }
+
+    @Test
+    fun gettingSharedPreferencesWithException() {
+        `when`(context.getSharedPreferences(eq("com.bugsnag.android"), eq(0))).thenThrow(RuntimeException())
+        prefMigrator = SharedPrefMigrator(context)
+        assertFalse(prefMigrator.hasPrefs())
+    }
+
+    @Test
     fun nullDeviceId() {
         `when`(prefs.getString("install.iud", null)).thenReturn(null)
         assertNull(prefMigrator.loadDeviceId(true))


### PR DESCRIPTION
## Goal

Prevent rare app crash while migrating old `SharedPreferences` data from older versions of `bugsnag-android`.

## Changeset

Added nullable check and catching exception for shared preferences

## Testing

Additional unit tests