### PR TITLE
Revert Example appcompile & target SDK

### DIFF
--- a/examples/sdk-app-example/app/build.gradle
+++ b/examples/sdk-app-example/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 
 android {
-    compileSdk 34
+    compileSdk 31
     ndkVersion "17.2.4988734"
 
     defaultConfig {
         applicationId "com.example.bugsnag.android"
         minSdkVersion 14
-        targetSdkVersion 34
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
## Goal
Avoid version conflicts on CI.

## Changelog
Reverted the Example app to using SDK 31 instead of 34