### PR TITLE
Increase AVD timeout to 120s to cover increased startup time

### DIFF
--- a/scripts/run-connected-checks.rb
+++ b/scripts/run-connected-checks.rb
@@ -44,8 +44,8 @@ begin
   # Wait for the emulator to boot
   start_time = Time.now
   until emulator_lines.any? { |line| line.include?('Boot completed') }
-    if Time.now - start_time > 60
-      raise 'Emulator did not boot in 60 seconds'
+    if Time.now - start_time > 120
+      raise 'Emulator did not boot in 120 seconds'
     end
   end
 


### PR DESCRIPTION
## Goal

The instrumentation tests fail because the AVD does not boot in 60 seconds. I've increased the timeout to 120 seconds, enough time for the AVD to boot.

## Testing

Covered by CI