### PR TITLE
Pipeline tidyup

### DIFF
--- a/.buildkite/block.step.yml
+++ b/.buildkite/block.step.yml
@@ -1,7 +1,12 @@
+agents:
+  queue: 'macos'
+
 steps:
-  - block: 'Trigger full build'
+  - label:
+    block: 'Trigger full build'
     key: 'trigger-full-build'
 
   - label: 'Upload the full test pipeline'
     depends_on: 'trigger-full-build'
     command: buildkite-agent pipeline upload .buildkite/pipeline.full.yml
+    timeout_in_minutes: 5

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: 'opensource'
+
 steps:
   - label: ':android: Build minimal fixture APK'
     key: "fixture-minimal"
@@ -10,7 +13,7 @@ steps:
       JAVA_VERSION: 17
 
   - label: ':android: Build Example App'
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     agents:
       queue: macos-14
     command: 'make example-app'
@@ -230,7 +233,7 @@ steps:
 
   - label: ':browserstack: Android 7 NDK r19 end-to-end tests - ANRs'
     depends_on: "fixture-r19"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -328,7 +331,7 @@ steps:
 
   - label: ':browserstack: Android 8 NDK r19 end-to-end tests - ANRs'
     depends_on: "fixture-r19"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -428,7 +431,7 @@ steps:
 
   - label: ':bitbar: Android 9 NDK r21 end-to-end tests - ANRs'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -529,7 +532,7 @@ steps:
 
   - label: ':browserstack: Android 10 NDK r21 end-to-end tests - ANRs'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -634,7 +637,7 @@ steps:
 
   - label: ':browserstack: Android 11 NDK r21 end-to-end tests - ANRs'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -735,7 +738,7 @@ steps:
 
   - label: ':browserstack: Android 13 NDK r21 end-to-end tests - ANRs'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -836,7 +839,7 @@ steps:
 
   - label: ':browserstack: Android 14 NDK r21 end-to-end tests - ANRs'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -891,6 +894,7 @@ steps:
   - label: 'Publish :rocket:'
     if: build.branch == "master"
     depends_on: 'android-common'
+    timeout_in_minutes: 30
     env:
       BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX: bugsnag-android-publish
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: 'opensource'
+
 steps:
 
   - label: 'Audit current licenses'
@@ -105,7 +108,7 @@ steps:
   #
   - label: ':bitbar: Android 7 NDK r19 smoke tests'
     depends_on: "fixture-r19"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -139,7 +142,7 @@ steps:
 
   - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
     depends_on: "fixture-r19"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -170,7 +173,7 @@ steps:
 
   - label: ':bitbar: Android 8 NDK r19 smoke tests'
     depends_on: "fixture-r19"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -202,7 +205,7 @@ steps:
 
   - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
     depends_on: "fixture-r19"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -231,7 +234,7 @@ steps:
 
   - label: ':bitbar: Android 9 NDK r21 smoke tests'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -265,7 +268,7 @@ steps:
 
   - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -292,7 +295,7 @@ steps:
 
   - label: ':bitbar: Android 10 NDK r21 smoke tests'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -326,7 +329,7 @@ steps:
 
   - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -358,7 +361,7 @@ steps:
   - label: ':bitbar: Android 11 NDK r21 smoke tests'
     key: 'android-11-smoke'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -393,7 +396,7 @@ steps:
   - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
     key: 'android-11-anr-smoke'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -532,7 +535,7 @@ steps:
 
   - label: ':bitbar: Android 13 NDK r21 smoke tests'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -566,7 +569,7 @@ steps:
 
   - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -597,7 +600,7 @@ steps:
 
   - label: ':bitbar: Android 14 NDK r21 smoke tests'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -631,7 +634,7 @@ steps:
 
   - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
     depends_on: "fixture-r21"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
@@ -660,9 +663,8 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
-
   - label: 'Conditionally include device farms/full tests'
     agents:
-      queue: macos-14
+      queue: macos
     command: sh -c .buildkite/pipeline_trigger.sh
-
+    timeout_in_minutes: 10

--- a/scripts/copy-build-files.rb
+++ b/scripts/copy-build-files.rb
@@ -8,7 +8,8 @@ destination = "build/fixture-#{ndk_version}"
 
 FileUtils.mkdir_p destination
 FileUtils.cp "features/fixtures/mazerunner/app/build/outputs/apk/#{build_mode}/fixture-#{ndk_version}.apk", "build/fixture-#{ndk_version}.apk"
-FileUtils.cp "features/fixtures/mazerunner/app/build/outputs/mapping/#{build_mode}/mapping.txt", "#{destination}/mapping.txt"
+mapping_txt = "features/fixtures/mazerunner/app/build/outputs/mapping/#{build_mode}/mapping.txt"
+FileUtils.cp mapping_txt, "#{destination}/mapping.txt" if File.exist? mapping_txt
 
 fixture_dir = 'features/fixtures/mazerunner'
 cxx_base = "#{fixture_dir}/cxx-scenarios/build/intermediates"


### PR DESCRIPTION
## Goal

General tidy-up of the Buildkite pipeline to:
- Ensure all steps have an adequate but not excessive timeout
- Agent queues are explicitly stated in each file (even if a default is used)
- Generic `macos` queue is used instead of specfic macOS versions where possible

## Testing

Covered by a full CI run.