### PR TITLE
Restored the expected timestamp format to NDK breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   [#2058](https://github.com/bugsnag/bugsnag-android/pull/2058)
 * Avoid racing ourselves in the `bugsnag-plugin-android-ndk` during multi-threaded startups
   [#2064](https://github.com/bugsnag/bugsnag-android/pull/2064)
+* Fixed a timestamp formatting issue that caused NDK crash breadcrumbs to be dropped
+  []()
 
 ## 6.6.1 (2024-07-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Avoid racing ourselves in the `bugsnag-plugin-android-ndk` during multi-threaded startups
   [#2064](https://github.com/bugsnag/bugsnag-android/pull/2064)
 * Fixed a timestamp formatting issue that caused NDK crash breadcrumbs to be dropped
-  []()
+  [#2066](https://github.com/bugsnag/bugsnag-android/pull/2066)
 
 ## 6.6.1 (2024-07-03)
 

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ObserverInterfaceTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.bugsnag.android.internal.DateUtils;
 import com.bugsnag.android.internal.StateObserver;
 
 import androidx.annotation.NonNull;
@@ -176,6 +177,8 @@ public class ObserverInterfaceTest {
         assertEquals(BreadcrumbType.MANUAL, crumb.type);
         assertEquals("Drift 4 units left", crumb.message);
         assertTrue(crumb.metadata.isEmpty());
+        // DateUtils.fromIso8601 throws an exception on failure, but we also check for nulls
+        assertNotNull(DateUtils.fromIso8601(crumb.timestamp));
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/BreadcrumbState.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.internal.DateUtils
 import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -42,8 +43,7 @@ internal class BreadcrumbState(
             StateEvent.AddBreadcrumb(
                 breadcrumb.impl.message,
                 breadcrumb.impl.type,
-                // an encoding of milliseconds since the epoch
-                "t${breadcrumb.impl.timestamp.time}",
+                DateUtils.toIso8601(breadcrumb.impl.timestamp),
                 breadcrumb.impl.metadata ?: mutableMapOf()
             )
         }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_writer.c
@@ -74,8 +74,8 @@ static size_t build_filename(bsg_environment *env, char *out) {
   memcpy(out, env->event_path, length);
   out[length++] = '/';
 
-  // the timestamp is encoded as unix time
-  length += bsg_uint64_to_string(now, &out[length]);
+  // the timestamp is encoded as unix time in millis
+  length += bsg_uint64_to_string(now * 1000uL, &out[length]);
 
   // append the api_key to the filename
   out[length++] = '_';


### PR DESCRIPTION
## Goal
Stop NDK breadcrumbs from being dropped due to invalid timestamps.

## Testing
Manually tested that the correct timetstamp is used. Also added to existing unit tests to assert the timestamp is as expected.