### PR TITLE
Avoid possible double-free in `setStaticJsonData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Updating existing feature flags no longer causes them to change location.
   [#1940](https://github.com/bugsnag/bugsnag-android/pull/1940)
+* Fixed possible NDK crash when constructing several concurrent `Client` instances
+  []()
 
 
 ## 6.0.0 (2023-11-20)

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.h
@@ -81,7 +81,7 @@ typedef struct {
    * On delivery, this data gets sent to the JVM alongside of the JSONified
    * event object.
    */
-  const char *static_json_data;
+  const char *_Atomic static_json_data;
 
 } bsg_environment;
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_writer.c
@@ -37,12 +37,12 @@ bool bsg_event_write(bsg_environment *env) {
 
   writer.dispose(&writer);
 
-  if (result && env->static_json_data != NULL) {
+  const char *static_json_data = atomic_load(&env->static_json_data);
+  if (result && static_json_data != NULL) {
     // Attempt to write the static data, but don't worry if it fails.
     // We'll check for truncated/missing static data on load.
     if (bsg_buffered_writer_open(&writer, env->next_event_static_data_path)) {
-      writer.write(&writer, env->static_json_data,
-                   strlen(env->static_json_data));
+      writer.write(&writer, static_json_data, strlen(static_json_data));
       writer.dispose(&writer);
     }
   }


### PR DESCRIPTION
## Goal
Avoid possible double-free in `setStaticJsonData` when it is called from multiple concurrent threads

## Changeset
- Replaced the standard `const char*` pointer with an atomic pointer in order to ensure that a double `free` is not possible.
- Added a `NULL` check to the result of `strdup`
- Replace the `strlen(data) == 0` with a quicker de reference check

## Testing
Relied on existing tests as this specific condition has no reliable repro