### PR TITLE
Disable kotlin null check intrinsics

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -58,7 +58,7 @@ public class ClientTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void testNullContext() {
         client = new Client(null, "api-key");
     }

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -4,5 +4,10 @@ android {
         jvmTarget = "1.6"
         apiVersion = "1.3"
         languageVersion = "1.4"
+        freeCompilerArgs += [
+                '-Xno-call-assertions',
+                '-Xno-receiver-assertions',
+                '-Xno-param-assertions'
+        ]
     }
 }


### PR DESCRIPTION
## Goal
Disable Kotlin's Intrinsic runtime null-checks so that we can continue to migrate more of our codebase to Kotlin without introducing binary-incompatibilities.

## Changeset
Adding kotlin compiler options for disable null checks

## Testing
Searching disassembled code to ensure that Intrinsics null checks are not included
