### PR TITLE
Add missing test expectations

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionSmokeScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AutoSessionSmokeScenario.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android.mazerunner.scenarios
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import com.bugsnag.android.Bugsnag
@@ -16,6 +17,8 @@ internal class AutoSessionSmokeScenario(
     eventMetadata: String?
 ) : Scenario(config, context, eventMetadata) {
 
+    private var sendError = true
+
     init {
         val baseDelivery = createDefaultDelivery()
         var intercept = true
@@ -23,13 +26,22 @@ internal class AutoSessionSmokeScenario(
         config.delivery = InterceptingDelivery(baseDelivery) {
             if (intercept) {
                 intercept = false
-                Bugsnag.notify(generateException())
+                continueScenario()
             }
         }
     }
 
-    override fun startScenario() {
-        super.startScenario()
+    override fun onActivityResumed(activity: Activity) {
+        if (!sendError) {
+            return
+        }
+
+        Bugsnag.notify(generateException())
+        sendError = false
+    }
+
+    private fun continueScenario() {
+        registerActivityLifecycleCallbacks()
         context.startActivity(Intent("com.bugsnag.android.mazerunner.UPDATE_CONTEXT"))
     }
 }

--- a/features/smoke_tests/03_sessions.feature
+++ b/features/smoke_tests/03_sessions.feature
@@ -45,6 +45,8 @@ Feature: Session functionality smoke tests
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "java.lang.RuntimeException"
     And the exception "message" equals "AutoSessionSmokeScenario"
+    And the event "context" equals "SecondActivity"
+    And the event "metaData.app.activeScreen" equals "SecondActivity"
     And the event "user.id" is not null
     And the event "device.id" is not null
     And the error payload field "events.0.user.id" equals the stored value "automated_user_id"


### PR DESCRIPTION
## Goal

Adds two checks that were missing from a test scenario.

## Design

The checks are essential to the test, which is designed to verify that the error report context reflects the Activity that is changed to.

## Testing

Covered by a basic CI run.