### PR TITLE
Report signal codes on native crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Native crashes will now include their signal code (where applicable) in the error message
+  [#2135](https://github.com/bugsnag/bugsnag-android/pull/2135)
+
 ## 6.11.0 (2025-01-22)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -48,6 +48,17 @@ struct sigaction *bsg_global_sigaction;
 /* the previous signal handler array */
 struct sigaction *bsg_global_sigaction_previous;
 
+#define MSG_SIGILL "Illegal instruction"
+#define MSG_SIGTRAP "Trace/breakpoint trap"
+#define MSG_SIGABRT "Abort program"
+#define MSG_SIGBUS "Bus error (bad memory access)"
+#define MSG_SIGFPE "Floating-point exception"
+#define MSG_SIGSEGV "Segmentation violation (invalid memory reference)"
+
+#define xstr(s) str(s)
+#define str(s) #s
+#define SIG_CODE_MESSAGE(msg, code) (msg ", code " xstr(code) " (" #code ")")
+
 /**
  * Native signals which will be captured by the Bugsnag signal handler™
  */
@@ -56,64 +67,58 @@ static const int bsg_native_signals[BSG_HANDLED_SIGNAL_COUNT + 1] = {
 static const char bsg_native_signal_names[BSG_HANDLED_SIGNAL_COUNT + 1][8] = {
     "SIGILL", "SIGTRAP", "SIGABRT", "SIGBUS", "SIGFPE", "SIGSEGV"};
 static const char bsg_native_signal_msgs[BSG_HANDLED_SIGNAL_COUNT + 1][60] = {
-    "Illegal instruction",
-    "Trace/breakpoint trap",
-    "Abort program",
-    "Bus error (bad memory access)",
-    "Floating-point exception",
-    "Segmentation violation (invalid memory reference)"};
+    MSG_SIGILL, MSG_SIGTRAP, MSG_SIGABRT, MSG_SIGBUS, MSG_SIGFPE, MSG_SIGSEGV};
 
-static const char bsg_native_signal_code_names[BSG_HANDLED_SIGNAL_COUNT +
-                                               1][BSG_SIGNAL_CODE_COUNT +
-                                                  1][67] = {
-    {"Illegal instruction, code 1 (ILLOPC)",
-     "Illegal instruction, code 2 (ILLOPN)",
-     "Illegal instruction, code 3 (ILLADR)",
-     "Illegal instruction, code 4 (ILLTRP)",
-     "Illegal instruction, code 5 (PRVOPC)",
-     "Illegal instruction, code 6 (PRVREG)",
-     "Illegal instruction, code 7 (COPROC)",
-     "Illegal instruction, code 8 (BADSTK)",
-     "Illegal instruction, code 9 (BADIADDR)",
-     "Illegal instruction, code 10 (BREAK)",
-     "Illegal instruction, code 11 (BNDMOD)"},
-    {"Trace/breakpoint trap, code 1 (BRKPT)",
-     "Trace/breakpoint trap, code 2 (TRACE)",
-     "Trace/breakpoint trap, code 3 (BRANCH)",
-     "Trace/breakpoint trap, code 4 (HWBKPT)",
-     "Trace/breakpoint trap, code 5 (UNK)",
-     "Trace/breakpoint trap, code 6 (PERF)"},
-    {0},
-    {"Bus error (bad memory access), code 1 (ADRALN)",
-     "Bus error (bad memory access), code 2 (ADRERR)",
-     "Bus error (bad memory access), code 3 (OBJERR)",
-     "Bus error (bad memory access), code 4 (MCEERR_AR)",
-     "Bus error (bad memory access), code 5 (MCEERR_AO)"},
-
-    {"Floating-point exception, code 1 (INTDIV)",
-     "Floating-point exception, code 2 (INTOVF)",
-     "Floating-point exception, code 3 (FLTDIV)",
-     "Floating-point exception, code 4 (FLTOVF)",
-     "Floating-point exception, code 5 (FLTUND)",
-     "Floating-point exception, code 6 (FLTRES)",
-     "Floating-point exception, code 7 (FLTINV)",
-     "Floating-point exception, code 8 (FLTSUB)",
-     "Floating-point exception, code 9 (DECOVF)",
-     "Floating-point exception, code 10 (DECDIV)",
-     "Floating-point exception, code 11 (DECERR)",
-     "Floating-point exception, code 12 (INVASC)",
-     "Floating-point exception, code 13 (INVDEC)",
-     "Floating-point exception, code 14 (FLTUNK)",
-     "Floating-point exception, code 15 (CONDTRAP)"},
-    {"Segmentation violation (invalid memory reference), code 1 (MAPERR)",
-     "Segmentation violation (invalid memory reference), code 2 (ACCERR)",
-     "Segmentation violation (invalid memory reference), code 3 (BNDERR)",
-     "Segmentation violation (invalid memory reference), code 4 (PKUERR)",
-     "Segmentation violation (invalid memory reference), code 5 (ACCADI)",
-     "Segmentation violation (invalid memory reference), code 6 (ADIDERR)",
-     "Segmentation violation (invalid memory reference), code 7 (ADIPERR)",
-     "Segmentation violation (invalid memory reference), code 8 (MTEAERR)",
-     "Segmentation violation (invalid memory reference), code 9 (MTESERR)"}};
+static const char
+    bsg_native_signal_code_names[BSG_HANDLED_SIGNAL_COUNT +
+                                 1][BSG_SIGNAL_CODE_COUNT + 1][72] = {
+        {SIG_CODE_MESSAGE(MSG_SIGILL, ILL_ILLOPC),
+         SIG_CODE_MESSAGE(MSG_SIGILL, ILL_ILLOPN),
+         SIG_CODE_MESSAGE(MSG_SIGILL, ILL_ILLADR),
+         SIG_CODE_MESSAGE(MSG_SIGILL, ILL_ILLTRP),
+         SIG_CODE_MESSAGE(MSG_SIGILL, ILL_PRVOPC),
+         SIG_CODE_MESSAGE(MSG_SIGILL, ILL_PRVREG),
+         SIG_CODE_MESSAGE(MSG_SIGILL, ILL_COPROC),
+         SIG_CODE_MESSAGE(MSG_SIGILL, ILL_BADSTK),
+         SIG_CODE_MESSAGE(MSG_SIGILL, ILL_BADIADDR),
+         SIG_CODE_MESSAGE(MSG_SIGILL, __ILL_BREAK),
+         SIG_CODE_MESSAGE(MSG_SIGILL, __ILL_BNDMOD)},
+        {SIG_CODE_MESSAGE(MSG_SIGTRAP, TRAP_BRKPT),
+         SIG_CODE_MESSAGE(MSG_SIGTRAP, TRAP_TRACE),
+         SIG_CODE_MESSAGE(MSG_SIGTRAP, TRAP_BRANCH),
+         SIG_CODE_MESSAGE(MSG_SIGTRAP, TRAP_HWBKPT),
+         SIG_CODE_MESSAGE(MSG_SIGTRAP, TRAP_UNK),
+         SIG_CODE_MESSAGE(MSG_SIGTRAP, TRAP_PERF)},
+        {0},
+        {SIG_CODE_MESSAGE(MSG_SIGBUS, BUS_ADRALN),
+         SIG_CODE_MESSAGE(MSG_SIGBUS, BUS_ADRERR),
+         SIG_CODE_MESSAGE(MSG_SIGBUS, BUS_OBJERR),
+         SIG_CODE_MESSAGE(MSG_SIGBUS, BUS_MCEERR_AR),
+         SIG_CODE_MESSAGE(MSG_SIGBUS, BUS_MCEERR_AO)},
+        {SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_INTDIV),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_INTOVF),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_FLTDIV),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_FLTOVF),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_FLTUND),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_FLTRES),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_FLTINV),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_FLTSUB),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, __FPE_DECOVF),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, __FPE_DECDIV),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, __FPE_DECERR),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, __FPE_INVASC),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, __FPE_INVDEC),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_FLTUNK),
+         SIG_CODE_MESSAGE(MSG_SIGFPE, FPE_CONDTRAP)},
+        {SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_MAPERR),
+         SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_ACCERR),
+         SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_BNDERR),
+         SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_PKUERR),
+         SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_ACCADI),
+         SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_ADIDERR),
+         SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_ADIPERR),
+         SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_MTEAERR),
+         SIG_CODE_MESSAGE(MSG_SIGSEGV, SEGV_MTESERR)}};
 
 static const int bsg_native_signal_codes[BSG_HANDLED_SIGNAL_COUNT +
                                          1][BSG_SIGNAL_CODE_COUNT + 1] = {
@@ -127,13 +132,17 @@ static const int bsg_native_signal_codes[BSG_HANDLED_SIGNAL_COUNT +
     {SEGV_MAPERR, SEGV_ACCERR, SEGV_BNDERR, SEGV_PKUERR, SEGV_ACCADI,
      SEGV_ADIDERR, SEGV_ADIPERR, SEGV_MTEAERR, SEGV_MTESERR}};
 
-const char *bsg_get_signal_code_description(const int signal,
-                                            const int signal_code) __asyncsafe {
+static const char *
+bsg_get_signal_code_description(const int signal,
+                                const int signal_code) __asyncsafe {
   for (int i = 0; i < BSG_HANDLED_SIGNAL_COUNT; i++) {
     if (bsg_native_signals[i] == signal) {
       for (int j = 0; j < BSG_SIGNAL_CODE_COUNT; j++) {
         if (bsg_native_signal_codes[i][j] == signal_code) {
           return bsg_native_signal_code_names[i][j];
+        } else if (*bsg_native_signal_code_names[i][j] == 0) {
+          // NULL in the signal_code_name array indicates no more known codes
+          break;
         }
       }
     }

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -132,12 +132,8 @@ const char *bsg_get_signal_code_description(const int signal,
   for (int i = 0; i < BSG_HANDLED_SIGNAL_COUNT; i++) {
     if (bsg_native_signals[i] == signal) {
       for (int j = 0; j < BSG_SIGNAL_CODE_COUNT; j++) {
-        printf("%s", "aaaaaaaaaaaaaaa,signal");
-        printf("%d", signal);
         if (bsg_native_signal_codes[i][j] == signal_code) {
           return bsg_native_signal_code_names[i][j];
-          printf("%s", "aaaaaaaaaaaaaaa,signal description");
-          printf("%s", bsg_native_signal_code_names[i][j]);
         }
       }
     }
@@ -286,12 +282,6 @@ void bsg_handle_signal(int signum, siginfo_t *info,
           bsg_get_signal_code_description(signal, signal_code);
       if (error_message == NULL || *error_message == 0) {
         error_message = (char *)bsg_native_signal_msgs[i];
-        printf("%s", "aaaaaaaaaaaaaaa, em is null or 0");
-
-      } else {
-        printf("%s", "aaaaaaaaaaaaaaa");
-        printf("%s", error_message);
-        printf("%d", signal_code);
       }
       bsg_strncpy(bsg_global_env->next_event.error.errorMessage, error_message,
                   sizeof(bsg_global_env->next_event.error.errorMessage));

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -17,7 +17,7 @@
 #include "../utils/threads.h"
 #define BSG_HANDLED_SIGNAL_COUNT 6
 #define BSG_SIGNAL_CODE_COUNT 15
-/**BSG_SIGNAL_CODE_COUNT
+/**
  * Function to capture signals and write reports to disk
  * @param signum The captured signal number
  * @param info handler info, flags
@@ -65,7 +65,7 @@ static const char bsg_native_signal_msgs[BSG_HANDLED_SIGNAL_COUNT + 1][60] = {
 
 static const char bsg_native_signal_code_names[BSG_HANDLED_SIGNAL_COUNT +
                                                1][BSG_SIGNAL_CODE_COUNT +
-                                                  1][72] = {
+                                                  1][67] = {
     {"Illegal instruction, code 1 (ILLOPC)",
      "Illegal instruction, code 2 (ILLOPN)",
      "Illegal instruction, code 3 (ILLADR)",
@@ -77,45 +77,43 @@ static const char bsg_native_signal_code_names[BSG_HANDLED_SIGNAL_COUNT +
      "Illegal instruction, code 9 (BADIADDR)",
      "Illegal instruction, code 10 (BREAK)",
      "Illegal instruction, code 11 (BNDMOD)"},
-    {"Trace/breakpoint trap, code 1 (TRAP_BRKPT)",
-     "Trace/breakpoint trap, code 2 (TRAP_TRACE)",
-     "Trace/breakpoint trap, code 3 (TRAP_BRANCH)",
-     "Trace/breakpoint trap, code 4 (TRAP_HWBKPT)",
-     "Trace/breakpoint trap, code 5 (TRAP_UNK)",
-     "Trace/breakpoint trap, code 6 (TRAP_PERF)"},
+    {"Trace/breakpoint trap, code 1 (BRKPT)",
+     "Trace/breakpoint trap, code 2 (TRACE)",
+     "Trace/breakpoint trap, code 3 (BRANCH)",
+     "Trace/breakpoint trap, code 4 (HWBKPT)",
+     "Trace/breakpoint trap, code 5 (UNK)",
+     "Trace/breakpoint trap, code 6 (PERF)"},
     {0},
-    {"Bus error (bad memory access), code 1 (BUS_ADRALN)",
-     "Bus error (bad memory access), code 2 (BUS_ADRERR)",
-     "Bus error (bad memory access), code 3 (BUS_OBJERR)",
-     "Bus error (bad memory access), code 4 (BUS_MCEERR_AR)",
-     "Bus error (bad memory access), code 5 (BUS_MCEERR_AO)"},
+    {"Bus error (bad memory access), code 1 (ADRALN)",
+     "Bus error (bad memory access), code 2 (ADRERR)",
+     "Bus error (bad memory access), code 3 (OBJERR)",
+     "Bus error (bad memory access), code 4 (MCEERR_AR)",
+     "Bus error (bad memory access), code 5 (MCEERR_AO)"},
 
-    {"Floating-point exception, code 1 (FPE_INTDIV)",
-     "Floating-point exception, code 2 (FPE_INTOVF)",
-     "Floating-point exception, code 3 (FPE_FLTDIV)",
-     "Floating-point exception, code 4 (FPE_FLTOVF)",
-     "Floating-point exception, code 5 (FPE_FLTUND)",
-     "Floating-point exception, code 6 (FPE_FLTRES)",
-     "Floating-point exception, code 7 (FPE_FLTINV)",
-     "Floating-point exception, code 8 (FPE_FLTSUB)",
-     "Floating-point exception, code 9 (__FPE_DECOVF)",
-     "Floating-point exception, code 10 (__FPE_DECDIV)",
-     "Floating-point exception, code 11 (__FPE_DECERR)",
-     "Floating-point exception, code 12 (__FPE_INVASC)",
-     "Floating-point exception, code 13 (__FPE_INVDEC)",
-     "Floating-point exception, code 14 (FPE_FLTUNK)",
-     "Floating-point exception, code 15 (FPE_CONDTRAP)"},
-    {"Segmentation violation (invalid memory reference), code 1 (SEGV_MAPERR)",
-     "Segmentation violation (invalid memory reference), code 2 (SEGV_ACCERR)",
-     "Segmentation violation (invalid memory reference), code 3 (SEGV_BNDERR)",
-     "Segmentation violation (invalid memory reference), code 4 (SEGV_PKUERR)",
-     "Segmentation violation (invalid memory reference), code 5 (SEGV_ACCADI)",
-     "Segmentation violation (invalid memory reference), code 6 (SEGV_ADIDERR)",
-     "Segmentation violation (invalid memory reference), code 7 (SEGV_ADIPERR)",
-     "Segmentation violation (invalid memory reference), code 8 (SEGV_MTEAERR)",
-     "Segmentation violation (invalid memory reference), code 9 "
-     "(SEGV_MTESERR)"},
-};
+    {"Floating-point exception, code 1 (INTDIV)",
+     "Floating-point exception, code 2 (INTOVF)",
+     "Floating-point exception, code 3 (FLTDIV)",
+     "Floating-point exception, code 4 (FLTOVF)",
+     "Floating-point exception, code 5 (FLTUND)",
+     "Floating-point exception, code 6 (FLTRES)",
+     "Floating-point exception, code 7 (FLTINV)",
+     "Floating-point exception, code 8 (FLTSUB)",
+     "Floating-point exception, code 9 (DECOVF)",
+     "Floating-point exception, code 10 (DECDIV)",
+     "Floating-point exception, code 11 (DECERR)",
+     "Floating-point exception, code 12 (INVASC)",
+     "Floating-point exception, code 13 (INVDEC)",
+     "Floating-point exception, code 14 (FLTUNK)",
+     "Floating-point exception, code 15 (CONDTRAP)"},
+    {"Segmentation violation (invalid memory reference), code 1 (MAPERR)",
+     "Segmentation violation (invalid memory reference), code 2 (ACCERR)",
+     "Segmentation violation (invalid memory reference), code 3 (BNDERR)",
+     "Segmentation violation (invalid memory reference), code 4 (PKUERR)",
+     "Segmentation violation (invalid memory reference), code 5 (ACCADI)",
+     "Segmentation violation (invalid memory reference), code 6 (ADIDERR)",
+     "Segmentation violation (invalid memory reference), code 7 (ADIPERR)",
+     "Segmentation violation (invalid memory reference), code 8 (MTEAERR)",
+     "Segmentation violation (invalid memory reference), code 9 (MTESERR)"}};
 
 static const int bsg_native_signal_codes[BSG_HANDLED_SIGNAL_COUNT +
                                          1][BSG_SIGNAL_CODE_COUNT + 1] = {
@@ -129,12 +127,17 @@ static const int bsg_native_signal_codes[BSG_HANDLED_SIGNAL_COUNT +
     {SEGV_MAPERR, SEGV_ACCERR, SEGV_BNDERR, SEGV_PKUERR, SEGV_ACCADI,
      SEGV_ADIDERR, SEGV_ADIPERR, SEGV_MTEAERR, SEGV_MTESERR}};
 
-const char *bsg_get_signal_code_description(const int signal) __asyncsafe {
+const char *bsg_get_signal_code_description(const int signal,
+                                            const int signal_code) __asyncsafe {
   for (int i = 0; i < BSG_HANDLED_SIGNAL_COUNT; i++) {
     if (bsg_native_signals[i] == signal) {
       for (int j = 0; j < BSG_SIGNAL_CODE_COUNT; j++) {
-        if (bsg_native_signal_codes[i][j] == signal) {
+        printf("%s", "aaaaaaaaaaaaaaa,signal");
+        printf("%d", signal);
+        if (bsg_native_signal_codes[i][j] == signal_code) {
           return bsg_native_signal_code_names[i][j];
+          printf("%s", "aaaaaaaaaaaaaaa,signal description");
+          printf("%s", bsg_native_signal_code_names[i][j]);
         }
       }
     }
@@ -274,14 +277,21 @@ void bsg_handle_signal(int signum, siginfo_t *info,
 
   for (int i = 0; i < BSG_HANDLED_SIGNAL_COUNT; i++) {
     const int signal = bsg_native_signals[i];
+    const int signal_code = info->si_code;
     if (signal == signum) {
       bsg_strncpy(bsg_global_env->next_event.error.errorClass,
                   (char *)bsg_native_signal_names[i],
                   sizeof(bsg_global_env->next_event.error.errorClass));
-
-      const char *error_message = bsg_get_signal_code_description(signal);
+      const char *error_message =
+          bsg_get_signal_code_description(signal, signal_code);
       if (error_message == NULL || *error_message == 0) {
         error_message = (char *)bsg_native_signal_msgs[i];
+        printf("%s", "aaaaaaaaaaaaaaa, em is null or 0");
+
+      } else {
+        printf("%s", "aaaaaaaaaaaaaaa");
+        printf("%s", error_message);
+        printf("%d", signal_code);
       }
       bsg_strncpy(bsg_global_env->next_event.error.errorMessage, error_message,
                   sizeof(bsg_global_env->next_event.error.errorMessage));

--- a/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/handlers/signal_handler.c
@@ -83,7 +83,7 @@ static const char bsg_native_signal_code_names[BSG_HANDLED_SIGNAL_COUNT +
      "Trace/breakpoint trap, code 4 (TRAP_HWBKPT)",
      "Trace/breakpoint trap, code 5 (TRAP_UNK)",
      "Trace/breakpoint trap, code 6 (TRAP_PERF)"},
-    {},
+    {0},
     {"Bus error (bad memory access), code 1 (BUS_ADRALN)",
      "Bus error (bad memory access), code 2 (BUS_ADRERR)",
      "Bus error (bad memory access), code 3 (BUS_OBJERR)",
@@ -280,7 +280,7 @@ void bsg_handle_signal(int signum, siginfo_t *info,
                   sizeof(bsg_global_env->next_event.error.errorClass));
 
       const char *error_message = bsg_get_signal_code_description(signal);
-      if (error_message == NULL) {
+      if (error_message == NULL || *error_message == 0) {
         error_message = (char *)bsg_native_signal_msgs[i];
       }
       bsg_strncpy(bsg_global_env->next_event.error.errorMessage, error_message,

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -53,7 +53,7 @@ Feature: Native crash reporting
       | SIGTRAP |
     And the exception "message" equals one of:
       | Illegal instruction, code 4 (ILLTRP)   |
-      | Trace/breakpoint trap, code 5 (TRAP_UNK) |
+      | Trace/breakpoint trap, code 1 (BRKPT) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true
@@ -133,7 +133,7 @@ Feature: Native crash reporting
       | SIGTRAP |
     And the exception "message" equals one of:
       | Illegal instruction, code 4 (ILLTRP)   |
-      | Trace/breakpoint trap, code 5 (TRAP_UNK) |
+      | Trace/breakpoint trap, code 1 (BRKPT)  |
     And the exception "type" equals "c"
     And the first significant stack frames match:
       | something_innocuous                                                                 | libmonochrome.so                    | (ignore) |

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -54,9 +54,9 @@ Feature: Native crash reporting
     And the exception "message" equals one of:
       | Illegal instruction                    |
       | Trace/breakpoint trap                  |
-      | Illegal instruction, code 4 (ILLTRP)   |
-      | Illegal instruction, code 1 (ILLOPC)   |
-      | Trace/breakpoint trap, code 1 (BRKPT)  |
+      | Illegal instruction, code 4 (ILL_ILLTRP)   |
+      | Illegal instruction, code 1 (ILL_ILLOPC)   |
+      | Trace/breakpoint trap, code 1 (TRAP_BRKPT)  |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true
@@ -137,8 +137,8 @@ Feature: Native crash reporting
     And the exception "message" equals one of:
       | Illegal instruction                    |
       | Trace/breakpoint trap                  |
-      | Illegal instruction, code 1 (ILLOPC)   |
-      | Trace/breakpoint trap, code 1 (BRKPT)  |
+      | Illegal instruction, code 1 (ILL_ILLOPC)   |
+      | Trace/breakpoint trap, code 1 (TRAP_BRKPT)  |
     And the exception "type" equals "c"
     And the first significant stack frames match:
       | something_innocuous                                                                 | libmonochrome.so                    | (ignore) |

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -55,6 +55,7 @@ Feature: Native crash reporting
       | Illegal instruction                    |
       | Trace/breakpoint trap                  |
       | Illegal instruction, code 4 (ILLTRP)   |
+      | Illegal instruction, code 1 (ILLOPC)   |
       | Trace/breakpoint trap, code 1 (BRKPT)  |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
@@ -136,7 +137,7 @@ Feature: Native crash reporting
     And the exception "message" equals one of:
       | Illegal instruction                    |
       | Trace/breakpoint trap                  |
-      | Illegal instruction, code 4 (ILLTRP)   |
+      | Illegal instruction, code 1 (ILLOPC)   |
       | Trace/breakpoint trap, code 1 (BRKPT)  |
     And the exception "type" equals "c"
     And the first significant stack frames match:

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -52,8 +52,8 @@ Feature: Native crash reporting
       | SIGILL  |
       | SIGTRAP |
     And the exception "message" equals one of:
-      | Illegal instruction   |
-      | Trace/breakpoint trap |
+      | Illegal instruction, code 4 (ILLTRP)   |
+      | Trace/breakpoint trap, code 5 (TRAP_UNK) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true
@@ -132,8 +132,8 @@ Feature: Native crash reporting
       | SIGILL  |
       | SIGTRAP |
     And the exception "message" equals one of:
-      | Illegal instruction   |
-      | Trace/breakpoint trap |
+      | Illegal instruction, code 4 (ILLTRP)   |
+      | Trace/breakpoint trap, code 5 (TRAP_UNK) |
     And the exception "type" equals "c"
     And the first significant stack frames match:
       | something_innocuous                                                                 | libmonochrome.so                    | (ignore) |

--- a/features/full_tests/native_crash_handling.feature
+++ b/features/full_tests/native_crash_handling.feature
@@ -52,8 +52,10 @@ Feature: Native crash reporting
       | SIGILL  |
       | SIGTRAP |
     And the exception "message" equals one of:
+      | Illegal instruction                    |
+      | Trace/breakpoint trap                  |
       | Illegal instruction, code 4 (ILLTRP)   |
-      | Trace/breakpoint trap, code 1 (BRKPT) |
+      | Trace/breakpoint trap, code 1 (BRKPT)  |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true
@@ -132,6 +134,8 @@ Feature: Native crash reporting
       | SIGILL  |
       | SIGTRAP |
     And the exception "message" equals one of:
+      | Illegal instruction                    |
+      | Trace/breakpoint trap                  |
       | Illegal instruction, code 4 (ILLTRP)   |
       | Trace/breakpoint trap, code 1 (BRKPT)  |
     And the exception "type" equals "c"

--- a/features/full_tests/native_signal_raise.feature
+++ b/features/full_tests/native_signal_raise.feature
@@ -12,7 +12,7 @@ Feature: Raising native signals
     And the exception "message" equals one of:
       | Illegal instruction                      |
       | Trace/breakpoint trap                    |
-      | Illegal instruction, code 4 (ILLTRP)     |
+      | Illegal instruction, code 4 (ILL_ILLTRP)     |
       | Trace/breakpoint trap, code 5 (TRAP_UNK) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
@@ -59,7 +59,7 @@ Feature: Raising native signals
     And the exception "errorClass" equals "SIGFPE"
     And the exception "message" equals one of:
       | Floating-point exception                  |
-      | Floating-point exception, code 8 (FLTSUB) |
+      | Floating-point exception, code 8 (FPE_FLTSUB) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true

--- a/features/full_tests/native_signal_raise.feature
+++ b/features/full_tests/native_signal_raise.feature
@@ -10,7 +10,9 @@ Feature: Raising native signals
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals "SIGILL"
     And the exception "message" equals one of:
-      | Illegal instruction, code 4 (ILLTRP)  |
+      | Illegal instruction                      |
+      | Trace/breakpoint trap                    |
+      | Illegal instruction, code 4 (ILLTRP)     |
       | Trace/breakpoint trap, code 5 (TRAP_UNK) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
@@ -55,7 +57,9 @@ Feature: Raising native signals
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals "SIGFPE"
-    And the exception "message" equals "Floating-point exception, code 8 (FLTSUB)"
+    And the exception "message" equals one of:
+      | Floating-point exception                  |
+      | Floating-point exception, code 8 (FLTSUB) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true
@@ -66,7 +70,9 @@ Feature: Raising native signals
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals "SIGTRAP"
-    And the exception "message" equals "Trace/breakpoint trap, code 5 (TRAP_UNK)"
+    And the exception "message" equals one of:
+      | Trace/breakpoint trap                    |
+      | Trace/breakpoint trap, code 5 (TRAP_UNK) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true

--- a/features/full_tests/native_signal_raise.feature
+++ b/features/full_tests/native_signal_raise.feature
@@ -10,8 +10,8 @@ Feature: Raising native signals
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals "SIGILL"
     And the exception "message" equals one of:
-      | Illegal instruction   |
-      | Trace/breakpoint trap |
+      | Illegal instruction, code 4 (ILLTRP)  |
+      | Trace/breakpoint trap, code 5 (TRAP_UNK) |
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true
@@ -55,7 +55,7 @@ Feature: Raising native signals
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals "SIGFPE"
-    And the exception "message" equals "Floating-point exception"
+    And the exception "message" equals "Floating-point exception, code 8 (FPE_FLTSUB)"
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true
@@ -66,7 +66,7 @@ Feature: Raising native signals
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals "SIGTRAP"
-    And the exception "message" equals "Trace/breakpoint trap"
+    And the exception "message" equals "Trace/breakpoint trap, code 5 (TRAP_UNK)"
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true

--- a/features/full_tests/native_signal_raise.feature
+++ b/features/full_tests/native_signal_raise.feature
@@ -55,7 +55,7 @@ Feature: Raising native signals
     And I wait to receive an error
     And the error payload contains a completed unhandled native report
     And the exception "errorClass" equals "SIGFPE"
-    And the exception "message" equals "Floating-point exception, code 8 (FPE_FLTSUB)"
+    And the exception "message" equals "Floating-point exception, code 8 (FLTSUB)"
     And the exception "type" equals "c"
     And the event "severity" equals "error"
     And the event "unhandled" is true


### PR DESCRIPTION
## Goal

Show corresponding signal code for native crashes

## Changeset
Added a table of signal code descriptions for error messages, covering all of the defined signal codes. Having all of the messages pre-generated (via a macro) we avoid possible overflows and undefined behaviour that could occur when generating the error message from within the signal handler.

## Testing

Existing e2e tests