### PR TITLE
Remove deprecated `Configuration.launchCrashThresholdMs`

### DIFF
--- a/bugsnag-android-core/api/bugsnag-android-core.api
+++ b/bugsnag-android-core/api/bugsnag-android-core.api
@@ -175,7 +175,6 @@ public class com/bugsnag/android/Configuration : com/bugsnag/android/CallbackAwa
 	public fun getEnabledErrorTypes ()Lcom/bugsnag/android/ErrorTypes;
 	public fun getEnabledReleaseStages ()Ljava/util/Set;
 	public fun getEndpoints ()Lcom/bugsnag/android/EndpointConfiguration;
-	public fun getLaunchCrashThresholdMs ()J
 	public fun getLaunchDurationMillis ()J
 	public fun getLogger ()Lcom/bugsnag/android/Logger;
 	public fun getMaxBreadcrumbs ()I
@@ -214,7 +213,6 @@ public class com/bugsnag/android/Configuration : com/bugsnag/android/CallbackAwa
 	public fun setEnabledErrorTypes (Lcom/bugsnag/android/ErrorTypes;)V
 	public fun setEnabledReleaseStages (Ljava/util/Set;)V
 	public fun setEndpoints (Lcom/bugsnag/android/EndpointConfiguration;)V
-	public fun setLaunchCrashThresholdMs (J)V
 	public fun setLaunchDurationMillis (J)V
 	public fun setLogger (Lcom/bugsnag/android/Logger;)V
 	public fun setMaxBreadcrumbs (I)V

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ManifestConfigLoaderTest.kt
@@ -51,8 +51,6 @@ class ManifestConfigLoaderTest {
             assertEquals(maxPersistedSessions, 128)
             assertEquals(maxReportedThreads, 200)
             assertTrue(sendLaunchCrashesSynchronously)
-            @Suppress("DEPRECATION")
-            assertEquals(launchCrashThresholdMs, 5000)
             assertEquals(launchDurationMillis, 5000)
             assertEquals("android", appType)
         }
@@ -128,8 +126,6 @@ class ManifestConfigLoaderTest {
             assertEquals(maxPersistedEvents, 52)
             assertEquals(maxPersistedSessions, 64)
             assertEquals(maxReportedThreads, 100)
-            @Suppress("DEPRECATION")
-            assertEquals(launchCrashThresholdMs, 7000)
             assertEquals(launchDurationMillis, 7000)
             assertFalse(sendLaunchCrashesSynchronously)
             assertEquals("react-native", appType)
@@ -142,14 +138,12 @@ class ManifestConfigLoaderTest {
         val data = Bundle().apply {
             putString("com.bugsnag.android.API_KEY", "5d1ec5bd39a74caa1267142706a7fb21")
             putBoolean("com.bugsnag.android.ENABLE_EXCEPTION_HANDLER", false)
-            putInt("com.bugsnag.android.LAUNCH_CRASH_THRESHOLD_MS", 8000)
         }
 
         val config = configLoader.load(data, null)
 
         with(config) {
             assertEquals("5d1ec5bd39a74caa1267142706a7fb21", apiKey)
-            assertEquals(8000, launchDurationMillis)
         }
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -216,28 +216,6 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Deprecated. Use {@link #getLaunchDurationMillis()} instead.
-     */
-    @Deprecated
-    public long getLaunchCrashThresholdMs() {
-        getLogger().w("The launchCrashThresholdMs configuration option is deprecated "
-                + "and will be removed in a future release. Please use "
-                + "launchDurationMillis instead.");
-        return getLaunchDurationMillis();
-    }
-
-    /**
-     * Deprecated. Use {@link #setLaunchDurationMillis(long)} instead.
-     */
-    @Deprecated
-    public void setLaunchCrashThresholdMs(long launchCrashThresholdMs) {
-        getLogger().w("The launchCrashThresholdMs configuration option is deprecated "
-                + "and will be removed in a future release. Please use "
-                + "launchDurationMillis instead.");
-        setLaunchDurationMillis(launchCrashThresholdMs);
-    }
-
-    /**
      * Sets whether or not Bugsnag should send crashes synchronously that occurred during
      * the application's launch period. By default this behavior is enabled.
      *

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ManifestConfigLoader.kt
@@ -39,7 +39,6 @@ internal class ManifestConfigLoader {
         private const val MAX_PERSISTED_EVENTS = "$BUGSNAG_NS.MAX_PERSISTED_EVENTS"
         private const val MAX_PERSISTED_SESSIONS = "$BUGSNAG_NS.MAX_PERSISTED_SESSIONS"
         private const val MAX_REPORTED_THREADS = "$BUGSNAG_NS.MAX_REPORTED_THREADS"
-        private const val LAUNCH_CRASH_THRESHOLD_MS = "$BUGSNAG_NS.LAUNCH_CRASH_THRESHOLD_MS"
         private const val LAUNCH_DURATION_MILLIS = "$BUGSNAG_NS.LAUNCH_DURATION_MILLIS"
         private const val SEND_LAUNCH_CRASHES_SYNCHRONOUSLY = "$BUGSNAG_NS.SEND_LAUNCH_CRASHES_SYNCHRONOUSLY"
         private const val APP_TYPE = "$BUGSNAG_NS.APP_TYPE"
@@ -81,10 +80,6 @@ internal class ManifestConfigLoader {
                 maxPersistedEvents = data.getInt(MAX_PERSISTED_EVENTS, maxPersistedEvents)
                 maxPersistedSessions = data.getInt(MAX_PERSISTED_SESSIONS, maxPersistedSessions)
                 maxReportedThreads = data.getInt(MAX_REPORTED_THREADS, maxReportedThreads)
-                launchDurationMillis = data.getInt(
-                    LAUNCH_CRASH_THRESHOLD_MS,
-                    launchDurationMillis.toInt()
-                ).toLong()
                 launchDurationMillis = data.getInt(
                     LAUNCH_DURATION_MILLIS,
                     launchDurationMillis.toInt()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationFacadeTest.java
@@ -88,13 +88,6 @@ public class ConfigurationFacadeTest {
         assertFalse(config.impl.getPersistUser());
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    public void launchCrashThresholdMsValid() {
-        config.setLaunchCrashThresholdMs(123456);
-        assertEquals(123456, config.impl.getLaunchDurationMillis());
-    }
-
     @Test
     public void launchDurationMillisValid() {
         config.setLaunchDurationMillis(123456);

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ConfigurationTest.java
@@ -72,19 +72,6 @@ public class ConfigurationTest {
         return BugsnagTestUtils.convert(config);
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    public void testLaunchThresholdDeprecated() {
-        assertEquals(5000L, config.getLaunchCrashThresholdMs());
-
-        config.setLaunchCrashThresholdMs(-5);
-        assertEquals(5000, config.getLaunchCrashThresholdMs());
-
-        int expected = 1500;
-        config.setLaunchCrashThresholdMs(expected);
-        assertEquals(expected, config.getLaunchCrashThresholdMs());
-    }
-
     @Test
     public void testLaunchThreshold() {
         assertEquals(5000L, config.getLaunchDurationMillis());

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ImmutableConfigTest.kt
@@ -93,8 +93,6 @@ internal class ImmutableConfigTest {
             assertEquals(seed.endpoints, endpoints)
 
             // behaviour
-            @Suppress("DEPRECATION") // tests deprecated option is set via launchDurationMillis
-            assertEquals(seed.launchCrashThresholdMs, launchDurationMillis)
             assertEquals(seed.launchDurationMillis, launchDurationMillis)
             assertTrue(sendLaunchCrashesSynchronously)
             assertEquals(NoopLogger, seed.logger)
@@ -164,8 +162,6 @@ internal class ImmutableConfigTest {
 
             // behaviour
             assertEquals(7000, seed.launchDurationMillis)
-            @Suppress("DEPRECATION") // should be same as launchDurationMillis
-            assertEquals(7000, seed.launchCrashThresholdMs)
             assertFalse(sendLaunchCrashesSynchronously)
             assertEquals(NoopLogger, seed.logger)
             assertEquals(37, seed.maxBreadcrumbs)

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
@@ -31,7 +31,7 @@ internal class LoadConfigurationKotlinScenario(
             Pattern.compile(".*java.net.UnknownHostException.*"),
             Pattern.compile(".*com.example.Custom.*")
         )
-        testConfig.launchCrashThresholdMs = 10000
+        testConfig.launchDurationMillis = 10000
         testConfig.maxBreadcrumbs = 1
         testConfig.persistUser = false
         testConfig.redactedKeys = setOf(Pattern.compile(".*filter_me_two.*"))


### PR DESCRIPTION
## Goal
Remove `Configuration.getLaunchCrashThresholdMs` and `Configuration.setLaunchCrashThresholdMs` as they were marked as deprecated for removal.

## Testing
Relied on existing tests.