### PR TITLE
add NdkLinkError to metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Introduced a new option in the `exitinfo` plugin for generating ANRs that does not have a matching Events (such as background ANRs)
   [#2116](https://github.com/bugsnag/bugsnag-android/pull/2116)
+* Add original error class and message to metadata for link errors loading BugSnag NDK libraries
+  [#2126](https://github.com/bugsnag/bugsnag-android/pull/2126)
 
 ## 6.10.0 (2024-11-14)
 

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -46,6 +46,9 @@ internal class NdkPlugin : Plugin {
     private fun performOneTimeSetup(client: Client) {
         libraryLoader.loadLibrary("bugsnag-ndk", client) {
             val error = it.errors[0]
+            it.addMetadata("LinkError", "errorClass", error.errorClass)
+            it.addMetadata("LinkError", "errorMessage", error.errorMessage)
+
             error.errorClass = "NdkLinkError"
             error.errorMessage = LOAD_ERR_MSG
             true


### PR DESCRIPTION
First-party pull request for https://github.com/bugsnag/bugsnag-android/pull/2124

## Goal
Make NdkLinkError and AnrLinkError reports consistent.

## Design
The commit 2f5a951 (PR #2070) already added metadata to AnrLinkError, so do the same for NdkLinkError.

## Changeset
Add additional metadata to the bug report of NdkLinkError.