### PR TITLE
Correct the nullability of apiKey on the internal configuration classes

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -6,7 +6,7 @@ import java.util.EnumSet
 import java.util.regex.Pattern
 
 internal class ConfigInternal(
-    var apiKey: String
+    var apiKey: String?
 ) : CallbackAware, MetadataAware, UserAware, FeatureFlagAware {
 
     private var user = User()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ImmutableConfig.kt
@@ -181,7 +181,7 @@ internal fun convertToImmutableConfig(
     )
 }
 
-private fun validateApiKey(value: String) {
+private fun validateApiKey(value: String?) {
     if (isInvalidApiKey(value)) {
         DebugLogger.w(
             "Invalid configuration. apiKey should be a 32-character hexademical string, got $value"


### PR DESCRIPTION
## Goal
Clarify the internal nullability of the `apiKey` property in the internal configuration classes

## Testing
Existing tests should continue to pass