### PR TITLE
Change to discardOldestFileIfNeeded sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [#2235](https://github.com/bugsnag/bugsnag-android/pull/2235)
 * Correct the reporting of the loadAddress for native system libraries and JIT frames
   [#2244](https://github.com/bugsnag/bugsnag-android/pull/2244)
+* Added deterministic sorting for `discardOldestFileIfNeeded` method to avoid potential crashes where mutliple files have the same last modified time
+  [#2181](https://github.com/bugsnag/bugsnag-android/pull/2189)
 
 ## 6.16.0 (2025-07-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Correct the reporting of the loadAddress for native system libraries and JIT frames
   [#2244](https://github.com/bugsnag/bugsnag-android/pull/2244)
 * Added deterministic sorting for `discardOldestFileIfNeeded` method to avoid potential crashes where mutliple files have the same last modified time
-  [#2181](https://github.com/bugsnag/bugsnag-android/pull/2189)
+  [#2189](https://github.com/bugsnag/bugsnag-android/pull/2189)
 
 ## 6.16.0 (2025-07-31)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -112,34 +112,32 @@ internal abstract class FileStore(
 
     fun discardOldestFileIfNeeded() {
         // Limit number of saved payloads to prevent disk space issues
-        if (isStorageDirValid(storageDir)) {
-            val listFiles = storageDir.listFiles() ?: return
-            if (listFiles.size < maxStoreCount) return
+        if (!isStorageDirValid(storageDir)) return
+        val listFiles = storageDir.listFiles() ?: return
+        if (listFiles.size < maxStoreCount) return
 
-            // Store lastModified to ensure it doesn't change during sort
-            val timestampedFiles = listFiles.mapTo(ArrayList(listFiles.size)) { file ->
-                FileWithTimestamp(file, file.lastModified())
-            }
+        // Store lastModified to ensure it doesn't change during sort
+        val timestampedFiles = listFiles.mapTo(ArrayList(listFiles.size)) { file ->
+            FileWithTimestamp(file, file.lastModified())
+        }
 
-            // Sort by cached lastModified timesstamps
-            timestampedFiles.sort()
+        // Sort by cached lastModified timestamps
+        timestampedFiles.sort()
 
-            // Number of files to discard takes into account that a new file may need to be written
-            val numberToDiscard = listFiles.size - maxStoreCount + 1
-            var discardedCount = 0
+        // Number of files to discard takes into account that a new file may need to be written
+        val numberToDiscard = listFiles.size - maxStoreCount + 1
+        var discardedCount = 0
 
-            for (fileMeta in timestampedFiles) {
-                val file = fileMeta.file
-                if (discardedCount == numberToDiscard) {
-                    return
-                } else if (!queuedFiles.contains(file)) {
-                    logger.w(
-                        "Discarding oldest error as stored error limit reached: '" +
-                            file.path + '\''
-                    )
-                    deleteStoredFiles(setOf(file))
-                    discardedCount++
-                }
+        for (fileMeta in timestampedFiles) {
+            val file = fileMeta.file
+            if (discardedCount == numberToDiscard) {
+                return
+            } else if (!queuedFiles.contains(file)) {
+                logger.w(
+                    "Discarding oldest error as stored error limit reached: '${file.path}'"
+                )
+                deleteStoredFiles(setOf(file))
+                discardedCount++
             }
         }
     }
@@ -198,16 +196,18 @@ internal abstract class FileStore(
             lock.unlock()
         }
     }
-}
 
-/**
- * A data holder for associating a {@link File} with its last modified timestamp.
- *
- * @param file The file to associate with a timestamp.
- * @param timestamp The last modified time of the file, cached to ensure consistent ordering.
- */
-private data class FileWithTimestamp(val file: File, val timestamp: Long) : Comparable<FileWithTimestamp> {
-    override fun compareTo(other: FileWithTimestamp): Int {
-        return timestamp.compareTo(other.timestamp)
+    /**
+     * A data holder for associating a {@link File} with its last modified timestamp.
+     *
+     * @param file The file to associate with a timestamp.
+     * @param timestamp The last modified time of the file, cached to ensure consistent ordering.
+     */
+    private data class FileWithTimestamp(
+        val file: File,
+        val timestamp: Long
+    ) : Comparable<FileWithTimestamp> {
+        override fun compareTo(other: FileWithTimestamp): Int =
+            timestamp.compareTo(other.timestamp)
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -115,7 +115,10 @@ internal abstract class FileStore(
         if (isStorageDirValid(storageDir)) {
             val listFiles = storageDir.listFiles() ?: return
             if (listFiles.size < maxStoreCount) return
-            val sortedListFiles = listFiles.sortedBy { it.lastModified() }
+            // ensures sorting deterministically when files have identical timestamps
+            val sortedListFiles = listFiles.sortedWith(
+                compareBy<File> { it.lastModified() }.thenBy { it.name }
+            )
             // Number of files to discard takes into account that a new file may need to be written
             val numberToDiscard = listFiles.size - maxStoreCount + 1
             var discardedCount = 0

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -200,6 +200,7 @@ internal abstract class FileStore(
         }
     }
 }
+
 /**
  * A data holder for associating a {@link File} with its last modified timestamp.
  *

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -128,7 +128,7 @@ internal abstract class FileStore(
             val numberToDiscard = listFiles.size - maxStoreCount + 1
             var discardedCount = 0
 
-            for (file in timestampedFiles) {
+            for (fileMeta in timestampedFiles) {
                 val file = fileMeta.file
                 if (discardedCount == numberToDiscard) {
                     return

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -128,7 +128,7 @@ internal abstract class FileStore(
             val numberToDiscard = listFiles.size - maxStoreCount + 1
             var discardedCount = 0
 
-            for (file in sortedListFiles) {
+            for (file in timestampedFiles.map { it.file }) {
                 if (discardedCount == numberToDiscard) {
                     return
                 } else if (!queuedFiles.contains(file)) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -128,7 +128,8 @@ internal abstract class FileStore(
             val numberToDiscard = listFiles.size - maxStoreCount + 1
             var discardedCount = 0
 
-            for (file in timestampedFiles.map { it.file }) {
+            for (file in timestampedFiles) {
+                val file = fileMeta.file
                 if (discardedCount == numberToDiscard) {
                     return
                 } else if (!queuedFiles.contains(file)) {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -118,13 +118,13 @@ internal abstract class FileStore(
 
             // Store lastModified to ensure it doesn't change between sorting
             val fileMeta = listFiles.map { file ->
-                file to file.lastModified()
+                FileWithTimestamp(file, file.lastModified())
             }
 
             // Sort by cached lastModified timesstamps
             val sortedListFiles = fileMeta
-                .sortedBy { it.second }
-                .map { it.first }
+                .sorted()
+                .map(FileWithTimestamp::file)
 
             // Number of files to discard takes into account that a new file may need to be written
             val numberToDiscard = listFiles.size - maxStoreCount + 1
@@ -198,5 +198,16 @@ internal abstract class FileStore(
         } finally {
             lock.unlock()
         }
+    }
+}
+/**
+ * A data holder for associating a {@link File} with its last modified timestamp.
+ *
+ * @param file The file to associate with a timestamp.
+ * @param timestamp The last modified time of the file, cached to ensure consistent ordering.
+ */
+private data class FileWithTimestamp(val file: File, val timestamp: Long) : Comparable<FileWithTimestamp> {
+    override fun compareTo(other: FileWithTimestamp): Int {
+        return timestamp.compareTo(other.timestamp)
     }
 }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -116,7 +116,7 @@ internal abstract class FileStore(
             val listFiles = storageDir.listFiles() ?: return
             if (listFiles.size < maxStoreCount) return
 
-            // Store lastModified to ensure it doesn't change between sorting
+            // Store lastModified to ensure it doesn't change during sort
             val timestampedFiles = listFiles.mapTo(ArrayList(listFiles.size)) { file ->
                 FileWithTimestamp(file, file.lastModified())
             }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -121,7 +121,7 @@ internal abstract class FileStore(
                 file to file.lastModified()
             }
 
-            //sort by cached lastModified timesstamps
+            // Sort by cached lastModified timesstamps
             val sortedListFiles = fileMeta
                 .sortedBy { it.second }
                 .map { it.first }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -117,7 +117,7 @@ internal abstract class FileStore(
             if (listFiles.size < maxStoreCount) return
 
             // Store lastModified to ensure it doesn't change between sorting
-            val fileMeta = listFiles.map { file ->
+            val timestampedFiles = listFiles.mapTo(ArrayList(listFiles.size)) { file ->
                 FileWithTimestamp(file, file.lastModified())
             }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/FileStore.kt
@@ -122,9 +122,7 @@ internal abstract class FileStore(
             }
 
             // Sort by cached lastModified timesstamps
-            val sortedListFiles = fileMeta
-                .sorted()
-                .map(FileWithTimestamp::file)
+            timestampedFiles.sort()
 
             // Number of files to discard takes into account that a new file may need to be written
             val numberToDiscard = listFiles.size - maxStoreCount + 1


### PR DESCRIPTION
## Goal
Fix rare `"Comparison method violates its general contract!"` crashes in `discardOldestFileIfNeeded` when the file timestamps change during the `sort()`.

## Design
Capture all of the `lastModified()` timestamps into a stable list before sorting.

## Testing
Relied on existing tests