### PR TITLE
Allow opting-out of BuildUUID generation

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
@@ -275,7 +275,8 @@ private fun collectBuildUuid(
     val bundle = appInfo?.metaData
     return when {
         bundle?.containsKey(BUILD_UUID) == true -> {
-            bundle.getString(BUILD_UUID) ?: bundle.getInt(BUILD_UUID).toString()
+            (bundle.getString(BUILD_UUID) ?: bundle.getInt(BUILD_UUID).toString())
+                .takeIf { it.isNotEmpty() }
         }
 
         appInfo != null -> {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -248,6 +248,24 @@ internal class ImmutableConfigTest {
     }
 
     @Test
+    fun sanitizeConfigEmptyBuildUuid() {
+        `when`(context.packageName).thenReturn("com.example.foo")
+        `when`(context.packageManager).thenReturn(packageManager)
+
+        // setup build uuid
+        val bundle = mock(Bundle::class.java)
+        `when`(bundle.containsKey("com.bugsnag.android.BUILD_UUID")).thenReturn(true)
+        `when`(bundle.getString("com.bugsnag.android.BUILD_UUID")).thenReturn("")
+        val appInfo = ApplicationInfo().apply { metaData = bundle }
+        `when`(packageManager.getApplicationInfo(anyString(), anyInt())).thenReturn(appInfo)
+
+        // validate build uuid
+        val seed = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        val config = sanitiseConfiguration(context, seed, connectivity, backgroundTaskService)
+        assertNull(config.buildUuid)
+    }
+
+    @Test
     fun sanitizeConfigBuildUuidInt() {
         `when`(context.packageName).thenReturn("com.example.foo")
         `when`(context.packageManager).thenReturn(packageManager)


### PR DESCRIPTION
## Goal
Allow opting-out of the BuildUUID generation by manually setting an empty `BUILD_UUID` metadata value.

## Testing
Added a unit test for the new behavior, and manually tested the process.