### PR TITLE
Simplify EventStore logic

### DIFF
--- a/bugsnag-android-core/detekt-baseline.xml
+++ b/bugsnag-android-core/detekt-baseline.xml
@@ -58,6 +58,7 @@
     <ID>SwallowedException:DeviceDataCollector.kt$DeviceDataCollector$exception: Exception</ID>
     <ID>SwallowedException:DeviceIdFilePersistence.kt$DeviceIdFilePersistence$exc: OverlappingFileLockException</ID>
     <ID>SwallowedException:EventStore.kt$EventStore$exception: RejectedExecutionException</ID>
+    <ID>SwallowedException:FileQueue.kt$FileQueue$e: Exception</ID>
     <ID>SwallowedException:ForegroundDetector.kt$ForegroundDetector$e: Exception</ID>
     <ID>SwallowedException:JsonHelperTest.kt$JsonHelperTest$e: IllegalArgumentException</ID>
     <ID>SwallowedException:PluginClient.kt$PluginClient$exc: ClassNotFoundException</ID>

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStorageModule.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStorageModule.kt
@@ -43,7 +43,9 @@ internal class EventStorageModule(
             cfg.logger,
             notifier,
             bgTaskService,
-            delegate.getOrNull(),
+            { exception, errorFile, context ->
+                delegate.getOrNull()?.onErrorIOFailure(exception, errorFile, context)
+            },
             callbackState
         )
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventStore.kt
@@ -1,14 +1,16 @@
 package com.bugsnag.android
 
 import android.os.SystemClock
+import androidx.annotation.VisibleForTesting
 import com.bugsnag.android.EventFilenameInfo.Companion.findTimestampInFilename
 import com.bugsnag.android.EventFilenameInfo.Companion.fromEvent
-import com.bugsnag.android.EventFilenameInfo.Companion.fromFile
 import com.bugsnag.android.JsonStream.Streamable
 import com.bugsnag.android.internal.BackgroundTaskService
+import com.bugsnag.android.internal.FileQueue
 import com.bugsnag.android.internal.ForegroundDetector
 import com.bugsnag.android.internal.ImmutableConfig
 import com.bugsnag.android.internal.TaskType
+import com.bugsnag.android.internal.WriteErrorHandler
 import java.io.File
 import java.util.Calendar
 import java.util.Date
@@ -24,25 +26,30 @@ import java.util.concurrent.TimeoutException
  */
 internal class EventStore(
     private val config: ImmutableConfig,
-    logger: Logger,
-    notifier: Notifier,
-    bgTaskService: BackgroundTaskService,
-    delegate: Delegate?,
-    callbackState: CallbackState
-) : FileStore(
-    File(config.persistenceDirectory.value, "bugsnag/errors"),
-    config.maxPersistedEvents,
-    logger,
-    delegate
-) {
-    private val notifier: Notifier
-    private val bgTaskService: BackgroundTaskService
+    private val logger: Logger,
+    private val notifier: Notifier,
+    private val bgTaskService: BackgroundTaskService,
+    writeErrorHandler: WriteErrorHandler?,
     private val callbackState: CallbackState
-    override val logger: Logger
-
+) {
     var onEventStoreEmptyCallback: () -> Unit = {}
     var onDiscardEventCallback: (EventPayload) -> Unit = {}
     private var isEmptyEventCallbackCalled: Boolean = false
+
+    private val queue = FileQueue(
+        File(config.persistenceDirectory.value, "bugsnag/errors"),
+        config.maxPersistedEvents,
+        logger,
+        EVENT_COMPARATOR,
+        writeErrorHandler
+    ) {
+        if (!isEmptyEventCallbackCalled) {
+            onEventStoreEmptyCallback()
+            isEmptyEventCallbackCalled = true
+        }
+    }
+
+    val storageDir: File by queue::storageDir
 
     /**
      * Flush startup crashes synchronously on the main thread. Startup crashes block the main thread
@@ -53,13 +60,9 @@ internal class EventStore(
             return
         }
         val future = try {
-            bgTaskService.submitTask(
-                TaskType.ERROR_REQUEST,
-                Runnable {
-                    flushLaunchCrashReport()
-                    notifyEventQueueEmpty()
-                }
-            )
+            bgTaskService.submitTask(TaskType.ERROR_REQUEST) {
+                flushLaunchCrashReport()
+            }
         } catch (exc: RejectedExecutionException) {
             logger.d("Failed to flush launch crash reports, continuing.", exc)
             return
@@ -91,36 +94,35 @@ internal class EventStore(
     }
 
     private fun flushLaunchCrashReport() {
-        val storedFiles = findStoredFiles()
-        val launchCrashReport = findLaunchCrashReport(storedFiles)
-
-        // cancel non-launch crash reports
-        launchCrashReport?.let { storedFiles.remove(it) }
-        cancelQueuedFiles(storedFiles)
-        if (launchCrashReport != null) {
+        val startupCrashProcessed = queue.processLastFile(this::isLaunchCrash) { report ->
             logger.i("Attempting to send the most recent launch crash report")
-            flushReports(listOf(launchCrashReport))
+            flushEventFile(report)
             logger.i("Continuing with Bugsnag initialisation")
-        } else {
+        }
+
+        if (!startupCrashProcessed) {
             logger.d("No startupcrash events to flush to Bugsnag.")
         }
     }
 
-    fun findLaunchCrashReport(storedFiles: Collection<File>): File? {
-        return storedFiles
-            .asSequence()
-            .filter { fromFile(it, config).isLaunchCrashReport() }
-            .maxWithOrNull(EVENT_COMPARATOR)
+    fun write(event: Streamable): File? {
+        return queue.write(getFilename(event), event)
+    }
+
+    fun enqueueContentForDelivery(payload: String, filename: String) {
+        queue.write(filename) { out ->
+            out.write(payload)
+        }
     }
 
     fun writeAndDeliver(streamable: Streamable): Future<String>? {
-        val filename = write(streamable) ?: return null
+        val file = queue.write(getFilename(streamable), streamable) ?: return null
         try {
             return bgTaskService.submitTask(
                 TaskType.ERROR_REQUEST,
                 Callable {
-                    flushEventFile(File(filename))
-                    filename
+                    flushEventFile(file)
+                    file.absolutePath
                 }
             )
         } catch (exception: RejectedExecutionException) {
@@ -134,26 +136,24 @@ internal class EventStore(
      */
     fun flushAsync() {
         try {
-            bgTaskService.submitTask(
-                TaskType.ERROR_REQUEST,
-                Runnable {
-                    val storedFiles = findStoredFiles()
-                    if (storedFiles.isEmpty()) {
-                        logger.d("No regular events to flush to Bugsnag.")
-                    }
-                    flushReports(storedFiles)
-                    notifyEventQueueEmpty()
+            bgTaskService.submitTask(TaskType.ERROR_REQUEST) {
+                if (queue.isEmpty()) {
+                    logger.d("No regular events to flush to Bugsnag.")
                 }
-            )
+                flushReports()
+            }
         } catch (exception: RejectedExecutionException) {
             logger.w("Failed to flush all on-disk errors, retaining unsent errors for later.")
         }
     }
 
-    private fun flushReports(storedReports: Collection<File>) {
-        if (!storedReports.isEmpty()) {
+    fun isEmpty() = queue.isEmpty()
+
+    private fun flushReports() {
+        queue.processEnqueuedFiles { storedReports ->
             val size = storedReports.size
             logger.i("Sending $size saved error(s) to Bugsnag")
+
             for (eventFile in storedReports) {
                 flushEventFile(eventFile)
             }
@@ -162,11 +162,9 @@ internal class EventStore(
 
     private fun flushEventFile(eventFile: File) {
         try {
-            val (apiKey) = fromFile(eventFile, config)
+            val (apiKey) = EventFilenameInfo.fromFile(eventFile, config)
             val payload = createEventPayload(eventFile, apiKey)
-            if (payload == null) {
-                deleteStoredFiles(setOf(eventFile))
-            } else {
+            if (payload != null) {
                 deliverEventPayload(eventFile, payload)
             }
         } catch (exception: Exception) {
@@ -179,7 +177,7 @@ internal class EventStore(
         val delivery = config.delivery
         when (delivery.deliver(payload, deliveryParams)) {
             DeliveryStatus.DELIVERED -> {
-                deleteStoredFiles(setOf(eventFile))
+                queue.delete(eventFile)
                 logger.i("Deleting sent error file $eventFile.name")
             }
 
@@ -197,15 +195,14 @@ internal class EventStore(
                 "Discarding over-sized event (${eventFile.length()}) after failed delivery"
             )
             discardEvents(eventFile)
-            deleteStoredFiles(setOf(eventFile))
+            queue.delete(eventFile)
         } else if (isTooOld(eventFile)) {
             logger.w(
                 "Discarding historical event (from ${getCreationDate(eventFile)}) after failed delivery"
             )
             discardEvents(eventFile)
-            deleteStoredFiles(setOf(eventFile))
+            queue.delete(eventFile)
         } else {
-            cancelQueuedFiles(setOf(eventFile))
             logger.w(
                 "Could not send previously saved error(s) to Bugsnag, will try again later"
             )
@@ -236,22 +233,20 @@ internal class EventStore(
 
     private fun handleEventFlushFailure(exc: Exception, eventFile: File) {
         logger.e(exc.message ?: "Failed to send event", exc)
-        deleteStoredFiles(setOf(eventFile))
+        queue.delete(eventFile)
     }
 
-    override fun getFilename(obj: Any?): String {
+    @VisibleForTesting
+    internal fun isLaunchCrash(file: File): Boolean {
+        return EventFilenameInfo.fromFile(file, config).isLaunchCrashReport()
+    }
+
+    private fun getFilename(obj: Any?): String {
         return obj?.let { fromEvent(obj = it, apiKey = null, config = config) }?.encode() ?: ""
     }
 
     fun getNdkFilename(obj: Any?, apiKey: String?): String {
         return obj?.let { fromEvent(obj = it, apiKey = apiKey, config = config) }?.encode() ?: ""
-    }
-
-    init {
-        this.logger = logger
-        this.notifier = notifier
-        this.bgTaskService = bgTaskService
-        this.callbackState = callbackState
     }
 
     private fun isTooBig(file: File): Boolean {
@@ -268,15 +263,8 @@ internal class EventStore(
         return Date(findTimestampInFilename(file))
     }
 
-    private fun notifyEventQueueEmpty() {
-        if (isEmpty() && !isEmptyEventCallbackCalled) {
-            onEventStoreEmptyCallback()
-            isEmptyEventCallbackCalled = true
-        }
-    }
-
     private fun discardEvents(eventFile: File) {
-        val eventFilenameInfo = fromFile(eventFile, config)
+        val eventFilenameInfo = EventFilenameInfo.fromFile(eventFile, config)
         onDiscardEventCallback(
             EventPayload(
                 eventFilenameInfo.apiKey,
@@ -290,6 +278,8 @@ internal class EventStore(
 
     companion object {
         private const val LAUNCH_CRASH_TIMEOUT_MS: Long = 2000
+        private const val oneMegabyte = 1024L * 1024L
+
         val EVENT_COMPARATOR: Comparator<in File?> = Comparator { lhs, rhs ->
             when {
                 lhs == null && rhs == null -> 0
@@ -298,6 +288,5 @@ internal class EventStore(
                 else -> lhs.compareTo(rhs)
             }
         }
-        private const val oneMegabyte = 1024L * 1024L
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -52,32 +52,6 @@ internal abstract class FileStore(
      */
     fun isEmpty(): Boolean = queuedFiles.isEmpty() && storageDir.list().isNullOrEmpty()
 
-    fun enqueueContentForDelivery(content: String?, filename: String) {
-        if (!isStorageDirValid(storageDir)) {
-            return
-        }
-        discardOldestFileIfNeeded()
-        lock.lock()
-        var out: Writer? = null
-        val filePath = File(storageDir, filename).absolutePath
-        try {
-            val fos = FileOutputStream(filePath)
-            out = BufferedWriter(OutputStreamWriter(fos, "UTF-8"))
-            out.write(content)
-        } catch (exc: Exception) {
-            val eventFile = File(filePath)
-            delegate?.onErrorIOFailure(exc, eventFile, "NDK Crash report copy")
-            IOUtils.deleteFile(eventFile, logger)
-        } finally {
-            try {
-                out?.close()
-            } catch (exception: Exception) {
-                logger.w("Failed to close unsent payload writer: $filename", exception)
-            }
-            lock.unlock()
-        }
-    }
-
     fun write(streamable: Streamable): String? {
         if (!isStorageDirValid(storageDir)) {
             return null

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/InternalReportDelegate.java
@@ -22,7 +22,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
 
-class InternalReportDelegate implements EventStore.Delegate {
+class InternalReportDelegate {
 
     static final String INTERNAL_DIAGNOSTICS_TAB = "BugsnagDiagnostics";
 
@@ -59,7 +59,6 @@ class InternalReportDelegate implements EventStore.Delegate {
         this.backgroundTaskService = backgroundTaskService;
     }
 
-    @Override
     public void onErrorIOFailure(Exception exc, File errorFile, String context) {
         // send an internal error to bugsnag with no cache
         SeverityReason severityReason = SeverityReason.newInstance(REASON_UNHANDLED_EXCEPTION);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -420,7 +420,7 @@ public class NativeInterface {
         Client client = getClient();
         ImmutableConfig config = client.getConfig();
         if (releaseStage == null
-                || releaseStage.length() == 0
+                || releaseStage.isEmpty()
                 || !config.shouldDiscardByReleaseStage()) {
             EventStore eventStore = client.getEventStore();
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/FileQueue.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/FileQueue.kt
@@ -1,0 +1,284 @@
+package com.bugsnag.android.internal
+
+import com.bugsnag.android.JsonStream
+import com.bugsnag.android.JsonStream.Streamable
+import com.bugsnag.android.Logger
+import java.io.Closeable
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.Writer
+import java.util.Collections
+import java.util.TreeSet
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+typealias WriteErrorHandler = (exception: Exception?, errorFile: File?, context: String?) -> Unit
+
+internal class FileQueue(
+    val storageDir: File,
+    private val maxStoreCount: Int,
+    private val logger: Logger,
+    private val comparator: Comparator<in File>,
+    private val writeErrorHandler: WriteErrorHandler?,
+    /**
+     * Callback invoked whenever the queue becomes empty (all files are blocked or deleted). The
+     * callback is always invoked under a lock, ensuring that the queue will not change state
+     * while the callback is being invoked.
+     */
+    private val onQueueEmptyCallback: () -> Unit,
+) {
+    /**
+     * This is all of files that are (for whatever reason) not considered to be "in" the queue.
+     * These can be files that (for whatever reason) cannot be deleted from the filesystem, or
+     * files that are actively being written or read.
+     */
+    private val blockedFiles = TreeSet(comparator)
+
+    private val lock = lockFor(storageDir)
+
+    init {
+        ensureStorageDirValid()
+    }
+
+    fun isEmpty(): Boolean = lock.withLock { isEmptyUnderLock() }
+
+    private fun ensureStorageDirValid(): Boolean {
+        try {
+            storageDir.mkdirs()
+        } catch (exception: Exception) {
+            logger.e("Could not prepare file storage directory", exception)
+            return false
+        }
+        return true
+    }
+
+    fun write(filename: String, streamable: Streamable): File? = lock.withLock {
+        write(filename) { out ->
+            val json = JsonStream(out)
+            json.value(streamable)
+            json.closeQuietly()
+        }
+    }
+
+    inline fun write(filename: String, writeContent: (Writer) -> Unit): File? = lock.withLock {
+        if (!ensureStorageDirValid()) {
+            return null
+        }
+        if (maxStoreCount == 0) {
+            return null
+        }
+
+        ensureSpaceForNewFile()
+        val file = File(storageDir, filename)
+        try {
+            logger.d("Saving payload: $filename")
+            FileOutputStream(file).bufferedWriter().use { out ->
+                writeContent(out)
+            }
+
+            logger.i("Saved payload to disk: '$filename'")
+            return file
+        } catch (exc: FileNotFoundException) {
+            logger.w("Ignoring FileNotFoundException - unable to create file", exc)
+        } catch (exc: Exception) {
+            writeErrorHandler?.invoke(exc, file, "Crash report serialization")
+            delete(file)
+        }
+
+        return null
+    }
+
+    /**
+     * Discard / delete the oldest files in the queue (according to [comparator]) until there
+     * are `maxStoreCount - 1` files enqueued (allowing space for a new file to be added).
+     */
+    private fun ensureSpaceForNewFile() = lock.withLock {
+        if (!ensureStorageDirValid()) {
+            return@withLock
+        }
+
+        val fileList = enqueuedFiles()
+        val discardCount = fileList.size - (maxStoreCount - 1)
+
+        if (discardCount > 0) {
+            logger.d("Discarding $discardCount old files from $storageDir")
+            delete(fileList.subList(0, discardCount))
+        }
+    }
+
+    /**
+     * Process the next file in the queue (optionally filtered by [filter]), returning `true`
+     * if a file was processed (even if the processing failed) and `false` if the queue
+     * is empty or no file matched [filter].
+     *
+     * This function operates under a lock and guarantees that the file will not be processed
+     * more than once, even if the processing fails. Upon returning any file processed by this
+     * function *will be removed from the queue*.
+     */
+    inline fun processNextFile(
+        filter: (File) -> Boolean = { true },
+        processor: (File) -> Unit
+    ): Boolean {
+        return processFile(comparator, filter, processor)
+    }
+
+    /**
+     * Same as [processNextFile] but will process the *last* (newest) file in the queue rather
+     * than the "next" (allowing the queue to be treated like a stack).
+     */
+    inline fun processLastFile(
+        filter: (File) -> Boolean = { true },
+        processor: (File) -> Unit
+    ): Boolean {
+        return processFile(Collections.reverseOrder(comparator), filter, processor)
+    }
+
+    inline fun processEnqueuedFiles(processor: FileQueue.(List<File>) -> Unit): Int =
+        lock.withLock {
+            try {
+                val files = enqueuedFiles()
+                if (files.isEmpty()) {
+                    return@withLock 0
+                }
+
+                this.processor(files)
+
+                return@withLock files.size
+            } finally {
+                checkQueueEmptyUnderLock()
+            }
+        }
+
+    internal inline fun processFile(
+        comparator: Comparator<in File>,
+        filter: (File) -> Boolean,
+        processor: (File) -> Unit,
+    ): Boolean = lock.withLock {
+        try {
+            val nextFile = getFileUnderLock(comparator, filter)
+                ?: return@withLock false
+
+            try {
+                processor(nextFile)
+            } catch (ex: Exception) {
+                // ensure we don't attempt to process this file again
+                cancelFile(nextFile)
+
+                logger.d("failed to process file '$nextFile', will try again later", ex)
+            }
+
+            return@withLock true
+        } finally {
+            checkQueueEmptyUnderLock()
+        }
+    }
+
+    internal inline fun getFileUnderLock(
+        comparator: Comparator<in File>,
+        filter: (File) -> Boolean,
+    ): File? {
+        val files = storageDir.listFiles()?.takeIf { it.isNotEmpty() } ?: return null
+        var file: File? = null
+
+        for (f in files) {
+            if (f !in blockedFiles && filter(f)) {
+                if (file == null || comparator.compare(f, file) < 0) {
+                    file = f
+                }
+            }
+        }
+
+        return file
+    }
+
+    fun enqueuedFiles(): List<File> = lock.withLock {
+        val files = storageDir.listFiles()?.toMutableList() ?: return emptyList()
+        files.removeAll(blockedFiles)
+        files.sortWith(comparator)
+
+        return@withLock files
+    }
+
+    fun delete(files: Iterable<File>) = lock.withLock {
+        files.forEach { file ->
+            if (!file.delete()) {
+                blockedFiles.add(file)
+            }
+        }
+
+        checkQueueEmptyUnderLock()
+    }
+
+    fun delete(file: File) {
+        if (file.parentFile != storageDir) {
+            return
+        }
+
+        lock.withLock {
+            if (!file.delete()) {
+                blockedFiles.add(file)
+            }
+
+            checkQueueEmptyUnderLock()
+        }
+    }
+
+    /**
+     * Treat the given file as deleted (non-persistently). This can be used to avoid attempting
+     * to re-read a file for as long as the process remains active, working around files that
+     * cannot be deleted or delivered (stopping these from blocking the queue).
+     */
+    fun cancelFile(file: File) {
+        if (file.parentFile != storageDir) {
+            return
+        }
+
+        lock.withLock {
+            blockedFiles.add(file)
+            checkQueueEmptyUnderLock()
+        }
+    }
+
+    private fun isEmptyUnderLock(): Boolean {
+        val files = storageDir.listFiles() ?: return true
+        if (files.isEmpty()) {
+            return true
+        }
+
+        // if all of the files are blocked, the queue is empty
+        return files.all { it in blockedFiles }
+    }
+
+    private fun checkQueueEmptyUnderLock() {
+        if (isEmptyUnderLock()) {
+            onQueueEmptyCallback()
+        }
+    }
+
+    private fun Closeable.closeQuietly() {
+        try {
+            close()
+        } catch (e: Exception) {
+            // ignore
+        }
+    }
+
+    internal companion object {
+        /**
+         * FileQueues share locks based on the directory the files are stored in. This allows
+         * multiple `FileQueue` instances to be created for the same directory, without the queues
+         * interfering with each other.
+         */
+        private val locks = HashMap<String, Lock>(4)
+
+        /**
+         * Get the shared `Lock` for the given queue directory.
+         */
+        @Synchronized
+        fun lockFor(queueDir: File): Lock {
+            return locks.getOrPut(queueDir.absolutePath) { ReentrantLock() }
+        }
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/FileQueue.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/FileQueue.kt
@@ -64,10 +64,10 @@ internal class FileQueue(
 
     inline fun write(filename: String, writeContent: (Writer) -> Unit): File? = lock.withLock {
         if (!ensureStorageDirValid()) {
-            return null
+            return@withLock null
         }
         if (maxStoreCount == 0) {
-            return null
+            return@withLock null
         }
 
         ensureSpaceForNewFile()
@@ -79,7 +79,7 @@ internal class FileQueue(
             }
 
             logger.i("Saved payload to disk: '$filename'")
-            return file
+            return@withLock file
         } catch (exc: FileNotFoundException) {
             logger.w("Ignoring FileNotFoundException - unable to create file", exc)
         } catch (exc: Exception) {
@@ -87,7 +87,7 @@ internal class FileQueue(
             delete(file)
         }
 
-        return null
+        return@withLock null
     }
 
     /**
@@ -96,7 +96,7 @@ internal class FileQueue(
      */
     private fun ensureSpaceForNewFile() = lock.withLock {
         if (!ensureStorageDirValid()) {
-            return@withLock
+            return
         }
 
         val fileList = enqueuedFiles()
@@ -194,7 +194,7 @@ internal class FileQueue(
     }
 
     fun enqueuedFiles(): List<File> = lock.withLock {
-        val files = storageDir.listFiles()?.toMutableList() ?: return emptyList()
+        val files = storageDir.listFiles()?.toMutableList() ?: return@withLock emptyList()
         files.removeAll(blockedFiles)
         files.sortWith(comparator)
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EmptyJsonObject.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EmptyJsonObject.kt
@@ -1,0 +1,13 @@
+package com.bugsnag.android
+
+import com.bugsnag.android.JsonStream.Streamable
+
+/**
+ * Test implementation of [Streamable] which writes only an empty JSON object.
+ */
+internal object EmptyJsonObject : Streamable {
+    override fun toStream(stream: JsonStream) {
+        stream.beginObject()
+            .endObject()
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventFilenameTest.kt
@@ -1,11 +1,9 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.EventStore.Companion.EVENT_COMPARATOR
-import com.bugsnag.android.FileStore.Delegate
 import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -58,26 +56,16 @@ internal class EventFilenameTest {
             NoopLogger,
             Notifier(),
             BackgroundTaskService(),
-            object : Delegate {
-                override fun onErrorIOFailure(
-                    exception: Exception?,
-                    errorFile: File?,
-                    context: String?
-                ) {
-                }
-            },
+            { _, _, _ -> },
             CallbackState()
         )
 
-        // no files
-        assertNull(eventStore.findLaunchCrashReport(emptyList()))
-
         // regular crash reports
         val jvmCrashReport = File("1504255147933_683c6b92-b325-4987-80ad-77086509ca1e.json")
-        assertNull(eventStore.findLaunchCrashReport(listOf(jvmCrashReport)))
+        assertFalse(eventStore.isLaunchCrash(jvmCrashReport))
         val ndkCrashReport =
             File("1504255147933_0000111122223333aaaabbbbcccc9999_c_my-uuid-123_not-jvm.json")
-        assertNull(eventStore.findLaunchCrashReport(listOf(ndkCrashReport)))
+        assertFalse(eventStore.isLaunchCrash(ndkCrashReport))
     }
 
     @Test
@@ -87,52 +75,13 @@ internal class EventFilenameTest {
             NoopLogger,
             Notifier(),
             BackgroundTaskService(),
-            object : Delegate {
-                override fun onErrorIOFailure(
-                    exception: Exception?,
-                    errorFile: File?,
-                    context: String?
-                ) {
-                }
-            },
+            { _, _, _ -> },
             CallbackState()
         )
 
         // startup crashes
         val expected = File("1504255147933_30b7e350-dcd1-4032-969e-98d30be62bbc_startupcrash.json")
-        assertEquals(expected, eventStore.findLaunchCrashReport(listOf(expected)))
-    }
-
-    @Test
-    fun testFindMultipleLaunchCrashReport() {
-        val eventStore = EventStore(
-            BugsnagTestUtils.generateImmutableConfig(),
-            NoopLogger,
-            Notifier(),
-            BackgroundTaskService(),
-            object : Delegate {
-                override fun onErrorIOFailure(
-                    exception: Exception?,
-                    errorFile: File?,
-                    context: String?
-                ) {
-                }
-            },
-            CallbackState()
-        )
-
-        // if multiple crashes exist, pick the most recent one
-        val expected = File("1664219155431_042c6195-a32c-2f84-11ae-77086509ca1e_startupcrash.json")
-        assertEquals(
-            expected,
-            eventStore.findLaunchCrashReport(
-                listOf(
-                    File("1504255147933_30b7e350-dcd1-4032-969e-98d30be62bbc_startupcrash.json"),
-                    expected,
-                    File("1404205127135_683c6b92-b325-4987-80ad-77086509ca1e_startupcrash.json")
-                )
-            )
-        )
+        assertTrue(eventStore.isLaunchCrash(expected))
     }
 
     @Test

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventStoreMaxLimitTest.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateEvent
-import com.bugsnag.android.FileStore.Delegate
 import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.ImmutableConfig
 import com.bugsnag.android.internal.convertToImmutableConfig
@@ -84,14 +83,7 @@ class EventStoreMaxLimitTest {
             NoopLogger,
             Notifier(),
             BackgroundTaskService(),
-            object : Delegate {
-                override fun onErrorIOFailure(
-                    exception: Exception?,
-                    errorFile: File?,
-                    context: String?
-                ) {
-                }
-            },
+            { _, _, _ -> },
             CallbackState()
         )
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashDeliveryTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/LaunchCrashDeliveryTest.kt
@@ -2,7 +2,6 @@ package com.bugsnag.android
 
 import com.bugsnag.android.BugsnagTestUtils.generateConfiguration
 import com.bugsnag.android.BugsnagTestUtils.generateEvent
-import com.bugsnag.android.FileStore.Delegate
 import com.bugsnag.android.internal.BackgroundTaskService
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -98,6 +97,9 @@ class LaunchCrashDeliveryTest {
         event.app.isLaunching = true
         event.apiKey = "First"
         eventStore.write(event)
+
+        // make absolutely certain there is a time difference between First and Second
+        Thread.sleep(1L)
         event.apiKey = "Second"
         eventStore.write(event)
 
@@ -161,14 +163,7 @@ class LaunchCrashDeliveryTest {
             NoopLogger,
             Notifier(),
             backgroundTaskService,
-            object : Delegate {
-                override fun onErrorIOFailure(
-                    exception: Exception?,
-                    errorFile: File?,
-                    context: String?
-                ) {
-                }
-            },
+            { _, _, _ -> },
             CallbackState()
         )
     }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/FileQueueTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/FileQueueTest.kt
@@ -1,0 +1,108 @@
+package com.bugsnag.android.internal
+
+import com.bugsnag.android.EmptyJsonObject
+import com.bugsnag.android.EventStore
+import com.bugsnag.android.NoopLogger
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.util.UUID
+
+class FileQueueTest {
+    private lateinit var dir: File
+    private lateinit var fileQueue: FileQueue
+
+    @Before
+    fun createFileQueue() {
+        dir = Files.createTempDirectory("tmp").toFile()
+        dir.deleteRecursively()
+        dir.mkdirs()
+
+        fileQueue = FileQueue(
+            dir,
+            10,
+            NoopLogger,
+            EventStore.EVENT_COMPARATOR,
+            { exception, _, _ -> throw requireNotNull(exception) },
+            {}
+        )
+    }
+
+    @After
+    fun cleanup() {
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun enqueuedFilesAreSorted() {
+        val expectedFirst = "1404205127135_683c6b92-b325-4987-80ad-77086509ca1e_startupcrash.json"
+        val expectedLast = "1664219155431_042c6195-a32c-2f84-11ae-77086509ca1e_startupcrash.json"
+
+        fileQueue.write(
+            "1504255147933_30b7e350-dcd1-4032-969e-98d30be62bbc_startupcrash.json",
+            EmptyJsonObject
+        )
+        fileQueue.write(expectedLast, EmptyJsonObject)
+        fileQueue.write(expectedFirst, EmptyJsonObject)
+
+        assertTrue(
+            "processLastFile returned false",
+            fileQueue.processLastFile { file ->
+                assertEquals(expectedLast, file.name)
+            }
+        )
+
+        assertTrue(
+            "processNextFile returned false",
+            fileQueue.processNextFile { file ->
+                assertEquals(expectedFirst, file.name)
+            }
+        )
+    }
+
+    @Test
+    fun flushWithDelete() {
+        val filenames = (1..10).map {
+            "${it.toString().padStart(4, '0')}_${UUID.randomUUID()}.json"
+        }
+
+        filenames.forEach { fileQueue.write(it, EmptyJsonObject) }
+        assertFalse(fileQueue.isEmpty())
+
+        var flushedFiles = 0
+        fileQueue.processEnqueuedFiles { files ->
+            files.forEachIndexed { index, file ->
+                val id = file.name.substringBefore('_').toInt()
+                assertEquals("files flushed in the wrong order: $file", index + 1, id)
+                if (id % 2 == 0) {
+                    fileQueue.delete(file)
+                }
+
+                flushedFiles++
+            }
+        }
+
+        assertEquals(filenames.size, flushedFiles)
+
+        val remainingFiles = fileQueue.enqueuedFiles()
+        assertEquals(5, remainingFiles.size)
+    }
+
+    @Test
+    fun limitsStoredFiles() {
+        val filenames = (0..100).map {
+            "${it.toString().padStart(4, '0')}_${UUID.randomUUID()}.json"
+        }
+
+        filenames.forEach { fileQueue.write(it, EmptyJsonObject) }
+
+        val enqueuedFiled = fileQueue.enqueuedFiles()
+        assertEquals(10, enqueuedFiled.size)
+        assertEquals(filenames.takeLast(10), enqueuedFiled.map { it.name })
+    }
+}

--- a/bugsnag-android/build.gradle.kts
+++ b/bugsnag-android/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     load(Versions.Plugins.AGP)
+    load(Versions.Plugins.kotlin)
     load(Versions.Plugins.licenseCheck)
 }
 


### PR DESCRIPTION
## Goal
Improve the consistency and simplify the implementation of `EventStore`.

## Design
Rather the maintaining a secondary in-memory queue within the state of `FileStore` (effectively leaking logic from the processing threads into the object state) we now have a `FileQueue` class which internalises the locking and processing, so processing the files is always done within the context of the `FileQueue` - leading to better consistency that should also be easier to reason.

Where previously retrieving the list of enqueued files would cause `FileStore` to "remember" which files were being processed, `FileStore` requires that a lambda be passed to process files within the queue. This means that the `FileQueue` controls any locking and consistency directly during file processing, rather than relying on the threading model and `EventStore`/`SessionStore` implementation for that consistency.

## Testing
Relied largely on the existing tests passing, with a new suite of tests for the `FileQueue` specifically.