### PR TITLE
In-memory ExitInfoPluginStore

### DIFF
--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/BugsnagExitInfoPlugin.kt
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/BugsnagExitInfoPlugin.kt
@@ -25,12 +25,11 @@ class BugsnagExitInfoPlugin @JvmOverloads constructor(
 
         val exitInfoPluginStore =
             ExitInfoPluginStore(client.immutableConfig)
-        val (oldPid, exitInfoKeys) = exitInfoPluginStore.load()
-        exitInfoPluginStore.persist(android.os.Process.myPid(), exitInfoKeys)
+        exitInfoPluginStore.currentPid = android.os.Process.myPid()
 
         val exitInfoCallback = ExitInfoCallback(
             client.appContext,
-            oldPid,
+            exitInfoPluginStore.previousPid,
             TombstoneEventEnhancer(
                 client.logger,
                 configuration.listOpenFds,


### PR DESCRIPTION
## Goal
Simplify the use of the `ExitInfoPluginStore` by retaining the data in-memory instead of constantly reloading from disk.

## Testing
Modified existing tests to match the new fields & behaviour