### PR TITLE
Reinstate instrumentation tests using MacOS test boxes as a platform

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,7 +91,7 @@ steps:
     plugins:
       artifacts#v1.9.0:
         upload:
-            - "bugsnag-*/build/reports/androidTests/connected/**/*"
+            - "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
       queue: macos-14-4
     command: './scripts/run-connected-checks.rb'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,9 +90,7 @@ steps:
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.9.0:
-        upload:
-          - "bugsnag-*/build/reports/androidTests/connected"
-        compressed: reports.zip
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
       queue: macos-14
     command: './scripts/run-connected-checks.rb'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -89,7 +89,7 @@ steps:
   - label: ':android: Instrumentation tests'
     timeout_in_minutes: 10
     agents:
-      queue: macos-14-5
+      queue: macos-14-4
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,6 +86,13 @@ steps:
       queue: macos-14
     command: './gradlew test'
 
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14-5
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
   #
   # BitBar steps
   #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,7 +93,7 @@ steps:
         upload:
             - "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14-4
+      queue: macos-14
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -88,6 +88,10 @@ steps:
 
   - label: ':android: Instrumentation tests'
     timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload:
+            - "bugsnag-*/build/reports/androidTests/connected"
     agents:
       queue: macos-14-4
     command: './scripts/run-connected-checks.rb'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,7 +90,8 @@ steps:
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*"
+        upload:
+          - "bugsnag-*/build/reports/androidTests/connected/**/*"
         compressed: reports.zip
     agents:
       queue: macos-14

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,8 +90,8 @@ steps:
     timeout_in_minutes: 10
     plugins:
       artifacts#v1.9.0:
-        upload:
-            - "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*"
+        compressed: reports.zip
     agents:
       queue: macos-14
     command: './scripts/run-connected-checks.rb'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,7 +91,7 @@ steps:
     plugins:
       artifacts#v1.9.0:
         upload:
-            - "bugsnag-*/build/reports/androidTests/connected"
+            - "bugsnag-*/build/reports/androidTests/connected/**/*"
     agents:
       queue: macos-14-4
     command: './scripts/run-connected-checks.rb'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,7 +91,7 @@ steps:
     plugins:
       artifacts#v1.9.0:
         upload:
-          - "bugsnag-*/build/reports/androidTests/connected/**/*"
+          - "bugsnag-*/build/reports/androidTests/connected"
         compressed: reports.zip
     agents:
       queue: macos-14

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StrictModeViolationTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StrictModeViolationTest.kt
@@ -48,7 +48,7 @@ class StrictModeViolationTest {
         // validate first stackframe
         val frame = err.stacktrace.first()
         assertEquals(
-            "com.bugsnag.android.StrictModeViolationTet.testThreadViolationCapture",
+            "com.bugsnag.android.StrictModeViolationTest.testThreadViolationCapture",
             frame.method
         )
         assertEquals("StrictModeViolationTest.kt", frame.file)

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StrictModeViolationTest.kt
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/StrictModeViolationTest.kt
@@ -48,7 +48,7 @@ class StrictModeViolationTest {
         // validate first stackframe
         val frame = err.stacktrace.first()
         assertEquals(
-            "com.bugsnag.android.StrictModeViolationTest.testThreadViolationCapture",
+            "com.bugsnag.android.StrictModeViolationTet.testThreadViolationCapture",
             frame.method
         )
         assertEquals("StrictModeViolationTest.kt", frame.file)

--- a/scripts/run-connected-checks.rb
+++ b/scripts/run-connected-checks.rb
@@ -7,17 +7,14 @@ raise('API_LEVEL environment variable must be set') unless ENV['API_LEVEL']
 target_api_level = ENV['API_LEVEL']
 
 # Check if the appropriate AVD exists based on given API level
-puts `echo $PATH`
-puts `which avdmanager`
 avd_exists = `avdmanager list avd -c | grep test-sdk-#{ENV['API_LEVEL']}`.strip
 
 if avd_exists.empty?
   puts "AVD test-sdk-#{target_api_level} does not exist, creating it now"
   # Determine if we're running on x86 or ARM
   sys_arch = `uname -m`.strip
-
+  sys_arch = 'arm64-v8a' if sys_arch.eql?('arm64')
   # Check to see if the appropriate SDK is installed
-  puts `which sdkmanager`
   sdk_installed = `sdkmanager --list_installed | grep "system-images;android-#{target_api_level};google_apis;#{sys_arch}"`.strip
 
   if sdk_installed.empty?

--- a/scripts/run-connected-checks.rb
+++ b/scripts/run-connected-checks.rb
@@ -7,6 +7,7 @@ raise('API_LEVEL environment variable must be set') unless ENV['API_LEVEL']
 target_api_level = ENV['API_LEVEL']
 
 # Check if the appropriate AVD exists based on given API level
+puts `echo $PATH`
 puts `which avdmanager`
 avd_exists = `avdmanager list avd -c | grep test-sdk-#{ENV['API_LEVEL']}`.strip
 

--- a/scripts/run-connected-checks.rb
+++ b/scripts/run-connected-checks.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+require 'pty'
+require 'open3'
+
+# Ensure API_LEVEL is set
+raise('API_LEVEL environment variable must be set') unless ENV['API_LEVEL']
+target_api_level = ENV['API_LEVEL']
+
+# Check if the appropriate AVD exists based on given API level
+avd_exists = `avdmanager list avd -c | grep test-sdk-#{ENV['API_LEVEL']}`.strip
+
+if avd_exists.empty?
+  puts "AVD test-sdk-#{target_api_level} does not exist, creating it now"
+  # Determine if we're running on x86 or ARM
+  sys_arch = `uname -m`.strip
+
+  # Check to see if the appropriate SDK is installed
+  sdk_installed = `sdkmanager --list_installed | grep "system-images;android-#{target_api_level};google_apis;#{sys_arch}"`.strip
+
+  if sdk_installed.empty?
+    # If not, install it
+    puts "The system image for API level #{target_api_level} is not installed, installing it now"
+    `sdkmanager "system-images;android-#{target_api_level};google_apis;#{sys_arch}"`
+  end
+  # Create the AVD
+  `avdmanager -s create avd -n test-sdk-#{target_api_level} -k "system-images;android-#{target_api_level};google_apis;#{sys_arch}"`
+else
+  puts "AVD test-sdk-#{target_api_level} already exists, skipping creation"
+end
+
+begin
+  emulator_pid = nil
+  emulator_lines = []
+  emulator_thread = Thread.new do
+    PTY.spawn('emulator', '-avd', "test-sdk-#{target_api_level}", '-no-window', '-gpu', 'swiftshader_indirect', '-noaudio', '-no-boot-anim', '-camera-back', 'none', '-no-snapshot-load') do |stdout, _stdin, pid|
+      emulator_pid = pid
+      stdout.each do |line|
+        emulator_lines << line
+        puts line
+      end
+    end
+  end
+
+  # Wait for the emulator to boot
+  start_time = Time.now
+  until emulator_lines.any? { |line| line.include?('Boot completed') }
+    if Time.now - start_time > 60
+      raise 'Emulator did not boot in 60 seconds'
+    end
+  end
+
+  puts 'Emulator booted successfully'
+
+  # Run the connectedCheck tests
+  exit_status = nil
+  Open3.popen2e('./gradlew connectedCheck -x :bugsnag-benchmarks:connectedCheck') do |_stdin, stdout_stderr, wait_thr|
+    stdout_stderr.each { |line| puts line }
+    exit_status = wait_thr.value
+  end
+ensure
+  # Stop the emulator
+  puts 'Stopping emulator process'
+  Process.kill('INT', emulator_pid) if emulator_pid
+  emulator_thread.join
+end
+
+unless exit_status.success?
+  exit(exit_status.exitstatus)
+end

--- a/scripts/run-connected-checks.rb
+++ b/scripts/run-connected-checks.rb
@@ -7,6 +7,7 @@ raise('API_LEVEL environment variable must be set') unless ENV['API_LEVEL']
 target_api_level = ENV['API_LEVEL']
 
 # Check if the appropriate AVD exists based on given API level
+puts `which avdmanager`
 avd_exists = `avdmanager list avd -c | grep test-sdk-#{ENV['API_LEVEL']}`.strip
 
 if avd_exists.empty?
@@ -15,6 +16,7 @@ if avd_exists.empty?
   sys_arch = `uname -m`.strip
 
   # Check to see if the appropriate SDK is installed
+  puts `which sdkmanager`
   sdk_installed = `sdkmanager --list_installed | grep "system-images;android-#{target_api_level};google_apis;#{sys_arch}"`.strip
 
   if sdk_installed.empty?


### PR DESCRIPTION
## Goal

We've had to remove our instrumentation tests from github actions for a variety of reasons.  This change adds a script which should add Android Virtual Devices and SDKs to our MacOS test boxes as required, using them to run the instrumentation tests.  The version of android we're testing against is determined by the API_LEVEL environment variable, which should allow us to run against several different API levels if we see the need to.

## Testing

It's successfully completed several test runs, and a [negative test run](https://buildkite.com/bugsnag/bugsnag-android/builds/11382#018faa41-5ed4-4b38-83d7-7f79fafa9f8b/62-1093) to ensure the script failed successfully.