### PR TITLE
Avoid possible crash in refresh symbol table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * FeatureFlags are now a copy-on-write structure, and so don't need to be defensive copied on a crashing thread
   [#2005](https://github.com/bugsnag/bugsnag-android/pull/2005)
 * The default redactedKeys in ObjectJsonStreamer is now static and shared, reducing the overhead of some leaveBreadcrumb calls (those with complex metadata)
-  []()
+  [#2008](https://github.com/bugsnag/bugsnag-android/pull/2008)
 
 * Allow `Bugsnag.startSession` to be called with automatic session tracking, and not have the first manual session be over written by the first automatic session.
   [#2006](https://github.com/bugsnag/bugsnag-android/pull/2006)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 * Allow `Bugsnag.startSession` to be called with automatic session tracking, and not have the first manual session be over written by the first automatic session.
   [#2006](https://github.com/bugsnag/bugsnag-android/pull/2006)
 
+### Bug fixes
+
+* Refreshing the NDK symbol table is now protected by a soft-lock to avoid possible double-free conditions
+  [#2007](https://github.com/bugsnag/bugsnag-android/pull/2007)
+
 ## 6.3.0 (2024-03-19)
 
 ### Enhancements


### PR DESCRIPTION
## Goal
Avoid possible double-free in `bugsnag_refresh_symbol_table` by protecting it with a soft-lock. 

## Design
Protected the `bugsnag_refresh_symbol_table` by wrapping it with a soft-lock. Concurrent calls to `bugsnag_refresh_symbol_table` will now be ignored (no-op).

## Testing
Manually tested & relied on existing tests.