### PR TITLE
Update proguard rules for React Native plugin (v5)

### DIFF
--- a/bugsnag-plugin-react-native/proguard-rules.pro
+++ b/bugsnag-plugin-react-native/proguard-rules.pro
@@ -1,3 +1,3 @@
 -keepattributes LineNumberTable,SourceFile
 -keepnames class com.facebook.react.common.JavascriptException { *; }
--keepnames class com.bugsnag.android.BugsnagReactNativePlugin { *; }
+-keep class com.bugsnag.android.BugsnagReactNativePlugin { *; }


### PR DESCRIPTION
## Goal

Backport of #1962 to v5