### PR TITLE
CMake version bump

### DIFF
--- a/bugsnag-android-core/CMakeLists.txt
+++ b/bugsnag-android-core/CMakeLists.txt
@@ -1,2 +1,3 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.19)
+project(bugsnag-android-core)
 add_subdirectory(src/main)

--- a/bugsnag-plugin-android-anr/CMakeLists.txt
+++ b/bugsnag-plugin-android-anr/CMakeLists.txt
@@ -1,2 +1,3 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.19)
+project(bugsnag-plugin-android-anr)
 add_subdirectory(src/main)

--- a/bugsnag-plugin-android-ndk/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.19)
+project(bugsnag-plugin-android-ndk)
 project(TEST)
 add_subdirectory(src/main)
 

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/BugsnagBuildPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/BugsnagBuildPlugin.kt
@@ -92,6 +92,7 @@ class BugsnagBuildPlugin : Plugin<Project> {
                 "-DANDROID_STL=c++_static"
             )
 
+
             val override: String? = project.findProperty("ABI_FILTERS") as String?
             val abis = override?.split(",") ?: mutableSetOf(
                 "arm64-v8a",
@@ -102,6 +103,7 @@ class BugsnagBuildPlugin : Plugin<Project> {
             ndk.setAbiFilters(abis)
         }
         externalNativeBuild.cmake.path = project.file("CMakeLists.txt")
+        externalNativeBuild.cmake.version = Versions.cmakeVersion
     }
 
     /**

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/Versions.kt
@@ -13,6 +13,7 @@ object Versions {
     val java = JavaVersion.VERSION_1_8
     val kotlin = "1.5.10"
     val kotlinLang = "1.5"
+    val cmakeVersion = "3.22.1"
 
     // plugins
     val androidGradlePlugin = "7.0.4"

--- a/dockerfiles/Dockerfile.android-common
+++ b/dockerfiles/Dockerfile.android-common
@@ -34,7 +34,7 @@ RUN yes | sdkmanager "ndk;19.2.5345600" > /dev/null
 RUN yes | sdkmanager "ndk;21.4.7075529" > /dev/null
 
 RUN yes | sdkmanager "cmake;3.6.4111459" > /dev/null
-RUN yes | sdkmanager "cmake;3.10.2.4988404" > /dev/null
+RUN yes | sdkmanager "cmake;3.22.1" > /dev/null
 RUN yes | sdkmanager "build-tools;30.0.3" > /dev/null
 
 # Install bundletool

--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/CMakeLists.txt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
+project(cxx-scenarios-bugsnag)
 
 find_package(bugsnag-plugin-android-ndk REQUIRED CONFIG)
 

--- a/features/fixtures/mazerunner/cxx-scenarios/CMakeLists.txt
+++ b/features/fixtures/mazerunner/cxx-scenarios/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
+project(cxx-scenarios)
 
 add_library(cxx-scenarios SHARED
         src/main/cpp/cxx-scenarios.cpp


### PR DESCRIPTION
## Goal
Bump CMake to version 3.22.1, and minimum required version to 3.19.

Also added the missing `project` directives to CMake will stop warning about them.

## Testing
Relied on existing tests