### PR TITLE
Startup timeout fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Sending startup crashes synchronously now uses a flexible timeout so that apps with slower startups don't ANR
   [#2075](https://github.com/bugsnag/bugsnag-android/pull/2075)
+  [#2080](https://github.com/bugsnag/bugsnag-android/pull/2080)
 
 ## 6.7.0 (2024-08-08)
 


### PR DESCRIPTION
## Goal
Use a reasonable timeout for startup crash delivery in cases when `Bugsnag.start` is called long after the app start.

## Changeset
If the startup crash synchronous timeout would be `<=0` we revert to the old behavior and block for up-to a full 2 seconds.

## Testing
Relied on the existing tests being more reliable.