### PR TITLE
Proguard rules for ErrorType & Telemetry.values()

### DIFF
--- a/bugsnag-android-core/proguard-rules.pro
+++ b/bugsnag-android-core/proguard-rules.pro
@@ -5,3 +5,9 @@
 -keep class com.bugsnag.android.BreadcrumbState { *; }
 -keep class com.bugsnag.android.BreadcrumbType { *; }
 -keep class com.bugsnag.android.Severity { *; }
+-keepclassmembers enum com.bugsnag.android.Telemetry {
+    public static com.bugsnag.android.Telemetry[] values();
+ }
+-keepclassmembers enum com.bugsnag.android.ErrorType {
+    public static com.bugsnag.android.Telemetry[] values();
+ }


### PR DESCRIPTION
## Goal
Don't crash apps on startup where the `enum.values()` functions are not included in the `keep` list by default. Fixes #2048 

## Design
Included specific Proguard consumer rules for `Telemetry.values()` and `ErrorType.values()`, ensuring that these members are not removed or obfuscated.

## Testing
Manually tested with app using fully customized Proguard rules.