### PR TITLE
docs(changelog): retrospective change of 6.11 to point at online docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-* Introduced a new option in the `exitinfo` plugin for generating ANRs that does not have a matching Events (such as background ANRs)
+* Introduced a new option in the `exitinfo` plugin for generating ANRs that does not have a matching Events (such as background ANRs). See our online docs for more information on enabling this feature: https://docs.bugsnag.com/platforms/android/reporting-exit-info.
   [#2116](https://github.com/bugsnag/bugsnag-android/pull/2116)
 * Add original error class and message to metadata for link errors loading BugSnag NDK libraries
   [#2126](https://github.com/bugsnag/bugsnag-android/pull/2126)


### PR DESCRIPTION
## Goal

Retrospectively modified the changelog entry to link to the online docs for the new ANR event synthesising.