### PR TITLE
Additional null-checks when handling callback names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Handle cases in NDK when `GetStringUTFChars` fails for callback names
+  [#1918](https://github.com/bugsnag/bugsnag-android/pull/1918)
+
 ## 5.31.2 (2023-10-11)
 
 ### Bug fixes

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -955,14 +955,24 @@ Java_com_bugsnag_android_ndk_NativeBridge_notifyAddCallback(JNIEnv *env,
                                                             jobject thiz,
                                                             jstring callback_) {
   const char *callback = bsg_safe_get_string_utf_chars(env, callback_);
+  if (!callback) {
+    return;
+  }
+
   bsg_notify_add_callback(&bsg_global_env->next_event, callback);
+  bsg_safe_release_string_utf_chars(env, callback_, callback);
 }
 
 JNIEXPORT void JNICALL
 Java_com_bugsnag_android_ndk_NativeBridge_notifyRemoveCallback(
     JNIEnv *env, jobject thiz, jstring callback_) {
   const char *callback = bsg_safe_get_string_utf_chars(env, callback_);
+  if (!callback) {
+    return;
+  }
+
   bsg_notify_remove_callback(&bsg_global_env->next_event, callback);
+  bsg_safe_release_string_utf_chars(env, callback_, callback);
 }
 
 JNIEXPORT void JNICALL


### PR DESCRIPTION
## Goal
Avoid possible SIGSEGV when `GetStringUTFChars` in `internal_metrics.c`.

## Design
- Sanity check the return value of `bsg_safe_get_string_utf_chars` in `notifyAddCallback` and `notifyRemoveCallback`
- Further `NULL` check the `api` name in `bsg_modify_callback_count`
- Limit the `strlen` check against the maximum expected length

## Testing
Relied on existing tests