### PR TITLE
Add release trigger for downstream targets to update

### DIFF
--- a/.github/workflows/downstream_updates.yml
+++ b/.github/workflows/downstream_updates.yml
@@ -1,0 +1,31 @@
+name: downstream-updates
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      target_version:
+        description: 'Version of the submodule to update downstream repos to'
+        required: true
+        type: string
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.target_version || github.event.release.tag_name }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    matrix:
+      downstream_repo: ['bugsnag/bugsnag-unity']
+    steps:
+      - name: Install libcurl4-openssl-dev and net-tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install libcurl4-openssl-dev net-tools
+
+      - run: >
+          curl -X POST https://api.github.com/repos/${{ matrix.downstream_repo }}/dispatches
+          -H 'Content-Type: application/json'
+          -H "Authorization: Bearer $GITHUB_TOKEN"
+          -d '{"event_type":"update-dependency","client_payload": {"target_submodule":"bugsnag-android", "target_version": "$RELEASE_VERSION"}}'


### PR DESCRIPTION
## Goal

Adds both an automated and manual trigger to kick off downstream builds, acquiring the newest version of the notifier as a submodule when appropriate.