### PR TITLE
Enhance events with tombstone and trace files in the BugsnagExitinfo plugin

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -426,4 +426,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     void setInternalMetrics(InternalMetrics metrics) {
         impl.setInternalMetrics(metrics);
     }
+
+    @NonNull
+    String getSeverityReason(){ return impl.getSeverityReasonType();}
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -426,7 +426,4 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     void setInternalMetrics(InternalMetrics metrics) {
         impl.setInternalMetrics(metrics);
     }
-
-    @NonNull
-    String getSeverityReason(){ return impl.getSeverityReasonType();}
 }

--- a/bugsnag-plugin-android-exitinfo/api/bugsnag-plugin-android-exitinfo.api
+++ b/bugsnag-plugin-android-exitinfo/api/bugsnag-plugin-android-exitinfo.api
@@ -1,0 +1,11 @@
+public final class com/bugsnag/android/BugsnagExitInfoPlugin : com/bugsnag/android/OnSendCallback, com/bugsnag/android/Plugin {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public fun <init> (ZZ)V
+	public fun <init> (ZZZ)V
+	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun load (Lcom/bugsnag/android/Client;)V
+	public fun onSend (Lcom/bugsnag/android/Event;)Z
+	public fun unload ()V
+}
+

--- a/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
+++ b/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
@@ -24,5 +24,7 @@
     <ID>NestedBlockDepth:TraceParser.kt$TraceParser$private fun parseThreadAttributes(line: String)</ID>
     <ID>ReturnCount:TraceParser.kt$TraceParser$@VisibleForTesting internal fun parseNativeFrame(line: String): Stackframe?</ID>
     <ID>SwallowedException:ExitInfoCallback.kt$ExitInfoCallback$exc: Throwable</ID>
+    <ID>UnusedPrivateProperty:BugsnagExitInfoPlugin.kt$BugsnagExitInfoPlugin$/** * Whether to add the list of open FDs to correlated reports */ private val listOpenFds: Boolean = true</ID>
+    <ID>UnusedPrivateProperty:BugsnagExitInfoPlugin.kt$BugsnagExitInfoPlugin$/** * Whether to report stored logcat messages metadata */ private val includeLogcat: Boolean = false</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
+++ b/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
@@ -23,5 +23,6 @@
     <ID>MaxLineLength:TraceParserTest.kt$TraceParserTest$"void* std::__1::__thread_proxy&lt;std::__1::tuple&lt;std::__1::unique_ptr&lt;std::__1::__thread_struct, std::__1::default_delete&lt;std::__1::__thread_struct> >, void (android::AsyncWorker::*)(), android::AsyncWorker*> >(void*)"</ID>
     <ID>NestedBlockDepth:TraceParser.kt$TraceParser$private fun parseThreadAttributes(line: String)</ID>
     <ID>ReturnCount:TraceParser.kt$TraceParser$@VisibleForTesting internal fun parseNativeFrame(line: String): Stackframe?</ID>
+    <ID>SwallowedException:ExitInfoCallback.kt$ExitInfoCallback$exc: Throwable</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/BugsnagExitInfoPlugin.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/BugsnagExitInfoPlugin.kt
@@ -6,8 +6,24 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 
 @RequiresApi(Build.VERSION_CODES.R)
-class BugsnagExitInfoPlugin(
-    private val context: Context
+class BugsnagExitInfoPlugin @JvmOverloads constructor(
+
+    /**
+     * Whether to add the list of open FDs to correlated reports
+     */
+    private val listOpenFds: Boolean = true,
+
+    /**
+     * Whether to report stored logcat messages metadata
+     */
+    private val includeLogcat: Boolean = false,
+
+    /**
+     * Turn of event correlation based on the processStateSummary field, this can
+     * set to `true` if the field is required by the app
+     */
+    private val disableProcessStateSummaryOverride: Boolean = false
+
 ) : Plugin, OnSendCallback {
 
     private var exitInfoCallback: ExitInfoCallback? = null
@@ -17,20 +33,22 @@ class BugsnagExitInfoPlugin(
     }
 
     override fun load(client: Client) {
-        client.addOnSession(
-            OnSessionCallback { session: Session ->
-                val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-                am.setProcessStateSummary(session.id.toByteArray())
-                return@OnSessionCallback true
-            }
+        if (!disableProcessStateSummaryOverride) {
+            client.addOnSession(
+                OnSessionCallback { session: Session ->
+                    val am = client.appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                    am.setProcessStateSummary(session.id.toByteArray())
+                    return@OnSessionCallback true
+                }
+            )
+        }
+        exitInfoCallback = ExitInfoCallback(
+            client.appContext,
+            TombstoneEventEnhancer(client.logger),
+            TraceEventEnhancer(client.logger, client.immutableConfig.projectPackages)
         )
-//        exitInfoCallback = ExitInfoCallback(
-        //        client.context,
-        //        TombstoneEventEnhancer(),
-        //        TraceEventEnhancer(client.logger, client.immutableConfig.projectPackages))
     }
 
     override fun unload() {
-        TODO("Not yet implemented")
     }
 }

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/BugsnagExitInfoPlugin.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/BugsnagExitInfoPlugin.kt
@@ -1,0 +1,36 @@
+package com.bugsnag.android
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.R)
+class BugsnagExitInfoPlugin(
+    private val context: Context
+) : Plugin, OnSendCallback {
+
+    private var exitInfoCallback: ExitInfoCallback? = null
+
+    override fun onSend(event: Event): Boolean {
+        return exitInfoCallback?.onSend(event) ?: true
+    }
+
+    override fun load(client: Client) {
+        client.addOnSession(
+            OnSessionCallback { session: Session ->
+                val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                am.setProcessStateSummary(session.id.toByteArray())
+                return@OnSessionCallback true
+            }
+        )
+//        exitInfoCallback = ExitInfoCallback(
+        //        client.context,
+        //        TombstoneEventEnhancer(),
+        //        TraceEventEnhancer(client.logger, client.immutableConfig.projectPackages))
+    }
+
+    override fun unload() {
+        TODO("Not yet implemented")
+    }
+}

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
@@ -22,7 +22,9 @@ internal class ExitInfoCallback(
                 ?: return true
 
         try {
-            if (exitInfo.reason == ApplicationExitInfo.REASON_CRASH_NATIVE) {
+            if (exitInfo.reason == ApplicationExitInfo.REASON_CRASH_NATIVE ||
+                exitInfo.reason == ApplicationExitInfo.REASON_SIGNALED
+            ) {
                 nativeEnhancer(event, exitInfo)
             } else if (exitInfo.reason == ApplicationExitInfo.REASON_ANR) {
                 anrEventEnhancer(event, exitInfo)

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
@@ -8,7 +8,8 @@ import androidx.annotation.RequiresApi
 
 internal class ExitInfoCallback(
     private val context: Context,
-    private val eventEnhancer: (Event, ApplicationExitInfo) -> Unit
+    private val nativeEnhancer: (Event, ApplicationExitInfo) -> Unit,
+    private val anrEventEnhancer: (Event, ApplicationExitInfo) -> Unit
 ) : OnSendCallback {
 
     @RequiresApi(Build.VERSION_CODES.R)
@@ -16,10 +17,19 @@ internal class ExitInfoCallback(
         val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         val allExitInfo = am.getHistoricalProcessExitReasons(context.packageName, 0, MAX_EXIT_INFO)
         val sessionIdBytes = event.session?.id?.toByteArray() ?: return true
-        val exitInfo = allExitInfo.find { it.processStateSummary?.contentEquals(sessionIdBytes) == true }
-            ?: return true
+        val exitInfo =
+            allExitInfo.find { it.processStateSummary?.contentEquals(sessionIdBytes) == true }
+                ?: return true
 
-        eventEnhancer(event, exitInfo)
+        try {
+            if (exitInfo.reason == ApplicationExitInfo.REASON_CRASH_NATIVE) {
+                nativeEnhancer(event, exitInfo)
+            } else if (exitInfo.reason == ApplicationExitInfo.REASON_ANR) {
+                anrEventEnhancer(event, exitInfo)
+            }
+        } catch (exc: Throwable) {
+            return true
+        }
         return true
     }
 

--- a/bugsnag-plugin-android-exitinfo/src/test/java/com/bugsnag/android/BugsnagExitInfoPluginStoreTest.kt
+++ b/bugsnag-plugin-android-exitinfo/src/test/java/com/bugsnag/android/BugsnagExitInfoPluginStoreTest.kt
@@ -10,7 +10,7 @@ import org.mockito.Mockito.`when`
 import java.io.File
 import java.nio.file.Files
 
-internal class ExitInfoPluginStoreTest {
+internal class BugsnagExitInfoPluginStoreTest {
 
     private lateinit var file: File
     private lateinit var exitInfoPluginStore: ExitInfoPluginStore

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -34,7 +34,7 @@
 /**
  * Version of the bugsnag_event struct. Serialized to report header.
  */
-#define BUGSNAG_EVENT_VERSION 12
+#define BUGSNAG_EVENT_VERSION 13
 
 #ifdef __cplusplus
 extern "C" {
@@ -234,7 +234,7 @@ typedef struct {
   char context[64];
   bugsnag_severity severity;
 
-  char session_id[33];
+  char session_id[37];
   char session_start[33];
   int handled_events;
   int unhandled_events;

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_reader.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_reader.c
@@ -9,7 +9,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-const int BSG_MIGRATOR_CURRENT_VERSION = 12;
+const int BSG_MIGRATOR_CURRENT_VERSION = 13;
 
 void bsg_read_feature_flags(int fd, bool expect_verification,
                             bsg_feature_flag **out_feature_flags,

--- a/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventOnDiskTests.cpp
+++ b/bugsnag-plugin-android-ndk/src/test/cpp/migrations/EventOnDiskTests.cpp
@@ -132,7 +132,7 @@ static void *create_full_event() {
 static const char *write_event(JNIEnv *env, jstring temp_file,
                                   void *(event_generator)()) {
   auto event_ctx = (bsg_environment *)calloc(1, sizeof(bsg_environment));
-  event_ctx->report_header.version = 12;
+  event_ctx->report_header.version = 13;
   const char *path = (*env).GetStringUTFChars(temp_file, nullptr);
   sprintf(event_ctx->next_event_path, "%s", path);
 


### PR DESCRIPTION
## Goal
Merge tombstone & trace data into BugSnag `Event`s when available.

## Changeset
Introduced `BugsnagExitInfoPlugin` to correlate `ApplicationExitInfo` data with BugSnag `Event`s before they are sent.

## Testing
Introduce new unit test and manual test on example app