### PR TITLE
Only set ANR unwind function if the bugsnag-plugin-android-anr.so was loaded successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Corrected the behavior when `Bugsnag.startSession` is called when `config.autoTrackSessions=true`, the first automatic session will now be correctly discarded
   [#2033](https://github.com/bugsnag/bugsnag-android/pull/2033)
+* Avoid a possible crash in the ANR plugin when the native ANR library failed to load.
+  [#2039](https://github.com/bugsnag/bugsnag-android/pull/2039)
 
 ## 6.5.0 (2024-05-15)
 

--- a/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
+++ b/bugsnag-plugin-android-anr/src/main/java/com/bugsnag/android/AnrPlugin.kt
@@ -67,22 +67,25 @@ internal class AnrPlugin : Plugin {
     }
 
     private fun performOneTimeSetup(client: Client) {
-        libraryLoader.loadLibrary("bugsnag-plugin-android-anr", client) {
+        val isLoaded = libraryLoader.loadLibrary("bugsnag-plugin-android-anr", client) {
             val error = it.errors[0]
             error.errorClass = "AnrLinkError"
             error.errorMessage = LOAD_ERR_MSG
             true
         }
-        @Suppress("UNCHECKED_CAST")
-        val clz = loadClass("com.bugsnag.android.NdkPlugin") as Class<Plugin>?
-        if (clz != null) {
-            val ndkPlugin = client.getPlugin(clz)
-            if (ndkPlugin != null) {
-                val method = ndkPlugin.javaClass.getMethod("getSignalUnwindStackFunction")
 
-                @Suppress("UNCHECKED_CAST")
-                val function = method.invoke(ndkPlugin) as Long
-                setUnwindFunction(function)
+        if (isLoaded) {
+            @Suppress("UNCHECKED_CAST")
+            val clz = loadClass("com.bugsnag.android.NdkPlugin") as Class<Plugin>?
+            if (clz != null) {
+                val ndkPlugin = client.getPlugin(clz)
+                if (ndkPlugin != null) {
+                    val method = ndkPlugin.javaClass.getMethod("getSignalUnwindStackFunction")
+
+                    @Suppress("UNCHECKED_CAST")
+                    val function = method.invoke(ndkPlugin) as Long
+                    setUnwindFunction(function)
+                }
             }
         }
     }


### PR DESCRIPTION
## Goal
Avoid a crash if the `bugsnag-plugin-android-anr.so` library failed to load, when attempting to set the stack unwinder function.

## Testing
Manually tested by removing the bugsnag-plugin-android-anr.so from a build