### PR TITLE
Remove Failed delivery internal reports

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.kt
@@ -208,7 +208,7 @@ internal class EventStore(
     }
 
     private fun handleEventFlushFailure(exc: Exception, eventFile: File) {
-        delegate?.onErrorIOFailure(exc, eventFile, "Crash Report Deserialization")
+        logger.e(exc.message ?: "Failed to send event", exc)
         deleteStoredFiles(setOf(eventFile))
     }
 


### PR DESCRIPTION
## Goal

Replaced failed delivery internal reports with more effective error information 

## Changeset

Removed the error report when a file is not (de)serialized correctly and replaced it with a logger error message. 

## Testing

Existing tests