### PR TITLE
Fix apikey tests

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
@@ -190,7 +190,7 @@ private fun validateApiKey(value: String) {
 }
 
 @VisibleForTesting
-fun isInvalidApiKey(apiKey: String): Boolean {
+fun isInvalidApiKey(apiKey: String?): Boolean {
     if (apiKey.isNullOrEmpty()) {
         throw IllegalArgumentException("No Bugsnag API Key set")
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyValidationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ApiKeyValidationTest.kt
@@ -12,6 +12,11 @@ internal class ApiKeyValidationTest {
         isInvalidApiKey("")
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun testNullApiKey() {
+        isInvalidApiKey(null)
+    }
+
     @Test
     fun testWrongSizeApiKey() {
         assertTrue(isInvalidApiKey("abfe05f"))

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
@@ -44,11 +44,6 @@ public class ConfigurationFacadeTest {
         assertEquals("ffffc5bd39a74caa1267142706a7fb21", config.impl.getApiKey());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void apiKeyInvalid() {
-        config.setApiKey(null);
-    }
-
     @Test
     public void appVersionValid() {
         config.setAppVersion("1.23");

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -286,6 +286,16 @@ internal class ImmutableConfigTest {
         assertEquals("", config.apiKey)
     }
 
+    @Test(expected = IllegalArgumentException::class)
+    fun testSettingNullApiKey() {
+        val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        seed.apiKey = ""
+        `when`(isInvalidApiKey(seed.apiKey)).thenThrow(IllegalArgumentException())
+        val config = sanitiseConfiguration(context, seed, connectivity)
+
+        assertEquals(null, config.apiKey)
+    }
+
     @Test
     fun testSettingWrongSizeApiKey() {
         val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")


### PR DESCRIPTION
## Goal

Fix apikey tests 

## Changeset

Attempting to use a null apiKey will throw an IllegalArgumentException during validation

## Testing

New unit tests