### PR TITLE
Include useful Activity.intent info in onCreate breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Include additional Intent information for Activity.onCreate breadcrumbs (action, categories, type, flags, id, extra keys)
+  [#2057](https://github.com/bugsnag/bugsnag-android/pull/2057)
+
 ## 6.6.1 (2024-07-03)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ActivityBreadcrumbCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ActivityBreadcrumbCollector.kt
@@ -2,6 +2,8 @@ package com.bugsnag.android
 
 import android.app.Activity
 import android.app.Application
+import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import java.util.WeakHashMap
 
@@ -11,8 +13,16 @@ internal class ActivityBreadcrumbCollector(
 
     private val prevState = WeakHashMap<Activity, String>()
 
-    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) =
-        leaveBreadcrumb(activity, "onCreate()", savedInstanceState != null)
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        leaveBreadcrumb(
+            activity,
+            "onCreate()",
+            mutableMapOf<String, Any>().apply {
+                set("hasBundle", savedInstanceState != null)
+                setActivityIntentMetadata(activity.intent)
+            }
+        )
+    }
 
     override fun onActivityStarted(activity: Activity) =
         leaveBreadcrumb(activity, "onStart()")
@@ -39,12 +49,8 @@ internal class ActivityBreadcrumbCollector(
     private fun leaveBreadcrumb(
         activity: Activity,
         lifecycleCallback: String,
-        hasBundle: Boolean? = null
+        metadata: MutableMap<String, Any> = mutableMapOf()
     ) {
-        val metadata = mutableMapOf<String, Any>()
-        if (hasBundle != null) {
-            metadata["hasBundle"] = hasBundle
-        }
         val previousVal = prevState[activity]
 
         if (previousVal != null) {
@@ -54,5 +60,25 @@ internal class ActivityBreadcrumbCollector(
         val activityName = getActivityName(activity)
         cb("$activityName#$lifecycleCallback", metadata)
         prevState[activity] = lifecycleCallback
+    }
+
+    private fun MutableMap<String, Any>.setActivityIntentMetadata(intent: Intent?) {
+        if (intent == null) return
+
+        intent.action?.let { set("action", it) }
+        intent.categories?.let { set("categories", it.joinToString(", ")) }
+        intent.type?.let { set("type", it) }
+
+        if (intent.flags != 0) {
+            @Suppress("MagicNumber") // hex radix
+            set("flags", "0x${intent.flags.toString(16)}")
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            intent.identifier?.let { set("id", it) }
+        }
+
+        set("hasData", intent.data != null)
+        set("hasExtras", intent.extras?.keySet()?.joinToString(", ") ?: false)
     }
 }

--- a/features/smoke_tests/03_sessions.feature
+++ b/features/smoke_tests/03_sessions.feature
@@ -57,6 +57,11 @@ Feature: Session functionality smoke tests
     And the event "session.events.unhandled" equals 0
     And the event "severityReason.unhandledOverridden" is false
 
+    And the event has a "state" breadcrumb named "SecondActivity#onCreate()"
+    And the breadcrumb named "SecondActivity#onCreate()" has "metaData.action" equal to "com.bugsnag.android.mazerunner.UPDATE_CONTEXT"
+    And the breadcrumb named "SecondActivity#onCreate()" has "metaData.hasBundle" is false
+    And the breadcrumb named "SecondActivity#onCreate()" has "metaData.hasExtras" is false
+
   @debug-safe
   Scenario: Manual session control works
     When I run "ManualSessionSmokeScenario" and relaunch the crashed app


### PR DESCRIPTION
## Goal
Include some more `Intent` metadata in `Activity.onCreate` breadcrumbs to help debugging.

## Design
When logging `onCreate` breadcrumbs we now selectively add the following to the breadcrumb metadata:

- [Intent.action](https://developer.android.com/reference/android/content/Intent#getAction())
- [Intent.categories](https://developer.android.com/reference/android/content/Intent#getCategories())
- [Intent.type](https://developer.android.com/reference/android/content/Intent#getType())
- [Intent.flags](https://developer.android.com/reference/android/content/Intent#getFlags())
- [Intent.identifier](https://developer.android.com/reference/android/content/Intent#getIdentifier())
- The keys of extras (no values are included)

We don't log the `Intent.data` as it would be too easy to leak sensitive data.

## Testing
Manual testing