### PR TITLE
Correctly copy `build.gradle.kts` instead of the old `build.gradle` during publishing

### DIFF
--- a/dockerfiles/Dockerfile.android-publisher
+++ b/dockerfiles/Dockerfile.android-publisher
@@ -5,7 +5,7 @@ WORKDIR /app
 # Copy gradle files
 COPY gradlew gradle.properties /app/
 COPY gradle/ /app/gradle/
-COPY build.gradle settings.gradle.kts /app/
+COPY build.gradle.kts settings.gradle.kts /app/
 COPY buildSrc/ buildSrc/
 
 # Copy sdk source files


### PR DESCRIPTION
## Goal
Correct the publishing step by copying the correct `build.gradle.kts` file.
