### PR TITLE
More open Event model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Include additional Intent information for Activity.onCreate breadcrumbs (action, categories, type, flags, id, extra keys)
   [#2057](https://github.com/bugsnag/bugsnag-android/pull/2057)
-* New APIs allowing new `Error`s, `Thread`s, and `Stackframe`s to be added to error reports (`Event`s)
+* New APIs allowing new `Error`s, `Thread`s, and `Stackframe`s to be added to `Event`s
   [#2060](https://github.com/bugsnag/bugsnag-android/pull/2060)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Include additional Intent information for Activity.onCreate breadcrumbs (action, categories, type, flags, id, extra keys)
   [#2057](https://github.com/bugsnag/bugsnag-android/pull/2057)
+* New APIs allowing new `Error`s, `Thread`s, and `Stackframe`s to be added to error reports (`Event`s)
+  [#2060](https://github.com/bugsnag/bugsnag-android/pull/2060)
 
 ### Bug fixes
 

--- a/bugsnag-android-core/api/bugsnag-android-core.api
+++ b/bugsnag-android-core/api/bugsnag-android-core.api
@@ -312,8 +312,7 @@ public final class com/bugsnag/android/EndpointConfiguration {
 }
 
 public class com/bugsnag/android/Error : com/bugsnag/android/JsonStream$Streamable {
-	public fun addStackframe (Ljava/lang/StackTraceElement;Ljava/util/Collection;)Lcom/bugsnag/android/Stackframe;
-	public fun addStackframe (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;)Lcom/bugsnag/android/Stackframe;
+	public fun addStackframe (Ljava/lang/String;Ljava/lang/String;J)Lcom/bugsnag/android/Stackframe;
 	public fun getErrorClass ()Ljava/lang/String;
 	public fun getErrorMessage ()Ljava/lang/String;
 	public fun getStacktrace ()Ljava/util/List;
@@ -360,6 +359,7 @@ public class com/bugsnag/android/Event : com/bugsnag/android/FeatureFlagAware, c
 	public fun addFeatureFlags (Ljava/lang/Iterable;)V
 	public fun addMetadata (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
 	public fun addMetadata (Ljava/lang/String;Ljava/util/Map;)V
+	public fun addThread (JLjava/lang/String;)Lcom/bugsnag/android/Thread;
 	public fun addThread (Ljava/lang/String;Ljava/lang/String;)Lcom/bugsnag/android/Thread;
 	public fun clearFeatureFlag (Ljava/lang/String;)V
 	public fun clearFeatureFlags ()V
@@ -770,6 +770,7 @@ public final class com/bugsnag/android/Telemetry : java/lang/Enum {
 }
 
 public class com/bugsnag/android/Thread : com/bugsnag/android/JsonStream$Streamable {
+	public fun addStackframe (Ljava/lang/String;Ljava/lang/String;J)Lcom/bugsnag/android/Stackframe;
 	public fun getErrorReportingThread ()Z
 	public fun getId ()Ljava/lang/String;
 	public fun getName ()Ljava/lang/String;
@@ -800,6 +801,7 @@ public final class com/bugsnag/android/Thread$State : java/lang/Enum {
 }
 
 public final class com/bugsnag/android/ThreadInternal : com/bugsnag/android/JsonStream$Streamable {
+	public final fun addStackframe (Ljava/lang/String;Ljava/lang/String;J)Lcom/bugsnag/android/Stackframe;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getStacktrace ()Ljava/util/List;

--- a/bugsnag-android-core/api/bugsnag-android-core.api
+++ b/bugsnag-android-core/api/bugsnag-android-core.api
@@ -312,6 +312,8 @@ public final class com/bugsnag/android/EndpointConfiguration {
 }
 
 public class com/bugsnag/android/Error : com/bugsnag/android/JsonStream$Streamable {
+	public fun addStackframe (Ljava/lang/StackTraceElement;Ljava/util/Collection;)Lcom/bugsnag/android/Stackframe;
+	public fun addStackframe (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;)Lcom/bugsnag/android/Stackframe;
 	public fun getErrorClass ()Ljava/lang/String;
 	public fun getErrorMessage ()Ljava/lang/String;
 	public fun getStacktrace ()Ljava/util/List;
@@ -350,11 +352,15 @@ public final class com/bugsnag/android/ErrorTypes {
 }
 
 public class com/bugsnag/android/Event : com/bugsnag/android/FeatureFlagAware, com/bugsnag/android/JsonStream$Streamable, com/bugsnag/android/MetadataAware, com/bugsnag/android/UserAware {
+	public fun addError (Ljava/lang/String;Ljava/lang/String;)Lcom/bugsnag/android/Error;
+	public fun addError (Ljava/lang/String;Ljava/lang/String;Lcom/bugsnag/android/ErrorType;)Lcom/bugsnag/android/Error;
+	public fun addError (Ljava/lang/Throwable;)Lcom/bugsnag/android/Error;
 	public fun addFeatureFlag (Ljava/lang/String;)V
 	public fun addFeatureFlag (Ljava/lang/String;Ljava/lang/String;)V
 	public fun addFeatureFlags (Ljava/lang/Iterable;)V
 	public fun addMetadata (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)V
 	public fun addMetadata (Ljava/lang/String;Ljava/util/Map;)V
+	public fun addThread (Ljava/lang/String;Ljava/lang/String;)Lcom/bugsnag/android/Thread;
 	public fun clearFeatureFlag (Ljava/lang/String;)V
 	public fun clearFeatureFlags ()V
 	public fun clearMetadata (Ljava/lang/String;)V
@@ -374,6 +380,8 @@ public class com/bugsnag/android/Event : com/bugsnag/android/FeatureFlagAware, c
 	public fun getThreads ()Ljava/util/List;
 	public fun getUser ()Lcom/bugsnag/android/User;
 	public fun isUnhandled ()Z
+	public fun leaveBreadcrumb (Ljava/lang/String;)Lcom/bugsnag/android/Breadcrumb;
+	public fun leaveBreadcrumb (Ljava/lang/String;Lcom/bugsnag/android/BreadcrumbType;Ljava/util/Map;)Lcom/bugsnag/android/Breadcrumb;
 	public fun setApiKey (Ljava/lang/String;)V
 	public fun setContext (Ljava/lang/String;)V
 	public fun setGroupingHash (Ljava/lang/String;)V

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BugsnagEventMapper.kt
@@ -197,12 +197,12 @@ internal class BugsnagEventMapper(
             thread["errorReportingThread"] == true,
             thread["state"] as? String ?: "",
             (thread["stacktrace"] as? List<Map<String, Any?>>)?.let { convertStacktrace(it) }
-                ?: Stacktrace(emptyList())
+                ?: Stacktrace(mutableListOf())
         )
     }
 
     internal fun convertStacktrace(trace: List<Map<String, Any?>>): Stacktrace {
-        return Stacktrace(trace.map { Stackframe(it) })
+        return Stacktrace(trace.mapTo(ArrayList(trace.size)) { Stackframe(it) })
     }
 
     internal fun deserializeSeverityReason(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
@@ -88,6 +88,16 @@ public class Error implements JsonStream.Streamable {
         return impl.getStacktrace();
     }
 
+    /**
+     * Add a new stackframe to the end of this Error returning the new Stackframe data object.
+     */
+    @NonNull
+    public Stackframe addStackframe(@Nullable String method,
+                                    @Nullable String file,
+                                    long lineNumber) {
+        return impl.addStackframe(method, file, lineNumber);
+    }
+
     @Override
     public void toStream(@NonNull JsonStream stream) throws IOException {
         impl.toStream(stream);
@@ -97,27 +107,5 @@ public class Error implements JsonStream.Streamable {
                                    @NonNull Collection<String> projectPackages,
                                    @NonNull Logger logger) {
         return ErrorInternal.Companion.createError(exc, projectPackages, logger);
-    }
-
-    /**
-     * A stackframe can be added to an error in an event
-     */
-
-    @Nullable
-    public Stackframe addStackframe(@Nullable StackTraceElement element,
-                                    @NonNull Collection<String> projectPackages) {
-        if (element != null) {
-            return impl.addStackframe(element, projectPackages, logger);
-        } else {
-            logNull("stackframe");
-        }
-        return null;
-    }
-
-    @NonNull
-    public Stackframe addStackframe(@Nullable String method,
-                                    @Nullable String file,
-                                    @Nullable Number lineNumber) {
-        return impl.addStackframe(method, file, lineNumber);
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
@@ -98,4 +98,9 @@ public class Error implements JsonStream.Streamable {
                                    @NonNull Logger logger) {
         return ErrorInternal.Companion.createError(exc, projectPackages, logger);
     }
+
+
+    public void addStackframe(@NonNull List<StackTraceElement> element) {
+        impl.addStackTrace(element);
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Error.java
@@ -99,8 +99,25 @@ public class Error implements JsonStream.Streamable {
         return ErrorInternal.Companion.createError(exc, projectPackages, logger);
     }
 
+    /**
+     * A stackframe can be added to an error in an event
+     */
 
-    public void addStackframe(@NonNull List<StackTraceElement> element) {
-        impl.addStackTrace(element);
+    @Nullable
+    public Stackframe addStackframe(@Nullable StackTraceElement element,
+                                    @NonNull Collection<String> projectPackages) {
+        if (element != null) {
+            return impl.addStackframe(element, projectPackages, logger);
+        } else {
+            logNull("stackframe");
+        }
+        return null;
+    }
+
+    @NonNull
+    public Stackframe addStackframe(@Nullable String method,
+                                    @Nullable String file,
+                                    @Nullable Number lineNumber) {
+        return impl.addStackframe(method, file, lineNumber);
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
@@ -7,7 +7,7 @@ internal class ErrorInternal @JvmOverloads internal constructor(
     var type: ErrorType = ErrorType.ANDROID
 ) : JsonStream.Streamable {
 
-    val stacktrace: List<Stackframe> = stacktrace.trace
+    val stacktrace: MutableList<Stackframe> = stacktrace.trace
 
     internal companion object {
         fun createError(
@@ -37,10 +37,19 @@ internal class ErrorInternal @JvmOverloads internal constructor(
         writer.endObject()
     }
 
-    fun addStackTrace(element: List<StackTraceElement>) {
-        val stackFrame = element.flatMap {
-            listOf(Stackframe(it.methodName, it.fileName, it.lineNumber, null))
-        }
-        stacktrace.toMutableList().addAll(stackFrame)
+    fun addStackframe(
+        element: StackTraceElement,
+        projectPackages: Collection<String>,
+        logger: Logger
+    ): Stackframe? {
+        val frame = Stacktrace.serializeStackframe(element, projectPackages, logger)
+        frame?.let { stacktrace.add(it) }
+        return frame
+    }
+
+    fun addStackframe(method: String?, file: String?, lineNumber: Number?): Stackframe {
+        val frame = Stackframe(method, file, lineNumber, null)
+        stacktrace.add(frame)
+        return frame
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
@@ -10,7 +10,11 @@ internal class ErrorInternal @JvmOverloads internal constructor(
     val stacktrace: List<Stackframe> = stacktrace.trace
 
     internal companion object {
-        fun createError(exc: Throwable, projectPackages: Collection<String>, logger: Logger): MutableList<Error> {
+        fun createError(
+            exc: Throwable,
+            projectPackages: Collection<String>,
+            logger: Logger
+        ): MutableList<Error> {
             return exc.safeUnrollCauses()
                 .mapTo(mutableListOf()) { currentEx ->
                     // Somehow it's possible for stackTrace to be null in rare cases
@@ -31,5 +35,12 @@ internal class ErrorInternal @JvmOverloads internal constructor(
         writer.name("type").value(type.desc)
         writer.name("stacktrace").value(stacktrace)
         writer.endObject()
+    }
+
+    fun addStackTrace(element: List<StackTraceElement>) {
+        val stackFrame = element.flatMap {
+            listOf(Stackframe(it.methodName, it.fileName, it.lineNumber, null))
+        }
+        stacktrace.toMutableList().addAll(stackFrame)
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorInternal.kt
@@ -9,6 +9,12 @@ internal class ErrorInternal @JvmOverloads internal constructor(
 
     val stacktrace: MutableList<Stackframe> = stacktrace.trace
 
+    fun addStackframe(method: String?, file: String?, lineNumber: Long): Stackframe {
+        val frame = Stackframe(method, file, lineNumber, null)
+        stacktrace.add(frame)
+        return frame
+    }
+
     internal companion object {
         fun createError(
             exc: Throwable,
@@ -20,8 +26,11 @@ internal class ErrorInternal @JvmOverloads internal constructor(
                     // Somehow it's possible for stackTrace to be null in rare cases
                     val stacktrace = currentEx.stackTrace ?: arrayOf<StackTraceElement>()
                     val trace = Stacktrace(stacktrace, projectPackages, logger)
-                    val errorInternal =
-                        ErrorInternal(currentEx.javaClass.name, currentEx.localizedMessage, trace)
+                    val errorInternal = ErrorInternal(
+                        currentEx.javaClass.name,
+                        currentEx.localizedMessage,
+                        trace
+                    )
 
                     return@mapTo Error(errorInternal, logger)
                 }
@@ -35,21 +44,5 @@ internal class ErrorInternal @JvmOverloads internal constructor(
         writer.name("type").value(type.desc)
         writer.name("stacktrace").value(stacktrace)
         writer.endObject()
-    }
-
-    fun addStackframe(
-        element: StackTraceElement,
-        projectPackages: Collection<String>,
-        logger: Logger
-    ): Stackframe? {
-        val frame = Stacktrace.serializeStackframe(element, projectPackages, logger)
-        frame?.let { stacktrace.add(it) }
-        return frame
-    }
-
-    fun addStackframe(method: String?, file: String?, lineNumber: Number?): Stackframe {
-        val frame = Stackframe(method, file, lineNumber, null)
-        stacktrace.add(frame)
-        return frame
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -66,7 +67,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      * Information extracted from the {@link Throwable} that caused the event can be found in this
      * field. The list contains at least one {@link Error} that represents the thrown object
      * with subsequent elements in the list populated from {@link Throwable#getCause()}.
-     * <p>
+     *
      * A reference to the actual {@link Throwable} object that caused the event is available
      * through {@link Event#getOriginalError()} ()}.
      */
@@ -167,7 +168,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      * All events with the same grouping hash will be grouped together into one error. This is an
      * advanced usage of the library and mis-using it will cause your events not to group properly
      * in your dashboard.
-     * <p>
+     *
      * As the name implies, this option accepts a hash of sorts.
      */
     public void setGroupingHash(@Nullable String groupingHash) {
@@ -179,7 +180,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      * All events with the same grouping hash will be grouped together into one error. This is an
      * advanced usage of the library and mis-using it will cause your events not to group properly
      * in your dashboard.
-     * <p>
+     *
      * As the name implies, this option accepts a hash of sorts.
      */
     @Nullable
@@ -362,7 +363,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     /**
      * Whether the event was a crash (i.e. unhandled) or handled error in which the system
      * continued running.
-     * <p>
+     *
      * Unhandled errors count towards your stability score. If you don't want certain errors
      * to count towards your stability score, you can alter this property through an
      * {@link OnErrorCallback}.
@@ -374,7 +375,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     /**
      * Whether the event was a crash (i.e. unhandled) or handled error in which the system
      * continued running.
-     * <p>
+     *
      * Unhandled errors count towards your stability score. If you don't want certain errors
      * to count towards your stability score, you can alter this property through an
      * {@link OnErrorCallback}.
@@ -443,25 +444,46 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
         impl.setInternalMetrics(metrics);
     }
 
-    public Error addError(Throwable error) {
+    /**
+     * Open API for adding errors, threads and breadcrumbs to the event.
+     */
+
+    @Nullable
+    public Error addError(@NonNull Throwable error) {
         if (error == null) {
             return null;
         }
         return impl.addError(error);
     }
 
-    public Error addError(String errorClass, String errorMessage) {
+    @Nullable
+    public Error addError(@NonNull String errorClass, @NonNull String errorMessage) {
         return impl.addError(errorClass, errorMessage, ErrorType.ANDROID);
     }
 
-
-    public Error addError(String errorClass, String errorMessage, ErrorType errorType) {
+    @Nullable
+    public Error addError(@NonNull String errorClass,
+                          @NonNull String errorMessage,
+                          @NonNull ErrorType errorType) {
         return impl.addError(errorClass, errorMessage, errorType);
     }
 
-    public Thread addThread(Thread thread) {
-        return impl.addThread(thread);
+    @Nullable
+    public Thread addThread(@NonNull String id,
+                            @NonNull String name) {
+        return impl.addThread(id, name, ErrorType.ANDROID, false,
+                Thread.State.RUNNABLE.getDescriptor());
     }
 
+    @NonNull
+    public Breadcrumb leaveBreadcrumb(@NonNull String message,
+                                      @NonNull BreadcrumbType type,
+                                      @Nullable Map<String, Object> metadata) {
+        return impl.leaveBreadcrumb(message, type, metadata, new Date());
+    }
 
+    @NonNull
+    public Breadcrumb leaveBreadcrumb(@NonNull String message) {
+        return impl.leaveBreadcrumb(message);
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -81,7 +81,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      */
     @NonNull
     public Error addError(@NonNull Throwable error) {
-        return impl.addError(error != null ? error : new Throwable());
+        return impl.addError(error);
     }
 
     /**
@@ -89,7 +89,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      * at the end of the {@link #getErrors() errors list}.
      */
     @NonNull
-    public Error addError(@NonNull String errorClass, @NonNull String errorMessage) {
+    public Error addError(@NonNull String errorClass, @Nullable String errorMessage) {
         return impl.addError(errorClass, errorMessage, ErrorType.ANDROID);
     }
 
@@ -99,7 +99,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      */
     @NonNull
     public Error addError(@NonNull String errorClass,
-                          @NonNull String errorMessage,
+                          @Nullable String errorMessage,
                           @NonNull ErrorType errorType) {
         return impl.addError(errorClass, errorMessage, errorType);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -76,7 +76,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     }
 
     /**
-     * Add a new error to this report and return its Error data. The new Error will appear at the
+     * Add a new error to this event and return its Error data. The new Error will appear at the
      * end of the {@link #getErrors() errors list}.
      */
     @NonNull
@@ -85,7 +85,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     }
 
     /**
-     * Add a new empty {@link ErrorType#ANDROID android} error to this report and return its Error
+     * Add a new empty {@link ErrorType#ANDROID android} error to this event and return its Error
      * data. The new Error will appear at the end of the {@link #getErrors() errors list}.
      */
     @NonNull
@@ -94,7 +94,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     }
 
     /**
-     * Add a new empty error to this report and return its Error data. The new Error will appear
+     * Add a new empty error to this event and return its Error data. The new Error will appear
      * at the end of the {@link #getErrors() errors list}.
      */
     @NonNull
@@ -115,8 +115,8 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
 
     /**
      * Create, add and return a new empty {@link Thread} object to this event with a given id
-     * and name. This can be used to augment the report with thread data that would not be picked
-     * up as part of a normal report being generated (for example: native threads managed
+     * and name. This can be used to augment the event with thread data that would not be picked
+     * up as part of a normal event being generated (for example: native threads managed
      * by cross-platform toolkits).
      *
      * @return a new Thread object of type {@link ErrorType#ANDROID} with no stacktrace
@@ -135,8 +135,8 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
 
     /**
      * Create, add and return a new empty {@link Thread} object to this event with a given id
-     * and name. This can be used to augment the report with thread data that would not be picked
-     * up as part of a normal report being generated (for example: native threads managed
+     * and name. This can be used to augment the event with thread data that would not be picked
+     * up as part of a normal event being generated (for example: native threads managed
      * by cross-platform toolkits).
      *
      * @return a new Thread object of type {@link ErrorType#ANDROID} with no stacktrace

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -52,7 +52,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
 
     /**
      * The Throwable object that caused the event in your application.
-     *
+     * <p>
      * Manipulating this field does not affect the error information reported to the
      * Bugsnag dashboard. Use {@link Event#getErrors()} to access and amend the representation of
      * the error that will be sent.
@@ -66,7 +66,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      * Information extracted from the {@link Throwable} that caused the event can be found in this
      * field. The list contains at least one {@link Error} that represents the thrown object
      * with subsequent elements in the list populated from {@link Throwable#getCause()}.
-     *
+     * <p>
      * A reference to the actual {@link Throwable} object that caused the event is available
      * through {@link Event#getOriginalError()} ()}.
      */
@@ -167,7 +167,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      * All events with the same grouping hash will be grouped together into one error. This is an
      * advanced usage of the library and mis-using it will cause your events not to group properly
      * in your dashboard.
-     *
+     * <p>
      * As the name implies, this option accepts a hash of sorts.
      */
     public void setGroupingHash(@Nullable String groupingHash) {
@@ -179,7 +179,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      * All events with the same grouping hash will be grouped together into one error. This is an
      * advanced usage of the library and mis-using it will cause your events not to group properly
      * in your dashboard.
-     *
+     * <p>
      * As the name implies, this option accepts a hash of sorts.
      */
     @Nullable
@@ -362,7 +362,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     /**
      * Whether the event was a crash (i.e. unhandled) or handled error in which the system
      * continued running.
-     *
+     * <p>
      * Unhandled errors count towards your stability score. If you don't want certain errors
      * to count towards your stability score, you can alter this property through an
      * {@link OnErrorCallback}.
@@ -374,7 +374,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     /**
      * Whether the event was a crash (i.e. unhandled) or handled error in which the system
      * continued running.
-     *
+     * <p>
      * Unhandled errors count towards your stability score. If you don't want certain errors
      * to count towards your stability score, you can alter this property through an
      * {@link OnErrorCallback}.
@@ -388,7 +388,7 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
      * using bugsnag-android-performance, but can also be set manually if required.
      *
      * @param traceId the ID of the trace the event occurred within
-     * @param spanId the ID of the span that the event occurred within
+     * @param spanId  the ID of the span that the event occurred within
      */
     public void setTraceCorrelation(@NonNull UUID traceId, long spanId) {
         if (traceId != null) {
@@ -442,4 +442,26 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     void setInternalMetrics(InternalMetrics metrics) {
         impl.setInternalMetrics(metrics);
     }
+
+    public Error addError(Throwable error) {
+        if (error == null) {
+            return null;
+        }
+        return impl.addError(error);
+    }
+
+    public Error addError(String errorClass, String errorMessage) {
+        return impl.addError(errorClass, errorMessage, ErrorType.ANDROID);
+    }
+
+
+    public Error addError(String errorClass, String errorMessage, ErrorType errorType) {
+        return impl.addError(errorClass, errorMessage, errorType);
+    }
+
+    public Thread addThread(Thread thread) {
+        return impl.addThread(thread);
+    }
+
+
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Event.java
@@ -85,8 +85,8 @@ public class Event implements JsonStream.Streamable, MetadataAware, UserAware, F
     }
 
     /**
-     * Add a new empty error to this report and return its Error data. The new Error will appear
-     * at the end of the {@link #getErrors() errors list}.
+     * Add a new empty {@link ErrorType#ANDROID android} error to this report and return its Error
+     * data. The new Error will appear at the end of the {@link #getErrors() errors list}.
      */
     @NonNull
     public Error addError(@NonNull String errorClass, @Nullable String errorMessage) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -347,7 +347,7 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
     }
 
     fun addThread(
-        id: String,
+        id: String?,
         name: String?,
         errorType: ErrorType,
         isErrorReportingThread: Boolean,
@@ -355,7 +355,7 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
     ): Thread {
         val thread = Thread(
             ThreadInternal(
-                id,
+                id.toString(),
                 name.toString(),
                 errorType,
                 isErrorReportingThread,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -329,12 +329,17 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
     fun addError(throwError: Throwable): Error? {
         val newErrors = Error.createError(throwError, projectPackages, logger)
         errors.addAll(newErrors)
-        return newErrors.firstOrNull()
+        return newErrors.first()
     }
 
-    fun addError(errorClass: String, errorMessage: String?, errorType: ErrorType): Error {
+    fun addError(errorClass: String?, errorMessage: String?, errorType: ErrorType?): Error {
         val error = Error(
-            ErrorInternal(errorClass, errorMessage, Stacktrace(ArrayList()), errorType),
+            ErrorInternal(
+                errorClass.toString(),
+                errorMessage,
+                Stacktrace(ArrayList()),
+                errorType ?: ErrorType.ANDROID
+            ),
             logger
         )
         errors.add(error)
@@ -343,7 +348,7 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
 
     fun addThread(
         id: String,
-        name: String,
+        name: String?,
         errorType: ErrorType,
         isErrorReportingThread: Boolean,
         state: String
@@ -351,7 +356,7 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
         val thread = Thread(
             ThreadInternal(
                 id,
-                name,
+                name.toString(),
                 errorType,
                 isErrorReportingThread,
                 state,
@@ -364,20 +369,18 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
     }
 
     fun leaveBreadcrumb(
-        message: String,
-        type: BreadcrumbType,
-        metadata: MutableMap<String, Any?>?,
-        timestamp: Date
+        message: String?,
+        type: BreadcrumbType?,
+        metadata: MutableMap<String, Any?>?
     ): Breadcrumb {
-        val breadcrumb = Breadcrumb(message, type, metadata, timestamp, logger)
-        breadcrumbs.add(breadcrumb)
-        return breadcrumb
-    }
+        val breadcrumb = Breadcrumb(
+            message.toString(),
+            type ?: BreadcrumbType.MANUAL,
+            metadata,
+            Date(),
+            logger
+        )
 
-    fun leaveBreadcrumb(
-        message: String
-    ): Breadcrumb {
-        val breadcrumb = Breadcrumb(message, logger)
         breadcrumbs.add(breadcrumb)
         return breadcrumb
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -324,4 +324,24 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
     override fun clearFeatureFlag(name: String) = featureFlags.clearFeatureFlag(name)
 
     override fun clearFeatureFlags() = featureFlags.clearFeatureFlags()
+
+    fun addError(throwError: Throwable): Error? {
+        val error = Error.createError(throwError, projectPackages, logger)
+        errors.addAll(error)
+        return error.firstOrNull()
+    }
+
+    fun addError(errorClass: String, errorMessage: String, errorType: ErrorType): Error {
+        val error = Error(
+            ErrorInternal(errorClass, errorMessage, Stacktrace(ArrayList()), errorType),
+            logger
+        )
+        errors.add(error)
+        return error
+    }
+
+    fun addThread(thread: Thread): Thread {
+        threads.add(thread)
+        return thread
+    }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventInternal.kt
@@ -326,10 +326,19 @@ internal class EventInternal : FeatureFlagAware, JsonStream.Streamable, Metadata
 
     override fun clearFeatureFlags() = featureFlags.clearFeatureFlags()
 
-    fun addError(throwError: Throwable): Error? {
-        val newErrors = Error.createError(throwError, projectPackages, logger)
-        errors.addAll(newErrors)
-        return newErrors.first()
+    fun addError(thrownError: Throwable?): Error {
+        if (thrownError == null) {
+            val newError = Error(
+                ErrorInternal("null", null, Stacktrace(ArrayList())),
+                logger
+            )
+            errors.add(newError)
+            return newError
+        } else {
+            val newErrors = Error.createError(thrownError, projectPackages, logger)
+            errors.addAll(newErrors)
+            return newErrors.first()
+        }
     }
 
     fun addError(errorClass: String?, errorMessage: String?, errorType: ErrorType?): Error {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Stacktrace.kt
@@ -26,7 +26,7 @@ internal class Stacktrace : JsonStream.Streamable {
             }
         }
 
-        public fun serializeStackframe(
+        fun serializeStackframe(
             el: StackTraceElement,
             projectPackages: Collection<String>,
             logger: Logger
@@ -63,7 +63,7 @@ internal class Stacktrace : JsonStream.Streamable {
         logger: Logger
     ) {
         val frames = limitTraceLength(stacktrace)
-        trace = frames.mapNotNullTo(ArrayList()) { Companion.serializeStackframe(it, projectPackages, logger) }
+        trace = frames.mapNotNullTo(ArrayList()) { serializeStackframe(it, projectPackages, logger) }
     }
 
     private fun limitTraceLength(frames: Array<StackTraceElement>): Array<StackTraceElement> {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Thread.java
@@ -160,6 +160,16 @@ public class Thread implements JsonStream.Streamable {
         return impl.getStacktrace();
     }
 
+    /**
+     * Add a new stackframe to the end of this thread returning the new Stackframe data object.
+     */
+    @NonNull
+    public Stackframe addStackframe(@Nullable String method,
+                                    @Nullable String file,
+                                    long lineNumber) {
+        return impl.addStackframe(method, file, lineNumber);
+    }
+
     @Override
     public void toStream(@NonNull JsonStream stream) throws IOException {
         impl.toStream(stream);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ThreadInternal.kt
@@ -13,6 +13,12 @@ class ThreadInternal internal constructor(
 
     var stacktrace: MutableList<Stackframe> = stacktrace.trace.toMutableList()
 
+    fun addStackframe(method: String?, file: String?, lineNumber: Long): Stackframe {
+        val frame = Stackframe(method, file, lineNumber, null)
+        stacktrace.add(frame)
+        return frame
+    }
+
     @Throws(IOException::class)
     override fun toStream(writer: JsonStream) {
         writer.beginObject()

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertSame;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,7 +25,7 @@ public class ErrorFacadeTest {
     @Before
     public void setUp() {
         logger = new InterceptingLogger();
-        trace = Collections.emptyList();
+        trace = new ArrayList<>();
         ErrorInternal impl = new ErrorInternal("com.bar.CrashyClass",
                 "Whoops", new Stacktrace(trace), ErrorType.ANDROID);
         error = new Error(impl, logger);

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -89,4 +89,15 @@ public class ErrorFacadeTest {
         assertEquals("NoSuchFile.dat", frame.getFile());
         assertEquals(1234L, frame.getLineNumber());
     }
+
+    @Test
+    public void addStackframeWithNulls() {
+        Stackframe frame = error.addStackframe(null, null, -1L);
+
+        // check the new frame is the last frame in the error stacktrace
+        assertSame(frame, error.getStacktrace().get(error.getStacktrace().size() - 1));
+        assertNull(frame.getMethod());
+        assertNull(frame.getFile());
+        assertEquals(-1L, frame.getLineNumber());
+    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorFacadeTest.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -72,5 +73,20 @@ public class ErrorFacadeTest {
     @Test
     public void stacktraceValid() {
         assertEquals(trace, error.getStacktrace());
+    }
+
+    @Test
+    public void addStackframe() {
+        Stackframe frame = error.addStackframe(
+                "SomeClass.fakeMethod",
+                "NoSuchFile.dat",
+                1234L
+        );
+
+        // check the new frame is the last frame in the error stacktrace
+        assertSame(frame, error.getStacktrace().get(error.getStacktrace().size() - 1));
+        assertEquals("SomeClass.fakeMethod", frame.getMethod());
+        assertEquals("NoSuchFile.dat", frame.getFile());
+        assertEquals(1234L, frame.getLineNumber());
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorSerializationTest.kt
@@ -14,13 +14,13 @@ internal class ErrorSerializationTest {
         @Parameters
         fun testCases() = generateSerializationTestCases(
             "error",
-            Error(ErrorInternal("foo", "bar", Stacktrace(listOf())), NoopLogger),
+            Error(ErrorInternal("foo", "bar", Stacktrace(mutableListOf())), NoopLogger),
             Error(
                 ErrorInternal(
                     "foo",
                     "bar",
                     Stacktrace(
-                        listOf(
+                        mutableListOf(
                             Stackframe(
                                 method = "foo()",
                                 file = "Bar.kt",
@@ -39,7 +39,7 @@ internal class ErrorSerializationTest {
                     "com.bugsnag.android.StacktraceSerializationTest",
                     "bar",
                     Stacktrace(
-                        listOf(
+                        mutableListOf(
                             Stackframe(
                                 method = "com.bugsnag.android.StacktraceSerializationTest\$Companion.inProject",
                                 file = "StacktraceSerializationTest.kt",

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFacadeTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import com.bugsnag.android.internal.ImmutableConfig;
@@ -194,5 +195,67 @@ public class EventFacadeTest {
         assertTrue(event.isUnhandled());
         event.setUnhandled(false);
         assertFalse(event.isUnhandled());
+    }
+
+    @Test
+    public void addThread() {
+        Thread newThread = event.addThread(123L, "Magic Thread");
+        assertSame(newThread, event.getThreads().get(event.getThreads().size() - 1));
+        assertEquals("123", newThread.getId());
+        assertEquals("Magic Thread", newThread.getName());
+        assertEquals(ErrorType.ANDROID, newThread.getType());
+        assertEquals(Thread.State.RUNNABLE, newThread.getState());
+        assertEquals(0, newThread.getStacktrace().size());
+    }
+
+    @Test
+    public void addError() {
+        Error newError = event.addError("ErrorClass", "No error message");
+        assertSame(newError, event.getErrors().get(event.getErrors().size() - 1));
+        assertEquals("ErrorClass", newError.getErrorClass());
+        assertEquals("No error message", newError.getErrorMessage());
+        assertEquals(ErrorType.ANDROID, newError.getType());
+        assertEquals(0, newError.getStacktrace().size());
+    }
+
+    @Test
+    public void addErrorWithType() {
+        Error newError = event.addError("ErrorClass", "No error message", ErrorType.DART);
+        assertSame(newError, event.getErrors().get(event.getErrors().size() - 1));
+        assertEquals("ErrorClass", newError.getErrorClass());
+        assertEquals("No error message", newError.getErrorMessage());
+        assertEquals(ErrorType.DART, newError.getType());
+        assertEquals(0, newError.getStacktrace().size());
+    }
+
+    @Test
+    public void addErrorNullThrowable() {
+        Error newError = event.addError(null);
+        assertSame(newError, event.getErrors().get(event.getErrors().size() - 1));
+        assertEquals("null", newError.getErrorClass());
+        assertNull(newError.getErrorMessage());
+        assertEquals(ErrorType.ANDROID, newError.getType());
+        assertEquals(0, newError.getStacktrace().size());
+    }
+
+    @Test
+    public void addThreadWithNulls() {
+        Thread newThread = event.addThread(null, null);
+        assertSame(newThread, event.getThreads().get(event.getThreads().size() - 1));
+        assertEquals("null", newThread.getId());
+        assertEquals("null", newThread.getName());
+        assertEquals(ErrorType.ANDROID, newThread.getType());
+        assertEquals(Thread.State.RUNNABLE, newThread.getState());
+        assertEquals(0, newThread.getStacktrace().size());
+    }
+
+    @Test
+    public void addBadError() {
+        Error newError = event.addError(null, null);
+        assertSame(newError, event.getErrors().get(event.getErrors().size() - 1));
+        assertEquals("null", newError.getErrorClass());
+        assertNull(newError.getErrorMessage());
+        assertEquals(ErrorType.ANDROID, newError.getType());
+        assertEquals(0, newError.getStacktrace().size());
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceSerializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceSerializationTest.kt
@@ -22,7 +22,7 @@ internal class StacktraceSerializationTest {
                 Stacktrace(arrayOf(), emptySet(), NoopLogger),
 
                 // empty custom frames ctor
-                Stacktrace(listOf(frame)),
+                Stacktrace(mutableListOf(frame)),
 
                 // basic
                 basic(),
@@ -57,7 +57,7 @@ internal class StacktraceSerializationTest {
         }
 
         private fun trimStacktraceListCtor(): Stacktrace {
-            val elements = (0..999).map { count ->
+            val elements = (0..999).mapTo(ArrayList()) { count ->
                 Stackframe("Foo", "Bar.kt", count, true).also { frame ->
                     // set different type for each frame
                     frame.type = when (count % 3) {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/StacktraceTest.kt
@@ -7,7 +7,7 @@ class StacktraceTest {
 
     @Test
     fun stackframeListTrimmed() {
-        val stackList = (1..300).map { index ->
+        val stackList = (1..300).mapTo(ArrayList()) { index ->
             Stackframe("A", "B", index, true)
         }
         val stacktrace = Stacktrace(stackList)

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadDeserializationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadDeserializationTest.kt
@@ -21,7 +21,7 @@ class ThreadDeserializationTest {
                         ErrorType.C,
                         false,
                         "",
-                        Stacktrace(emptyList())
+                        Stacktrace(mutableListOf())
                     ),
                     NoopLogger
                 ),
@@ -32,7 +32,7 @@ class ThreadDeserializationTest {
                         ErrorType.ANDROID,
                         false,
                         "",
-                        Stacktrace(emptyList())
+                        Stacktrace(mutableListOf())
                     ),
                     NoopLogger
                 ),
@@ -47,7 +47,7 @@ class ThreadDeserializationTest {
                         ErrorType.ANDROID,
                         false,
                         "happy",
-                        Stacktrace(emptyList())
+                        Stacktrace(mutableListOf())
                     ),
                     NoopLogger
                 )

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -111,5 +112,16 @@ public class ThreadFacadeTest {
         assertEquals("SomeClass.fakeMethod", frame.getMethod());
         assertEquals("NoSuchFile.dat", frame.getFile());
         assertEquals(1234L, frame.getLineNumber());
+    }
+
+    @Test
+    public void addStackframeWithNulls() {
+        Stackframe frame = thread.addStackframe(null, null, -1L);
+
+        // check the new frame is the last frame in the thread stacktrace
+        assertSame(frame, thread.getStacktrace().get(thread.getStacktrace().size() - 1));
+        assertNull(frame.getMethod());
+        assertNull(frame.getFile());
+        assertEquals(-1L, frame.getLineNumber());
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ThreadFacadeTest.java
@@ -3,6 +3,7 @@ package com.bugsnag.android;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
@@ -95,5 +96,20 @@ public class ThreadFacadeTest {
         thread.setStacktrace(null);
         assertEquals(stacktrace.getTrace(), thread.getStacktrace());
         assertNotNull(logger.getMsg());
+    }
+
+    @Test
+    public void addStackframe() {
+        Stackframe frame = thread.addStackframe(
+                "SomeClass.fakeMethod",
+                "NoSuchFile.dat",
+                1234L
+        );
+
+        // check the new frame is the last frame in the thread stacktrace
+        assertSame(frame, thread.getStacktrace().get(thread.getStacktrace().size() - 1));
+        assertEquals("SomeClass.fakeMethod", frame.getMethod());
+        assertEquals("NoSuchFile.dat", frame.getFile());
+        assertEquals(1234L, frame.getLineNumber());
     }
 }

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ErrorDeserializer.java
@@ -19,7 +19,7 @@ class ErrorDeserializer implements MapDeserializer<Error> {
     public Error deserialize(Map<String, Object> map) {
         String type = MapUtils.getOrThrow(map, "type");
         List<Map<String, Object>> stacktrace = MapUtils.getOrThrow(map, "stacktrace");
-        List<Stackframe> frames = new ArrayList<>();
+        List<Stackframe> frames = new ArrayList<>(stacktrace.size());
 
         for (Map<String, Object> frame : stacktrace) {
             frames.add(stackframeDeserializer.deserialize(frame));

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeStackDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/NativeStackDeserializer.java
@@ -30,7 +30,7 @@ class NativeStackDeserializer implements MapDeserializer<List<Stackframe>> {
     @Override
     public List<Stackframe> deserialize(Map<String, Object> map) {
         List<Map<String, Object>> nativeStack = MapUtils.getOrThrow(map, "nativeStack");
-        List<Stackframe> frames = new ArrayList<>();
+        List<Stackframe> frames = new ArrayList<>(nativeStack.size());
 
         for (Map<String, Object> frame : nativeStack) {
             frames.add(deserializeStackframe(frame, projectPackages));

--- a/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
+++ b/bugsnag-plugin-react-native/src/main/java/com/bugsnag/android/ThreadDeserializer.java
@@ -19,7 +19,7 @@ class ThreadDeserializer implements MapDeserializer<Thread> {
     public Thread deserialize(Map<String, Object> map) {
         String type = MapUtils.getOrThrow(map, "type");
         List<Map<String, Object>> stacktrace = MapUtils.getOrThrow(map, "stacktrace");
-        List<Stackframe> frames = new ArrayList<>();
+        List<Stackframe> frames = new ArrayList<>(stacktrace.size());
 
         for (Map<String, Object> frame : stacktrace) {
             frames.add(stackframeDeserializer.deserialize(frame));

--- a/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
+++ b/bugsnag-plugin-react-native/src/test/java/com/bugsnag/android/ThreadSerializerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -34,7 +35,7 @@ public class ThreadSerializerTest {
         frame.put("inProject", true);
 
         Stackframe stackframe = new Stackframe("foo()", "Bar.kt", 55, true);
-        List<Stackframe> frames = Collections.singletonList(stackframe);
+        List<Stackframe> frames = new ArrayList<>(Collections.singletonList(stackframe));
         Stacktrace stacktrace = new Stacktrace(frames);
         thread = new Thread("1", "fake-thread", ErrorType.ANDROID,
                 true, Thread.State.RUNNABLE, stacktrace, NoopLogger.INSTANCE);


### PR DESCRIPTION
## Goal

Open up more Event model APIs, that users can add new Errors, Threads, and leave breadcrumbs at an `Event` level.

## Changeset

The `Event` class includes new methods to:
- add a new `Thread` object to the `Event`
- add a new `Error` object to the `Event`
- leave additional `Event` level breadcrumbs

The `Error` and `Thread` classes include new methods to add `Stackframe`s.

## Testing
New unit tests added.