### PR TITLE
Background EventStore start

### DIFF
--- a/bugsnag-android-core/api/bugsnag-android-core.api
+++ b/bugsnag-android-core/api/bugsnag-android-core.api
@@ -109,7 +109,6 @@ public class com/bugsnag/android/BugsnagVmViolationListener : android/os/StrictM
 }
 
 public class com/bugsnag/android/Client : com/bugsnag/android/CallbackAware, com/bugsnag/android/FeatureFlagAware, com/bugsnag/android/MetadataAware, com/bugsnag/android/UserAware {
-	protected final field eventStore Lcom/bugsnag/android/EventStore;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Lcom/bugsnag/android/Configuration;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;)V

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -77,7 +77,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
     final MemoryTrimState memoryTrimState = new MemoryTrimState();
 
     @NonNull
-    protected final EventStore eventStore;
+    private final Provider<EventStore> eventStore;
 
     final SessionTracker sessionTracker;
 
@@ -138,7 +138,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
                 data.put("networkState", networkState);
                 leaveAutoBreadcrumb("Connectivity changed", BreadcrumbType.STATE, data);
                 if (hasConnection) {
-                    eventStore.flushAsync();
+                    getEventStore().flushAsync();
                     sessionTracker.flushAsync();
                 }
                 return null;
@@ -201,10 +201,10 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
                 dataCollectionModule, bgTaskService, trackerModule, systemServiceModule, notifier,
                 callbackState);
 
-        eventStore = eventStorageModule.getEventStore().get();
+        eventStore = eventStorageModule.getEventStore();
 
-        deliveryDelegate = new DeliveryDelegate(logger, eventStorageModule.getEventStore(),
-                immutableConfig, callbackState, notifier, bgTaskService);
+        deliveryDelegate = new DeliveryDelegate(logger, eventStore, immutableConfig, callbackState,
+                notifier, bgTaskService);
 
         exceptionHandler = new ExceptionHandler(this, logger);
 
@@ -245,7 +245,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
             @NonNull DeviceDataCollector deviceDataCollector,
             @NonNull AppDataCollector appDataCollector,
             @NonNull BreadcrumbState breadcrumbState,
-            @NonNull EventStore eventStore,
+            @NonNull Provider<EventStore> eventStore,
             SystemBroadcastReceiver systemBroadcastReceiver,
             SessionTracker sessionTracker,
             Connectivity connectivity,
@@ -296,8 +296,8 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         }
 
         // Flush any on-disk errors and sessions
-        eventStore.flushOnLaunch();
-        eventStore.flushAsync();
+        eventStore.get().flushOnLaunch();
+        eventStore.get().flushAsync();
         sessionTracker.flushAsync();
 
         // These call into NdkPluginCaller to sync with the native side, so they must happen later
@@ -1091,7 +1091,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
 
     @NonNull
     EventStore getEventStore() {
-        return eventStore;
+        return eventStore.get();
     }
 
     /**

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -203,7 +203,7 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
 
         eventStore = eventStorageModule.getEventStore().get();
 
-        deliveryDelegate = new DeliveryDelegate(logger, eventStore,
+        deliveryDelegate = new DeliveryDelegate(logger, eventStorageModule.getEventStore(),
                 immutableConfig, callbackState, notifier, bgTaskService);
 
         exceptionHandler = new ExceptionHandler(this, logger);

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -442,7 +442,7 @@ public class NativeInterface {
      * @param reportFile the file to enqueue for delivery
      */
     public static void deliverReport(@NonNull File reportFile) {
-        EventStore eventStore = getClient().eventStore;
+        EventStore eventStore = getClient().getEventStore();
         File eventFile = new File(eventStore.getStorageDir(), reportFile.getName());
         if (reportFile.renameTo(eventFile)) {
             eventStore.flushAsync();

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientFacadeTest.java
@@ -124,7 +124,7 @@ public class ClientFacadeTest {
                 deviceDataCollector,
                 appDataCollector,
                 breadcrumbState,
-                eventStore,
+                new ValueProvider<EventStore>(eventStore),
                 systemBroadcastReceiver,
                 sessionTracker,
                 connectivity,

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/DeliveryDelegateTest.kt
@@ -3,6 +3,7 @@ package com.bugsnag.android
 import com.bugsnag.android.BugsnagTestUtils.generateImmutableConfig
 import com.bugsnag.android.internal.BackgroundTaskService
 import com.bugsnag.android.internal.StateObserver
+import com.bugsnag.android.internal.dag.ValueProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -35,7 +36,7 @@ internal class DeliveryDelegateTest {
         deliveryDelegate =
             DeliveryDelegate(
                 logger,
-                eventStore,
+                ValueProvider(eventStore),
                 config,
                 callbackState,
                 notifier,

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -13,13 +13,13 @@ class InternalHooks {
     }
 
     public static void setEventStoreEmptyCallback(Client client, Function0<Unit> callback) {
-        client.eventStore.setOnEventStoreEmptyCallback(callback);
+        client.getEventStore().setOnEventStoreEmptyCallback(callback);
     }
 
     public static void setDiscardEventCallback(
             Client client,
             Function1<EventPayload, Unit> callback) {
-        client.eventStore.setOnDiscardEventCallback(callback);
+        client.getEventStore().setOnDiscardEventCallback(callback);
     }
 
     static void deliver(@NonNull Client client, @NonNull Event event) {

--- a/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/BugsnagInternals.java
+++ b/features/fixtures/mazerunner/app/src/main/java/com/bugsnag/android/BugsnagInternals.java
@@ -4,6 +4,6 @@ public class BugsnagInternals {
     private BugsnagInternals() {}
 
     public static void flush() {
-        Bugsnag.client.eventStore.flushAsync();
+        Bugsnag.client.getEventStore().flushAsync();
     }
 }


### PR DESCRIPTION
## Goal
Reduce the chances of ANRs during normal startup on devices with slow I/O.

## Changeset
Moved the `EventStore` blocking to as late as possible during startup to allow more time for devices with slow I/O.

## Testing
Replied on existing tests as the change should be transparent