### PR TITLE
Record process importance for jvm android errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Enhancements
+
+* `bugsnag-plugin-android-exitinfo` now includes `exitReason` and `processImportance` in the `APP` tab on the dashboard
+  [#1968](https://github.com/bugsnag/bugsnag-android/pull/1968)
+
 ### Bug fixes
 
 * Avoid any possibility of multiple conflicting native crash handlers or stack-unwinders running concurrently

--- a/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
+++ b/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>CyclomaticComplexMethod:ExitInfoCallback.kt$ExitInfoCallback$override fun onSend(event: Event): Boolean</ID>
     <ID>LongParameterList:TombstoneParser.kt$TombstoneParser$( exitInfo: ApplicationExitInfo, listOpenFds: Boolean, includeLogcat: Boolean, threadConsumer: (BugsnagThread) -> Unit, fileDescriptorConsumer: (Int, String, String) -> Unit, logcatConsumer: (String) -> Unit )</ID>
     <ID>MagicNumber:TraceParser.kt$TraceParser$16</ID>
     <ID>MagicNumber:TraceParser.kt$TraceParser$3</ID>

--- a/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
+++ b/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
@@ -2,7 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:ExitInfoCallback.kt$ExitInfoCallback$override fun onSend(event: Event): Boolean</ID>
+    <ID>CyclomaticComplexMethod:ExitInfoCallback.kt$ExitInfoCallback$private fun exitReasonOf(exitInfo: ApplicationExitInfo)</ID>
     <ID>LongParameterList:TombstoneParser.kt$TombstoneParser$( exitInfo: ApplicationExitInfo, listOpenFds: Boolean, includeLogcat: Boolean, threadConsumer: (BugsnagThread) -> Unit, fileDescriptorConsumer: (Int, String, String) -> Unit, logcatConsumer: (String) -> Unit )</ID>
     <ID>MagicNumber:TraceParser.kt$TraceParser$16</ID>
     <ID>MagicNumber:TraceParser.kt$TraceParser$3</ID>

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
@@ -68,7 +68,7 @@ internal class ExitInfoCallback(
         ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING -> "top sleeping"
         ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE -> "visible"
         ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE -> "perceptible"
-        ActivityManager.RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE -> "can not save state"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE -> "can't save state"
         ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE -> "service"
         ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED -> "cached"
         ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE -> "gone"

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
@@ -22,6 +22,42 @@ internal class ExitInfoCallback(
             ?: findExitInfoByPid(allExitInfo) ?: return true
 
         try {
+            val reason = when (exitInfo.reason) {
+                ApplicationExitInfo.REASON_UNKNOWN -> "unknown reason (${exitInfo.reason})"
+                ApplicationExitInfo.REASON_EXIT_SELF -> "exit self"
+                ApplicationExitInfo.REASON_SIGNALED -> "signaled"
+                ApplicationExitInfo.REASON_LOW_MEMORY -> "low memory"
+                ApplicationExitInfo.REASON_CRASH -> "crash"
+                ApplicationExitInfo.REASON_CRASH_NATIVE -> "crash native"
+                ApplicationExitInfo.REASON_ANR -> "ANR"
+                ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "initialization failure"
+                ApplicationExitInfo.REASON_PERMISSION_CHANGE -> "permission change"
+                ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "excessive resource usage"
+                ApplicationExitInfo.REASON_USER_REQUESTED -> "user requested"
+                ApplicationExitInfo.REASON_USER_STOPPED -> "user stopped"
+                ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "dependency died"
+                ApplicationExitInfo.REASON_OTHER -> "other"
+                ApplicationExitInfo.REASON_FREEZER -> "freezer"
+                ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE -> "package state change"
+                ApplicationExitInfo.REASON_PACKAGE_UPDATED -> "package updated"
+                else -> "unknown reason (${exitInfo.reason})"
+            }
+            event.addMetadata("App", "exit reason", reason)
+
+            val importance = when (exitInfo.importance) {
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND -> "foreground"
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE -> "foreground service"
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING -> "top sleeping"
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE -> "visible"
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE -> "perceptible"
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE -> "can not save state"
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE -> "service"
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED -> "cached"
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE -> "gone"
+                else -> "unknown importance ${exitInfo.importance}"
+            }
+            event.addMetadata("App", "process importance", importance)
+
             if (exitInfo.reason == ApplicationExitInfo.REASON_CRASH_NATIVE ||
                 exitInfo.reason == ApplicationExitInfo.REASON_SIGNALED
             ) {

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/ExitInfoCallback.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -17,46 +18,19 @@ internal class ExitInfoCallback(
     override fun onSend(event: Event): Boolean {
         val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         val allExitInfo = am.getHistoricalProcessExitReasons(context.packageName, 0, MAX_EXIT_INFO)
+        Log.e("Bugsnag", "allExitInfo: $allExitInfo")
         val sessionIdBytes = event.session?.id?.toByteArray() ?: return true
+        Log.e("Bugsnag", "sessionIdBytes: $sessionIdBytes")
         val exitInfo = findExitInfoBySessionId(allExitInfo, sessionIdBytes)
             ?: findExitInfoByPid(allExitInfo) ?: return true
+        Log.e("Bugsnag", "exitInfo: $exitInfo")
 
         try {
-            val reason = when (exitInfo.reason) {
-                ApplicationExitInfo.REASON_UNKNOWN -> "unknown reason (${exitInfo.reason})"
-                ApplicationExitInfo.REASON_EXIT_SELF -> "exit self"
-                ApplicationExitInfo.REASON_SIGNALED -> "signaled"
-                ApplicationExitInfo.REASON_LOW_MEMORY -> "low memory"
-                ApplicationExitInfo.REASON_CRASH -> "crash"
-                ApplicationExitInfo.REASON_CRASH_NATIVE -> "crash native"
-                ApplicationExitInfo.REASON_ANR -> "ANR"
-                ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "initialization failure"
-                ApplicationExitInfo.REASON_PERMISSION_CHANGE -> "permission change"
-                ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "excessive resource usage"
-                ApplicationExitInfo.REASON_USER_REQUESTED -> "user requested"
-                ApplicationExitInfo.REASON_USER_STOPPED -> "user stopped"
-                ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "dependency died"
-                ApplicationExitInfo.REASON_OTHER -> "other"
-                ApplicationExitInfo.REASON_FREEZER -> "freezer"
-                ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE -> "package state change"
-                ApplicationExitInfo.REASON_PACKAGE_UPDATED -> "package updated"
-                else -> "unknown reason (${exitInfo.reason})"
-            }
-            event.addMetadata("App", "exit reason", reason)
+            val reason = exitReasonOf(exitInfo)
+            event.addMetadata("app", "exitReason", reason)
 
-            val importance = when (exitInfo.importance) {
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND -> "foreground"
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE -> "foreground service"
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING -> "top sleeping"
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE -> "visible"
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE -> "perceptible"
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE -> "can not save state"
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE -> "service"
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED -> "cached"
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE -> "gone"
-                else -> "unknown importance ${exitInfo.importance}"
-            }
-            event.addMetadata("App", "process importance", importance)
+            val importance = importanceDescriptionOf(exitInfo)
+            event.addMetadata("app", "processImportance", importance)
 
             if (exitInfo.reason == ApplicationExitInfo.REASON_CRASH_NATIVE ||
                 exitInfo.reason == ApplicationExitInfo.REASON_SIGNALED
@@ -69,6 +43,40 @@ internal class ExitInfoCallback(
             return true
         }
         return true
+    }
+
+    private fun exitReasonOf(exitInfo: ApplicationExitInfo) = when (exitInfo.reason) {
+        ApplicationExitInfo.REASON_UNKNOWN -> "unknown reason (${exitInfo.reason})"
+        ApplicationExitInfo.REASON_EXIT_SELF -> "exit self"
+        ApplicationExitInfo.REASON_SIGNALED -> "signaled"
+        ApplicationExitInfo.REASON_LOW_MEMORY -> "low memory"
+        ApplicationExitInfo.REASON_CRASH -> "crash"
+        ApplicationExitInfo.REASON_CRASH_NATIVE -> "crash native"
+        ApplicationExitInfo.REASON_ANR -> "ANR"
+        ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "initialization failure"
+        ApplicationExitInfo.REASON_PERMISSION_CHANGE -> "permission change"
+        ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "excessive resource usage"
+        ApplicationExitInfo.REASON_USER_REQUESTED -> "user requested"
+        ApplicationExitInfo.REASON_USER_STOPPED -> "user stopped"
+        ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "dependency died"
+        ApplicationExitInfo.REASON_OTHER -> "other"
+        ApplicationExitInfo.REASON_FREEZER -> "freezer"
+        ApplicationExitInfo.REASON_PACKAGE_STATE_CHANGE -> "package state change"
+        ApplicationExitInfo.REASON_PACKAGE_UPDATED -> "package updated"
+        else -> "unknown reason (${exitInfo.reason})"
+    }
+
+    private fun importanceDescriptionOf(exitInfo: ApplicationExitInfo) = when (exitInfo.importance) {
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND -> "foreground"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE -> "foreground service"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING -> "top sleeping"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE -> "visible"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE -> "perceptible"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE -> "can not save state"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE -> "service"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED -> "cached"
+        ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE -> "gone"
+        else -> "unknown importance ${exitInfo.importance}"
     }
 
     private fun findExitInfoBySessionId(

--- a/bugsnag-plugin-android-exitinfo/src/test/java/com/bugsnag/android/ExitInfoCallbackTest.kt
+++ b/bugsnag-plugin-android-exitinfo/src/test/java/com/bugsnag/android/ExitInfoCallbackTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import android.content.Context
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -107,5 +108,16 @@ internal class ExitInfoCallbackTest {
         assertTrue(exitInfoCallback.onSend(event))
         verify(nativeEnhancer, times(0)).invoke(event, exitInfo1)
         verify(anrEventEnhancer, times(0)).invoke(event, exitInfo1)
+    }
+
+    @Test
+    fun testUnknownExitReasonAndImportance() {
+        `when`(exitInfos.first().processStateSummary).thenReturn("1".toByteArray())
+        `when`(event.session?.id).thenReturn("1")
+        `when`(exitInfo1.reason).thenReturn(ApplicationExitInfo.REASON_UNKNOWN)
+        `when`(exitInfo1.importance).thenReturn(ActivityManager.RunningAppProcessInfo.REASON_UNKNOWN)
+        assertTrue(exitInfoCallback.onSend(event))
+        assertEquals("0", exitInfo1.reason.toString())
+        assertEquals("0", exitInfo1.importance.toString())
     }
 }

--- a/bugsnag-plugin-android-exitinfo/src/test/java/com/bugsnag/android/ExitInfoCallbackTest.kt
+++ b/bugsnag-plugin-android-exitinfo/src/test/java/com/bugsnag/android/ExitInfoCallbackTest.kt
@@ -3,7 +3,6 @@ package com.bugsnag.android
 import android.app.ActivityManager
 import android.app.ApplicationExitInfo
 import android.content.Context
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -117,7 +116,7 @@ internal class ExitInfoCallbackTest {
         `when`(exitInfo1.reason).thenReturn(ApplicationExitInfo.REASON_UNKNOWN)
         `when`(exitInfo1.importance).thenReturn(ActivityManager.RunningAppProcessInfo.REASON_UNKNOWN)
         assertTrue(exitInfoCallback.onSend(event))
-        assertEquals("0", exitInfo1.reason.toString())
-        assertEquals("0", exitInfo1.importance.toString())
+        verify(event, times(1)).addMetadata("app", "exitReason", "unknown reason (0)")
+        verify(event, times(1)).addMetadata("app", "processImportance", "unknown importance (0)")
     }
 }

--- a/features/fixtures/mazerunner/bugsnag-dependency.gradle
+++ b/features/fixtures/mazerunner/bugsnag-dependency.gradle
@@ -16,5 +16,6 @@ dependencies {
         project.logger.lifecycle("Compiling full mazerunner fixture with ANR/NDK scenarios")
         implementation "com.bugsnag:bugsnag-android:9.9.9"
         implementation "com.bugsnag:bugsnag-plugin-android-okhttp:9.9.9"
+        implementation "com.bugsnag:bugsnag-plugin-android-exitinfo:9.9.9"
     }
 }

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/ExitInfoScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/ExitInfoScenario.kt
@@ -1,0 +1,26 @@
+package com.bugsnag.android.mazerunner.scenarios
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.bugsnag.android.Bugsnag
+import com.bugsnag.android.Configuration
+
+class ExitInfoScenario(
+    config: com.bugsnag.android.Configuration,
+    context: android.content.Context,
+    eventMetadata: String?
+) : Scenario(config, context, eventMetadata) {
+    external fun crash(value: Int): Int
+    override fun startScenario() {
+        super.startScenario()
+        Bugsnag.startSession()
+        val main: android.os.Handler = android.os.Handler(android.os.Looper.getMainLooper())
+        main.postDelayed(object : java.lang.Runnable {
+            override fun run() {
+                crash(2726)
+            }
+        }, 500)
+    }
+}

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner
 
 import android.util.Log
+import com.bugsnag.android.BugsnagExitInfoPlugin
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.Delivery
 import com.bugsnag.android.DeliveryParams
@@ -19,6 +20,7 @@ fun prepareConfig(
     logFilter: (msg: String) -> Boolean
 ): Configuration {
     val config = Configuration(apiKey)
+    config.addPlugin(BugsnagExitInfoPlugin())
 
     if (notify.isNotEmpty() && sessions.isNotEmpty()) {
         config.endpoints = EndpointConfiguration(notify, sessions)

--- a/features/full_tests/exit_information.feature
+++ b/features/full_tests/exit_information.feature
@@ -1,0 +1,15 @@
+Feature: Application exitInfo is reported in crashes
+
+  Background:
+    Given I clear all persistent data
+
+  @skip_below_android_11
+  Scenario: Application exitInfo is reported in crashes
+    When I set the screen orientation to portrait
+    And I run "ExitInfoScenario" and relaunch the crashed app
+    And I configure Bugsnag for "ExitInfoScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
+    And the error payload field "events.0.metaData.app.processImportance" equals "foreground"
+    And the error payload field "events.0.metaData.app.exitReason" equals "crash"
+

--- a/features/full_tests/usage.feature
+++ b/features/full_tests/usage.feature
@@ -53,7 +53,7 @@ Feature: Reporting Errors with usage info
     And the event "usage.callbacks.ndkOnError" equals 1
     And the event "usage.callbacks.onBreadcrumb" equals 3
     And the event "usage.callbacks.onError" equals 2
-    And the event "usage.callbacks.onSession" equals 2
+    And the event "usage.callbacks.onSession" equals 3
 
   Scenario: Report an unhandled exception with custom configuration and set callbacks, usage disabled
     When I configure the app to run in the "disable-usage" state
@@ -87,7 +87,7 @@ Feature: Reporting Errors with usage info
     And the event "usage.config.maxPersistedSessions" equals 1000
     And the event "usage.callbacks.onBreadcrumb" equals 1
     And the event "usage.callbacks.onError" equals 2
-    And the event "usage.callbacks.onSession" equals 4
+    And the event "usage.callbacks.onSession" equals 5
 
   Scenario: Report a native exception with custom configuration and set callbacks, usage disabled
     When I configure the app to run in the "disable-usage" state
@@ -121,7 +121,7 @@ Feature: Reporting Errors with usage info
     And the event "usage.callbacks.ndkOnError" equals 1
     And the event "usage.callbacks.onBreadcrumb" equals 1
     And the event "usage.callbacks.onError" equals 2
-    And the event "usage.callbacks.onSession" equals 4
+    And the event "usage.callbacks.onSession" equals 5
     And the event "usage.callbacks.event_set_user" is true
     And the event "usage.callbacks.app_set_binary_arch" is true
     And the event "usage.callbacks.device_get_model" is true


### PR DESCRIPTION
## Goal

Introduce application exit reason and process importance to BugSnag-ExitInfo Plugin for android 11+ devices and displayed on dashboard under metadata app.

## Changeset

Decoded application exit reason and process importance to strings for app metadata

## Testing

New unit tests and end to end test