### PR TITLE
ReactNative: Allow strings or numbers to be used for thread-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
   [#2005](https://github.com/bugsnag/bugsnag-android/pull/2005)
 * The default redactedKeys in ObjectJsonStreamer is now static and shared, reducing the overhead of some leaveBreadcrumb calls (those with complex metadata)
   [#2008](https://github.com/bugsnag/bugsnag-android/pull/2008)
-
 * Allow `Bugsnag.startSession` to be called with automatic session tracking, and not have the first manual session be over written by the first automatic session.
   [#2006](https://github.com/bugsnag/bugsnag-android/pull/2006)
 

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -27,8 +27,11 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
 
         Boolean errorReportingThread = MapUtils.<Boolean>getOrNull(map, "errorReportingThread");
         errorReportingThread = errorReportingThread == null ? false : errorReportingThread;
+
+        Object threadId = MapUtils.getOrThrow(map, "id");
+
         return new Thread(
-                MapUtils.<Long>getOrThrow(map, "id").toString(),
+                threadId.toString(),
                 MapUtils.<String>getOrThrow(map, "name"),
                 ErrorType.valueOf(type.toUpperCase(Locale.US)),
                 errorReportingThread,


### PR DESCRIPTION
## Goal
Allow ReactNative apps to report the thread id as either a number or string.

## Design
Don't assume the type of the `thread.id` fields reported by ReactNative, and simply call `toString()` on the resulting object.

## Testing
New unit testing for both String and Long based thread IDs