### PR TITLE
Trim excess threads onSend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Excess threads (over `Configuration.getMaxReportedThreads`) are trimmed more reliably when the payload is modified before sending (in an `OnSendCallback` for example) 
+  [#2148](https://github.com/bugsnag/bugsnag-android/pull/2148)
+
 ## 6.12.0 (2025-02-18)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EventPayload.kt
@@ -80,6 +80,29 @@ class EventPayload @JvmOverloads internal constructor(
             dataTrimmed
         )
 
+        val threadCount = event.threads.size
+        val maxReportedThreads = config.maxReportedThreads
+        if (threadCount > maxReportedThreads) {
+            event.threads.subList(maxReportedThreads, threadCount).clear()
+
+            event.threads.add(
+                Thread(
+                    "",
+                    "[${threadCount - maxReportedThreads} threads omitted as the " +
+                        "maxReportedThreads limit ($maxReportedThreads) was exceeded]",
+                    ErrorType.UNKNOWN,
+                    false,
+                    Thread.State.UNKNOWN,
+                    Stacktrace(
+                        arrayOf(StackTraceElement("", "", "-", 0)),
+                        config.projectPackages,
+                        logger
+                    ),
+                    logger
+                )
+            )
+        }
+
         json = rebuildPayloadCache()
         if (json.size <= maxSizeBytes) {
             return this

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EventPayloadTrimTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EventPayloadTrimTest.kt
@@ -1,0 +1,64 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+private const val MAX_STRING_LENGTH = 256
+private const val BIG_STRING_LENGTH = MAX_STRING_LENGTH * 4
+
+@RunWith(MockitoJUnitRunner::class)
+class EventPayloadTrimTest {
+
+    @Mock
+    lateinit var client: Client
+
+    @Test
+    fun testTrimPayload() {
+        val event = BugsnagTestUtils.generateEvent()
+        event.addMetadata("trimming", "bigString", "*".repeat(BIG_STRING_LENGTH))
+
+        // remove any existing threads to keep this test simple
+        event.threads.clear()
+        repeat(times = 10) { threadIdx ->
+            event.addThread(threadIdx.toLong(), "test thread $threadIdx")
+        }
+
+        event.breadcrumbs.clear()
+        repeat(times = 10) { breadcrumbIdx ->
+            event.leaveBreadcrumb("breadcrumb $breadcrumbIdx")
+        }
+
+        val config = BugsnagTestUtils.generateImmutableConfig(
+            Configuration("abc123").apply {
+                maxBreadcrumbs = 2
+                maxReportedThreads = 2
+                maxStringValueLength = MAX_STRING_LENGTH
+            }
+        )
+
+        val notifier = Notifier(name = "Test Notifier", version = "9.9.9")
+        val payload = EventPayload(null, event, null, notifier, config)
+        val trimmed = requireNotNull(payload.trimToSize(BIG_STRING_LENGTH).event)
+
+        assertEquals(
+            "${"*".repeat(MAX_STRING_LENGTH)}***<${BIG_STRING_LENGTH - MAX_STRING_LENGTH}> CHARS TRUNCATED***",
+            trimmed.getMetadata("trimming")!!["bigString"]
+        )
+
+        val threads = trimmed.threads
+        assertEquals(3, threads.size)
+        assertEquals("test thread 0", threads[0].name)
+        assertEquals("test thread 1", threads[1].name)
+        assertEquals(
+            "[8 threads omitted as the maxReportedThreads limit (2) was exceeded]",
+            threads[2].name
+        )
+
+        val breadcrumbs = trimmed.breadcrumbs
+        assertEquals(1, breadcrumbs.size)
+        assertEquals("Removed, along with 9 older breadcrumbs, to reduce payload size", breadcrumbs[0].message)
+    }
+}


### PR DESCRIPTION
## Goal

Trim event threads if the size is  too large

## Design
Threads are now be trimmed less equal config `maxReportedThreads`  in `EventPayload` 

## Testing
Introduced a new unit test to cover `EventPayload.trimToSize`