### PR TITLE
Skip the InForegroundScenario on Samsung devices

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InForegroundScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/InForegroundScenario.kt
@@ -6,6 +6,7 @@ import android.os.Handler
 import android.os.Looper
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
+import com.bugsnag.android.mazerunner.log
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -29,6 +30,7 @@ internal class InForegroundScenario(
         Handler(Looper.getMainLooper()).post {
             // debounce so this can only ever occur once
             if (!triggered.getAndSet(true)) {
+                log("onActivityStopped is finished, calling Bugsnag.notify in the background")
                 Bugsnag.notify(generateException())
             }
         }

--- a/features/full_tests/in_foreground.feature
+++ b/features/full_tests/in_foreground.feature
@@ -4,6 +4,7 @@ Feature: In foreground field populates correctly
     Given I clear all persistent data
 
   @skip_android_13
+  @skip_samsung
   Scenario: Test handled exception in background
     When I run "InForegroundScenario"
     And I send the app to the background for 5 seconds


### PR DESCRIPTION
## Goal
Skip the `InForegroundScenario` on Samsung devices.
