### PR TITLE
Move foreground logic out of SessionTracker

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/AppDataCollectorTest.kt
@@ -75,7 +75,7 @@ class AppDataCollectorTest {
             client.memoryTrimState
         )
         client.context = "Some Custom Context"
-        client.sessionTracker.updateForegroundTracker("MyActivity", true, 0L)
+        client.sessionTracker.updateContext("MyActivity", true)
         val app = collector.getAppDataMetadata()
         assertEquals("MyActivity", app["activeScreen"] as String)
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/ForegroundDetectorTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/ForegroundDetectorTest.kt
@@ -1,6 +1,9 @@
 package com.bugsnag.android.internal
 
 import android.app.Activity
+import android.os.Message
+import com.bugsnag.android.internal.ForegroundDetector.MSG_SEND_BACKGROUND
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -20,5 +23,34 @@ class ForegroundDetectorTest {
         assertFalse(ForegroundDetector.isInForeground)
         ForegroundDetector.onActivityStarted(testActivity)
         assertTrue(ForegroundDetector.isInForeground)
+    }
+
+    @Test
+    fun backgroundDelayedMessage() {
+        var callbackTriggered = false
+
+        val foregroundCallback = object : ForegroundDetector.OnActivityCallback {
+            override fun onForegroundStatus(foreground: Boolean, timestamp: Long) {
+                callbackTriggered = true
+            }
+
+            override fun onActivityStarted(activity: Activity) = Unit
+            override fun onActivityStopped(activity: Activity) = Unit
+        }
+
+        ForegroundDetector.registerActivityCallbacks(foregroundCallback)
+        ForegroundDetector.backgroundSent = false
+        ForegroundDetector.isInForeground = true
+
+        val message = Message()
+        message.what = MSG_SEND_BACKGROUND
+        message.arg1 = -1 // 0xffffffff
+        message.arg2 = -1 // 0xffffffff
+
+        assertTrue(ForegroundDetector.handleMessage(message))
+        assertEquals(-1 /* 0xffffffffffffffff */, ForegroundDetector.lastExitedForegroundMs)
+        assertFalse(ForegroundDetector.isInForeground)
+        assertTrue(ForegroundDetector.backgroundSent)
+        assertTrue(callbackTriggered)
     }
 }


### PR DESCRIPTION
## Goal
Move the foreground/background tracking logic from `SessionTracker` to the new `ForegroundDetector` singleton.

## Changes
Moved the `lastExitedForegroundMs` and `lastEnteredForegroundMs` timestamps out of `SessionTracker` and into `ForegroundDetector`.

This PR also reworks the "background" trigger slightly to avoid the 700ms timeout when the last `Activity` stops (where possible). Now we use [isChangingConfigurations](https://developer.android.com/reference/android/app/Activity#isChangingConfigurations()) when an `Activity` stops to detect whether we expect the `Activity` to (almost) immediately restart. If this is not the case we send the "inBackground" event immediately.

## Testing
Modified existing tests.