### PR TITLE
Avoid any possibility of multiple conflicting native crash handlers or stack-unwinders running concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Avoid any possibility of multiple conflicting native crash handlers or stack-unwinders running concurrently
+  [#1960](https://github.com/bugsnag/bugsnag-android/pull/1960)
+
 ## 6.1.0 (2023-12-05)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -68,7 +68,7 @@ bool bsg_run_on_error() {
 }
 
 bool bsg_begin_handling_crash() {
-  static bool expected = false;
+  bool expected = false;
   return atomic_compare_exchange_strong(&bsg_global_env->handling_crash,
                                         &expected, true);
 }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
@@ -142,7 +142,7 @@ ssize_t bsg_unwind_crash_stack(bugsnag_stackframe stack[BUGSNAG_FRAMES_MAX],
   // we always check unwinding_crash_stack and set *before* attempting to
   // retrieve the crash unwinder to avoid picking up an unwinder that is about
   // to be destroyed by bsg_unwinder_refresh
-  static bool expected = false;
+  bool expected = false;
   if (!std::atomic_compare_exchange_strong(&unwinding_crash_stack, &expected,
                                            true)) {
     return 0;


### PR DESCRIPTION
## Goal
Avoid any possibility of multiple conflicting native crash handlers or stack-unwinders running concurrently

## Design
Stop using `static` fields as the expected values for `atomic_compare_exchange_strong`. When `atomic_compare_exchange_strong` fails it overwrites these with the actual value that was read, given that we exclusively used this with `bool` values, a rapid series of signals (across different threads) could cause the `expected` value to flip resulting any all further `atomic_compare_exchange_strong` operations to start succeeding.

## Testing
Neither unit testing nor automated testing can reliably reproduce this behavior. So we rely on our existing tests not starting to fail.