### PR TITLE
Restrict permissions of default github token in signing workflow

### DIFF
--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -1,5 +1,7 @@
 name: Sign release assets
 
+permissions: read-all
+
 on:
   release:
     types: [released]


### PR DESCRIPTION
## Goal

Reduces the default permissions of the github token to read only