### PR TITLE
Decode bsg notifier and app info into event

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NativeEventDecoder.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NativeEventDecoder.kt
@@ -1,0 +1,109 @@
+package com.bugsnag.android
+
+import androidx.annotation.VisibleForTesting
+import com.bugsnag.android.ndk.getCString
+import com.bugsnag.android.ndk.getNativeBool
+import com.bugsnag.android.ndk.getNativeInt
+import com.bugsnag.android.ndk.getNativeTime
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.channels.FileChannel
+
+private const val BUGSNAG_EVENT_VERSION = 13
+
+@Suppress("MagicNumber") // this class is filled with numbers defined in event.h
+internal object NativeEventDecoder {
+
+    fun decode(
+        client: Client,
+        event: File,
+        @Suppress("UNUSED_PARAMETER")
+        staticData: File = File(event.parentFile, event.name + ".static_data.json")
+    ): Event {
+
+        val newEvent = NativeInterface.createEvent(
+            null,
+            client,
+            SeverityReason.newInstance(SeverityReason.REASON_HANDLED_EXCEPTION)
+        )
+
+        return event.inputStream().channel.use {
+            // map the entire file in READ_ONLY mode
+            val eventBytes = it.map(FileChannel.MapMode.READ_ONLY, 0L, event.length())
+            eventBytes.order(ByteOrder.nativeOrder())
+            decodeEventFromBytes(eventBytes, newEvent)
+        }
+    }
+
+    @VisibleForTesting
+    internal fun decodeEventFromBytes(
+        eventBytes: ByteBuffer,
+        event: Event
+    ): Event {
+
+        val header = decodeHeader(eventBytes)
+        require(header.version == BUGSNAG_EVENT_VERSION) { "Unsupported event version: ${header.version}" }
+
+        decodeNotifier(eventBytes, event)
+        decodeAppInfoToAppWithState(eventBytes, event)
+
+        return event
+    }
+
+    private fun decodeNotifier(eventBytes: ByteBuffer, event: Event) {
+        val name = eventBytes.getCString(64)
+        val version = eventBytes.getCString(16)
+        val url = eventBytes.getCString(64)
+
+        event.session?.notifier?.name = name
+        event.session?.notifier?.version = version
+        event.session?.notifier?.url = url
+    }
+
+    private fun decodeAppInfoToAppWithState(eventBytes: ByteBuffer, event: Event) {
+        val id = eventBytes.getCString(64)
+        val releaseStage = eventBytes.getCString(64)
+        val type = eventBytes.getCString(32)
+        val version = eventBytes.getCString(32)
+        @Suppress("UNUSED_VARIABLE") val activeScreen = eventBytes.getCString(64)
+        val versionCode = eventBytes.getLong()
+        val buildUuid = eventBytes.getCString(64)
+        val duration = eventBytes.getLong()
+        val durationInForeground = eventBytes.getLong()
+        @Suppress("UNUSED_VARIABLE") val durationMsOffset = eventBytes.getLong()
+        @Suppress("UNUSED_VARIABLE") val durationInForegroundMsOffset = eventBytes.getNativeTime()
+        val inForeground = eventBytes.getNativeBool()
+        val isLaunching = eventBytes.getNativeBool()
+        val binaryArch = eventBytes.getCString(32)
+
+        event.app = AppWithState(
+            binaryArch = binaryArch,
+            id = id,
+            releaseStage = releaseStage,
+            version = version,
+            codeBundleId = null,
+            buildUuid = buildUuid,
+            type = type,
+            versionCode = versionCode,
+            duration = duration,
+            durationInForeground = durationInForeground,
+            inForeground = inForeground,
+            isLaunching = isLaunching
+        )
+    }
+
+    private fun decodeHeader(eventBytes: ByteBuffer): NativeEventHeader {
+        return NativeEventHeader(
+            eventBytes.getNativeInt(),
+            eventBytes.getNativeInt(),
+            eventBytes.getCString(64)
+        )
+    }
+
+    private data class NativeEventHeader(
+        val version: Int,
+        val bigEndian: Int,
+        val osBuild: String
+    )
+}

--- a/bugsnag-plugin-android-ndk/src/test/java/com/bugsnag/android/NativeEventDecoder64bitTest.kt
+++ b/bugsnag-plugin-android-ndk/src/test/java/com/bugsnag/android/NativeEventDecoder64bitTest.kt
@@ -1,0 +1,64 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.ndk.NativeArch
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+@RunWith(MockitoJUnitRunner::class)
+class NativeEventDecoder64bitTest {
+    private val crashDump64BitData =
+        this::class.java.getResourceAsStream("/aarch64-emulator.crash_dump")!!.readBytes()
+
+    private val event = mock(Event::class.java)
+    private val session = mock(Session::class.java)
+    private val notifier = mock(Notifier::class.java)
+
+    @Before
+    fun setupArchitecture() {
+        NativeArch._is32Bit = false
+    }
+
+    @After
+    fun unSetupArchitecture() {
+        NativeArch._is32Bit = null
+    }
+
+    @Test
+    fun testNativeEventDecode() {
+        val data = ByteBuffer.wrap(crashDump64BitData)
+        data.order(ByteOrder.LITTLE_ENDIAN)
+        val captor = ArgumentCaptor.forClass(AppWithState::class.java)
+        `when`(event.session).thenReturn(session)
+        `when`(session.notifier).thenReturn(notifier)
+
+        NativeEventDecoder.decodeEventFromBytes(data, event)
+
+        verify(event).app = captor.capture()
+
+        verify(notifier).name = ""
+        verify(notifier).version = ""
+        verify(notifier).url = ""
+
+        assertEquals("com.example.bugsnag.android", captor.value.id)
+        assertEquals("production", captor.value.releaseStage)
+        assertEquals("android", captor.value.type)
+        assertEquals("1.0", captor.value.version)
+        assertEquals(1L, captor.value.versionCode)
+        assertEquals("c4cedba4-9c34-48c7-a26e-d658c1e98c67", captor.value.buildUuid)
+        assertEquals(1070L, captor.value.duration)
+        assertEquals(1000L, captor.value.durationInForeground)
+        assertEquals(true, captor.value.inForeground)
+        assertEquals(true, captor.value.isLaunching)
+        assertEquals("arm64", captor.value.binaryArch)
+    }
+}

--- a/bugsnag-plugin-android-ndk/src/test/java/com/bugsnag/android/NativeEventDecoderTest.kt
+++ b/bugsnag-plugin-android-ndk/src/test/java/com/bugsnag/android/NativeEventDecoderTest.kt
@@ -1,0 +1,64 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.ndk.NativeArch
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.MockitoJUnitRunner
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+@RunWith(MockitoJUnitRunner::class)
+class NativeEventDecoderTest {
+    private val sample32BitData =
+        this::class.java.getResourceAsStream("/arm32-droid-razr.crash_dump")!!.readBytes()
+
+    private val event = mock(Event::class.java)
+    private val session = mock(Session::class.java)
+    private val notifier = mock(Notifier::class.java)
+
+    @Before
+    fun setupArchitecture() {
+        NativeArch._is32Bit = true
+    }
+
+    @After
+    fun unSetupArchitecture() {
+        NativeArch._is32Bit = null
+    }
+
+    @Test
+    fun test32BitPrimitives() {
+        val data = ByteBuffer.wrap(sample32BitData)
+        data.order(ByteOrder.LITTLE_ENDIAN)
+        val captor = ArgumentCaptor.forClass(AppWithState::class.java)
+        `when`(event.session).thenReturn(session)
+        `when`(session.notifier).thenReturn(notifier)
+
+        NativeEventDecoder.decodeEventFromBytes(data, event)
+
+        verify(event).app = captor.capture()
+
+        verify(notifier).name = ""
+        verify(notifier).version = ""
+        verify(notifier).url = ""
+
+        assertEquals("com.example.bugsnag.android", captor.value.id)
+        assertEquals("development", captor.value.releaseStage)
+        assertEquals("android", captor.value.type)
+        assertEquals("1.0", captor.value.version)
+        assertEquals(1L, captor.value.versionCode)
+        assertEquals("4450ef3c-ac1f-47e1-9fc3-3a2d90e59dc4", captor.value.buildUuid)
+        assertEquals(4340L, captor.value.duration)
+        assertEquals(4000L, captor.value.durationInForeground)
+        assertEquals(true, captor.value.inForeground)
+        assertEquals(true, captor.value.isLaunching)
+        assertEquals("arm32", captor.value.binaryArch)
+    }
+}


### PR DESCRIPTION
## Goal

Decoded C layer `bsg_notifier `and `bsg_app_info` into event `AppWithState` and `Notifier` in Kotlin.

## Changeset

Adding netive decoders for bsg_notifier `and `bsg_app_info` to `AppWithState` and `Notifier` in `Event`

## Testing

Introduced new tests