### PR TITLE
Update AGP and related versions for mazerunner

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -6,14 +6,16 @@ steps:
       queue: macos-14
     artifact_paths: build/fixture-minimal.apk
     command: make fixture-minimal
+    env:
+      JAVA_VERSION: 17
 
   - label: ':android: Build Example App'
     timeout_in_minutes: 5
     agents:
       queue: macos-14
+    command: 'make example-app'
     env:
       JAVA_VERSION: 17
-    command: 'make example-app'
 
   - label: ':android: Build debug fixture APK'
     key: "fixture-debug"
@@ -24,6 +26,8 @@ steps:
       - "build/fixture-debug.apk"
       - "build/fixture-debug/*"
     command: make fixture-debug
+    env:
+      JAVA_VERSION: 17
 
   - label: ':android: Build Scan'
     timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,8 @@ steps:
       - bundle install
       - make fixture-r19
       - bundle exec upload-app --farm=bb --app=./build/fixture-r19.apk --app-id-file=build/fixture-r19-url.txt
+    env:
+      JAVA_VERSION: 17
 
   - label: ':android: Build fixture APK r21'
     key: "fixture-r21"
@@ -35,6 +37,8 @@ steps:
       - bundle install
       - make fixture-r21
       - bundle exec upload-app --farm=bb --app=./build/fixture-r21.apk --app-id-file=build/fixture-r21-url.txt
+    env:
+      JAVA_VERSION: 17
 
   - label: ':android: Coding standards checks'
     timeout_in_minutes: 20
@@ -67,6 +71,8 @@ steps:
     commands:
       - cd features/fixtures/mazerunner
       - ./gradlew ktlintCheck detekt checkstyle
+    env:
+      JAVA_VERSION: 17
 
   - label: ':android: Android size reporting'
     timeout_in_minutes: 10

--- a/Makefile
+++ b/Makefile
@@ -34,31 +34,31 @@ notifier:
 
 fixture-r19: notifier
 	# Build the r19 test fixture
-	@./gradlew -PTEST_FIXTURE_NDK_VERSION=19.2.5345600 \
+	@cd ./features/fixtures/mazerunner && ./gradlew -PTEST_FIXTURE_NDK_VERSION=19.2.5345600 \
                -PTEST_FIXTURE_NAME=fixture-r19.apk \
-	           -p=features/fixtures/mazerunner assembleRelease -x check
+                assembleRelease -x check
 	@ruby scripts/copy-build-files.rb release r19
 
 fixture-r21: notifier
 	# Build the r21 test fixture
-	@./gradlew -PTEST_FIXTURE_NDK_VERSION=21.4.7075529 \
+	@cd ./features/fixtures/mazerunner && ./gradlew -PTEST_FIXTURE_NDK_VERSION=21.4.7075529 \
                -PTEST_FIXTURE_NAME=fixture-r21.apk \
-               -p=features/fixtures/mazerunner assembleRelease -x check
+               assembleRelease -x check
 	@ruby scripts/copy-build-files.rb release r21
 
 fixture-minimal: notifier
 	# Build the minimal test fixture
-	@./gradlew -PMINIMAL_FIXTURE=true \
+	@cd ./features/fixtures/mazerunner && ./gradlew -PMINIMAL_FIXTURE=true \
 	           -PTEST_FIXTURE_NDK_VERSION=17.2.4988734 \
                -PTEST_FIXTURE_NAME=fixture-minimal.apk \
-               -p=features/fixtures/mazerunner assembleRelease -x check
+               assembleRelease -x check
 	@ruby scripts/copy-build-files.rb release minimal
 
 fixture-debug: notifier
 	# Build the minimal test fixture
-	@./gradlew -PTEST_FIXTURE_NDK_VERSION=17.2.4988734 \
+	@cd ./features/fixtures/mazerunner && ./gradlew -PTEST_FIXTURE_NDK_VERSION=17.2.4988734 \
                -PTEST_FIXTURE_NAME=fixture-debug.apk \
-               -p=features/fixtures/mazerunner assembleDebug -x check
+               assembleDebug -x check
 	@ruby scripts/copy-build-files.rb debug debug
 
 example-app:

--- a/features/fixtures/mazerunner/app/build.gradle
+++ b/features/fixtures/mazerunner/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 34
         versionName "1.1.14"
         manifestPlaceholders = [
@@ -79,6 +79,7 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    namespace 'com.bugsnag.android.mazerunner'
 }
 
 dependencies {

--- a/features/fixtures/mazerunner/app/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/app/detekt-baseline.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues/>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>MagicNumber:MainActivity.kt$MainActivity$1000</ID>
     <ID>MagicNumber:MainActivity.kt$MainActivity$250</ID>

--- a/features/fixtures/mazerunner/app/proguard-rules.pro
+++ b/features/fixtures/mazerunner/app/proguard-rules.pro
@@ -1,2 +1,4 @@
 -keep class com.bugsnag.android.mazerunner.** {*;}
 -keep class com.bugsnag.android.DeliveryDelegate {*;}
+-keepattributes LineNumberTable,SourceFile
+-renamesourcefileattribute SourceFile

--- a/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bugsnag.android.mazerunner">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- always enable GWP ASAN tool to detect native memory bugs. see
         https://developer.android.com/ndk/guides/gwp-asan-->

--- a/features/fixtures/mazerunner/build.gradle
+++ b/features/fixtures/mazerunner/build.gradle
@@ -18,16 +18,16 @@ buildscript {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
-    ext.kotlin_version = "1.4.32"
+    ext.kotlin_version = "1.8.20"
 
     dependencies {
         def agpVersion = project.hasProperty("USE_AGP_VERSION")
                 ? project.property("USE_AGP_VERSION")
-                : "7.1.0"
+                : "8.3.2"
 
         project.logger.lifecycle("Using AGP $agpVersion")
         classpath "com.android.tools.build:gradle:$agpVersion"
-        classpath "com.bugsnag:bugsnag-android-gradle-plugin:7.1.0"
+        classpath "com.bugsnag:bugsnag-android-gradle-plugin:8.1.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.18.1"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.0"

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/build.gradle
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/build.gradle
@@ -37,6 +37,7 @@ android {
 
     buildFeatures.prefab = true
     packagingOptions.jniLibs.pickFirsts += ["**/libbugsnag-ndk.so"]
+    namespace 'com.bugsnag.android.mazerunner.cxxscenariosbugsnag'
 }
 
 dependencies {

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/detekt-baseline.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues/>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>MagicNumber:CXXExceptionSmokeScenario.kt$CXXExceptionSmokeScenario$500</ID>
     <ID>MagicNumber:CXXExceptionSmokeScenario.kt$CXXExceptionSmokeScenario$999</ID>

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.bugsnag.android.mazerunner.cxxscenariosbugsnag" />
+<manifest />

--- a/features/fixtures/mazerunner/cxx-scenarios/build.gradle
+++ b/features/fixtures/mazerunner/cxx-scenarios/build.gradle
@@ -34,6 +34,7 @@ android {
             path "CMakeLists.txt"
         }
     }
+    namespace 'com.bugsnag.android.mazerunner.cxxscenarios'
 }
 
 dependencies {

--- a/features/fixtures/mazerunner/cxx-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/cxx-scenarios/detekt-baseline.xml
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues/>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>MagicNumber:CXXDelayedCrashScenario.kt$CXXDelayedCrashScenario$405</ID>
     <ID>MagicNumber:CXXIgnoredSigabrtScenario.kt$CXXIgnoredSigabrtScenario$2726</ID>

--- a/features/fixtures/mazerunner/cxx-scenarios/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/cxx-scenarios/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.bugsnag.android.mazerunner.cxxscenarios" />
+<manifest />

--- a/features/fixtures/mazerunner/gradle.properties
+++ b/features/fixtures/mazerunner/gradle.properties
@@ -1,3 +1,6 @@
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true

--- a/features/fixtures/mazerunner/gradle.properties
+++ b/features/fixtures/mazerunner/gradle.properties
@@ -1,6 +1,3 @@
-android.defaults.buildfeatures.buildconfig=true
-android.nonFinalResIds=false
-android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.parallel=true

--- a/features/fixtures/mazerunner/gradle/wrapper/gradle-wrapper.properties
+++ b/features/fixtures/mazerunner/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/features/fixtures/mazerunner/jvm-scenarios/build.gradle
+++ b/features/fixtures/mazerunner/jvm-scenarios/build.gradle
@@ -32,6 +32,7 @@ android {
     lintOptions {
         tasks.lint.enabled = false
     }
+    namespace 'com.bugsnag.android.mazerunner.jvmscenarios'
 }
 
 dependencies {
@@ -42,7 +43,7 @@ dependencies {
         implementation "com.squareup.okhttp3:okhttp:3.12.0"
     } else {
         project.logger.lifecycle("Using OkHttp 4 dependency in test fixture")
-        implementation "com.squareup.okhttp3:okhttp:4.9.1"
+        implementation "com.squareup.okhttp3:okhttp:4.12.0"
     }
     implementation "com.bugsnag:bugsnag-android-performance:1.2.2"
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -1,9 +1,9 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues/>
+  <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>MagicNumber:AnrHelper.kt$1000</ID>
-    <ID>MagicNumber:AnrHelper.kt$&lt;no name provided>$60000</ID>
+    <ID>MagicNumber:AnrHelper.kt$&lt;no name provided&gt;$60000</ID>
     <ID>MagicNumber:AutoDetectAnrsFalseScenario.kt$AutoDetectAnrsFalseScenario$100000</ID>
     <ID>MagicNumber:AutoDetectAnrsTrueScenario.kt$AutoDetectAnrsTrueScenario$100000</ID>
     <ID>MagicNumber:BugsnagInitScenario.kt$BugsnagInitScenario$25</ID>
@@ -22,11 +22,11 @@
     <ID>MagicNumber:Scenario.kt$Scenario$100</ID>
     <ID>MagicNumber:Scenario.kt$Scenario$1000</ID>
     <ID>MagicNumber:StartupCrashFlushScenario.kt$StartupCrashFlushScenario$6000</ID>
-    <ID>MagicNumber:TestHarnessHooks.kt$&lt;no name provided>$500</ID>
+    <ID>MagicNumber:TestHarnessHooks.kt$&lt;no name provided&gt;$500</ID>
     <ID>MagicNumber:TrimmedStacktraceScenario.kt$TrimmedStacktraceScenario$100000</ID>
     <ID>MagicNumber:UnhandledExceptionEventDetailChangeScenario.kt$UnhandledExceptionEventDetailChangeScenario$123</ID>
     <ID>MagicNumber:UnhandledExceptionEventDetailChangeScenario.kt$UnhandledExceptionEventDetailChangeScenario$123456</ID>
-    <ID>ThrowingExceptionsWithoutMessageOrCause:AnrHelper.kt$&lt;no name provided>$IllegalStateException()</ID>
+    <ID>ThrowingExceptionsWithoutMessageOrCause:AnrHelper.kt$&lt;no name provided&gt;$IllegalStateException()</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:BugsnagInitScenario.kt$BugsnagInitScenario$RuntimeException()</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:CustomPluginNotifierDescriptionScenario.kt$CustomPluginNotifierDescriptionScenario$RuntimeException()</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:TestHarnessHooks.kt$RuntimeException()</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/AndroidManifest.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.bugsnag.android.mazerunner.jvmscenarios" />
+<manifest />

--- a/features/smoke_tests/02_handled.feature
+++ b/features/smoke_tests/02_handled.feature
@@ -22,9 +22,9 @@ Feature: Handled smoke tests
     # Stacktrace validation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event "exceptions.0.stacktrace.0.method" ends with "HandledJavaSmokeScenario.startScenario"
-    And the exception "stacktrace.0.file" equals "HandledJavaSmokeScenario.java"
+    And the exception "stacktrace.0.file" equals "SourceFile"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 8
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 56
     And the event "exceptions.0.stacktrace.0.inProject" is true
     And the error payload field "events.0.projectPackages" is a non-empty array
     And the event "projectPackages.0" equals "com.bugsnag.android.mazerunner"
@@ -133,9 +133,9 @@ Feature: Handled smoke tests
     # Stacktrace validation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event "exceptions.0.stacktrace.0.method" ends with "generateException"
-    And the exception "stacktrace.0.file" equals "Scenario.kt"
+    And the exception "stacktrace.0.file" equals "SourceFile"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 1
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 11
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     # Overwritten App data

--- a/features/smoke_tests/04_unhandled.feature
+++ b/features/smoke_tests/04_unhandled.feature
@@ -25,9 +25,9 @@ Feature: Unhandled smoke tests
     # Stacktrace validation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event "exceptions.0.stacktrace.0.method" ends with "UnhandledJavaLoadedConfigScenario.startScenario"
-    And the exception "stacktrace.0.file" equals "UnhandledJavaLoadedConfigScenario.java"
+    And the exception "stacktrace.0.file" equals "SourceFile"
     # R8 minification alters the lineNumber, see the mapping file/source code for the original value
-    And the event "exceptions.0.stacktrace.0.lineNumber" equals 7
+    And the event "exceptions.0.stacktrace.0.lineNumber" equals 41
     And the event "exceptions.0.stacktrace.0.inProject" is true
 
     And the thread with name "main" contains the error reporting flag


### PR DESCRIPTION
## Goal

The MazeRunner test fixtures can be built with AGP 8.3.2 to ensure we remain compatible.

## Changeset

Update AGP, Gradle and okhttp version

## Testing

Existing end to end tests