### PR TITLE
feat(report): add NdkLinkError to metadata

### DIFF
--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -46,6 +46,9 @@ internal class NdkPlugin : Plugin {
     private fun performOneTimeSetup(client: Client) {
         libraryLoader.loadLibrary("bugsnag-ndk", client) {
             val error = it.errors[0]
+            it.addMetadata("LinkError", "errorClass", error.errorClass)
+            it.addMetadata("LinkError", "errorMessage", error.errorMessage)
+
             error.errorClass = "NdkLinkError"
             error.errorMessage = LOAD_ERR_MSG
             true


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Make NdkLinkError and AnrLinkError reports consistent.

## Design

<!-- Why was this approach used? -->
The commit 2f5a951 (PR #2070) already added metadata to AnrLinkError, so do the same for NdkLinkError.

## Changeset

<!-- What changed? -->
Add additional metadata to the bug report of NdkLinkError.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
It builds and runs on the example app.
I didn't add any new tests.