### PR TITLE
Update makefile version checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,23 +67,13 @@ example-app:
 	@cd ./examples/sdk-app-example/ && ./gradlew clean assembleRelease
 
 bump:
-ifneq ($(shell git diff --staged),)
-	@git diff --staged
-	@$(error You have uncommitted changes. Push or discard them to continue)
+ifneq ($(VERSION),)
+	@echo "Bumping version to $(VERSION)"
+	@./scripts/bump-version.sh $(VERSION)
+else
+	@echo "Please provide a version number"
+	@./scripts/bump-version.sh
 endif
-ifeq ($(VERSION),)
-	@$(error VERSION is not defined. Run with `make VERSION=number bump`)
-endif
-ifeq ($(shell echo $(VERSION) | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$'),)
-	@$(error VERSION must be in the format MAJOR.MINOR.PATCH)
-endif
-	@echo Bumping the version number to $(VERSION)
-	@sed -i '' "s/bugsnag-android:.*\"/bugsnag-android:$(VERSION)\"/" examples/sdk-app-example/app/build.gradle
-	@sed -i '' "s/bugsnag-plugin-android-okhttp:.*\"/bugsnag-plugin-android-okhttp:$(VERSION)\"/" examples/sdk-app-example/app/build.gradle
-	@sed -i '' "s/VERSION_NAME=.*/VERSION_NAME=$(VERSION)/" gradle.properties
-	@sed -i '' "s/var version: String = .*/var version: String = \"$(VERSION)\",/"\
-	 bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
-	@sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
 
 .PHONY: check
 check:

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ endif
 ifeq ($(VERSION),)
 	@$(error VERSION is not defined. Run with `make VERSION=number bump`)
 endif
+ifeq ($(shell echo $(VERSION) | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$'),)
+	@$(error VERSION must be in the format MAJOR.MINOR.PATCH)
+endif
 	@echo Bumping the version number to $(VERSION)
 	@sed -i '' "s/bugsnag-android:.*\"/bugsnag-android:$(VERSION)\"/" examples/sdk-app-example/app/build.gradle
 	@sed -i '' "s/bugsnag-plugin-android-okhttp:.*\"/bugsnag-plugin-android-okhttp:$(VERSION)\"/" examples/sdk-app-example/app/build.gradle

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$1" != "" ]]; then
+  VERSION=$1
+elif [[ "$BRANCH" =~ ^release/v.*$ ]]; then
+  VERSION=${BRANCH#release/v}
+else
+  echo "Error: Current branch '$BRANCH' does not appear to be a release branch."
+  echo "Please specify VERSION manually:"
+  echo "$(basename $0) <version-number>"
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: VERSION '$VERSION' is not in a valid format (e.g., 1.2.3)."
+  exit 1
+fi
+
+echo Bumping the version number to $VERSION
+sed -i '' "s/bugsnag-android:.*\"/bugsnag-android:$VERSION\"/" examples/sdk-app-example/app/build.gradle
+sed -i '' "s/bugsnag-plugin-android-okhttp:.*\"/bugsnag-plugin-android-okhttp:$VERSION\"/" examples/sdk-app-example/app/build.gradle
+sed -i '' "s/VERSION_NAME=.*/VERSION_NAME=$VERSION/" gradle.properties
+sed -i '' "s/var version: String = .*/var version: String = \"$VERSION\",/"\
+ bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+sed -i '' "s/## TBD/## $VERSION ($(date '+%Y-%m-%d'))/" CHANGELOG.md
+


### PR DESCRIPTION
## Goal

make bump does no verification of the version syntax, allowing us to accidentally bump to version strings that Gradle cannot order / match and potentially breaking our recommended com.bugsnag:bugsnag-android:5.+ syntax.

## Changeset

Added regex version checking for major.minor.patch on make bump.