### PR TITLE
Remove the use of `substr` from `bsg_check_invalid_libname`

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/stack_unwinder.cpp
@@ -39,12 +39,20 @@ static void bsg_fallback_symbols(const uint64_t addr,
 }
 
 static bool bsg_check_invalid_libname(const std::string &filename) {
+  const auto length = filename.length();
+  // turn clang-format off - for clarity in the string compare:
+  // clang-format off
   return filename.empty() ||
          // if the filename ends-in ".apk" then the lib was loaded without
          // extracting it from the apk we consider these as "invalid" to trigger
          // the use of a fallback filename
-         (filename.length() >= 4 &&
-          filename.substr(filename.length() - 4, 4) == ".apk");
+         (length >= 4 &&
+          // compare char-by-char to avoid the allocation is substr
+          filename[length - 4] == '.' &&
+          filename[length - 3] == 'a' &&
+          filename[length - 2] == 'p' &&
+          filename[length - 1] == 'k');
+  // clang-format on
 }
 
 void bsg_unwinder_init() {


### PR DESCRIPTION
## Goal
Remove the use of `std::string::substr` from `bsg_check_invalid_libname` to avoid possible deadlocks.

## Design
Test the characters of the `filename` one at a time instead of using the `string::substr` method, which can allocate a new string to be returned.

## Testing
Relied on existing tests