### PR TITLE
release/v5.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBC
+## 5.32.0 (2023-12-12)
 
 ### Enhancements
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,7 +7,7 @@ import java.io.IOException
  */
 class Notifier @JvmOverloads constructor(
     var name: String = "Android Bugsnag Notifier",
-    var version: String = "5.31.3",
+    var version: String = "5.32.0",
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 

--- a/examples/sdk-app-example/app/build.gradle
+++ b/examples/sdk-app-example/app/build.gradle
@@ -38,8 +38,8 @@ android {
 }
 
 dependencies {
-    implementation "com.bugsnag:bugsnag-android:5.31.3"
-    implementation "com.bugsnag:bugsnag-plugin-android-okhttp:5.31.3"
+    implementation "com.bugsnag:bugsnag-android:5.32.0"
+    implementation "com.bugsnag:bugsnag-plugin-android-okhttp:5.32.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "com.google.android.material:material:1.4.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx4096m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
-VERSION_NAME=5.31.3
+VERSION_NAME=5.32.0
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git


### PR DESCRIPTION
### Enhancements

* The maximum time taken to collect Event.threads can now be controlled using 'Configuration.threadCollectionTimeLimitMillis' (default 5000ms)
  [#1952](https://github.com/bugsnag/bugsnag-android/pull/1952)