### PR TITLE
Identify the error reporting thread in native crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Native crashes will now identify the crashing/error reporting thread
+  [#2087](https://github.com/bugsnag/bugsnag-android/pull/2087)
+
 ## 6.8.0 (2024-09-30)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/jni/event.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/event.h
@@ -191,6 +191,7 @@ typedef struct {
 
 typedef struct {
   pid_t id;
+  bool is_reporting_thread;
   char name[16];
   char state[13];
 } bsg_thread;

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/cpp_handler.cpp
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <stdexcept>
 #include <string>
+#include <unistd.h>
 
 #include "../utils/crash_info.h"
 #include "../utils/serializer.h"
@@ -58,7 +59,7 @@ void bsg_handle_cpp_terminate() {
 
   if (bsg_global_env->send_threads != SEND_THREADS_NEVER) {
     bsg_global_env->next_event.thread_count = bsg_capture_thread_states(
-        bsg_global_env->next_event.threads, BUGSNAG_THREADS_MAX);
+        gettid(), bsg_global_env->next_event.threads, BUGSNAG_THREADS_MAX);
   } else {
     bsg_global_env->next_event.thread_count = 0;
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -188,7 +188,7 @@ void bsg_handle_signal(int signum, siginfo_t *info,
 
   if (bsg_global_env->send_threads != SEND_THREADS_NEVER) {
     bsg_global_env->next_event.thread_count = bsg_capture_thread_states(
-        bsg_global_env->next_event.threads, BUGSNAG_THREADS_MAX);
+        gettid(), bsg_global_env->next_event.threads, BUGSNAG_THREADS_MAX);
   } else {
     bsg_global_env->next_event.thread_count = 0;
   }

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_writer.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/serializer/event_writer.c
@@ -605,6 +605,12 @@ static bool bsg_write_threads(BSG_KSJSONEncodeContext *json,
       CHECKED(bsg_ksjsonbeginObject(json, NULL));
       {
         CHECKED(JSON_LIMITED_STRING_ELEMENT("id", id_string));
+
+        if (thread->is_reporting_thread) {
+          CHECKED(
+              bsg_ksjsonaddBooleanElement(json, "errorReportingThread", true));
+        }
+
         CHECKED(JSON_LIMITED_STRING_ELEMENT("name", thread->name));
         CHECKED(JSON_LIMITED_STRING_ELEMENT("state", thread->state));
         CHECKED(JSON_CONSTANT_ELEMENT("type", "c"));

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.c
@@ -167,7 +167,8 @@ static bool read_thread_state(bsg_thread *dest, const char *tid) {
   return parse_success;
 }
 
-size_t bsg_capture_thread_states(bsg_thread *threads, size_t max_threads) {
+size_t bsg_capture_thread_states(pid_t reporting_tid, bsg_thread *threads,
+                                 size_t max_threads) {
   size_t total_thread_count = 0;
   struct dirent64 *entry;
   char buffer[1024];
@@ -187,6 +188,8 @@ size_t bsg_capture_thread_states(bsg_thread *threads, size_t max_threads) {
     for (offset = 0; offset < available && total_thread_count < max_threads;) {
       entry = (struct dirent64 *)(buffer + offset);
       if (read_thread_state(&threads[total_thread_count], entry->d_name)) {
+        threads[total_thread_count].is_reporting_thread =
+            threads[total_thread_count].id == reporting_tid;
         total_thread_count += 1;
       }
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/utils/threads.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define MAX_STAT_PATH_LENGTH 64
 
-size_t bsg_capture_thread_states(bsg_thread *threads,
+size_t bsg_capture_thread_states(pid_t reporting_tid, bsg_thread *threads,
                                  size_t max_threads) __asyncsafe;
 
 #ifdef __cplusplus

--- a/features/smoke_tests/04_unhandled.feature
+++ b/features/smoke_tests/04_unhandled.feature
@@ -292,3 +292,9 @@ Feature: Unhandled smoke tests
     # Breadcrumbs
     And the event has a "manual" breadcrumb named "CXXExceptionSmokeScenario"
 
+    # Threads validation
+    And the error payload field "events.0.threads" is a non-empty array
+    And the event "threads.0.id" matches "^[0-9]+$"
+    And the event "threads.0.name" is not null
+    And the event "threads.0.type" equals "c"
+    And the thread with name "roid.mazerunner" contains the error reporting flag


### PR DESCRIPTION
## Goal
Identify the error reporting thread in native crashes

## Design
Introduced the error reporting thread boolean marker to the `bsg_thread` structure, and attempt to match the TID with the currently running thread (within the signal handler & C++ exception handler).

## Testing
Additional steps added to the existing native smoke test