### PR TITLE
NDK: Iterate over breadcrumb metadata keys directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Enhancements
 
 * `Configuration.maxBreadcrumbs` is now obeyed by `bugsnag-plugin-android-ndk`, so native events will include the correct number of breadcrumbs
-  []()
+  [#2020](https://github.com/bugsnag/bugsnag-android/pull/2020)
+* `bugsnag-plugin-android-ndk` will no longer create an `ArrayList` copy of metadata keys when leaving breadcrumbs
+  [#2022](https://github.com/bugsnag/bugsnag-android/pull/2022)
 
 ## 6.4.0 (2024-04-15)
 

--- a/bugsnag-plugin-android-ndk/proguard-rules.pro
+++ b/bugsnag-plugin-android-ndk/proguard-rules.pro
@@ -1,6 +1,7 @@
 -keepattributes LineNumberTable,SourceFile
 -keep class com.bugsnag.android.ndk.OpaqueValue {
     java.lang.String getJson();
+    static java.lang.Object makeSafe(java.lang.Object);
 }
 -keep class com.bugsnag.android.ndk.NativeBridge { *; }
 -keep class com.bugsnag.android.NdkPlugin { *; }

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -121,7 +121,7 @@ class NativeBridge(private val bgTaskService: BackgroundTaskService) : StateObse
                 event.message,
                 event.type.toNativeValue(),
                 event.timestamp,
-                makeSafeMetadata(event.metadata)
+                event.metadata
             )
 
             NotifyHandled -> addHandledEvent()
@@ -169,13 +169,6 @@ class NativeBridge(private val bgTaskService: BackgroundTaskService) : StateObse
 
             is StateEvent.ClearFeatureFlag -> clearFeatureFlag(event.name)
             is StateEvent.ClearFeatureFlags -> clearFeatureFlags()
-        }
-    }
-
-    private fun makeSafeMetadata(metadata: Map<String, Any?>): Map<String, Any?> {
-        if (metadata.isEmpty()) return metadata
-        return object : Map<String, Any?> by metadata {
-            override fun get(key: String): Any? = OpaqueValue.makeSafe(metadata[key])
         }
     }
 

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/OpaqueValue.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/OpaqueValue.kt
@@ -7,12 +7,12 @@ import java.io.StringWriter
  * Marker class for values that are `BSG_METADATA_OPAQUE_VALUE` in the C layer
  */
 internal class OpaqueValue(val json: String) {
-    companion object {
+    internal companion object {
         private const val MAX_NDK_STRING_LENGTH = 64
         private const val US_ASCII_MAX_CODEPOINT = 127
         private const val INITIAL_BUFFER_SIZE = 256
 
-        private fun isStringNDKSupported(value: String): Boolean {
+        fun isStringNDKSupported(value: String): Boolean {
             // anything over 63 characters is definitely not supported
             if (value.length >= MAX_NDK_STRING_LENGTH) return false
 
@@ -27,7 +27,7 @@ internal class OpaqueValue(val json: String) {
             return value.toByteArray().size < MAX_NDK_STRING_LENGTH
         }
 
-        private fun encode(value: Any): String {
+        fun encode(value: Any): String {
             val writer = StringWriter(INITIAL_BUFFER_SIZE)
             writer.use { JsonStream(it).value(value, false) }
             return writer.toString()
@@ -38,6 +38,7 @@ internal class OpaqueValue(val json: String) {
          * is both a compatible type and fits into the available space. This method can return
          * any one of: `Boolean`, `Number`, `String`, `OpaqueValue` or `null`.
          */
+        @JvmStatic
         fun makeSafe(value: Any?): Any? = when {
             value is Boolean -> value
             value is Number -> value

--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.c
@@ -218,6 +218,8 @@ bool bsg_jni_cache_init(JNIEnv *env) {
   CACHE_CLASS(OpaqueValue, "com/bugsnag/android/ndk/OpaqueValue");
   CACHE_METHOD(OpaqueValue, OpaqueValue_getJson, "getJson",
                "()Ljava/lang/String;");
+  CACHE_STATIC_METHOD(OpaqueValue, OpaqueValue_makeSafe, "makeSafe",
+                      "(Ljava/lang/Object;)Ljava/lang/Object;");
 
   CACHE_ENUM_CONSTANT(ErrorType_C, "com/bugsnag/android/ErrorType", "C");
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
@@ -89,6 +89,7 @@ typedef struct {
 
   jclass OpaqueValue;
   jmethodID OpaqueValue_getJson;
+  jmethodID OpaqueValue_makeSafe;
 
   jobject ErrorType_C;
 } bsg_jni_cache_t;


### PR DESCRIPTION
## Goal
Remove the allocation of an `ArrayList` when copying the metadata for breadcrumbs.

## Design
The NDK `bsg_populate_crumb_metadata` method now uses the `Map.entrySet.iterator()` instead of first copying the keys to an `ArrayList` and then iterating over that (using `Map.get` for the values). While this is a relatively trivial overhead reduction, it has the added benefit that most `Map` implementation optimize this form of iteration, and avoid the allocation overhead of the `ArrayList`.

## Testing
Manual testing, and relied on existing end to end tests.