### PR TITLE
Disable anr in flaky scenario

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OomScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OomScenario.kt
@@ -12,8 +12,11 @@ internal class OomScenario(
     context: Context,
     eventMetadata: String
 ) : Scenario(config, context, eventMetadata) {
-
     private val queue = LinkedList<Array<String>>()
+
+    init {
+        config.enabledErrorTypes.anrs = false
+    }
 
     override fun startScenario() {
         super.startScenario()

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJavaLoadedConfigScenario.java
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/UnhandledJavaLoadedConfigScenario.java
@@ -17,6 +17,7 @@ public class UnhandledJavaLoadedConfigScenario extends Scenario {
                                              @NonNull Context context,
                                              @Nullable String eventMetadata) {
         super(config, context, eventMetadata);
+        config.getEnabledErrorTypes().setAnrs(false);
     }
 
     @Override


### PR DESCRIPTION
## Goal

Fixed flaky end to end scenario

## Changeset

Set the `enabledErrorTypes.anr` false in configuration

## Testing

Existing tests