### PR TITLE
Update proguard rules for React Native plugin

### DIFF
--- a/bugsnag-plugin-react-native/proguard-rules.pro
+++ b/bugsnag-plugin-react-native/proguard-rules.pro
@@ -1,3 +1,3 @@
 -keepattributes LineNumberTable,SourceFile
 -keepnames class com.facebook.react.common.JavascriptException { *; }
--keepnames class com.bugsnag.android.BugsnagReactNativePlugin { *; }
+-keep class com.bugsnag.android.BugsnagReactNativePlugin { *; }


### PR DESCRIPTION
## Goal

React Native 0.73 has updated AGP to 8.x, which now runs R8 in "full mode" by default. This causes RN projects with Bugsnag to crash, as the current proguard rule for `BugsnagReactNativePlugin` (`-keepnames`) is not sufficient to prevent the class from being obfuscated.

## Design

Updated the proguard rule to use `-keep` instead of `-keepnames`

## Testing

Tested manually on a React Native project. Test fixtures for `@bugsnag/react-native` will also be updated to enable Proguard once this fix is released.