### PR TITLE
Guard against errors when terminating the app in e2e tests

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
@@ -1,6 +1,8 @@
 package com.bugsnag.android.mazerunner.scenarios;
 
 import static com.bugsnag.android.mazerunner.AnrHelperKt.createDeadlock;
+import static com.bugsnag.android.mazerunner.LogKt.getZeroEventsLogMessages;
+
 
 import com.bugsnag.android.Configuration;
 
@@ -10,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Collections;
+import java.util.List;
 
 public class JvmAnrOutsideReleaseStagesScenario extends Scenario {
 
@@ -27,5 +30,10 @@ public class JvmAnrOutsideReleaseStagesScenario extends Scenario {
     public void startScenario() {
         super.startScenario();
         createDeadlock();
+    }
+
+    @Override
+    public List<String> getInterceptedLogMessages() {
+        return getZeroEventsLogMessages(getStartBugsnagOnly());
     }
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/JvmAnrOutsideReleaseStagesScenario.java
@@ -3,7 +3,6 @@ package com.bugsnag.android.mazerunner.scenarios;
 import static com.bugsnag.android.mazerunner.AnrHelperKt.createDeadlock;
 import static com.bugsnag.android.mazerunner.LogKt.getZeroEventsLogMessages;
 
-
 import com.bugsnag.android.Configuration;
 
 import android.content.Context;

--- a/features/full_tests/auto_notify.feature
+++ b/features/full_tests/auto_notify.feature
@@ -26,7 +26,8 @@ Feature: Switching automatic error detection on/off for Unity
     When I run "AutoDetectAnrsFalseScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    And I close and relaunch the app
+    And I wait for 10 seconds
+    And I close and relaunch the app after an ANR
     And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
     Then Bugsnag confirms it has no errors to send
     And I wait for 10 seconds

--- a/features/full_tests/detect_anr_jvm.feature
+++ b/features/full_tests/detect_anr_jvm.feature
@@ -56,4 +56,10 @@ Feature: ANRs triggered in JVM code are captured
     When I run "JvmAnrOutsideReleaseStagesScenario"
     And I wait for 2 seconds
     And I tap the screen 3 times
-    Then I should receive no errors
+    And I wait for 10 seconds
+    And I close and relaunch the app after an ANR
+    And I configure Bugsnag for "JvmAnrOutsideReleaseStagesScenario"
+    Then Bugsnag confirms it has no errors to send
+    And I wait for 10 seconds
+    #  Wait extra 10 seconds in the end, so appium will have enough time to terminated the previous anr session
+

--- a/features/full_tests/detect_anr_jvm.feature
+++ b/features/full_tests/detect_anr_jvm.feature
@@ -62,4 +62,3 @@ Feature: ANRs triggered in JVM code are captured
     Then Bugsnag confirms it has no errors to send
     And I wait for 10 seconds
     #  Wait extra 10 seconds in the end, so appium will have enough time to terminated the previous anr session
-

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -70,14 +70,22 @@ When("I configure Bugsnag for {string}") do |event_type|
   execute_command :start_bugsnag, event_type
 end
 
+When("I terminate the app") do
+  Maze.driver.terminate_app Maze.driver.app_id
+end
+
 When("I close and relaunch the app") do
-  if Maze.config.legacy_driver?
-    Maze.driver.close_app
-    Maze.driver.launch_app
-  else
+  Maze.driver.terminate_app Maze.driver.app_id
+  Maze.driver.activate_app Maze.driver.app_id
+end
+
+When("I close and relaunch the app after an ANR") do
+  begin
     Maze.driver.terminate_app Maze.driver.app_id
-    Maze.driver.activate_app Maze.driver.app_id
+  rescue Selenium::WebDriver::Error::ServerError
+    # Swallow any error, as Android may already have terminated the app
   end
+  Maze.driver.activate_app Maze.driver.app_id
 end
 
 When('I set the screen orientation to portrait') do


### PR DESCRIPTION
## Goal

Rescue failures when calling the Appium `terminate_app` routine, caused when Android already terminated the app.

## Testing

Covered by a full CI run.