### PR TITLE
Corrections to fix v6 publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 6.0.0 (2023-11-15)
+## 6.0.0 (2023-11-16)
 
 ### Breaking Changes
 
@@ -8,6 +8,7 @@
 - (breaking API change) Removed `ThreadType` in favour of `ErrorType` bringing bugsnag-android inline with other platform SDKs
 - (breaking API change) Removed the deprecated `Configuration.launchCrashThresholdMs` accessors and manifest entry (which was previously replaced by `Configuration.launchDurationMillis`)
 - (breaking API change) `Thread.id` is now a `String` instead of an `int`
+- (breaking API change) The legacy `bugsnag-android-ndk` module has been removed in favor of `bugsnag-plugin-android-ndk`
 - (behaviour change) API Key validation has moved to `Bugsnag.start` (instead of when the `Configuration` is created), this means that `Bugsnag.start` will now fail with an exception if no API key is provided
 - (behaviour change) When no `BUILD_UUID` is specified one is automatically derived from your `.dex` files in order to match your bytecode to the appropriate `mapping.txt` file exactly.
 

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ConfigSerializer.java
@@ -16,7 +16,6 @@ class ConfigSerializer implements MapSerializer<ImmutableConfig> {
         map.put("autoDetectErrors", config.getAutoDetectErrors());
         map.put("autoTrackSessions", config.getAutoTrackSessions());
         map.put("sendThreads", config.getSendThreads().toString());
-        map.put("discardClasses", config.getDiscardClasses());
         map.put("projectPackages", config.getProjectPackages());
         map.put("enabledReleaseStages", config.getEnabledReleaseStages());
         map.put("releaseStage", config.getReleaseStage());

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ConfigSerializerTest.java
@@ -38,10 +38,6 @@ public class ConfigSerializerTest {
         assertTrue((Boolean) map.get("autoTrackSessions"));
         assertEquals("ALWAYS", map.get("sendThreads"));
 
-        Matcher matcher = Pattern.compile("com.example.DiscardClass", Pattern.LITERAL)
-                .matcher(map.get("discardClasses").toString());
-        assertTrue(matcher.find());
-
         assertEquals(Collections.singleton("production"), map.get("enabledReleaseStages"));
         assertEquals(Collections.singleton("com.example"), map.get("projectPackages"));
         assertEquals("production", map.get("releaseStage"));

--- a/dockerfiles/Dockerfile.android-publisher
+++ b/dockerfiles/Dockerfile.android-publisher
@@ -10,7 +10,6 @@ COPY buildSrc/ buildSrc/
 
 # Copy sdk source files
 COPY bugsnag-android/ bugsnag-android/
-COPY bugsnag-android-ndk/ bugsnag-android-ndk/
 COPY bugsnag-plugin-android-anr/ bugsnag-plugin-android-anr/
 COPY bugsnag-android-core/ bugsnag-android-core/
 COPY bugsnag-plugin-android-ndk/ bugsnag-plugin-android-ndk/

--- a/features/full_tests/strict_mode_legacy.feature
+++ b/features/full_tests/strict_mode_legacy.feature
@@ -22,10 +22,3 @@ Feature: Reporting Strict Mode Violations
     And the exception "errorClass" equals "android.os.StrictMode$StrictModeViolation"
     And the event "metaData.StrictMode.Violation" equals "NetworkOperation"
     And the event "severityReason.type" equals "strictMode"
-
-# In Android <9 StrictMode kills VM policy violations with SIGKILL, so no requests are received.
-  @skip_above_android_8
-  Scenario: StrictMode Activity leak violation
-    When I run "StrictModeFileUriExposeScenario" and relaunch the crashed app
-    And I configure Bugsnag for "StrictModeFileUriExposeScenario"
-    Then Bugsnag confirms it has no errors to send


### PR DESCRIPTION
## Goal
Fix the publishing step by removing the legacy `bugsnag-android-ndk` module (which was previously replaced by `bugsnag-plugin-android-ndk`).

Also removed the flaky "StrictMode Activity leak violation" scenario as it flakes on Android 7 more than it passes, and does not assert that the notifier is working as expected. Instead it was only running on Android 7 & 8, and asserted that the StrictMode violation was *not* being caught by the notifier (as the notifier is incapable of reporting that violation on those platform versions).

The scenario flaked as it has a hard-dependency on the device being able to open a "leaked" file by Intent. When no third-party app is installed to action the leaking intent the scenario flaked. Handling this case within the scenario would exactly mimic the *expected* behavior of the scenario (negating the test completely).

## Testing
Relied on existing testing.