### PR TITLE
Introduce `bugsnag-android-appstart` module for auto-start

### DIFF
--- a/bugsnag-android-appstart/README.md
+++ b/bugsnag-android-appstart/README.md
@@ -1,0 +1,20 @@
+# bugsnag-android-appstart
+
+Auto-start BugSnag using
+the [Android App Startup Library](https://developer.android.com/topic/libraries/app-startup).
+
+## Getting Started
+1. [Create a Bugsnag account](https://www.bugsnag.com)
+1. Add this module to your app dependencies:
+```kotlin
+dependencies {
+    // ...
+    implementation("com.bugsnag:bugsnag-android-appstart:6.+")
+}
+```
+1. Add your API key to your `AndroidManifest.xml`:
+```xml
+<meta-data
+    android:name="com.bugsnag.android.API_KEY"
+    android:value="your-api-key" />
+```

--- a/bugsnag-android-appstart/api/bugsnag-android-appstart.api
+++ b/bugsnag-android-appstart/api/bugsnag-android-appstart.api
@@ -1,0 +1,7 @@
+public final class com/bugsnag/android/BugsnagInitializer : androidx/startup/Initializer {
+	public fun <init> ()V
+	public fun create (Landroid/content/Context;)Lcom/bugsnag/android/Client;
+	public synthetic fun create (Landroid/content/Context;)Ljava/lang/Object;
+	public fun dependencies ()Ljava/util/List;
+}
+

--- a/bugsnag-android-appstart/build.gradle
+++ b/bugsnag-android-appstart/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id("bugsnag-build-plugin")
+}
+
+apply plugin: "com.android.library"
+
+dependencies {
+    api(project(":bugsnag-android-core"))
+}
+
+apply from: "../gradle/kotlin.gradle"
+
+dependencies {
+    implementation("androidx.startup:startup-runtime:1.0.0")
+}

--- a/bugsnag-android-appstart/gradle.properties
+++ b/bugsnag-android-appstart/gradle.properties
@@ -1,0 +1,2 @@
+pomName=Bugsnag Android Initializer
+artefactId=bugsnag-android-appstart

--- a/bugsnag-android-appstart/lint-baseline.xml
+++ b/bugsnag-android-appstart/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.0.2" type="baseline" client="gradle" name="AGP (7.0.2)" variant="all" version="7.0.2">
+
+</issues>

--- a/bugsnag-android-appstart/src/main/AndroidManifest.xml
+++ b/bugsnag-android-appstart/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.bugsnag.android.startup">
+
+    <application>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            tools:node="merge"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false">
+            <meta-data
+                android:name="com.bugsnag.android.BugsnagInitializer"
+                android:value="androidx.startup" />
+        </provider>
+    </application>
+</manifest>

--- a/bugsnag-android-appstart/src/main/java/com/bugsnag/android/BugsnagInitializer.kt
+++ b/bugsnag-android-appstart/src/main/java/com/bugsnag/android/BugsnagInitializer.kt
@@ -1,0 +1,9 @@
+package com.bugsnag.android
+
+import android.content.Context
+import androidx.startup.Initializer
+
+class BugsnagInitializer : Initializer<Client> {
+    override fun create(context: Context): Client = Bugsnag.start(context)
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,7 @@ gradleEnterprise {
 include(
     ":bugsnag-android",
     ":bugsnag-android-core",
+    ":bugsnag-android-appstart",
     ":bugsnag-plugin-android-anr",
     ":bugsnag-plugin-android-exitinfo",
     ":bugsnag-plugin-android-ndk",


### PR DESCRIPTION
## Goal
Introduce a quick-start module that will automatically call `Bugsnag.start` as part of the application startup process.

## Testing
Manually tested in Example App.