### PR TITLE
fix UnhandledJavaLoadedConfigScenario

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJavaLoadedConfigScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJavaLoadedConfigScenario.java
@@ -27,7 +27,8 @@ public class UnhandledJavaLoadedConfigScenario extends Scenario {
         testConfig.setContext("FooContext");
         Bugsnag.start(this.getContext(), testConfig);
         Bugsnag.addMetadata("TestData", "password", "NotTellingYou");
-        throw new RuntimeException("UnhandledJavaLoadedConfigScenario");
-    }
 
+        throw new RuntimeException("UnhandledJavaLoadedConfigScenario");
+
+    }
 }


### PR DESCRIPTION
## Goal

Fix UnhandledJavaLoadedConfigScenario that causing flaky end to end test

## Changeset

Moving unhandled error to a background thread so the crash handler would not causing ANR in the end to end test for unhandled java exception with loaded configuration

## Testing
Existing tests