### PR TITLE
release v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## TBD
+## 6.2.1 (2024-03-18)
 
 ### Bug fixes
 
 * Use PushLocalFrame/PopLocalFrame instead of DeleteLocalRef to avoid creating "holes" in the local ref table that are not always reused, leading to possible crashes in the ANR handler
-  []()
+  [#1988](https://github.com/bugsnag/bugsnag-android/pull/1988)
+
+* Removed makeSafe as it is no longer applicable, and slows-down the creation of breadcrumbs and adding metadata
+  [#1990](https://github.com/bugsnag/bugsnag-android/pull/1990)
 
 ## 6.2.0 (2024-02-08)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,7 +7,7 @@ import java.io.IOException
  */
 class Notifier @JvmOverloads constructor(
     var name: String = "Android Bugsnag Notifier",
-    var version: String = "6.2.0",
+    var version: String = "6.2.1",
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 

--- a/examples/sdk-app-example/app/build.gradle
+++ b/examples/sdk-app-example/app/build.gradle
@@ -41,8 +41,8 @@ android {
 }
 
 dependencies {
-    implementation "com.bugsnag:bugsnag-android:6.2.0"
-    implementation "com.bugsnag:bugsnag-plugin-android-okhttp:6.2.0"
+    implementation "com.bugsnag:bugsnag-android:6.2.1"
+    implementation "com.bugsnag:bugsnag-plugin-android-okhttp:6.2.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "androidx.appcompat:appcompat:1.4.0"
     implementation "com.google.android.material:material:1.4.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx4096m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
-VERSION_NAME=6.2.0
+VERSION_NAME=6.2.1
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git


### PR DESCRIPTION
### Bug fixes

* Use PushLocalFrame/PopLocalFrame instead of DeleteLocalRef to avoid creating "holes" in the local ref table that are not always reused, leading to possible crashes in the ANR handler
  [#1988](https://github.com/bugsnag/bugsnag-android/pull/1988)
  
* Removed makeSafe as it is no longer applicable, and slows-down the creation of breadcrumbs and adding metadata
  [#1990](https://github.com/bugsnag/bugsnag-android/pull/1990)