### PR TITLE
Adds signing workflow for releases

### DIFF
--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -1,0 +1,30 @@
+name: Sign release assets
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to sign'
+        required: true
+        type: string
+jobs:
+  sign-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install gpg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gnupg
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.PLATFORMS_GPG_KEY_BASE64 }}" | base64 --decode | gpg --batch --import
+      - name: Sign assets
+        uses: bugsnag/platforms-release-signer@main
+        with:
+          github_token: ${{ secrets.PLATFORMS_SIGNING_GITHUB_TOKEN }}
+          full_repository: ${{ github.repository }}
+          release_tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+          key_id: ${{ secrets.PLATFORMS_GPG_KEY_ID }}
+          key_passphrase: ${{ secrets.PLATFORMS_GPG_KEY_PASSPHRASE }}


### PR DESCRIPTION
## Goal

Adds a workflow that will:
- Download all assets from a given release (set automatically when triggered by a release)
- Create a signature for each asset using our platforms release GPG key
- Confirm that signatures are correct for the asset and key
- Upload the signatures to the release

## Testing

[A test run can be observed here](https://github.com/Cawllec/node-listener/actions/runs/11839817383/job/32992184486), and [the outcome of the test run can be observed here](https://github.com/Cawllec/node-listener/releases/tag/v1.0.0).  Note that these did not use our platforms release key.

For full testing this will need to be merged and then manually run against a previous release.