### PR TITLE
Add testing on Android 15

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -869,6 +869,108 @@ steps:
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
 
+
+  - label: ':bitbar: Android 15 NDK r21 end-to-end tests - batch 1'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
+          - "--exclude=features/full_tests/anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_15"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':bitbar: Android 15 NDK r21 end-to-end tests - batch 2'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 60
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
+          - "--exclude=features/full_tests/anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_15"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+
+  - label: ':browserstack: Android 15 NDK r21 end-to-end tests - ANRs'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
+    plugins:
+      artifacts#v1.9.0:
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests/anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_15"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
+    env:
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+
   # If there is a tag present activate a manual publishing step
 
   - block: 'Trigger package publish'

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
@@ -33,7 +33,7 @@ internal class DiscardOldSessionScenario(
 
     fun waitForSessionFile() {
         val dir = sessionDir()
-        while (dir.listFiles()!!.isEmpty()) {
+        while (dir.listFiles().isNullOrEmpty()) {
             Thread.sleep(100)
         }
     }

--- a/features/full_tests/native_session_tracking.feature
+++ b/features/full_tests/native_session_tracking.feature
@@ -24,13 +24,17 @@ Feature: NDK Session Tracking
     And the error payload field "events.0.session.events.unhandled" equals 1
 
   Scenario: Starting a session, notifying, followed by a C crash
-    When I run "CXXSessionInfoCrashScenario" and relaunch the crashed app
-    And I configure Bugsnag for "CXXSessionInfoCrashScenario"
+    When I run "CXXSessionInfoCrashScenario"
     And I wait to receive a session
+    And I wait to receive 2 errors
+    And I discard the oldest session
+    And I discard the oldest error
+    And I discard the oldest error
+
+    And I relaunch the app after a crash
+    And I configure Bugsnag for "CXXSessionInfoCrashScenario"
+    # The fixture will now send the unhandled error plus the 2 handled errors
+    # again,  because they are invoked after the delivery of the session.
     And I wait to receive 3 errors
-    And I discard the oldest error
-    And I discard the oldest error
-    Then the error payload contains a completed handled native report
-    And the event contains session info
     And the error payload field "events.0.session.events.unhandled" equals 1
     And the error payload field "events.0.session.events.handled" equals 2

--- a/features/full_tests/naughty_strings.feature
+++ b/features/full_tests/naughty_strings.feature
@@ -26,8 +26,6 @@ Feature: The notifier handles user data containing unusual strings
     And the error payload field "events.0.metaData.custom.val_13" equals "𝓣𝓱𝓮 𝓺𝓾𝓲𝓬𝓴 𝓫𝓻𝓸𝔀𝓷 𝓯𝓸𝔁 𝓳𝓾𝓶𝓹𝓼 𝓸𝓿𝓮𝓻 𝓽𝓱𝓮 𝓵𝓪𝔃𝔂 𝓭𝓸𝓰"
     And the error payload field "events.0.metaData.custom.val_14" equals "گچپژ"
 
-# commented out some failing unicode assertions and skipped Android <6 until PLAT-5606 is addressed
-  @skip_below_android_6
   Scenario: Test unhandled NDK error
     When I run "CXXNaughtyStringsScenario" and relaunch the crashed app
     And I configure Bugsnag for "CXXNaughtyStringsScenario"

--- a/features/full_tests/startup_anr.feature
+++ b/features/full_tests/startup_anr.feature
@@ -9,8 +9,7 @@ Feature: onCreate ANR
   @skip_android_10
 # Android 13+ Note: we no longer have permission to inject BACK button events, which are used to
 # trigger the ANR - so the test is not valid on Android 13 either
-  @skip_android_13
-  @skip_android_14
+  @skip_above_android_13
   Scenario: onCreate ANR is reported
     When I clear any error dialogue
     And I run "ConfigureStartupAnrScenario"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,16 +24,16 @@ Before('@skip') do |scenario|
   skip_this_scenario("Skipping scenario")
 end
 
+Before('@skip_above_android_13') do |scenario|
+  skip_this_scenario("Skipping scenario") if Maze.config.os_version >= 13
+end
+
 Before('@skip_above_android_11') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version >= 11
 end
 
 Before('@skip_above_android_8') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version >= 9
-end
-
-Before('@skip_above_android_7') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version >= 8
 end
 
 Before('@skip_below_android_11') do |scenario|
@@ -48,34 +48,6 @@ Before('@skip_below_android_9') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version < 9
 end
 
-Before('@skip_below_android_8') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version < 8
-end
-
-Before('@skip_below_android_6') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version < 6
-end
-
-Before('@skip_below_android_5') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version < 5
-end
-
-Before('@skip_android_14') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version.floor == 14
-end
-
-Before('@skip_android_13') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version.floor == 13
-end
-
 Before('@skip_android_10') do |scenario|
   skip_this_scenario("Skipping scenario") if Maze.config.os_version.floor == 10
-end
-
-Before('@skip_android_7') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version.floor == 7
-end
-
-Before('@skip_android_6') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.config.os_version.floor == 6
 end


### PR DESCRIPTION
## Goal

Add testing on Android 15.

## Design

Follows the existing pattern of using BrowserStack for ANR scenarios and BitBar for the rest.  The Android 15 devices we have on BitBar are a little limited currently, but I have asked for some more to be added.

## Testing

Covered by a full CI run.