### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+* Set default endpoints based on API key [#2190](https://github.com/bugsnag/bugsnag-android/pull/2190)
+
 * Allow the metadata in `leaveBreadcrumb` to be null rather than enforcing non-null, aligning `bugsnag-android` with our other SDKs
   [#2180](https://github.com/bugsnag/bugsnag-android/pull/2180)
 

--- a/bugsnag-android-core/api/bugsnag-android-core.api
+++ b/bugsnag-android-core/api/bugsnag-android-core.api
@@ -321,8 +321,10 @@ public final class com/bugsnag/android/EndpointConfiguration {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getNotify ()Ljava/lang/String;
 	public final fun getSessions ()Ljava/lang/String;
+	public fun hashCode ()I
 }
 
 public class com/bugsnag/android/Error : com/bugsnag/android/JsonStream$Streamable {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -40,29 +40,17 @@ internal class ConfigInternal(
         }
     var delivery: Delivery? = null
 
-    private var _endpoints: EndpointConfiguration? = null
     private fun isHubApiKey(): Boolean =
         apiKey?.startsWith(HUB_PREFIX) == true
 
+    private var _endpoints: EndpointConfiguration? = null
     var endpoints: EndpointConfiguration
-        get() {
-            val current = _endpoints
-            val empty = current == null ||
-                    (current.notify.isBlank() && current.sessions.isBlank())
-
-            return if (empty) {
-                if (isHubApiKey()) {
-                    EndpointConfiguration(HUB_NOTIFY, HUB_SESSION)
-                } else {
-                    EndpointConfiguration(DEFAULT_NOTIFY, DEFAULT_SESSION)
-                }
-            } else {
-                current
-            }
-        }
-        set(value) {
-            _endpoints = value
-        }
+        get() = _endpoints
+            ?.takeUnless { it.notify.isEmpty() && it.sessions.isEmpty() }
+            ?: if (isHubApiKey())
+                EndpointConfiguration(HUB_NOTIFY, HUB_SESSION)
+            else EndpointConfiguration(DEFAULT_NOTIFY, DEFAULT_SESSION)
+        set(value) { _endpoints = value }
 
     var maxBreadcrumbs: Int = DEFAULT_MAX_BREADCRUMBS
     var maxPersistedEvents: Int = DEFAULT_MAX_PERSISTED_EVENTS
@@ -184,10 +172,10 @@ internal class ConfigInternal(
         private const val DEFAULT_THREAD_COLLECTION_TIME_LIMIT_MS: Long = 5000
         private const val DEFAULT_LAUNCH_CRASH_THRESHOLD_MS: Long = 5000
         private const val DEFAULT_MAX_STRING_VALUE_LENGTH = 10000
-        private const val DEFAULT_NOTIFY   = "https://notify.bugsnag.com"
-        private const val DEFAULT_SESSION  = "https://sessions.bugsnag.com"
-        private const val HUB_NOTIFY    = "https://notify.insighthub.smartbear.com"
-        private const val HUB_SESSION   = "https://sessions.insighthub.smartbear.com"
+        private const val DEFAULT_NOTIFY = "https://notify.bugsnag.com"
+        private const val DEFAULT_SESSION = "https://sessions.bugsnag.com"
+        private const val HUB_NOTIFY = "https://notify.insighthub.smartbear.com"
+        private const val HUB_SESSION = "https://sessions.insighthub.smartbear.com"
         private const val HUB_PREFIX = "00000"
         @JvmStatic
         fun load(context: Context): Configuration = load(context, null)

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -46,9 +46,7 @@ internal class ConfigInternal(
     private var _endpoints: EndpointConfiguration? = null
     var endpoints: EndpointConfiguration
         get() = _endpoints
-            ?.takeUnless { it.notify.isEmpty() && it.sessions.isEmpty() }
-            ?: if (isHubApiKey())
-                EndpointConfiguration(HUB_NOTIFY, HUB_SESSION)
+            ?: if (isHubApiKey()) EndpointConfiguration(HUB_NOTIFY, HUB_SESSION)
             else EndpointConfiguration(DEFAULT_NOTIFY, DEFAULT_SESSION)
         set(value) { _endpoints = value }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -9,6 +9,14 @@ internal class ConfigInternal(
     var apiKey: String?
 ) : CallbackAware, MetadataAware, UserAware, FeatureFlagAware {
 
+    private companion object {
+        private const val DEFAULT_NOTIFY   = "https://notify.bugsnag.com"
+        private const val DEFAULT_SESSION  = "https://sessions.bugsnag.com"
+        private const val HUB_NOTIFY    = "https://notify.insighthub.smartbear.com"
+        private const val HUB_SESSION   = "https://sessions.insighthub.smartbear.com"
+        private const val HUB_PREFIX = "00000"
+    }
+
     private var user = User()
 
     @JvmField
@@ -39,7 +47,31 @@ internal class ConfigInternal(
             field = value ?: NoopLogger
         }
     var delivery: Delivery? = null
-    var endpoints: EndpointConfiguration = EndpointConfiguration()
+
+    private var _endpoints: EndpointConfiguration? = null
+    private fun isHubApiKey(): Boolean =
+        apiKey?.startsWith(HUB_PREFIX) == true
+
+    var endpoints: EndpointConfiguration
+        get() {
+            val current = _endpoints
+            val empty = current == null ||
+                    (current.notify.isBlank() && current.sessions.isBlank())
+
+            return if (empty) {
+                if (isHubApiKey()) {
+                    EndpointConfiguration(HUB_NOTIFY, HUB_SESSION)
+                } else {
+                    EndpointConfiguration(DEFAULT_NOTIFY, DEFAULT_SESSION)
+                }
+            } else {
+                current
+            }
+        }
+        set(value) {
+            _endpoints = value
+        }
+
     var maxBreadcrumbs: Int = DEFAULT_MAX_BREADCRUMBS
     var maxPersistedEvents: Int = DEFAULT_MAX_PERSISTED_EVENTS
     var maxPersistedSessions: Int = DEFAULT_MAX_PERSISTED_SESSIONS

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ConfigInternal.kt
@@ -9,14 +9,6 @@ internal class ConfigInternal(
     var apiKey: String?
 ) : CallbackAware, MetadataAware, UserAware, FeatureFlagAware {
 
-    private companion object {
-        private const val DEFAULT_NOTIFY   = "https://notify.bugsnag.com"
-        private const val DEFAULT_SESSION  = "https://sessions.bugsnag.com"
-        private const val HUB_NOTIFY    = "https://notify.insighthub.smartbear.com"
-        private const val HUB_SESSION   = "https://sessions.insighthub.smartbear.com"
-        private const val HUB_PREFIX = "00000"
-    }
-
     private var user = User()
 
     @JvmField
@@ -192,7 +184,11 @@ internal class ConfigInternal(
         private const val DEFAULT_THREAD_COLLECTION_TIME_LIMIT_MS: Long = 5000
         private const val DEFAULT_LAUNCH_CRASH_THRESHOLD_MS: Long = 5000
         private const val DEFAULT_MAX_STRING_VALUE_LENGTH = 10000
-
+        private const val DEFAULT_NOTIFY   = "https://notify.bugsnag.com"
+        private const val DEFAULT_SESSION  = "https://sessions.bugsnag.com"
+        private const val HUB_NOTIFY    = "https://notify.insighthub.smartbear.com"
+        private const val HUB_SESSION   = "https://sessions.insighthub.smartbear.com"
+        private const val HUB_PREFIX = "00000"
         @JvmStatic
         fun load(context: Context): Configuration = load(context, null)
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
@@ -16,4 +16,22 @@ class EndpointConfiguration(
      * Configures the endpoint to which sessions should be sent
      */
     val sessions: String = "https://sessions.bugsnag.com"
-)
+){
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as EndpointConfiguration
+
+        if (notify != other.notify) return false
+        if (sessions != other.sessions) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = notify.hashCode()
+        result = 31 * result + sessions.hashCode()
+        return result
+    }
+}

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
@@ -16,7 +16,7 @@ class EndpointConfiguration(
      * Configures the endpoint to which sessions should be sent
      */
     val sessions: String = "https://sessions.bugsnag.com"
-){
+) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
@@ -10,10 +10,10 @@ class EndpointConfiguration(
     /**
      * Configures the endpoint to which events should be sent
      */
-    val notify: String = "https://notify.bugsnag.com",
+    val notify: String = "",
 
     /**
      * Configures the endpoint to which sessions should be sent
      */
-    val sessions: String = "https://sessions.bugsnag.com"
+    val sessions: String = ""
 )

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/EndpointConfiguration.kt
@@ -10,10 +10,10 @@ class EndpointConfiguration(
     /**
      * Configures the endpoint to which events should be sent
      */
-    val notify: String = "",
+    val notify: String = "https://notify.bugsnag.com",
 
     /**
      * Configures the endpoint to which sessions should be sent
      */
-    val sessions: String = ""
+    val sessions: String = "https://sessions.bugsnag.com"
 )

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EndpointConfigValidationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EndpointConfigValidationTest.kt
@@ -37,16 +37,4 @@ class EndpointConfigValidationTest {
         assertEquals("https://notify.example.com", config.endpoints.notify)
         assertEquals("https://sessions.example.com", config.endpoints.sessions)
     }
-
-    /**
-     * Both overrides passed as empty strings → treated the same as
-     * “unset”, so the SDK falls back to the normal default selection.
-     */
-    @Test
-    fun blankOverridesFallBackToDefault() {
-        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
-        config.endpoints = EndpointConfiguration("", "")
-        assertEquals(_defaultNotify, config.endpoints.notify)
-        assertEquals(_defaultSession, config.endpoints.sessions)
-    }
 }

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/EndpointConfigValidationTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/EndpointConfigValidationTest.kt
@@ -1,0 +1,52 @@
+package com.bugsnag.android
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EndpointConfigValidationTest {
+
+    private val _defaultNotify = "https://notify.bugsnag.com"
+    private val _defaultSession = "https://sessions.bugsnag.com"
+    private val _hubNotify = "https://notify.insighthub.smartbear.com"
+    private val _hubSession = "https://sessions.insighthub.smartbear.com"
+
+    /** No custom endpoints*/
+    @Test
+    fun defaultEndpoints() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        assertEquals(_defaultNotify, config.endpoints.notify)
+        assertEquals(_defaultSession, config.endpoints.sessions)
+    }
+
+    /** No custom endpoints with a Hub key*/
+    @Test
+    fun defaultEndpointsForHubKey() {
+        val config = Configuration("00000bd39a74caa1267142706a7fb21")
+        assertEquals(_hubNotify, config.endpoints.notify)
+        assertEquals(_hubSession, config.endpoints.sessions)
+    }
+
+    /** Both endpoints overridden → custom values are honoured verbatim */
+    @Test
+    fun customEndpointsProvided() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        config.endpoints = EndpointConfiguration(
+            "https://notify.example.com",
+            "https://sessions.example.com"
+        )
+        assertEquals("https://notify.example.com", config.endpoints.notify)
+        assertEquals("https://sessions.example.com", config.endpoints.sessions)
+    }
+
+    /**
+     * Both overrides passed as empty strings → treated the same as
+     * “unset”, so the SDK falls back to the normal default selection.
+     */
+    @Test
+    fun blankOverridesFallBackToDefault() {
+        val config = Configuration("5d1ec5bd39a74caa1267142706a7fb21")
+        config.endpoints = EndpointConfiguration("", "")
+        assertEquals(_defaultNotify, config.endpoints.notify)
+        assertEquals(_defaultSession, config.endpoints.sessions)
+    }
+}


### PR DESCRIPTION
## Goal

Set default endpoints based on API key. If no endpoint is configured, payloads should be sent to `*.insighthub.smartbear.com` if the API key starts with `00000`.

## Changeset

- changed ConfigInternal.kt to return the correct defaults based on api key if no custom endpoints have been configured.
- added comparison methods to EndpointConfiguration class to ensure unit tests compare the values of the endpoints inside rather than the objects. 

## Testing

Added unit tests