### PR TITLE
Add other downstream repos for automatic updates

### DIFF
--- a/.github/workflows/downstream_updates.yml
+++ b/.github/workflows/downstream_updates.yml
@@ -17,7 +17,7 @@ jobs:
       RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.target_version || github.event.release.tag_name }}
     strategy:
       matrix:
-        downstream_repo: ['bugsnag/bugsnag-unity']
+        downstream_repo: ['bugsnag/bugsnag-unity', 'bugsnag/bugsnag-js', 'bugsnag/bugsnag-flutter', 'bugsnag/bugsnag-unreal']
     steps:
       - name: Install libcurl4-openssl-dev and net-tools
         run: |


### PR DESCRIPTION
## Goal

Adds bugsnags flutter, JS (RN), and unreal repos to the bumpsnag workflow, to update them when a new version of the notifier is released.