### PR TITLE
Fixed the logic of discarding session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Corrected the behavior when `Bugsnag.startSession` is called when `config.autoTrackSessions=true`, the first automatic session will now be correctly discarded
+  [#2033](https://github.com/bugsnag/bugsnag-android/pull/2033)
+
 ## 6.5.0 (2024-05-15)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/SessionTracker.java
@@ -36,7 +36,7 @@ class SessionTracker extends BaseObservable implements ForegroundDetector.OnActi
     private volatile Session currentSession = null;
     final BackgroundTaskService backgroundTaskService;
     final Logger logger;
-    private boolean shouldSuppressFirstAutoSession = false;
+    private boolean shouldSuppressFirstAutoSession = true;
 
     SessionTracker(ImmutableConfig configuration,
                    CallbackState callbackState,
@@ -108,8 +108,12 @@ class SessionTracker extends BaseObservable implements ForegroundDetector.OnActi
                     && existingSession != null
                     && !existingSession.isAutoCaptured()
                     && shouldSuppressFirstAutoSession) {
-                shouldSuppressFirstAutoSession = true;
+                shouldSuppressFirstAutoSession = false;
                 return true;
+            }
+
+            if (autoCaptured) {
+                shouldSuppressFirstAutoSession = false;
             }
         }
         return false;


### PR DESCRIPTION
## Goal

Discard the first automatic session when sessions are mixed with manual session

## Changeset

Changing the logic for discarding session method

## Testing

unit tests