### PR TITLE
Make ExitInfoPlugin config more Java friendly

### DIFF
--- a/bugsnag-plugin-android-exitinfo/api/bugsnag-plugin-android-exitinfo.api
+++ b/bugsnag-plugin-android-exitinfo/api/bugsnag-plugin-android-exitinfo.api
@@ -1,10 +1,22 @@
 public final class com/bugsnag/android/BugsnagExitInfoPlugin : com/bugsnag/android/Plugin {
 	public fun <init> ()V
-	public fun <init> (Z)V
-	public fun <init> (ZZ)V
-	public fun <init> (ZZZ)V
-	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/bugsnag/android/ExitInfoPluginConfiguration;)V
+	public synthetic fun <init> (Lcom/bugsnag/android/ExitInfoPluginConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun load (Lcom/bugsnag/android/Client;)V
 	public fun unload ()V
+}
+
+public final class com/bugsnag/android/ExitInfoPluginConfiguration {
+	public fun <init> ()V
+	public fun <init> (ZZZ)V
+	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisableProcessStateSummaryOverride ()Z
+	public final fun getIncludeLogcat ()Z
+	public final fun getListOpenFds ()Z
+	public fun hashCode ()I
+	public final fun setDisableProcessStateSummaryOverride (Z)V
+	public final fun setIncludeLogcat (Z)V
+	public final fun setListOpenFds (Z)V
 }
 

--- a/bugsnag-plugin-android-exitinfo/build.gradle
+++ b/bugsnag-plugin-android-exitinfo/build.gradle
@@ -15,6 +15,12 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-javalite:3.24.2'
 }
 
+android.libraryVariants.configureEach { variant ->
+    variant.processJavaResourcesProvider.configure {
+        exclude('**/*.proto')
+    }
+}
+
 protobuf {
     protoc {
         artifact = 'com.google.protobuf:protoc:3.24.2'
@@ -22,7 +28,7 @@ protobuf {
     generateProtoTasks {
         all().configureEach { task ->
             task.builtins {
-                java{
+                java {
                     option "lite"
                 }
             }

--- a/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
+++ b/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
@@ -24,6 +24,7 @@
     <ID>MaxLineLength:TraceParserTest.kt$TraceParserTest$"void* std::__1::__thread_proxy&lt;std::__1::tuple&lt;std::__1::unique_ptr&lt;std::__1::__thread_struct, std::__1::default_delete&lt;std::__1::__thread_struct> >, void (android::AsyncWorker::*)(), android::AsyncWorker*> >(void*)"</ID>
     <ID>NestedBlockDepth:TraceParser.kt$TraceParser$private fun parseThreadAttributes(line: String)</ID>
     <ID>ReturnCount:TraceParser.kt$TraceParser$@VisibleForTesting internal fun parseNativeFrame(line: String): Stackframe?</ID>
+    <ID>SwallowedException:BugsnagExitInfoPlugin.kt$BugsnagExitInfoPlugin$e: Exception</ID>
     <ID>SwallowedException:ExitInfoCallback.kt$ExitInfoCallback$exc: Throwable</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoPluginConfiguration.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoPluginConfiguration.kt
@@ -1,0 +1,39 @@
+package com.bugsnag.android
+
+class ExitInfoPluginConfiguration(
+    /**
+     * Whether to add the list of open file descriptors to correlated reports
+     */
+    var listOpenFds: Boolean = true,
+
+    /**
+     * Whether to report stored logcat messages metadata
+     */
+    var includeLogcat: Boolean = false,
+
+    /**
+     * Turn off event correlation based on the
+     * [processStateSummary](ActivityManager.setProcessStateSummary) field. This can set to `true`
+     * to stop `BugsnagExitInfoPlugin` overwriting the field if it is being used by the app.
+     */
+    var disableProcessStateSummaryOverride: Boolean = false
+) {
+    constructor() : this(true, false, false)
+
+    internal fun copy() =
+        ExitInfoPluginConfiguration(listOpenFds, includeLogcat, disableProcessStateSummaryOverride)
+
+    override fun equals(other: Any?): Boolean {
+        return other is ExitInfoPluginConfiguration &&
+            listOpenFds == other.listOpenFds &&
+            includeLogcat == other.includeLogcat &&
+            disableProcessStateSummaryOverride == other.disableProcessStateSummaryOverride
+    }
+
+    override fun hashCode(): Int {
+        var result = listOpenFds.hashCode()
+        result = 31 * result + includeLogcat.hashCode()
+        result = 31 * result + disableProcessStateSummaryOverride.hashCode()
+        return result
+    }
+}

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoPluginStore.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoPluginStore.kt
@@ -15,7 +15,6 @@ internal class ExitInfoPluginStore(config: ImmutableConfig) {
             try {
                 val text = pid.toString()
                 file.writeText(text)
-                logger.d("Persisted: $text")
             } catch (exc: Throwable) {
                 logger.w("Unexpectedly failed to persist PID.", exc)
             }


### PR DESCRIPTION
## Goal
Make the `ExitInfoPlugin` a little more Java friendly by adding a dedicated `ExitInfoPluginConfiguration` instead of named arguments / defaults in the `ExitInfoPlugin` constructor.

This PR also includes a few minor tidy-ups detailed in the changeset:

## Changeset

- Moved the plugin config to a new `ExitInfoPluginConfiguration`
- Wrapped `ActivityManager` access in a `safeGetActivityManager` method
- Blocked the `protobuf` plugin from including `tombstone.proto` sources in the library resources (which in turn were leaking into release `.apk` files)
- Removed a debug log message that slipped through

## Testing
Relied on existing tests.