### PR TITLE
Update the downstream updates action to match the 'next' version

### DIFF
--- a/.github/workflows/downstream_updates.yml
+++ b/.github/workflows/downstream_updates.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.target_version || github.event.release.tag_name }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    matrix:
-      downstream_repo: ['bugsnag/bugsnag-unity']
+    strategy:
+      matrix:
+        downstream_repo: ['bugsnag/bugsnag-unity']
     steps:
       - name: Install libcurl4-openssl-dev and net-tools
         run: |
@@ -27,5 +27,5 @@ jobs:
       - run: >
           curl -X POST https://api.github.com/repos/${{ matrix.downstream_repo }}/dispatches
           -H 'Content-Type: application/json'
-          -H "Authorization: Bearer $GITHUB_TOKEN"
+          -H "Authorization: Bearer ${{ secrets.DEP_UPDATER_BEARER_TOKEN }}"
           -d '{"event_type":"update-dependency","client_payload": {"target_submodule":"bugsnag-android", "target_version": "$RELEASE_VERSION"}}'


### PR DESCRIPTION
## Goal

For whatever reason this wasn't corrected on this branch, and is required for any v5 releases made.