### PR TITLE
Metadata in leaveBreadcrumb should be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Allow the metadata in `leaveBreadcrumb` to be null rather than enforcing non-null, aligning `bugsnag-android` with our other SDKs
+  [#2180](https://github.com/bugsnag/bugsnag-android/pull/2180)
+
 ## 6.13.0 (2025-04-15)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -305,7 +305,7 @@ public final class Bugsnag {
      * @param type     A category for the breadcrumb
      */
     public static void leaveBreadcrumb(@NonNull String message,
-                                       @NonNull Map<String, Object> metadata,
+                                       @Nullable Map<String, Object> metadata,
                                        @NonNull BreadcrumbType type) {
         getClient().leaveBreadcrumb(message, metadata, type);
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -961,9 +961,9 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
      * @param type     A category for the breadcrumb
      */
     public void leaveBreadcrumb(@NonNull String message,
-                                @NonNull Map<String, Object> metadata,
+                                @Nullable Map<String, Object> metadata,
                                 @NonNull BreadcrumbType type) {
-        if (message != null && type != null && metadata != null) {
+        if (message != null && type != null) {
             breadcrumbState.add(new Breadcrumb(message, type, metadata, new Date(), logger));
         } else {
             logNull("leaveBreadcrumb");

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -473,9 +473,9 @@ public class ClientFacadeTest {
     }
 
     @Test
-    public void leaveComplexBreadcrumbInvalid3() {
+    public void leaveComplexBreadcrumbWithNullMetadata() {
         client.leaveBreadcrumb("foo", null, BreadcrumbType.NAVIGATION);
-        verify(breadcrumbState, times(0)).add(any(Breadcrumb.class));
+        verify(breadcrumbState, times(1)).add(any(Breadcrumb.class));
     }
 
     @Test

--- a/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
+++ b/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
@@ -5,7 +5,6 @@
     <ID>CyclomaticComplexMethod:CodeStrings.kt$@RequiresApi(Build.VERSION_CODES.R) @SuppressLint("SwitchIntDef") @Suppress("DEPRECATION") internal fun importanceDescriptionOf(exitInfo: ApplicationExitInfo)</ID>
     <ID>CyclomaticComplexMethod:CodeStrings.kt$@RequiresApi(Build.VERSION_CODES.R) internal fun exitReasonOf(exitInfo: ApplicationExitInfo)</ID>
     <ID>LongParameterList:TombstoneParser.kt$TombstoneParser$( exitInfo: ApplicationExitInfo, listOpenFds: Boolean, includeLogcat: Boolean, threadConsumer: (BugsnagThread) -> Unit, fileDescriptorConsumer: (Int, String, String) -> Unit, logcatConsumer: (String) -> Unit )</ID>
-    <ID>MagicNumber:BugsnagExitInfoPlugin.kt$BugsnagExitInfoPlugin$100</ID>
     <ID>MagicNumber:TraceParser.kt$TraceParser$16</ID>
     <ID>MagicNumber:TraceParser.kt$TraceParser$3</ID>
     <ID>MaxLineLength:ExitInfoCallbackTest.kt$ExitInfoCallbackTest$exitInfoCallback = ExitInfoCallback(context, nativeEnhancer, anrEventEnhancer, null, ApplicationExitInfoMatcher(context, 100))</ID>

--- a/scripts/run-connected-checks.rb
+++ b/scripts/run-connected-checks.rb
@@ -44,8 +44,8 @@ begin
   # Wait for the emulator to boot
   start_time = Time.now
   until emulator_lines.any? { |line| line.include?('Boot completed') }
-    if Time.now - start_time > 60
-      raise 'Emulator did not boot in 60 seconds'
+    if Time.now - start_time > 120
+      raise 'Emulator did not boot in 120 seconds'
     end
   end
 


### PR DESCRIPTION
## Changeset

Allow the metadata in leaveBreadcrumb to be null rather than enforcing non-null , aligning `bugsnag-android` with our other SDKs.

## Testing

Updated existing test