### PR TITLE
Reduce use of Atomics in Session

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
@@ -28,7 +28,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
     private App app;
     private Device device;
 
-    private final AtomicBoolean autoCaptured = new AtomicBoolean(false);
+    private volatile boolean autoCaptured = false;
     private final AtomicInteger unhandledCount = new AtomicInteger();
     private final AtomicInteger handledCount = new AtomicInteger();
     private final AtomicBoolean tracked = new AtomicBoolean(false);
@@ -41,7 +41,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
                 session.unhandledCount.get(), session.handledCount.get(), session.notifier,
                 session.logger, session.getApiKey());
         copy.tracked.set(session.tracked.get());
-        copy.autoCaptured.set(session.isAutoCaptured());
+        copy.autoCaptured = session.isAutoCaptured();
         return copy;
     }
 
@@ -68,7 +68,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
         this.id = id;
         this.startedAt = new Date(startedAt.getTime());
         this.user = user;
-        this.autoCaptured.set(autoCaptured);
+        this.autoCaptured = autoCaptured;
         this.apiKey = apiKey;
     }
 
@@ -198,16 +198,20 @@ public final class Session implements JsonStream.Streamable, UserAware {
         return copySession(this);
     }
 
-    AtomicBoolean isTracked() {
-        return tracked;
+    boolean markTracked() {
+        return tracked.compareAndSet(false, true);
+    }
+
+    boolean markPaused() {
+        return isPaused.compareAndSet(true, false);
     }
 
     boolean isAutoCaptured() {
-        return autoCaptured.get();
+        return autoCaptured;
     }
 
     void setAutoCaptured(boolean autoCaptured) {
-        this.autoCaptured.set(autoCaptured);
+        this.autoCaptured = autoCaptured;
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Session.java
@@ -32,7 +32,7 @@ public final class Session implements JsonStream.Streamable, UserAware {
     private final AtomicInteger unhandledCount = new AtomicInteger();
     private final AtomicInteger handledCount = new AtomicInteger();
     private final AtomicBoolean tracked = new AtomicBoolean(false);
-    final AtomicBoolean isPaused = new AtomicBoolean(false);
+    private final AtomicBoolean isPaused = new AtomicBoolean(false);
 
     private String apiKey;
 
@@ -202,8 +202,16 @@ public final class Session implements JsonStream.Streamable, UserAware {
         return tracked.compareAndSet(false, true);
     }
 
-    boolean markPaused() {
+    boolean markResumed() {
         return isPaused.compareAndSet(true, false);
+    }
+
+    void markPaused() {
+        isPaused.set(true);
+    }
+
+    boolean isPaused() {
+        return isPaused.get();
     }
 
     boolean isAutoCaptured() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -120,7 +120,7 @@ class SessionTracker extends BaseObservable implements ForegroundDetector.OnActi
         Session session = currentSession;
 
         if (session != null) {
-            session.isPaused.set(true);
+            session.markPaused();
             updateState(StateEvent.PauseSession.INSTANCE);
         }
     }
@@ -133,7 +133,7 @@ class SessionTracker extends BaseObservable implements ForegroundDetector.OnActi
             session = startSession(false);
             resumed = false;
         } else {
-            resumed = session.markPaused();
+            resumed = session.markResumed();
         }
 
         if (session != null) {
@@ -205,7 +205,7 @@ class SessionTracker extends BaseObservable implements ForegroundDetector.OnActi
     Session getCurrentSession() {
         Session session = currentSession;
 
-        if (session != null && !session.isPaused.get()) {
+        if (session != null && !session.isPaused()) {
             return session;
         }
         return null;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -133,7 +133,7 @@ class SessionTracker extends BaseObservable implements ForegroundDetector.OnActi
             session = startSession(false);
             resumed = false;
         } else {
-            resumed = session.isPaused.compareAndSet(true, false);
+            resumed = session.markPaused();
         }
 
         if (session != null) {
@@ -191,7 +191,7 @@ class SessionTracker extends BaseObservable implements ForegroundDetector.OnActi
         session.setDevice(client.getDeviceDataCollector().generateDevice());
         boolean deliverSession = callbackState.runOnSessionTasks(session, logger);
 
-        if (deliverSession && session.isTracked().compareAndSet(false, true)) {
+        if (deliverSession && session.markTracked()) {
             currentSession = session;
             notifySessionStartObserver(session);
             flushInMemorySession(session);

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
@@ -141,7 +141,8 @@ class SessionTest {
             assertEquals(startedAt, copy.startedAt)
             assertEquals(getUser(), copy.getUser()) // make a shallow copy
             assertEquals(isAutoCaptured, copy.isAutoCaptured)
-            assertEquals(isTracked.get(), copy.isTracked.get())
+            assertEquals(markTracked(), copy.markTracked())
+            assertEquals(markPaused(), copy.markPaused())
             assertEquals(session.unhandledCount, copy.unhandledCount)
             assertEquals(session.handledCount, copy.handledCount)
         }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/SessionTest.kt
@@ -142,6 +142,8 @@ class SessionTest {
             assertEquals(getUser(), copy.getUser()) // make a shallow copy
             assertEquals(isAutoCaptured, copy.isAutoCaptured)
             assertEquals(markTracked(), copy.markTracked())
+            assertEquals(markResumed(), copy.markResumed())
+            assertEquals(isPaused, copy.isPaused)
             assertEquals(markPaused(), copy.markPaused())
             assertEquals(session.unhandledCount, copy.unhandledCount)
             assertEquals(session.handledCount, copy.handledCount)


### PR DESCRIPTION
## Goal

Reduce use of Atomics in Session, so the value is more accurate syncing between multiple threads. 

## Changeset

Change autoCaptured type from AtomicBoolean to volatile boolean since it does not use specific atomic method.
