### PR TITLE
Prevent device data collector may causing a rare app crash while calculating free memory

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -45,6 +45,8 @@
     <ID>SwallowedException:BugsnagEventMapper.kt$BugsnagEventMapper$catch (pe: IllegalArgumentException) { ndkDateFormatHolder.get()!!.parse(this) ?: throw IllegalArgumentException("cannot parse date $this") }</ID>
     <ID>SwallowedException:ConnectivityCompat.kt$ConnectivityLegacy$catch (e: NullPointerException) { // in some rare cases we get a remote NullPointerException via Parcel.readException null }</ID>
     <ID>SwallowedException:ContextExtensions.kt$catch (exc: RuntimeException) { null }</ID>
+    <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (e: Throwable) { null }</ID>
+    <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (e: Throwable) { return null }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exc: Exception) { false }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get battery status") }</ID>
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$catch (exception: Exception) { logger.w("Could not get locationStatus") }</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt
@@ -242,21 +242,26 @@ internal class DeviceDataCollector(
     /**
      * Get the amount of memory remaining on the device
      */
-    private fun calculateFreeMemory(): Long? {
+    fun calculateFreeMemory(): Long? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            val freeMemory = appContext.getActivityManager()
-                ?.let { am -> ActivityManager.MemoryInfo().also { am.getMemoryInfo(it) } }
-                ?.availMem
-
-            if (freeMemory != null) {
-                return freeMemory
+            try {
+                val freeMemory = appContext.getActivityManager()
+                    ?.let { am -> ActivityManager.MemoryInfo().also { am.getMemoryInfo(it) } }
+                    ?.availMem
+                if (freeMemory != null) {
+                    return freeMemory
+                }
+            } catch (e: Throwable) {
+                return null
             }
         }
 
-        return runCatching {
+        return try {
             @Suppress("PrivateApi")
             AndroidProcess::class.java.getDeclaredMethod("getFreeMemory").invoke(null) as Long?
-        }.getOrNull()
+        } catch (e: Throwable) {
+            null
+        }
     }
 
     /**


### PR DESCRIPTION
## Goal

Prevent DeviceDataCollector crashing the app when the ActivityManager cannot be reached.

## Changeset

Added try and catch for throwable exception.

## Testing

Additional unit tests