### PR TITLE
Adding open file descriptors to metadata

### DIFF
--- a/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
+++ b/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
@@ -24,7 +24,6 @@
     <ID>NestedBlockDepth:TraceParser.kt$TraceParser$private fun parseThreadAttributes(line: String)</ID>
     <ID>ReturnCount:TraceParser.kt$TraceParser$@VisibleForTesting internal fun parseNativeFrame(line: String): Stackframe?</ID>
     <ID>SwallowedException:ExitInfoCallback.kt$ExitInfoCallback$exc: Throwable</ID>
-    <ID>UnusedPrivateProperty:BugsnagExitInfoPlugin.kt$BugsnagExitInfoPlugin$/** * Whether to add the list of open FDs to correlated reports */ private val listOpenFds: Boolean = true</ID>
     <ID>UnusedPrivateProperty:BugsnagExitInfoPlugin.kt$BugsnagExitInfoPlugin$/** * Whether to report stored logcat messages metadata */ private val includeLogcat: Boolean = false</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/BugsnagExitInfoPlugin.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/BugsnagExitInfoPlugin.kt
@@ -39,9 +39,10 @@ class BugsnagExitInfoPlugin @JvmOverloads constructor(
                 }
             )
         }
+
         exitInfoCallback = ExitInfoCallback(
             client.appContext,
-            TombstoneEventEnhancer(client.logger),
+            TombstoneEventEnhancer(client.logger, listOpenFds),
             TraceEventEnhancer(client.logger, client.immutableConfig.projectPackages)
         )
         client.addOnSend(exitInfoCallback)

--- a/bugsnag-plugin-android-exitinfo/src/test/java/com/bugsnag/android/TombstoneEventEnhancerTest.kt
+++ b/bugsnag-plugin-android-exitinfo/src/test/java/com/bugsnag/android/TombstoneEventEnhancerTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import android.app.ApplicationExitInfo
 import com.bugsnag.android.internal.ImmutableConfig
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
@@ -12,7 +13,7 @@ internal class TombstoneEventEnhancerTest {
 
     private val logger = mock(Logger::class.java)
 
-    private val tombstoneEventEnhancer = TombstoneEventEnhancer(logger)
+    private val tombstoneEventEnhancer = TombstoneEventEnhancer(logger, true)
 
     @Test
     fun testTombstoneEnhancer() {
@@ -49,5 +50,9 @@ internal class TombstoneEventEnhancerTest {
         assertEquals(667096L, testThread.stacktrace.first().lineNumber)
         assertEquals("__rt_sigtimedwait", testThread.stacktrace.first().method)
         assertEquals("__start_thread", testThread.stacktrace.last().method)
+
+        val firstFd = event.getMetadata("Open FileDescriptors")!!["0"] as Map<*, *>
+        assertEquals("/dev/null", firstFd["path"])
+        assertNull(firstFd["owner"])
     }
 }


### PR DESCRIPTION
## Goal

Users are able to add `Open File Descriptors` into BugSnag `Metadata` when available.

## Changeset

An open file descriptors control to add `Open File Descriptors` from `ApplicationExitInfo` to  BugSnag `Metadata` 

## Testing

Unit tests and manual test on example app