### PR TITLE
Move CI steps to macOS 14 build servers

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -3,21 +3,21 @@ steps:
     key: "fixture-minimal"
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     artifact_paths: build/fixture-minimal.apk
     command: make fixture-minimal
 
   - label: ':android: Build Example App'
     timeout_in_minutes: 5
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: 'make example-app'
 
   - label: ':android: Build debug fixture APK'
     key: "fixture-debug"
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     artifact_paths:
       - "build/fixture-debug.apk"
       - "build/fixture-debug/*"
@@ -26,7 +26,7 @@ steps:
   - label: ':android: Build Scan'
     timeout_in_minutes: 10
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: './gradlew clean assembleRelease check --scan'
 
   #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,6 @@ steps:
     agents:
       queue: macos-14
     commands:
-      - rbenv local 2.7.7
       - bundle install
       - ./scripts/audit-dependency-licenses.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,9 @@ steps:
     timeout_in_minutes: 30
     agents:
       queue: macos-14
-    command: ./scripts/audit-dependency-licenses.sh
+    commands: 
+      - bundle install
+      - ./scripts/audit-dependency-licenses.sh
 
   - label: ':android: Build fixture APK r19'
     key: "fixture-r19"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,14 +3,14 @@ steps:
   - label: 'Audit current licenses'
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: ./scripts/audit-dependency-licenses.sh
 
   - label: ':android: Build fixture APK r19'
     key: "fixture-r19"
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     artifact_paths:
       - "build/fixture-r19.apk"
       - "build/fixture-r19-url.txt"
@@ -24,7 +24,7 @@ steps:
     key: "fixture-r21"
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     artifact_paths:
       - "build/fixture-r21.apk"
       - "build/fixture-r21-url.txt"
@@ -37,31 +37,31 @@ steps:
   - label: ':android: Coding standards checks'
     timeout_in_minutes: 20
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: './gradlew --continue checkstyle detekt lint ktlintCheck'
 
   - label: ':android: Binary compatibility checks'
     timeout_in_minutes: 20
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: './gradlew apiCheck'
 
   - label: ':android: CppCheck'
     timeout_in_minutes: 10
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: 'bash ./scripts/run-cpp-check.sh'
 
   - label: ':android: ClangFormat'
     timeout_in_minutes: 10
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: 'bash ./scripts/run-clang-format-ci-check.sh'
 
   - label: ':android: Lint mazerunner scenarios'
     timeout_in_minutes: 10
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     commands:
       - cd features/fixtures/mazerunner
       - ./gradlew ktlintCheck detekt checkstyle
@@ -69,13 +69,13 @@ steps:
   - label: ':android: Android size reporting'
     timeout_in_minutes: 10
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: scripts/run-sizer.sh
 
   - label: ':android: JVM tests'
     timeout_in_minutes: 10
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: './gradlew test'
 
   #
@@ -346,6 +346,6 @@ steps:
 
   - label: 'Conditionally include device farms/full tests'
     agents:
-      queue: macos-12-arm
+      queue: macos-14
     command: sh -c .buildkite/pipeline_trigger.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,8 @@ steps:
     timeout_in_minutes: 30
     agents:
       queue: macos-14
-    commands: 
+    commands:
+      - rbenv local 2.7.7
       - bundle install
       - ./scripts/audit-dependency-licenses.sh
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem 'bugsnag-maze-runner', '~>9.0'
 # Or follow master:
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner'
 
-gem "license_finder", "~> 6.13"
+gem "license_finder", "~> 7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,13 +78,13 @@ GEM
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
       uri_template (~> 0.7)
-    license_finder (6.15.0)
+    license_finder (7.1.0)
       bundler
       rubyzip (>= 1, < 3)
-      thor (~> 1.0.1)
+      thor (~> 1.2)
       tomlrb (>= 1.3, < 2.1)
       with_env (= 1.1.0)
-      xml-simple (~> 1.1.5)
+      xml-simple (~> 1.1.9)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0206)
@@ -113,7 +113,7 @@ GEM
       ffi (~> 1.1)
     test-unit (3.5.9)
       power_assert
-    thor (1.0.1)
+    thor (1.3.1)
     tomlrb (2.0.3)
     unf (0.1.4)
       unf_ext
@@ -135,7 +135,7 @@ PLATFORMS
 
 DEPENDENCIES
   bugsnag-maze-runner (~> 9.0)
-  license_finder (~> 6.13)
+  license_finder (~> 7.0)
 
 BUNDLED WITH
    2.4.8

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/seqlock.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/seqlock.h
@@ -25,7 +25,7 @@ bsg_seqlock_status_t bsg_seqlock_optimistic_read(bsg_seqlock_t *lock);
 
 bool bsg_seqlock_validate(bsg_seqlock_t *lock, bsg_seqlock_status_t expected);
 
-#define bsg_seqlock_is_write_locked(c) (((c)&1uLL) != 0)
+#define bsg_seqlock_is_write_locked(c) (((c) & 1uLL) != 0)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Goal

Refresh the CI pipeline to use our new, more-performant, CI build servers running macOS 14.

## Changeset

We need to bump the License Finder as the new servers use Ruby 3 by default.  A newer version of clangformat also meant making a small formatting change.

## Testing

Covered by a full CI run.