### PR TITLE
Update CHANGELOG for v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,26 @@
 
 ## TBD
 
+### Breaking Changes
+
+- (breaking API change) Redacted Keys and Discard Classes are now matched as a `Pattern` instead of `String`
+- (breaking API change) Removed `ThreadType` in favour of `ErrorType` bringing bugsnag-android inline with other platform SDKs
+- (breaking API change) Removed the deprecated `Configuration.launchCrashThresholdMs` accessors and manifest entry (which was previously replaced by `Configuration.launchDurationMillis`)
+- (breaking API change) `Thread.id` is now a `String` instead of an `int`
+- (behaviour change) API Key validation has moved to `Bugsnag.start` (instead of when the `Configuration` is created), this means that `Bugsnag.start` will now fail with an exception if no API key is provided
+- (behaviour change) When no `BUILD_UUID` is specified one is automatically derived from your `.dex` files in order to match your bytecode to the appropriate `mapping.txt` file exactly.
+
+Please see our [Upgrade Guide](./UPGRADING.md) for more information on moving from v5.x to v6.0.0.
+  
 ### Enhancements
 
-* Generate a Build ID value if one is not provided in the AndroidManifest.xml
-  [#1865](https://github.com/bugsnag/bugsnag-android/pull/1865)
+- bugsnag-plugin-android-ndk is now available as a Prefab to make access to our C API easier than ever
+- New foreground tracking based on Activity tracking, bringing inForeground closer to the behaviour of ProcessLifecycleOwner
+- [bugsnag-plugin-android-exitinfo](bugsnag-plugin-android-exitinfo/README.md) can be added to enhance native and ANR crash reports from Android 11
+  - Stack traces for all threads in native crashes
+  - Open FDs on native crashes
+  - Include the application logcat output in native crashes
+  - More detailed ANR thread stack traces
 
 ## 5.31.3 (2023-11-06)
 
@@ -65,9 +81,6 @@
 
 * ANR or NDK detection warnings can be suppressed (using `enabledErrorTypes`) when plugin is excluded.
   [#1832](https://github.com/bugsnag/bugsnag-android/pull/1832)
-
-* Support using regexes to define redacted keys and discard classes.
-  [#1856](https://github.com/bugsnag/bugsnag-android/pull/1856)
 
 ## 5.29.0 (2023-03-23)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,52 @@
 Upgrading Guide
 ===============
 
+Upgrade from 5.X to 6.X
+-----------------------
+
+__This version contains several breaking changes__.
+
+### Key points
+
+- `redactedKeys` and `discardClasses` are now matched as a `Pattern` instead of `String`
+- `ThreadType` has been removed in favour of `ErrorType` bringing bugsnag-android inline with other platform SDKs
+- `Thread.id` is now a `String` instead of an `int` bringing bugsnag-android inline with other platform SDKs
+- API Key validation has moved to `Bugsnag.start` (instead of when the `Configuration` is created), this means that `Bugsnag.start` will now fail with an exception if no API key is provided
+- When no `BUILD_UUID` is specified one is automatically derived from your `.dex` files in order to match your bytecode to the appropriate `mapping.txt` file exactly. This behaviour can be opted-out of by setting `BUILD_UUID` to a blank (empty) string value:
+  ```xml
+  <meta-data android:name="com.bugsnag.android.BUILD_UUID" android:value="" />
+  ```
+
+### redactedKeys & discardClasses
+
+The properties / accessors for redacted keys and discard classes remain the same, but the type has been changed from `String` to `Pattern` to allow for more flexible matches (matching is done with `Pattern.matches`).
+
+To retain the same behaviour as v5.X replace:
+
+```kotlin
+configuration.redactedKeys = setOf("password", "secret")
+```
+
+with
+
+```kotlin
+configuration.redactedKeys = setOf(
+    Pattern.compile(".*password.*"),
+    Pattern.compile(".*secret.*"),
+)
+```
+
+### ThreadType removal
+
+The `ThreadType` enum has been removed in favour of the existing `ErrorType` enum (this follows the same pattern as our other platform notifiers). Simply replace any references to `ThreadType` with `ErrorType`, the constant values remain the same:
+
+```kotlin
+Bugsnag.addOnError { event ->
+    event.threads.first().type = ErrorType.UNKNOWN
+    return@addOnError true
+}
+```
+
 Upgrade from 4.X to 5.X
 -----------------------
 

--- a/bugsnag-plugin-android-exitinfo/README.md
+++ b/bugsnag-plugin-android-exitinfo/README.md
@@ -1,0 +1,10 @@
+# bugsnag-plugin-android-exitinfo
+
+This module enhances your crash reports on Android 11+ devices by merging data captured in
+the [ApplicationExitInfo](https://developer.android.com/reference/android/app/ApplicationExitInfo).
+
+## High-level Overview
+
+This module correlates `ApplicationExitInfo` traces and tombstones with reports being sent by
+bugsnag-android-core, and augments the existing error reports with information extracted from
+these files (such as the full stack-traces from all threads in native crashes).


### PR DESCRIPTION
## Goal
Update the CHANGELOG in preparation for the v6 release. This PR also adds a README to the exitinfo module.