### PR TITLE
Skip flaking e2e tests

### DIFF
--- a/features/full_tests/in_foreground.feature
+++ b/features/full_tests/in_foreground.feature
@@ -3,6 +3,8 @@ Feature: In foreground field populates correctly
   Background:
     Given I clear all persistent data
 
+  # TODO: Skipped pending PLAT-10634
+  @skip
   Scenario: Test handled exception in background
     When I run "InForegroundScenario"
     And I send the app to the background for 5 seconds

--- a/features/full_tests/native_event_tracking.feature
+++ b/features/full_tests/native_event_tracking.feature
@@ -12,6 +12,8 @@ Feature: Synchronizing app/device metadata in the native layer
     And the event "unhandled" is false
     And the "codeIdentifier" of stack frame 0 is not null
 
+  # TODO: Skipped pending PLAT-10634
+  @skip
   Scenario: Capture foreground state while in the background
     When I run "CXXBackgroundNotifyScenario"
     And I send the app to the background for 5 seconds


### PR DESCRIPTION
## Goal

Skip flaking e2e tests.

## Testing

Covered by a basic CI run.