### PR TITLE
Add support for the `correlation` field for ReactNative

### DIFF
--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/EventDeserializerTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 import java.util.Date
+import java.util.UUID
 
 @RunWith(MockitoJUnitRunner::class)
 class EventDeserializerTest {
@@ -39,6 +40,10 @@ class EventDeserializerTest {
         map["app"] = mapOf(Pair("id", "app-id"))
         map["device"] =
             mapOf(Pair("id", "device-id"), Pair("runtimeVersions", mutableMapOf<String, Any>()))
+        map["correlation"] = mapOf(
+            "traceId" to "b39e53513eec3c68b5e5c34dc43611e0",
+            "spanId" to "51d886b3a693a406"
+        )
 
         `when`(client.config).thenReturn(TestData.generateConfig())
         `when`(client.getLogger()).thenReturn(object : Logger {})
@@ -91,6 +96,13 @@ class EventDeserializerTest {
         assertEquals("device-id", event.device.id)
         assertEquals("123", event.getMetadata("custom", "id"))
         assertEquals(TestData.generateConfig().apiKey, event.apiKey)
+
+        assertEquals(
+            UUID(-5503870086187041688L, -5339647044406079008L),
+            TestHooks.getCorrelatedTraceId(event)
+        )
+
+        assertEquals(5897611818193626118L, TestHooks.getCorrelatedSpanId(event))
     }
 
     @Test

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestHooks.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/TestHooks.java
@@ -1,8 +1,24 @@
 package com.bugsnag.android;
 
+import androidx.annotation.Nullable;
+
+import java.util.UUID;
+
 class TestHooks {
     static boolean getUnhandledOverridden(Event event) {
         return event.getImpl().getUnhandledOverridden();
+    }
+
+    @Nullable
+    static UUID getCorrelatedTraceId(Event event) {
+        TraceCorrelation traceCorrelation = event.getImpl().getTraceCorrelation();
+        return traceCorrelation != null ? traceCorrelation.getTraceId() : null;
+    }
+
+    @Nullable
+    static Long getCorrelatedSpanId(Event event) {
+        TraceCorrelation traceCorrelation = event.getImpl().getTraceCorrelation();
+        return traceCorrelation != null ? traceCorrelation.getSpanId() : null;
     }
 
     static MetadataState generateMetadataState() {


### PR DESCRIPTION
## Goal
Allow ReactNative apps to add correlation metadata to `Event`s

## Changeset
Attempt to decode and set the `traceId` & `correlationId` when they are both available and valid.

## Testing
Added new fields to the existing unit tests