### PR TITLE
Reduce flakes for OkHttpDeliveryScenario

### DIFF
--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/mazerunner/MazerunnerApp.kt
@@ -30,6 +30,7 @@ class MazerunnerApp : Application() {
             val policy = StrictMode.VmPolicy.Builder()
                 .detectNonSdkApiUsage()
                 .penaltyDeath()
+                .penaltyLog()
                 .build()
             StrictMode.setVmPolicy(policy)
         }

--- a/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
+++ b/features/fixtures/mazerunner/jvm-scenarios/detekt-baseline.xml
@@ -26,6 +26,7 @@
     <ID>MagicNumber:TrimmedStacktraceScenario.kt$TrimmedStacktraceScenario$100000</ID>
     <ID>MagicNumber:UnhandledExceptionEventDetailChangeScenario.kt$UnhandledExceptionEventDetailChangeScenario$123</ID>
     <ID>MagicNumber:UnhandledExceptionEventDetailChangeScenario.kt$UnhandledExceptionEventDetailChangeScenario$123456</ID>
+    <ID>MaxLineLength:OkHttpDeliveryScenario.kt$OkHttpDeliveryScenario$// StrictMode policy violation: android.os.strictmode.NonSdkApiUsedViolation: Lcom/android/org/conscrypt/OpenSSLSocketImpl;-&gt;setUseSessionTickets(Z)V</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:AnrHelper.kt$&lt;no name provided&gt;$IllegalStateException()</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:BugsnagInitScenario.kt$BugsnagInitScenario$RuntimeException()</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:CustomPluginNotifierDescriptionScenario.kt$CustomPluginNotifierDescriptionScenario$RuntimeException()</ID>

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OkHttpDeliveryScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/OkHttpDeliveryScenario.kt
@@ -1,6 +1,7 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
+import android.os.StrictMode
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.okhttp.OkHttpDelivery
 import java.lang.RuntimeException
@@ -12,6 +13,12 @@ internal class OkHttpDeliveryScenario(
 ) : Scenario(config, context, eventMetadata) {
 
     init {
+        // there is a StrictMode violation within the OkHttp version we use, so we turn off
+        // StrictMode for this scenario
+        // StrictMode policy violation: android.os.strictmode.NonSdkApiUsedViolation: Lcom/android/org/conscrypt/OpenSSLSocketImpl;->setUseSessionTickets(Z)V
+        StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.LAX)
+        StrictMode.setVmPolicy(StrictMode.VmPolicy.LAX)
+
         config.delivery = OkHttpDelivery()
     }
 


### PR DESCRIPTION
## Goal
Reduce flakes for OkHttpDeliveryScenario

## Changeset
- Turn off StrictMode for the OkHttpDeliveryScenario.
- Adjusted the StrictMode penalty for the MazeRunner fixture to also log any StrictMode violations

## Testing
Relied on the existing tests passing with fewer flakes.