### PR TITLE
Ensure NDK environment is properly initialized before using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Handle rare cases where we need to deserialize threads that don't have a valid `state` property
   [#2058](https://github.com/bugsnag/bugsnag-android/pull/2058)
+* Avoid racing ourselves in the `bugsnag-plugin-android-ndk` during multi-threaded startups
+  [#2064](https://github.com/bugsnag/bugsnag-android/pull/2064)
 
 ## 6.6.1 (2024-07-03)
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/internal_metrics.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/internal_metrics.c
@@ -140,7 +140,8 @@ static void bsg_modify_callback_count(bugsnag_event *event, const char *api,
   for (; i < total_callbacks && event->set_callback_counts[i].name[0] != 0;
        i++) {
     set_callback_count *callback_counter = &event->set_callback_counts[i];
-    if (strcmp(callback_counter->name, api) == 0) {
+    if (strncmp(callback_counter->name, api, sizeof(callback_counter->name)) ==
+        0) {
       callback_counter->count += delta;
       if (callback_counter->count < 0) {
         callback_counter->count = 0;
@@ -157,13 +158,14 @@ static void bsg_modify_callback_count(bugsnag_event *event, const char *api,
 
 void bsg_set_callback_count(bugsnag_event *event, const char *api,
                             int32_t count) {
-  if (!internal_metrics_enabled || event == NULL) {
+  if (!internal_metrics_enabled || event == NULL || !api) {
     return;
   }
 
   static const int total_callbacks =
       sizeof(event->set_callback_counts) / sizeof(*event->set_callback_counts);
-  if (strlen(api) >= sizeof(event->set_callback_counts[0].name)) {
+  if (strnlen(api, sizeof(event->set_callback_counts[0].name)) >=
+      sizeof(event->set_callback_counts[0].name)) {
     // API name is too big to store.
     return;
   }


### PR DESCRIPTION
## Goal
Avoid racing ourselves during multi-threaded startups.

## Changes

`request_env_write_lock` now returns the `bsg_environment*` that should captured locally and addressed. If the method returns `NULL` the lock is not acquired (released before returning) so null-checks on the returned `bsg_environment*` can exit immediately (after basic cleanup) without being concerned with releasing the lock.

## Testing
Relied on existing tests