### PR TITLE
Rationalise BitBar CI concurrency group

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -53,7 +53,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Debug fixture smoke tests'
@@ -81,7 +81,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-debug"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 7 NDK r19 end-to-end tests - batch 1'
@@ -111,7 +111,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 7 NDK r19 end-to-end tests - batch 2'
@@ -141,7 +141,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 8 NDK r19 end-to-end tests - batch 1'
@@ -169,7 +169,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 8 NDK r19 end-to-end tests - batch 2'
@@ -197,7 +197,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 9 NDK r21 end-to-end tests - batch 1'
@@ -227,7 +227,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 9 NDK r21 end-to-end tests - batch 2'
@@ -257,7 +257,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 10 NDK r21 end-to-end tests - batch 1'
@@ -287,7 +287,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 10 NDK r21 end-to-end tests - batch 2'
@@ -317,7 +317,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
@@ -351,7 +351,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 11 NDK r21 end-to-end tests - batch 2'
@@ -381,7 +381,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 13 NDK r21 end-to-end tests - batch 1'
@@ -411,7 +411,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 13 NDK r21 end-to-end tests - batch 2'
@@ -441,7 +441,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   # If there is a tag present activate a manual publishing step

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -121,7 +121,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 8 NDK r19 smoke tests'
@@ -148,7 +148,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 9 NDK r21 smoke tests'
@@ -177,7 +177,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 10 NDK r21 smoke tests'
@@ -206,7 +206,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 11 NDK r21 smoke tests'
@@ -236,7 +236,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
  # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
@@ -271,7 +271,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
@@ -302,7 +302,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 13 NDK r21 smoke tests'
@@ -331,7 +331,7 @@ steps:
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: 'Conditionally include device farms/full tests'


### PR DESCRIPTION
## Goal

NOTE: Please let me merge this PR myself, it needs to be merged as the same time as several others to avoid unnecessary failures on CI.

Rationalise the Buildkite concurrency group used to control access to BitBar across all of our repos.

## Design

We were using separate groups fro web and device usage, when in fact they are counted towards the same usage limit.  All groups are now being renamed to simply 'bitbar' with a limit of 25.

The main mistake that I could make here is missing an instance of the old groups (`bitbar-app` and `bitbar-web`, so I am using the global find and replace function of my IDE.

## Changeset

Buildkite concurrency group changes only.

## Testing

Verified by peer review.  