### PR TITLE
Check init malloc failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Allow the metadata in `leaveBreadcrumb` to be null rather than enforcing non-null, aligning `bugsnag-android` with our other SDKs
   [#2180](https://github.com/bugsnag/bugsnag-android/pull/2180)
 
+### Bug fixes
+
+* Sanity check the allocation in the installation of `bugsnag-plugin-android-ndk` to avoid a possible crash when allocation fails
+  [#2191](https://github.com/bugsnag/bugsnag-android/pull/2191)
+
 ## 6.13.0 (2025-04-15)
 
 ### Enhancements

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -164,6 +164,11 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
   }
 
   bsg_environment *bugsnag_env = calloc(1, sizeof(bsg_environment));
+  if (bugsnag_env == NULL) {
+    BUGSNAG_LOG("Failed to allocate memory for bsg_environment");
+    return;
+  }
+
   bsg_unwinder_init();
   bugsnag_env->report_header.big_endian =
       htonl(47) == 47; // potentially too clever, see man 3 htonl
@@ -328,6 +333,10 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
 
   if (name != NULL && timestamp != NULL) {
     bugsnag_breadcrumb *crumb = calloc(1, sizeof(bugsnag_breadcrumb));
+    if (crumb == NULL) {
+      goto end;
+    }
+
     bsg_strncpy(crumb->name, name, sizeof(crumb->name));
     bsg_strncpy(crumb->timestamp, timestamp, sizeof(crumb->timestamp));
 


### PR DESCRIPTION
## Goal
Ensure that the initial `bugsnag_env` allocation is successful before attempting to populate it.

## Testing
Relying on existing tests.