### PR TITLE
Flexible timeout for EventStore.flushOnLaunch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Add original error class and message to metadata for link errors loading BugSnag libraries
   [#2070](https://github.com/bugsnag/bugsnag-android/pull/2070)
 
+### Bug fixes
+
+* Sending startup crashes synchronously now uses a flexible timeout so that apps with slower startups don't ANR
+  [#2075](https://github.com/bugsnag/bugsnag-android/pull/2075)
+
 ## 6.7.0 (2024-08-08)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.kt
@@ -1,15 +1,16 @@
 package com.bugsnag.android
 
+import android.os.SystemClock
 import com.bugsnag.android.EventFilenameInfo.Companion.findTimestampInFilename
 import com.bugsnag.android.EventFilenameInfo.Companion.fromEvent
 import com.bugsnag.android.EventFilenameInfo.Companion.fromFile
 import com.bugsnag.android.JsonStream.Streamable
 import com.bugsnag.android.internal.BackgroundTaskService
+import com.bugsnag.android.internal.ForegroundDetector
 import com.bugsnag.android.internal.ImmutableConfig
 import com.bugsnag.android.internal.TaskType
 import java.io.File
 import java.util.Calendar
-import java.util.Comparator
 import java.util.Date
 import java.util.concurrent.Callable
 import java.util.concurrent.ExecutionException
@@ -17,10 +18,10 @@ import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import kotlin.math.max
 
 /**
- * Store and flush Event reports which couldn't be sent immediately due to
- * lack of network connectivity.
+ * Store and flush Event reports.
  */
 internal class EventStore(
     private val config: ImmutableConfig,
@@ -42,7 +43,8 @@ internal class EventStore(
     override val logger: Logger
 
     /**
-     * Flush startup crashes synchronously on the main thread
+     * Flush startup crashes synchronously on the main thread. Startup crashes block the main thread
+     * when being sent (subject to [Configuration.setSendLaunchCrashesSynchronously])
      */
     fun flushOnLaunch() {
         if (!config.sendLaunchCrashesSynchronously) {
@@ -58,13 +60,20 @@ internal class EventStore(
             return
         }
         try {
-            future.get(LAUNCH_CRASH_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            // Calculate the maximum amount of time we are prepared to block while sending
+            // startup crashes, based on how long we think startup has taken so-far.
+            // This attempts to mitigate possible startup ANRs that can occur when other SDKs
+            // have blocked the main thread before this code is reached.
+            val currentStartupDuration =
+                SystemClock.elapsedRealtime() - ForegroundDetector.startupTime
+            val timeout = max(0, LAUNCH_CRASH_TIMEOUT_MS - currentStartupDuration)
+            future.get(timeout, TimeUnit.MILLISECONDS)
         } catch (exc: InterruptedException) {
-            logger.d("Failed to send launch crash reports within 2s timeout, continuing.", exc)
+            logger.d("Failed to send launch crash reports within timeout, continuing.", exc)
         } catch (exc: ExecutionException) {
-            logger.d("Failed to send launch crash reports within 2s timeout, continuing.", exc)
+            logger.d("Failed to send launch crash reports within timeout, continuing.", exc)
         } catch (exc: TimeoutException) {
-            logger.d("Failed to send launch crash reports within 2s timeout, continuing.", exc)
+            logger.d("Failed to send launch crash reports within timeout, continuing.", exc)
         }
     }
 
@@ -159,6 +168,7 @@ internal class EventStore(
                 deleteStoredFiles(setOf(eventFile))
                 logger.i("Deleting sent error file $eventFile.name")
             }
+
             DeliveryStatus.UNDELIVERED -> undeliveredEventPayload(eventFile)
             DeliveryStatus.FAILURE -> {
                 val exc: Exception = RuntimeException("Failed to deliver event payload")

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ForegroundDetector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/ForegroundDetector.kt
@@ -55,6 +55,12 @@ internal object ForegroundDetector : ActivityLifecycleCallbacks, Handler.Callbac
 
     private var waitingForActivityRestart: Boolean = false
 
+    /**
+     * Marks the timestamp (relative to [SystemClock.elapsedRealtime]) that we initialised for the
+     * first time.
+     */
+    internal val startupTime = SystemClock.elapsedRealtime()
+
     @VisibleForTesting
     internal var backgroundSent = true
 


### PR DESCRIPTION
## Goal
Avoid startup ANRs in apps that have slow startups where sending the fixed 2 second timeout can cause the overall startup time to be long enough that an ANR will be reported.

## Changeset
The startup crash timeout is now calculated based on the amount of time the startup has already taken. The flush timeout is now a *maximum* of 2 seconds (and a minimum of `0`).

## Testing
Manually checked the calculated timeouts, otherwise relying on existing tests.