### PR TITLE
LibraryLoader will retry System.loadLibrary exactly once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Attempt a second `System.loadLibrary` for native modules in case of library loading race-conditions
+  [#2170](https://github.com/bugsnag/bugsnag-android/pull/2170)
+
 ## 6.12.1 (2025-03-03)
 
 ### Bug fixes

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
@@ -39,8 +39,14 @@ class LibraryLoader {
             try {
                 System.loadLibrary(name);
                 loaded = true;
-            } catch (UnsatisfiedLinkError error) {
-                client.notify(error, callback);
+            } catch (UnsatisfiedLinkError ignored) {
+                // retry once in case the failure wasn't permanent
+                try {
+                    System.loadLibrary(name);
+                    loaded = true;
+                } catch (UnsatisfiedLinkError error) {
+                    client.notify(error, callback);
+                }
             }
         }
     }


### PR DESCRIPTION
## Goal
Work around possible `System.loadLibrary` race conditions by retrying native library loads exactly once if they fail.

## Testing
Relied on existing tests