### PR TITLE
Add license-check and release to the bugsnag-android module

### DIFF
--- a/bugsnag-android/build.gradle.kts
+++ b/bugsnag-android/build.gradle.kts
@@ -18,3 +18,6 @@ dependencies {
     add("api", project(":bugsnag-plugin-android-anr"))
     add("api", project(":bugsnag-plugin-android-ndk"))
 }
+
+apply(from = rootProject.file("gradle/license-check.gradle"))
+apply(from = rootProject.file("gradle/release.gradle"))


### PR DESCRIPTION
## Goal
Correct the release scripts (adding the `release` script to the `bugsnag-android` meta-module).

## Testing
Tested with local publishing