### PR TITLE
Avoid possible crashes in the ANR handler where the local reference table is exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Use PushLocalFrame/PopLocalFrame instead of DeleteLocalRef to avoid creating "holes" in the local ref table that are not always reused, leading to possible crashes in the ANR handler
+  []()
+
 ## 6.2.0 (2024-02-08)
 
 ### Enhancements


### PR DESCRIPTION
## Goal
Avoid possible crashes in the ANR handler where the local reference table is exhausted.

## Design
Replaced the use of `DeleteLocalRef` with `PushLocalFrame`/`PopLocalFrame` to simplify the handling of the local references.

## Testing
Manually tested and relied on existing tests