### PR TITLE
Work around NPEs from `Intent.getExtras`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Sending startup crashes synchronously now uses a flexible timeout so that apps with slower startups don't ANR
   [#2075](https://github.com/bugsnag/bugsnag-android/pull/2075)
   [#2080](https://github.com/bugsnag/bugsnag-android/pull/2080)
+* Work around a possible platform NullPointerException when calling `Intent.getExtras` (https://github.com/bugsnag/bugsnag-android/issues/2082)
+  [#2083](https://github.com/bugsnag/bugsnag-android/pull/2083)
 
 ## 6.7.0 (2024-08-08)
 

--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -49,6 +49,7 @@
     <ID>ProtectedMemberInFinalClass:EventInternal.kt$EventInternal$protected fun updateSeverityReason(@SeverityReason.SeverityReasonType reason: String)</ID>
     <ID>ReturnCount:DefaultDelivery.kt$DefaultDelivery$fun deliver( urlString: String, json: ByteArray, headers: Map&lt;String, String?> ): DeliveryStatus</ID>
     <ID>SpreadOperator:FileStore.kt$FileStore$(*listFiles)</ID>
+    <ID>SwallowedException:ActivityBreadcrumbCollector.kt$ActivityBreadcrumbCollector$re: Exception</ID>
     <ID>SwallowedException:AppDataCollector.kt$AppDataCollector$e: Exception</ID>
     <ID>SwallowedException:BugsnagEventMapper.kt$BugsnagEventMapper$pe: IllegalArgumentException</ID>
     <ID>SwallowedException:ConnectivityCompat.kt$ConnectivityLegacy$e: NullPointerException</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ActivityBreadcrumbCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ActivityBreadcrumbCollector.kt
@@ -79,6 +79,11 @@ internal class ActivityBreadcrumbCollector(
         }
 
         set("hasData", intent.data != null)
-        set("hasExtras", intent.extras?.keySet()?.joinToString(", ") ?: false)
+
+        try {
+            set("hasExtras", intent.extras?.keySet()?.joinToString(", ") ?: false)
+        } catch (re: Exception) {
+            // deliberately ignore
+        }
     }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ActivityLifecycleBreadcrumbTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ActivityLifecycleBreadcrumbTest.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android
 
 import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -10,6 +11,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 import org.mockito.junit.MockitoJUnitRunner
 
 @RunWith(MockitoJUnitRunner::class)
@@ -119,5 +122,16 @@ internal class ActivityLifecycleBreadcrumbTest {
 
         tracker.onActivityStarted(activity2)
         assertEquals("onCreate()", resultMetadata!!["previous"])
+    }
+
+    @Test
+    fun failGetExtras() {
+        val mockIntent = mock(Intent::class.java)
+        `when`(mockIntent.extras).thenThrow(NullPointerException())
+        `when`(activity.intent).thenReturn(mockIntent)
+
+        tracker.onActivityCreated(activity, null)
+        assertFalse(resultMetadata!!["hasBundle"] as Boolean)
+        assertFalse(resultMetadata!!["hasData"] as Boolean)
     }
 }


### PR DESCRIPTION
## Goal
Fix #2082 by wrapping the `Intent.getExtras()` in a `try {} catch {}`

## Testing
Introduced a new unit test to cover this specific case.