### PR TITLE
Skip ANR test jobs on Android 10

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -531,6 +531,7 @@ steps:
     concurrency_method: eager
 
   - label: ':browserstack: Android 10 NDK r21 end-to-end tests - ANRs'
+    skip: All ANR scenarios are skipped on Android 10
     depends_on: "fixture-r21"
     timeout_in_minutes: 30
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -328,6 +328,7 @@ steps:
     concurrency_method: eager
 
   - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
+    skip: All ANR scenarios are skipped on Android 10
     depends_on: "fixture-r21"
     timeout_in_minutes: 30
     plugins:


### PR DESCRIPTION
## Goal

Skip ANR test jobs on Android 10 - all ANR scenarios are skipped on Android 10 anyway.

## Testing

Covered by CI.