### PR TITLE
Safer setProcessStateSummary in ExitInfo plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* The `bugsnag-plugin-android-exitinfo` plugin now calls `setProcessState` (if configured) on a background thread and swallows any rate-limiting errors, so that it does not block the main thread during startup
+  [#2197](https://github.com/bugsnag/bugsnag-android/pull/2197)
+
 ## 6.14.0 (2025-06-04)
 
 ### Enhancements

--- a/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
+++ b/bugsnag-plugin-android-exitinfo/detekt-baseline.xml
@@ -27,7 +27,8 @@
     <ID>MaxLineLength:TraceParserTest.kt$TraceParserTest$"void* std::__1::__thread_proxy&lt;std::__1::tuple&lt;std::__1::unique_ptr&lt;std::__1::__thread_struct, std::__1::default_delete&lt;std::__1::__thread_struct> >, void (android::AsyncWorker::*)(), android::AsyncWorker*> >(void*)"</ID>
     <ID>NestedBlockDepth:TraceParser.kt$TraceParser$private fun parseThreadAttributes(line: String)</ID>
     <ID>ReturnCount:TraceParser.kt$TraceParser$@VisibleForTesting internal fun parseNativeFrame(line: String): Stackframe?</ID>
-    <ID>SwallowedException:BugsnagExitInfoPlugin.kt$BugsnagExitInfoPlugin$e: Exception</ID>
+    <ID>SwallowedException:BugsnagExitInfoPlugin.kt$BugsnagExitInfoPlugin.SessionProcessStateSummaryCallback$e: Exception</ID>
+    <ID>SwallowedException:BugsnagExitInfoPlugin.kt$e: Exception</ID>
     <ID>SwallowedException:ExitInfoCallback.kt$ExitInfoCallback$exc: Throwable</ID>
     <ID>SwallowedException:ExitInfoPluginStore.kt$ExitInfoPluginStore$exc: Throwable</ID>
   </CurrentIssues>


### PR DESCRIPTION
## Goal
Avoid timeouts and crashes stemming from rate limiting or slow IPC calls when using `setProcessStateSummary` in the ExitInfo Plugin.

## Changes
The `SessionCallback` now uses the `BackgroundTaskService` to enqueue the call to `setProcessStateSummary` and further swallows any exceptions raised by the call.

## Testing
Relied on existing tests.