### PR TITLE
Remove Warning log when persisted user file not loaded

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/UserStoreTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/UserStoreTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.bugsnag.android.internal.ImmutableConfig
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -145,11 +146,8 @@ internal class UserStoreTest {
             prefMigrator,
             NoopLogger
         )
-        val user = store.load(User()).user
-        assertEquals("device-id-123", user.id)
-        assertNull(user.email)
-        assertNull(user.name)
-        assertEquals("", file.readText())
+        store.load(User()).user
+        assertFalse(file.exists())
     }
 
     /**
@@ -159,7 +157,7 @@ internal class UserStoreTest {
     fun saveWithoutPersistUser() {
         val store = UserStore(generateConfig(false), "", file, prefMigrator, NoopLogger)
         store.save(User("123", "joe@yahoo.com", "Joe Bloggs"))
-        assertEquals("", file.readText())
+        assertFalse(file.exists())
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SynchronizedStreamableStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SynchronizedStreamableStore.kt
@@ -13,7 +13,7 @@ import kotlin.concurrent.withLock
  * This class is made thread safe through the use of a [ReadWriteLock].
  */
 internal class SynchronizedStreamableStore<T : JsonStream.Streamable>(
-    private val file: File
+    internal val file: File
 ) {
 
     private val lock = ReentrantReadWriteLock()


### PR DESCRIPTION
## Goal

Warning log would not show when persisted user file is not loaded

## Changeset

Add persisted user file exist checks and config persist user check in when loading user

## Testing

Manual test and refactor existing tests