### PR TITLE
Don't use strings for `BreadcrumbType` in NDK

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -387,7 +387,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_pausedSession(
 }
 
 JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
-    JNIEnv *env, jobject _this, jstring name_, jstring crumb_type,
+    JNIEnv *env, jobject _this, jstring name_, jint crumb_type,
     jstring timestamp_, jobject metadata) {
 
   if (!bsg_jni_cache->initialized) {
@@ -395,28 +395,41 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
     return;
   }
   const char *name = bsg_safe_get_string_utf_chars(env, name_);
-  const char *type = bsg_safe_get_string_utf_chars(env, crumb_type);
   const char *timestamp = bsg_safe_get_string_utf_chars(env, timestamp_);
 
-  if (name != NULL && type != NULL && timestamp != NULL) {
+  if (name != NULL && timestamp != NULL) {
     bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
     bsg_strncpy(crumb->name, name, sizeof(crumb->name));
     bsg_strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
-    if (strcmp(type, "user") == 0) {
-      crumb->type = BSG_CRUMB_USER;
-    } else if (strcmp(type, "error") == 0) {
+
+    // the values of crumb_type are defined in
+    // NativeBridge.BreadcrumbType.toNativeValue()
+    switch (crumb_type) {
+    case 0:
       crumb->type = BSG_CRUMB_ERROR;
-    } else if (strcmp(type, "log") == 0) {
+      break;
+    case 1:
       crumb->type = BSG_CRUMB_LOG;
-    } else if (strcmp(type, "navigation") == 0) {
+      break;
+    case 2:
+      crumb->type = BSG_CRUMB_MANUAL;
+      break;
+    case 3:
       crumb->type = BSG_CRUMB_NAVIGATION;
-    } else if (strcmp(type, "request") == 0) {
-      crumb->type = BSG_CRUMB_REQUEST;
-    } else if (strcmp(type, "state") == 0) {
-      crumb->type = BSG_CRUMB_STATE;
-    } else if (strcmp(type, "process") == 0) {
+      break;
+    case 4:
       crumb->type = BSG_CRUMB_PROCESS;
-    } else {
+      break;
+    case 5:
+      crumb->type = BSG_CRUMB_REQUEST;
+      break;
+    case 6:
+      crumb->type = BSG_CRUMB_STATE;
+      break;
+    case 7:
+      crumb->type = BSG_CRUMB_USER;
+      break;
+    default:
       crumb->type = BSG_CRUMB_MANUAL;
     }
 
@@ -428,7 +441,6 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
     free(crumb);
   }
   bsg_safe_release_string_utf_chars(env, name_, name);
-  bsg_safe_release_string_utf_chars(env, crumb_type, type);
   bsg_safe_release_string_utf_chars(env, timestamp_, timestamp);
 }
 


### PR DESCRIPTION
## Goal
Small reduction in overhead when leaving breadcrumbs: use integers to represent the `BreadcrumbType` instead of strings.

## Design
While the string values for `BreadcrumbType` on the Java/Kotlin code were constants, they required a call to `GetStringUTFChars` and `strcmp` to evaluate which enum value to use.

The new implementation uses an exhaustive `when` which means:
- the transfer values are not sensitive to the ordering of the `enum` values (as `ordinal` would be)
- any adding or removing of `enum` values will cause compiler failures

## Testing
Relied on existing tests.