### PR TITLE
Isolate CI step that used AVD

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
 #  - label: 'Audit current licenses'
 #    timeout_in_minutes: 30
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    commands:
 #      - bundle install
 #      - ./scripts/audit-dependency-licenses.sh
@@ -15,7 +15,7 @@ steps:
 #    key: "fixture-r19"
 #    timeout_in_minutes: 30
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    artifact_paths:
 #      - "build/fixture-r19.apk"
 #      - "build/fixture-r19-url.txt"
@@ -33,7 +33,7 @@ steps:
 #    key: "fixture-r21"
 #    timeout_in_minutes: 30
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    artifact_paths:
 #      - "build/fixture-r21.apk"
 #      - "build/fixture-r21-url.txt"
@@ -50,31 +50,31 @@ steps:
 #  - label: ':android: Coding standards checks'
 #    timeout_in_minutes: 20
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    command: './gradlew --continue checkstyle detekt lint ktlintCheck'
 #
 #  - label: ':android: Binary compatibility checks'
 #    timeout_in_minutes: 20
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    command: './gradlew apiCheck'
 #
 #  - label: ':android: CppCheck'
 #    timeout_in_minutes: 10
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    command: 'bash ./scripts/run-cpp-check.sh'
 #
 #  - label: ':android: ClangFormat'
 #    timeout_in_minutes: 10
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    command: 'bash ./scripts/run-clang-format-ci-check.sh'
 #
 #  - label: ':android: Lint mazerunner scenarios'
 #    timeout_in_minutes: 10
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    commands:
 #      - cd features/fixtures/mazerunner
 #      - ./gradlew ktlintCheck detekt checkstyle
@@ -84,13 +84,13 @@ steps:
 #  - label: ':android: Android size reporting'
 #    timeout_in_minutes: 10
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    command: scripts/run-sizer.sh
 #
 #  - label: ':android: JVM tests'
 #    timeout_in_minutes: 10
 #    agents:
-#      queue: macos-14
+#      queue: macos-14-isolated
 #    command: './gradlew test'
 
   - label: ':android: Instrumentation tests'
@@ -99,7 +99,7 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14
+      queue: macos-14-isolated
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
@@ -110,7 +110,7 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14
+      queue: macos-14-isolated
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
@@ -121,7 +121,7 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14
+      queue: macos-14-isolated
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
@@ -132,7 +132,7 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14
+      queue: macos-14-isolated
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
@@ -143,7 +143,7 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14
+      queue: macos-14-isolated
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
@@ -154,7 +154,7 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14
+      queue: macos-14-isolated
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
@@ -165,7 +165,7 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14
+      queue: macos-14-isolated
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
@@ -176,7 +176,183 @@ steps:
       artifacts#v1.9.0:
         upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
     agents:
-      queue: macos-14
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14-isolated
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,96 +2,96 @@ agents:
   queue: 'opensource'
 
 steps:
-
-  - label: 'Audit current licenses'
-    timeout_in_minutes: 30
-    agents:
-      queue: macos-14
-    commands:
-      - bundle install
-      - ./scripts/audit-dependency-licenses.sh
-
-  - label: ':android: Build fixture APK r19'
-    key: "fixture-r19"
-    timeout_in_minutes: 30
-    agents:
-      queue: macos-14
-    artifact_paths:
-      - "build/fixture-r19.apk"
-      - "build/fixture-r19-url.txt"
-      - "build/bs-fixture-r19-url.txt"
-      - "build/fixture-r19/*"
-    commands:
-      - bundle install
-      - make fixture-r19
-      - bundle exec upload-app --farm=bb --app=./build/fixture-r19.apk --app-id-file=build/fixture-r19-url.txt
-      - bundle exec upload-app --farm=bs --app=./build/fixture-r19.apk --app-id-file=build/bs-fixture-r19-url.txt
-    env:
-      JAVA_VERSION: 17
-
-  - label: ':android: Build fixture APK r21'
-    key: "fixture-r21"
-    timeout_in_minutes: 30
-    agents:
-      queue: macos-14
-    artifact_paths:
-      - "build/fixture-r21.apk"
-      - "build/fixture-r21-url.txt"
-      - "build/bs-fixture-r21-url.txt"
-      - "build/fixture-r21/*"
-    commands:
-      - bundle install
-      - make fixture-r21
-      - bundle exec upload-app --farm=bb --app=./build/fixture-r21.apk --app-id-file=build/fixture-r21-url.txt
-      - bundle exec upload-app --farm=bs --app=./build/fixture-r21.apk --app-id-file=build/bs-fixture-r21-url.txt
-    env:
-      JAVA_VERSION: 17
-
-  - label: ':android: Coding standards checks'
-    timeout_in_minutes: 20
-    agents:
-      queue: macos-14
-    command: './gradlew --continue checkstyle detekt lint ktlintCheck'
-
-  - label: ':android: Binary compatibility checks'
-    timeout_in_minutes: 20
-    agents:
-      queue: macos-14
-    command: './gradlew apiCheck'
-
-  - label: ':android: CppCheck'
-    timeout_in_minutes: 10
-    agents:
-      queue: macos-14
-    command: 'bash ./scripts/run-cpp-check.sh'
-
-  - label: ':android: ClangFormat'
-    timeout_in_minutes: 10
-    agents:
-      queue: macos-14
-    command: 'bash ./scripts/run-clang-format-ci-check.sh'
-
-  - label: ':android: Lint mazerunner scenarios'
-    timeout_in_minutes: 10
-    agents:
-      queue: macos-14
-    commands:
-      - cd features/fixtures/mazerunner
-      - ./gradlew ktlintCheck detekt checkstyle
-    env:
-      JAVA_VERSION: 17
-
-  - label: ':android: Android size reporting'
-    timeout_in_minutes: 10
-    agents:
-      queue: macos-14
-    command: scripts/run-sizer.sh
-
-  - label: ':android: JVM tests'
-    timeout_in_minutes: 10
-    agents:
-      queue: macos-14
-    command: './gradlew test'
+#
+#  - label: 'Audit current licenses'
+#    timeout_in_minutes: 30
+#    agents:
+#      queue: macos-14
+#    commands:
+#      - bundle install
+#      - ./scripts/audit-dependency-licenses.sh
+#
+#  - label: ':android: Build fixture APK r19'
+#    key: "fixture-r19"
+#    timeout_in_minutes: 30
+#    agents:
+#      queue: macos-14
+#    artifact_paths:
+#      - "build/fixture-r19.apk"
+#      - "build/fixture-r19-url.txt"
+#      - "build/bs-fixture-r19-url.txt"
+#      - "build/fixture-r19/*"
+#    commands:
+#      - bundle install
+#      - make fixture-r19
+#      - bundle exec upload-app --farm=bb --app=./build/fixture-r19.apk --app-id-file=build/fixture-r19-url.txt
+#      - bundle exec upload-app --farm=bs --app=./build/fixture-r19.apk --app-id-file=build/bs-fixture-r19-url.txt
+#    env:
+#      JAVA_VERSION: 17
+#
+#  - label: ':android: Build fixture APK r21'
+#    key: "fixture-r21"
+#    timeout_in_minutes: 30
+#    agents:
+#      queue: macos-14
+#    artifact_paths:
+#      - "build/fixture-r21.apk"
+#      - "build/fixture-r21-url.txt"
+#      - "build/bs-fixture-r21-url.txt"
+#      - "build/fixture-r21/*"
+#    commands:
+#      - bundle install
+#      - make fixture-r21
+#      - bundle exec upload-app --farm=bb --app=./build/fixture-r21.apk --app-id-file=build/fixture-r21-url.txt
+#      - bundle exec upload-app --farm=bs --app=./build/fixture-r21.apk --app-id-file=build/bs-fixture-r21-url.txt
+#    env:
+#      JAVA_VERSION: 17
+#
+#  - label: ':android: Coding standards checks'
+#    timeout_in_minutes: 20
+#    agents:
+#      queue: macos-14
+#    command: './gradlew --continue checkstyle detekt lint ktlintCheck'
+#
+#  - label: ':android: Binary compatibility checks'
+#    timeout_in_minutes: 20
+#    agents:
+#      queue: macos-14
+#    command: './gradlew apiCheck'
+#
+#  - label: ':android: CppCheck'
+#    timeout_in_minutes: 10
+#    agents:
+#      queue: macos-14
+#    command: 'bash ./scripts/run-cpp-check.sh'
+#
+#  - label: ':android: ClangFormat'
+#    timeout_in_minutes: 10
+#    agents:
+#      queue: macos-14
+#    command: 'bash ./scripts/run-clang-format-ci-check.sh'
+#
+#  - label: ':android: Lint mazerunner scenarios'
+#    timeout_in_minutes: 10
+#    agents:
+#      queue: macos-14
+#    commands:
+#      - cd features/fixtures/mazerunner
+#      - ./gradlew ktlintCheck detekt checkstyle
+#    env:
+#      JAVA_VERSION: 17
+#
+#  - label: ':android: Android size reporting'
+#    timeout_in_minutes: 10
+#    agents:
+#      queue: macos-14
+#    command: scripts/run-sizer.sh
+#
+#  - label: ':android: JVM tests'
+#    timeout_in_minutes: 10
+#    agents:
+#      queue: macos-14
+#    command: './gradlew test'
 
   - label: ':android: Instrumentation tests'
     timeout_in_minutes: 10
@@ -103,632 +103,711 @@ steps:
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
-  #
-  # BitBar steps
-  #
-  - label: ':bitbar: Android 7 NDK r19 smoke tests'
-    depends_on: "fixture-r19"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r19-url.txt"
-          - "build/fixture-r19/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r19-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_7"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
 
-  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
-    depends_on: "fixture-r19"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r19-url.txt"
-          - "build/fixture-r19/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r19-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_7"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 8 NDK r19 smoke tests'
-    depends_on: "fixture-r19"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r19-url.txt"
-          - "build/fixture-r19/*"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r19-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_8"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
-    depends_on: "fixture-r19"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r19-url.txt"
-          - "build/fixture-r19/*"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r19-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_8"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 9 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_9"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_9"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 10 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_10"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
-    skip: All ANR scenarios are skipped on Android 10
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_10"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 11 NDK r21 smoke tests'
-    key: 'android-11-smoke'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_11"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
-    key: 'android-11-anr-smoke'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_11"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
- # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
-  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
-  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
-  # by inspecting the devices logs.
-  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
-    depends_on:
-      - "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-k].*.feature"
-          - "--exclude=features/full_tests/anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_12"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 12 NDK r21 end-to-end tests - ANRs'
-    depends_on:
-      - "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests/anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_12"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
-    depends_on:
-      - "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^l-z].*.feature"
-          - "--exclude=features/full_tests/anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_12"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 13 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_13"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_13"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':bitbar: Android 14 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/fixture-r21-url.txt"
-          - "--appium-version=1.22"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--farm=bb"
-          - "--device=ANDROID_14"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_14"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 15 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--exclude=features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_15"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: ':browserstack: Android 15 NDK r21 ANR smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_15"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-
-  - label: 'Conditionally include device farms/full tests'
-    agents:
-      queue: macos
-    command: sh -c .buildkite/pipeline_trigger.sh
+  - label: ':android: Instrumentation tests'
     timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+  - label: ':android: Instrumentation tests'
+    timeout_in_minutes: 10
+    plugins:
+      artifacts#v1.9.0:
+        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
+    agents:
+      queue: macos-14
+    command: './scripts/run-connected-checks.rb'
+    env:
+      API_LEVEL: 30
+
+
+#  #
+#  # BitBar steps
+#  #
+#  - label: ':bitbar: Android 7 NDK r19 smoke tests'
+#    depends_on: "fixture-r19"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r19-url.txt"
+#          - "build/fixture-r19/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r19-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_7"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
+#    depends_on: "fixture-r19"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r19-url.txt"
+#          - "build/fixture-r19/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r19-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_7"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 8 NDK r19 smoke tests'
+#    depends_on: "fixture-r19"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r19-url.txt"
+#          - "build/fixture-r19/*"
+#        upload: "maze_output/failed/**/*"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r19-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_8"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
+#    depends_on: "fixture-r19"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r19-url.txt"
+#          - "build/fixture-r19/*"
+#        upload: "maze_output/failed/**/*"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r19-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_8"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 9 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_9"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_9"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 10 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_10"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
+#    skip: All ANR scenarios are skipped on Android 10
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_10"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 11 NDK r21 smoke tests'
+#    key: 'android-11-smoke'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_11"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
+#    key: 'android-11-anr-smoke'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_11"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+# # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
+#  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
+#  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
+#  # by inspecting the devices logs.
+#  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
+#    depends_on:
+#      - "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/full_tests"
+#          - "--exclude=features/full_tests/[^a-k].*.feature"
+#          - "--exclude=features/full_tests/anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_12"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 12 NDK r21 end-to-end tests - ANRs'
+#    depends_on:
+#      - "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/full_tests/anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_12"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
+#    depends_on:
+#      - "fixture-r21"
+#    timeout_in_minutes: 60
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/full_tests"
+#          - "--exclude=features/full_tests/[^l-z].*.feature"
+#          - "--exclude=features/full_tests/anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_12"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 13 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_13"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_13"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':bitbar: Android 14 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/fixture-r21-url.txt"
+#          - "--appium-version=1.22"
+#          - "--no-tunnel"
+#          - "--aws-public-ip"
+#          - "--farm=bb"
+#          - "--device=ANDROID_14"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 25
+#    concurrency_group: 'bitbar'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_14"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^main|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 15 NDK r21 smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests"
+#          - "--exclude=features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_15"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^master|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: ':browserstack: Android 15 NDK r21 ANR smoke tests'
+#    depends_on: "fixture-r21"
+#    timeout_in_minutes: 30
+#    plugins:
+#      artifacts#v1.9.0:
+#        download:
+#          - "build/bs-fixture-r21-url.txt"
+#          - "build/fixture-r21/*"
+#        upload:
+#          - "maze_output/failed/**/*"
+#          - "maze_output/metrics.csv"
+#      docker-compose#v4.7.0:
+#        pull: maze-runner
+#        run: maze-runner
+#        service-ports: true
+#        command:
+#          - "features/smoke_tests/01_anr.feature"
+#          - "--app=@build/bs-fixture-r21-url.txt"
+#          - "--appium-version=1.22.0"
+#          - "--farm=bs"
+#          - "--device=ANDROID_15"
+#      test-collector#v1.10.2:
+#        files: "reports/TEST-*.xml"
+#        format: "junit"
+#        branch: "^master|next$$"
+#    env:
+#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+#    concurrency: 5
+#    concurrency_group: 'browserstack-app'
+#    concurrency_method: eager
+#
+#  - label: 'Conditionally include device farms/full tests'
+#    agents:
+#      queue: macos
+#    command: sh -c .buildkite/pipeline_trigger.sh
+#    timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,96 +2,96 @@ agents:
   queue: 'opensource'
 
 steps:
-#
-#  - label: 'Audit current licenses'
-#    timeout_in_minutes: 30
-#    agents:
-#      queue: macos-14-isolated
-#    commands:
-#      - bundle install
-#      - ./scripts/audit-dependency-licenses.sh
-#
-#  - label: ':android: Build fixture APK r19'
-#    key: "fixture-r19"
-#    timeout_in_minutes: 30
-#    agents:
-#      queue: macos-14-isolated
-#    artifact_paths:
-#      - "build/fixture-r19.apk"
-#      - "build/fixture-r19-url.txt"
-#      - "build/bs-fixture-r19-url.txt"
-#      - "build/fixture-r19/*"
-#    commands:
-#      - bundle install
-#      - make fixture-r19
-#      - bundle exec upload-app --farm=bb --app=./build/fixture-r19.apk --app-id-file=build/fixture-r19-url.txt
-#      - bundle exec upload-app --farm=bs --app=./build/fixture-r19.apk --app-id-file=build/bs-fixture-r19-url.txt
-#    env:
-#      JAVA_VERSION: 17
-#
-#  - label: ':android: Build fixture APK r21'
-#    key: "fixture-r21"
-#    timeout_in_minutes: 30
-#    agents:
-#      queue: macos-14-isolated
-#    artifact_paths:
-#      - "build/fixture-r21.apk"
-#      - "build/fixture-r21-url.txt"
-#      - "build/bs-fixture-r21-url.txt"
-#      - "build/fixture-r21/*"
-#    commands:
-#      - bundle install
-#      - make fixture-r21
-#      - bundle exec upload-app --farm=bb --app=./build/fixture-r21.apk --app-id-file=build/fixture-r21-url.txt
-#      - bundle exec upload-app --farm=bs --app=./build/fixture-r21.apk --app-id-file=build/bs-fixture-r21-url.txt
-#    env:
-#      JAVA_VERSION: 17
-#
-#  - label: ':android: Coding standards checks'
-#    timeout_in_minutes: 20
-#    agents:
-#      queue: macos-14-isolated
-#    command: './gradlew --continue checkstyle detekt lint ktlintCheck'
-#
-#  - label: ':android: Binary compatibility checks'
-#    timeout_in_minutes: 20
-#    agents:
-#      queue: macos-14-isolated
-#    command: './gradlew apiCheck'
-#
-#  - label: ':android: CppCheck'
-#    timeout_in_minutes: 10
-#    agents:
-#      queue: macos-14-isolated
-#    command: 'bash ./scripts/run-cpp-check.sh'
-#
-#  - label: ':android: ClangFormat'
-#    timeout_in_minutes: 10
-#    agents:
-#      queue: macos-14-isolated
-#    command: 'bash ./scripts/run-clang-format-ci-check.sh'
-#
-#  - label: ':android: Lint mazerunner scenarios'
-#    timeout_in_minutes: 10
-#    agents:
-#      queue: macos-14-isolated
-#    commands:
-#      - cd features/fixtures/mazerunner
-#      - ./gradlew ktlintCheck detekt checkstyle
-#    env:
-#      JAVA_VERSION: 17
-#
-#  - label: ':android: Android size reporting'
-#    timeout_in_minutes: 10
-#    agents:
-#      queue: macos-14-isolated
-#    command: scripts/run-sizer.sh
-#
-#  - label: ':android: JVM tests'
-#    timeout_in_minutes: 10
-#    agents:
-#      queue: macos-14-isolated
-#    command: './gradlew test'
+
+  - label: 'Audit current licenses'
+    timeout_in_minutes: 30
+    agents:
+      queue: macos-14
+    commands:
+      - bundle install
+      - ./scripts/audit-dependency-licenses.sh
+
+  - label: ':android: Build fixture APK r19'
+    key: "fixture-r19"
+    timeout_in_minutes: 30
+    agents:
+      queue: macos-14
+    artifact_paths:
+      - "build/fixture-r19.apk"
+      - "build/fixture-r19-url.txt"
+      - "build/bs-fixture-r19-url.txt"
+      - "build/fixture-r19/*"
+    commands:
+      - bundle install
+      - make fixture-r19
+      - bundle exec upload-app --farm=bb --app=./build/fixture-r19.apk --app-id-file=build/fixture-r19-url.txt
+      - bundle exec upload-app --farm=bs --app=./build/fixture-r19.apk --app-id-file=build/bs-fixture-r19-url.txt
+    env:
+      JAVA_VERSION: 17
+
+  - label: ':android: Build fixture APK r21'
+    key: "fixture-r21"
+    timeout_in_minutes: 30
+    agents:
+      queue: macos-14
+    artifact_paths:
+      - "build/fixture-r21.apk"
+      - "build/fixture-r21-url.txt"
+      - "build/bs-fixture-r21-url.txt"
+      - "build/fixture-r21/*"
+    commands:
+      - bundle install
+      - make fixture-r21
+      - bundle exec upload-app --farm=bb --app=./build/fixture-r21.apk --app-id-file=build/fixture-r21-url.txt
+      - bundle exec upload-app --farm=bs --app=./build/fixture-r21.apk --app-id-file=build/bs-fixture-r21-url.txt
+    env:
+      JAVA_VERSION: 17
+
+  - label: ':android: Coding standards checks'
+    timeout_in_minutes: 20
+    agents:
+      queue: macos-14
+    command: './gradlew --continue checkstyle detekt lint ktlintCheck'
+
+  - label: ':android: Binary compatibility checks'
+    timeout_in_minutes: 20
+    agents:
+      queue: macos-14
+    command: './gradlew apiCheck'
+
+  - label: ':android: CppCheck'
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14
+    command: 'bash ./scripts/run-cpp-check.sh'
+
+  - label: ':android: ClangFormat'
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14
+    command: 'bash ./scripts/run-clang-format-ci-check.sh'
+
+  - label: ':android: Lint mazerunner scenarios'
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14
+    commands:
+      - cd features/fixtures/mazerunner
+      - ./gradlew ktlintCheck detekt checkstyle
+    env:
+      JAVA_VERSION: 17
+
+  - label: ':android: Android size reporting'
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14
+    command: scripts/run-sizer.sh
+
+  - label: ':android: JVM tests'
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14
+    command: './gradlew test'
 
   - label: ':android: Instrumentation tests'
     timeout_in_minutes: 10
@@ -103,887 +103,632 @@ steps:
     command: './scripts/run-connected-checks.rb'
     env:
       API_LEVEL: 30
-
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  #
+  # BitBar steps
+  #
+  - label: ':bitbar: Android 7 NDK r19 smoke tests'
+    depends_on: "fixture-r19"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r19-url.txt"
+          - "build/fixture-r19/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r19-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_7"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
+    depends_on: "fixture-r19"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r19-url.txt"
+          - "build/fixture-r19/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r19-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_7"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':bitbar: Android 8 NDK r19 smoke tests'
+    depends_on: "fixture-r19"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r19-url.txt"
+          - "build/fixture-r19/*"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r19-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_8"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
+    depends_on: "fixture-r19"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r19-url.txt"
+          - "build/fixture-r19/*"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r19-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_8"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':bitbar: Android 9 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_9"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_9"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':bitbar: Android 10 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_10"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
+    skip: All ANR scenarios are skipped on Android 10
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_10"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':bitbar: Android 11 NDK r21 smoke tests'
+    key: 'android-11-smoke'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_11"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
+    key: 'android-11-anr-smoke'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_11"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
+  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
+  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
+  # by inspecting the devices logs.
+  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
+    depends_on:
+      - "fixture-r21"
+    timeout_in_minutes: 60
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^a-k].*.feature"
+          - "--exclude=features/full_tests/anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_12"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 12 NDK r21 end-to-end tests - ANRs'
+    depends_on:
+      - "fixture-r21"
+    timeout_in_minutes: 60
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests/anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_12"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
+    depends_on:
+      - "fixture-r21"
+    timeout_in_minutes: 60
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/full_tests"
+          - "--exclude=features/full_tests/[^l-z].*.feature"
+          - "--exclude=features/full_tests/anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_12"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':bitbar: Android 13 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_13"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_13"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':bitbar: Android 14 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/fixture-r21-url.txt"
+          - "--appium-version=1.22"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
+          - "--device=ANDROID_14"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_14"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^main|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 15 NDK r21 smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests"
+          - "--exclude=features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_15"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^master|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
+  - label: ':browserstack: Android 15 NDK r21 ANR smoke tests'
+    depends_on: "fixture-r21"
+    timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
+        download:
+          - "build/bs-fixture-r21-url.txt"
+          - "build/fixture-r21/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/metrics.csv"
+      docker-compose#v4.7.0:
+        pull: maze-runner
+        run: maze-runner
+        service-ports: true
+        command:
+          - "features/smoke_tests/01_anr.feature"
+          - "--app=@build/bs-fixture-r21-url.txt"
+          - "--appium-version=1.22.0"
+          - "--farm=bs"
+          - "--device=ANDROID_15"
+      test-collector#v1.10.2:
+        files: "reports/TEST-*.xml"
+        format: "junit"
+        branch: "^master|next$$"
     env:
-      API_LEVEL: 30
+      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
 
-  - label: ':android: Instrumentation tests'
+  - label: 'Conditionally include device farms/full tests'
+    agents:
+      queue: macos
+    command: sh -c .buildkite/pipeline_trigger.sh
     timeout_in_minutes: 10
-    plugins:
-      artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
-    env:
-      API_LEVEL: 30
-
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
-    plugins:
-      artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
-    env:
-      API_LEVEL: 30
-
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
-    plugins:
-      artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
-    env:
-      API_LEVEL: 30
-
-  - label: ':android: Instrumentation tests'
-    timeout_in_minutes: 10
-    plugins:
-      artifacts#v1.9.0:
-        upload: "bugsnag-*/build/reports/androidTests/connected/**/*.html"
-    agents:
-      queue: macos-14-isolated
-    command: './scripts/run-connected-checks.rb'
-    env:
-      API_LEVEL: 30
-
-
-#  #
-#  # BitBar steps
-#  #
-#  - label: ':bitbar: Android 7 NDK r19 smoke tests'
-#    depends_on: "fixture-r19"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r19-url.txt"
-#          - "build/fixture-r19/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r19-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_7"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
-#    depends_on: "fixture-r19"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r19-url.txt"
-#          - "build/fixture-r19/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r19-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_7"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 8 NDK r19 smoke tests'
-#    depends_on: "fixture-r19"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r19-url.txt"
-#          - "build/fixture-r19/*"
-#        upload: "maze_output/failed/**/*"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r19-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_8"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 8 NDK r19 ANR smoke tests'
-#    depends_on: "fixture-r19"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r19-url.txt"
-#          - "build/fixture-r19/*"
-#        upload: "maze_output/failed/**/*"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r19-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_8"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 9 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_9"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 9 NDK r21 ANR smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_9"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 10 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_10"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 10 NDK r21 ANR smoke tests'
-#    skip: All ANR scenarios are skipped on Android 10
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_10"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 11 NDK r21 smoke tests'
-#    key: 'android-11-smoke'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_11"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 11 NDK r21 ANR smoke tests'
-#    key: 'android-11-anr-smoke'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_11"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-# # Android 11+ devices have the GWP-ASAN tool enabled which randomly samples native memory
-#  # to detect misuse (such as use-after-free, buffer overflow). If a failure is detected then
-#  # the device will raise a SIGABRT mentioning GWP-ASAN - this can be investigated further
-#  # by inspecting the devices logs.
-#  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 1'
-#    depends_on:
-#      - "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/full_tests"
-#          - "--exclude=features/full_tests/[^a-k].*.feature"
-#          - "--exclude=features/full_tests/anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_12"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 12 NDK r21 end-to-end tests - ANRs'
-#    depends_on:
-#      - "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/full_tests/anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_12"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 12 NDK r21 end-to-end tests - batch 2'
-#    depends_on:
-#      - "fixture-r21"
-#    timeout_in_minutes: 60
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/full_tests"
-#          - "--exclude=features/full_tests/[^l-z].*.feature"
-#          - "--exclude=features/full_tests/anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_12"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 13 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_13"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 13 NDK r21 ANR smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_13"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':bitbar: Android 14 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/fixture-r21-url.txt"
-#          - "--appium-version=1.22"
-#          - "--no-tunnel"
-#          - "--aws-public-ip"
-#          - "--farm=bb"
-#          - "--device=ANDROID_14"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 25
-#    concurrency_group: 'bitbar'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 14 NDK r21 ANR smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_14"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^main|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 15 NDK r21 smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests"
-#          - "--exclude=features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_15"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^master|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: ':browserstack: Android 15 NDK r21 ANR smoke tests'
-#    depends_on: "fixture-r21"
-#    timeout_in_minutes: 30
-#    plugins:
-#      artifacts#v1.9.0:
-#        download:
-#          - "build/bs-fixture-r21-url.txt"
-#          - "build/fixture-r21/*"
-#        upload:
-#          - "maze_output/failed/**/*"
-#          - "maze_output/metrics.csv"
-#      docker-compose#v4.7.0:
-#        pull: maze-runner
-#        run: maze-runner
-#        service-ports: true
-#        command:
-#          - "features/smoke_tests/01_anr.feature"
-#          - "--app=@build/bs-fixture-r21-url.txt"
-#          - "--appium-version=1.22.0"
-#          - "--farm=bs"
-#          - "--device=ANDROID_15"
-#      test-collector#v1.10.2:
-#        files: "reports/TEST-*.xml"
-#        format: "junit"
-#        branch: "^master|next$$"
-#    env:
-#      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-#    concurrency: 5
-#    concurrency_group: 'browserstack-app'
-#    concurrency_method: eager
-#
-#  - label: 'Conditionally include device farms/full tests'
-#    agents:
-#      queue: macos
-#    command: sh -c .buildkite/pipeline_trigger.sh
-#    timeout_in_minutes: 10


### PR DESCRIPTION
## Goal

Due to issues with running multiple AVD instances on the same box, its best if we move that step to the isolated queue to prevent the steps from erroring when multiple tests are running on the same box.

## Testing

Covered by CI