### PR TITLE
e2e test flake fixes

### DIFF
--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
@@ -1,7 +1,6 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
-import android.util.Log
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
@@ -32,8 +31,7 @@ internal class DiscardOldSessionScenario(
     fun sessionDir(): File {
         log("Waiting for session folder to be created")
 
-        var folder: File? = null;
-
+        var folder: File? = null
         while (folder == null) {
             Thread.sleep(100)
             folder = File(context.cacheDir, "bugsnag/sessions")

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
@@ -1,9 +1,11 @@
 package com.bugsnag.android.mazerunner.scenarios
 
 import android.content.Context
+import android.util.Log
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
+import com.bugsnag.android.mazerunner.log
 import java.io.File
 import java.util.Calendar
 
@@ -28,14 +30,26 @@ internal class DiscardOldSessionScenario(
     }
 
     fun sessionDir(): File {
-        return File(context.cacheDir, "bugsnag/sessions")
+        log("Waiting for session folder to be created")
+
+        var folder: File? = null;
+
+        while (folder == null) {
+            Thread.sleep(100)
+            folder = File(context.cacheDir, "bugsnag/sessions")
+        }
+        log("Session folder has been created")
+
+        return folder
     }
 
     fun waitForSessionFile() {
         val dir = sessionDir()
+        log("Waiting for session files to be created")
         while (dir.listFiles()!!.isEmpty()) {
             Thread.sleep(100)
         }
+        log("Session files have been created")
     }
 
     fun oldifySessionFiles() {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
-import com.bugsnag.android.mazerunner.log
 import java.io.File
 import java.util.Calendar
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/DiscardOldSessionScenario.kt
@@ -29,25 +29,14 @@ internal class DiscardOldSessionScenario(
     }
 
     fun sessionDir(): File {
-        log("Waiting for session folder to be created")
-
-        var folder: File? = null
-        while (folder == null) {
-            Thread.sleep(100)
-            folder = File(context.cacheDir, "bugsnag/sessions")
-        }
-        log("Session folder has been created")
-
-        return folder
+        return File(context.cacheDir, "bugsnag/sessions")
     }
 
     fun waitForSessionFile() {
         val dir = sessionDir()
-        log("Waiting for session files to be created")
-        while (dir.listFiles()!!.isEmpty()) {
+        while (dir.listFiles().isNullOrEmpty()) {
             Thread.sleep(100)
         }
-        log("Session files have been created")
     }
 
     fun oldifySessionFiles() {

--- a/features/full_tests/native_session_tracking.feature
+++ b/features/full_tests/native_session_tracking.feature
@@ -24,13 +24,17 @@ Feature: NDK Session Tracking
     And the error payload field "events.0.session.events.unhandled" equals 1
 
   Scenario: Starting a session, notifying, followed by a C crash
-    When I run "CXXSessionInfoCrashScenario" and relaunch the crashed app
-    And I configure Bugsnag for "CXXSessionInfoCrashScenario"
+    When I run "CXXSessionInfoCrashScenario"
     And I wait to receive a session
+    And I wait to receive 2 errors
+    And I discard the oldest session
+    And I discard the oldest error
+    And I discard the oldest error
+
+    And I relaunch the app after a crash
+    And I configure Bugsnag for "CXXSessionInfoCrashScenario"
+    # The fixture will now send the unhandled error plus the 2 handled errors
+    # again,  because they are invoked after the delivery of the session.
     And I wait to receive 3 errors
-    And I discard the oldest error
-    And I discard the oldest error
-    Then the error payload contains a completed handled native report
-    And the event contains session info
     And the error payload field "events.0.session.events.unhandled" equals 1
     And the error payload field "events.0.session.events.handled" equals 2


### PR DESCRIPTION
## Goal

Fixes a couple of e2e test flakes:

- `CXXSessionInfoCrashScenario` will perform the same sequence of notifying errors and causing a crash after the relaunch, because it hangs off of session delivery, so I've updated the scenario to simply expect the additional two handled errors (the 2nd unhandled error is of course not sent because the fixture is not relaunched a second time).
- `DiscardOldSessionScenario` was flaking due to a `NullPointerException` caused when the `bugsnag/sessions` folder had not yet been created.  I've changed the condition to simply retry if null.

## Testing

Covered by CI.