### PR TITLE
Avoid compiling regexes in ObjectJsonStreamer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * FeatureFlags are now a copy-on-write structure, and so don't need to be defensive copied on a crashing thread
   [#2005](https://github.com/bugsnag/bugsnag-android/pull/2005)
+* The default redactedKeys in ObjectJsonStreamer is now static and shared, reducing the overhead of some leaveBreadcrumb calls (those with complex metadata)
+  []()
 
 * Allow `Bugsnag.startSession` to be called with automatic session tracking, and not have the first manual session be over written by the first automatic session.
   [#2006](https://github.com/bugsnag/bugsnag-android/pull/2006)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ObjectJsonStreamer.kt
@@ -11,9 +11,11 @@ internal class ObjectJsonStreamer {
     companion object {
         internal const val REDACTED_PLACEHOLDER = "[REDACTED]"
         internal const val OBJECT_PLACEHOLDER = "[OBJECT]"
+
+        internal val DEFAULT_REDACTED_KEYS = setOf(Pattern.compile(".*password.*", Pattern.CASE_INSENSITIVE))
     }
 
-    var redactedKeys = setOf(Pattern.compile(".*password.*", Pattern.CASE_INSENSITIVE))
+    var redactedKeys = DEFAULT_REDACTED_KEYS
 
     // Write complex/nested values to a JsonStreamer
     @Throws(IOException::class)


### PR DESCRIPTION
## Goal
Reduce the overhead of constructing `ObjectJsonStreamer` instances (and therefore leaving complex breadcrumbs) by sharing the default `redactedKeys` (which is immutable).

## Design
An `ObjectJsonStreamer` is allocated internally each time a breadcrumb metadata item needs to be JSON encoded early (because it is too complex for the NDK layer to handle directly). Each of these was causing the default `redactedKeys` pattern to be compiled. Since the default `redactedKeys` set is immutable, it can be safely shared instead.

## Testing
Relied on existing tests.