### PR TITLE
Send e2e test results to Buildkite TestAnalystics

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -62,6 +62,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -86,6 +92,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_9"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -116,6 +128,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-debug"
     concurrency: 25
@@ -144,6 +162,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_9"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-debug"
     concurrency: 5
@@ -178,6 +202,12 @@ steps:
           - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--exclude=features/full_tests/anr.feature"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -211,6 +241,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -242,6 +278,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_7"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -274,6 +316,12 @@ steps:
           - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--exclude=features/full_tests/anr.feature"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -306,6 +354,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -335,6 +389,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_8"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -369,6 +429,12 @@ steps:
           - "--exclude=features/full_tests/[^a-k].*.feature"
           - "--exclude=features/full_tests/anr.feature"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -403,6 +469,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -434,6 +506,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_9"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -468,6 +546,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -502,6 +586,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -532,6 +622,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_10"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -570,6 +666,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -604,6 +706,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -634,6 +742,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_11"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -668,6 +782,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -702,6 +822,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -732,6 +858,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_13"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -766,6 +898,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -800,6 +938,12 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -830,6 +974,12 @@ steps:
           - "--farm=bs"
           - "--device=ANDROID_14"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -39,7 +39,9 @@ steps:
   # BitBar steps
   #
 
+  # Minimal tests job skipped as there are only ANR scenarios, run separately using BS
   - label: ':bitbar: Minimal fixture end-to-end tests'
+    skip: "Only ANR scenarios are run again the minimal fixture at present"
     depends_on: "fixture-minimal"
     timeout_in_minutes: 30
     plugins:
@@ -104,7 +106,9 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
+  # Minimal tests job skipped as there are only ANR scenarios, run separately using BS
   - label: ':bitbar: Debug fixture smoke tests'
+    skip: "Only ANR scenarios are run again the minimal fixture at present"
     depends_on: "fixture-debug"
     timeout_in_minutes: 30
     plugins:

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -68,7 +68,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -99,7 +99,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -136,7 +136,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-debug"
     concurrency: 25
@@ -171,7 +171,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-debug"
     concurrency: 5
@@ -212,7 +212,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -252,7 +252,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -290,7 +290,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -329,7 +329,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -368,7 +368,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -404,7 +404,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -445,7 +445,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -486,7 +486,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -524,7 +524,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -565,7 +565,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -606,7 +606,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -643,7 +643,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -688,7 +688,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -729,7 +729,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -766,7 +766,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -807,7 +807,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -848,7 +848,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -885,7 +885,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -926,7 +926,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -967,7 +967,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -1004,7 +1004,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -65,9 +65,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -95,9 +96,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -131,9 +133,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-debug"
     concurrency: 25
@@ -165,9 +168,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-debug"
     concurrency: 5
@@ -205,9 +209,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -244,9 +249,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -281,9 +287,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -319,9 +326,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -357,9 +365,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -392,9 +401,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -432,9 +442,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -472,9 +483,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -509,9 +521,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -549,9 +562,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -589,9 +603,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -625,9 +640,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -669,9 +685,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -709,9 +726,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -745,9 +763,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -785,9 +804,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -825,9 +845,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -861,9 +882,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -901,9 +923,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -941,9 +964,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -977,9 +1001,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -130,526 +130,532 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
 
-  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
-    depends_on: "fixture-r19"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r19-url.txt"
-          - "build/fixture-r19/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r19-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_7"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 8 NDK r19 smoke tests'
-    depends_on: "fixture-r19"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r19-url.txt"
-          - "build/fixture-r19/*"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r19-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22"
-          - "--farm=bb"
-          - "--device=ANDROID_8"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
-    depends_on: "fixture-r19"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r19-url.txt"
-          - "build/fixture-r19/*"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r19-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_8"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 9 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22"
-          - "--farm=bb"
-          - "--device=ANDROID_9"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_9"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 10 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22"
-          - "--farm=bb"
-          - "--device=ANDROID_10"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_10"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 11 NDK r21 smoke tests'
-    key: 'android-11-smoke'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22"
-          - "--farm=bb"
-          - "--device=ANDROID_11"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
-    key: 'android-11-anr-smoke'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_11"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
- # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
-  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
-  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
-  # by inspecting the devices logs.
-  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
-    depends_on:
-      - "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--exclude=features/full_tests/anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22"
-          - "--farm=bb"
-          - "--device=ANDROID_12"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 12 NDK r21 end-to-end tests - batch ANR'
-    depends_on:
-      - "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests/anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_12"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
-    depends_on:
-      - "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--exclude=features/full_tests/anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22"
-          - "--farm=bb"
-          - "--device=ANDROID_12"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 13 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22"
-          - "--farm=bb"
-          - "--device=ANDROID_13"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_13"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 14 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22"
-          - "--farm=bb"
-          - "--device=ANDROID_14"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-          - "--app-package=com.bugsnag.android.mazerunner"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_14"
-          - "--fail-fast"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-
-  - label: 'Conditionally include device farms/full tests'
-    agents:
-      queue: macos-14
-    command: sh -c .buildkite/pipeline_trigger.sh
+#  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
+#    depends_on: "fixture-r19"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r19-url.txt"
+#          - "build/fixture-r19/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r19-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_7"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 8 NDK r19 smoke tests'
+#    depends_on: "fixture-r19"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r19-url.txt"
+#          - "build/fixture-r19/*"
+#        upload: "maze_output/failed/**/*"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r19-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22"
+#          - "--farm=bb"
+#          - "--device=ANDROID_8"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
+#    depends_on: "fixture-r19"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r19-url.txt"
+#          - "build/fixture-r19/*"
+#        upload: "maze_output/failed/**/*"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r19-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_8"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 9 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22"
+#          - "--farm=bb"
+#          - "--device=ANDROID_9"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_9"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 10 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22"
+#          - "--farm=bb"
+#          - "--device=ANDROID_10"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_10"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 11 NDK r21 smoke tests'
+#    key: 'android-11-smoke'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22"
+#          - "--farm=bb"
+#          - "--device=ANDROID_11"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
+#    key: 'android-11-anr-smoke'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_11"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+# # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
+#  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
+#  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
+#  # by inspecting the devices logs.
+#  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
+#    depends_on:
+#      - "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/full_tests"
+#          - "--exclude=features/full_tests/[^a-k].*.feature"
+#          - "--exclude=features/full_tests/anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22"
+#          - "--farm=bb"
+#          - "--device=ANDROID_12"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 12 NDK r21 end-to-end tests - batch ANR'
+#    depends_on:
+#      - "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/full_tests/anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_12"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
+#    depends_on:
+#      - "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/full_tests"
+#          - "--exclude=features/full_tests/[^l-z].*.feature"
+#          - "--exclude=features/full_tests/anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22"
+#          - "--farm=bb"
+#          - "--device=ANDROID_12"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 13 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22"
+#          - "--farm=bb"
+#          - "--device=ANDROID_13"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_13"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 14 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22"
+#          - "--farm=bb"
+#          - "--device=ANDROID_14"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+#          - "--app-package=com.bugsnag.android.mazerunner"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_14"
+#          - "--fail-fast"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#
+#  - label: 'Conditionally include device farms/full tests'
+#    agents:
+#      queue: macos-14
+#    command: sh -c .buildkite/pipeline_trigger.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -142,520 +142,610 @@ steps:
     concurrency_group: 'bitbar'
     concurrency_method: eager
 
-#  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
-#    depends_on: "fixture-r19"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r19-url.txt"
-#          - "build/fixture-r19/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r19-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_7"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 8 NDK r19 smoke tests'
-#    depends_on: "fixture-r19"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r19-url.txt"
-#          - "build/fixture-r19/*"
-#        upload: "maze_output/failed/**/*"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r19-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22"
-#          - "--farm=bb"
-#          - "--device=ANDROID_8"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
-#    depends_on: "fixture-r19"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r19-url.txt"
-#          - "build/fixture-r19/*"
-#        upload: "maze_output/failed/**/*"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r19-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_8"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 9 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22"
-#          - "--farm=bb"
-#          - "--device=ANDROID_9"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_9"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 10 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22"
-#          - "--farm=bb"
-#          - "--device=ANDROID_10"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_10"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 11 NDK r21 smoke tests'
-#    key: 'android-11-smoke'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22"
-#          - "--farm=bb"
-#          - "--device=ANDROID_11"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
-#    key: 'android-11-anr-smoke'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_11"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-# # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
-#  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
-#  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
-#  # by inspecting the devices logs.
-#  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
-#    depends_on:
-#      - "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/full_tests"
-#          - "--exclude=features/full_tests/[^a-k].*.feature"
-#          - "--exclude=features/full_tests/anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22"
-#          - "--farm=bb"
-#          - "--device=ANDROID_12"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 12 NDK r21 end-to-end tests - batch ANR'
-#    depends_on:
-#      - "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/full_tests/anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_12"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
-#    depends_on:
-#      - "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/full_tests"
-#          - "--exclude=features/full_tests/[^l-z].*.feature"
-#          - "--exclude=features/full_tests/anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22"
-#          - "--farm=bb"
-#          - "--device=ANDROID_12"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 13 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22"
-#          - "--farm=bb"
-#          - "--device=ANDROID_13"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_13"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 14 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22"
-#          - "--farm=bb"
-#          - "--device=ANDROID_14"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
-#          - "--app-package=com.bugsnag.android.mazerunner"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_14"
-#          - "--fail-fast"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#
-#  - label: 'Conditionally include device farms/full tests'
-#    agents:
-#      queue: macos-14
-#    command: sh -c .buildkite/pipeline_trigger.sh
+  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
+    depends_on: "fixture-r19"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r19-url.txt"
+          - "build/fixture-r19/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r19-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_7"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: ':bitbar: Android 8 NDK r19 smoke tests'
+    depends_on: "fixture-r19"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r19-url.txt"
+          - "build/fixture-r19/*"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r19-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22"
+          - "--farm=bb"
+          - "--device=ANDROID_8"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
+    depends_on: "fixture-r19"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r19-url.txt"
+          - "build/fixture-r19/*"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r19-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_8"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: ':bitbar: Android 9 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22"
+          - "--farm=bb"
+          - "--device=ANDROID_9"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_9"
+          - "--fail-fast"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: ':bitbar: Android 10 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22"
+          - "--farm=bb"
+          - "--device=ANDROID_10"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_10"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: ':bitbar: Android 11 NDK r21 smoke tests'
+    key: 'android-11-smoke'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
+    key: 'android-11-anr-smoke'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_11"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+ # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
+  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
+  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
+  # by inspecting the devices logs.
+  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
+    depends_on:
+      - "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
+          - "--exclude=features/full_tests/anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22"
+          - "--farm=bb"
+          - "--device=ANDROID_12"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':browserstack: Android 12 NDK r21 end-to-end tests - batch ANR'
+    depends_on:
+      - "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests/anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_12"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
+    depends_on:
+      - "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
+          - "--exclude=features/full_tests/anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22"
+          - "--farm=bb"
+          - "--device=ANDROID_12"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':bitbar: Android 13 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22"
+          - "--farm=bb"
+          - "--device=ANDROID_13"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_13"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+  - label: ':bitbar: Android 14 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22"
+          - "--farm=bb"
+          - "--device=ANDROID_14"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--app-activity=com.bugsnag.android.mazerunner.MainActivity"
+          - "--app-package=com.bugsnag.android.mazerunner"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_14"
+          - "--fail-fast"
+          - "--format=junit"
+          - "--out=reports"
+          - "--format=pretty"
+      test-collector#v1.0.0:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
+
+  - label: 'Conditionally include device farms/full tests'
+    agents:
+      queue: macos-14
+    command: sh -c .buildkite/pipeline_trigger.sh
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -133,9 +133,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -169,9 +170,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -206,9 +208,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -240,9 +243,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -279,9 +283,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -348,9 +353,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -384,9 +390,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -424,9 +431,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -461,9 +469,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -506,9 +515,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -543,9 +553,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -584,9 +595,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -623,9 +635,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -659,9 +672,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -698,9 +712,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -734,9 +749,10 @@ steps:
           - "--format=junit"
           - "--out=reports"
           - "--format=pretty"
-      test-collector#v1.0.0:
+      test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
+        branch: "^master|next\$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,7 +136,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -173,7 +173,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -211,7 +211,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 25
@@ -246,7 +246,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
     concurrency: 5
@@ -286,7 +286,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -356,7 +356,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -393,7 +393,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -434,7 +434,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -472,7 +472,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -518,7 +518,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -556,7 +556,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -598,7 +598,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -638,7 +638,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -675,7 +675,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5
@@ -715,7 +715,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 25
@@ -752,7 +752,7 @@ steps:
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
         format: "junit"
-        branch: "^master|next\$"
+        branch: "^master|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
     concurrency: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - ./build:/app/build
       - ./features/:/app/features/
       - ./maze_output:/app/maze_output
+      - ./reports/:/app/reports/
       - /var/run/docker.sock:/var/run/docker.sock
 
   android-license-audit:


### PR DESCRIPTION
## Goal

Send Maze Runner test results to Buildkite TestAnalytics.

## Design

1. Output tests results from Maze Runner in Junit XML format using the `--format` option (has to be given twice to avoid losing the default `pretty` output).
2. Use the `test-collector` Buildkite pluging to send the results on - this needs the API key to be set in the `BUILDKITE_ANALYTICS_TOKEN` environment variable, which I've done in our s3 bucket.

## Testing

I've run a full build to make sure I've not broken the pipeline YAML, but it can't be tested fully until it's on `next`.