### PR TITLE
Use JNI_OnLoad to link the NDK plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Enhancements
+
+* `bugsnag-plugin-android-ndk` no longer exports the `Java_` JNI functions, and instead uses the JNI `RegisterNatives` API to register the native methods.
+  [#2205](https://github.com/bugsnag/bugsnag-android/pull/2205)
+
 ### Bug fixes
 
 * The `bugsnag-plugin-android-exitinfo` plugin now calls `setProcessState` (if configured) on a background thread and swallows any rate-limiting errors, so that it does not block the main thread during startup

--- a/bugsnag-plugin-android-ndk/api/bugsnag-plugin-android-ndk.api
+++ b/bugsnag-plugin-android-ndk/api/bugsnag-plugin-android-ndk.api
@@ -33,7 +33,6 @@ public final class com/bugsnag/android/ndk/NativeBridge : com/bugsnag/android/in
 	public final fun updateContext (Ljava/lang/String;)V
 	public final fun updateInForeground (ZLjava/lang/String;)V
 	public final fun updateIsLaunching (Z)V
-	public final fun updateLastRunInfo (I)V
 	public final fun updateLowMemory (ZLjava/lang/String;)V
 	public final fun updateOrientation (Ljava/lang/String;)V
 	public final fun updateUserEmail (Ljava/lang/String;)V

--- a/bugsnag-plugin-android-ndk/build.gradle.kts
+++ b/bugsnag-plugin-android-ndk/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     loadDefaultPlugins()
-    id("bugsnag-ndk-table-plugin")
+    id("bugsnag-jni-link-table-plugin")
 }
 
 android {

--- a/bugsnag-plugin-android-ndk/build.gradle.kts
+++ b/bugsnag-plugin-android-ndk/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     loadDefaultPlugins()
+    id("bugsnag-ndk-table-plugin")
 }
 
 android {

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -35,8 +35,6 @@ include_directories(
         jni/external/libunwindstack-ndk/include
 )
 
-target_include_directories(bugsnag-ndk PRIVATE ${BUGSNAG_DIR}/assets/include)
-
 target_link_libraries(
         # Specifies the target library.
         bugsnag-ndk

--- a/bugsnag-plugin-android-ndk/src/main/exported_native_symbols-RelWithDebInfo.txt
+++ b/bugsnag-plugin-android-ndk/src/main/exported_native_symbols-RelWithDebInfo.txt
@@ -6,6 +6,7 @@ global:
     __emutls_get_address;
     __gxx_personality_v0;
     Java_*;
+    JNI_OnLoad;
     extern "C++" {
         "std::get_terminate()";
         "std::set_terminate(void (*)())";

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/ndk/NativeBridge.kt
@@ -84,13 +84,12 @@ class NativeBridge(private val bgTaskService: BackgroundTaskService) : StateObse
     external fun updateContext(context: String)
     external fun updateInForeground(inForeground: Boolean, activityName: String)
     external fun updateIsLaunching(isLaunching: Boolean)
-    external fun updateLastRunInfo(consecutiveLaunchCrashes: Int)
     external fun updateOrientation(orientation: String)
     external fun updateUserId(newValue: String)
     external fun updateUserEmail(newValue: String)
     external fun updateUserName(newValue: String)
-    external fun getSignalUnwindStackFunction(): Long
     external fun updateLowMemory(newValue: Boolean, memoryTrimLevelDescription: String)
+    external fun getSignalUnwindStackFunction(): Long
     external fun addFeatureFlag(name: String, variant: String?)
     external fun clearFeatureFlag(name: String)
     external fun clearFeatureFlags()
@@ -139,7 +138,6 @@ class NativeBridge(private val bgTaskService: BackgroundTaskService) : StateObse
                 event.contextActivity ?: ""
             )
 
-            is StateEvent.UpdateLastRunInfo -> updateLastRunInfo(event.consecutiveLaunchCrashes)
             is StateEvent.UpdateIsLaunching -> {
                 updateIsLaunching(event.isLaunching)
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -933,6 +933,9 @@ static void JNI_NativeBridge_setInternalMetricsEnabled(JNIEnv *env,
   bsg_set_internal_metrics_enabled(enabled);
 }
 
+// These headers are included here to ensure that the JNI methods are
+// declared (above) as static, avoiding the need to forward declare them
+
 #include "NativeBridge_JNI.h"
 #include "NdkPlugin_JNI.h"
 

--- a/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/bugsnag_ndk.c
@@ -84,8 +84,7 @@ void bsg_finish_handling_crash() {
   bsg_global_env->handling_crash = false;
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_NdkPlugin_enableCrashReporting(
-    JNIEnv *env, jobject _this) {
+static void JNI_NdkPlugin_enableCrashReporting(JNIEnv *env, jobject _this) {
   if (bsg_global_env == NULL) {
     BUGSNAG_LOG(
         "Attempted to enable crash reporting without first calling install()");
@@ -95,14 +94,12 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_NdkPlugin_enableCrashReporting(
   bsg_handler_install_cpp(bsg_global_env);
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_NdkPlugin_disableCrashReporting(
-    JNIEnv *env, jobject _this) {
+static void JNI_NdkPlugin_disableCrashReporting(JNIEnv *env, jobject _this) {
   bsg_handler_uninstall_signal();
   bsg_handler_uninstall_cpp();
 }
 
-JNIEXPORT jstring JNICALL
-Java_com_bugsnag_android_NdkPlugin_getBinaryArch(JNIEnv *env, jobject _this) {
+static jstring JNI_NdkPlugin_getBinaryArch(JNIEnv *env, jobject _this) {
 #if defined(__i386__)
   const char *binary_arch = "x86";
 #elif defined(__x86_64__)
@@ -117,9 +114,7 @@ Java_com_bugsnag_android_NdkPlugin_getBinaryArch(JNIEnv *env, jobject _this) {
   return bsg_safe_new_string_utf(env, binary_arch);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_enableCrashReporting(JNIEnv *env,
-                                                               jobject _this) {
+static void JNI_NativeBridge_enableCrashReporting(JNIEnv *env, jobject _this) {
   if (bsg_global_env == NULL) {
     BUGSNAG_LOG(
         "Attempted to enable crash reporting without first calling install()");
@@ -129,9 +124,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_enableCrashReporting(JNIEnv *env,
   bsg_handler_install_cpp(bsg_global_env);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_disableCrashReporting(JNIEnv *env,
-                                                                jobject _this) {
+static void JNI_NativeBridge_disableCrashReporting(JNIEnv *env, jobject _this) {
   bsg_handler_uninstall_signal();
   bsg_handler_uninstall_cpp();
 }
@@ -152,12 +145,14 @@ void bsg_update_next_run_info(bsg_environment *env) {
           launch_crashes, crashed_value);
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_install(
-    JNIEnv *env, jobject _this, jstring _api_key, jstring _event_path,
-    jstring _last_run_info_path, jstring _event_uuid,
-    jint consecutive_launch_crashes, jboolean auto_detect_ndk_crashes,
-    jint _api_level, jboolean is32bit, jint send_threads,
-    jint max_breadcrumbs) {
+static void JNI_NativeBridge_install(JNIEnv *env, jobject _this,
+                                     jstring _api_key, jstring _event_path,
+                                     jstring _last_run_info_path,
+                                     jstring _event_uuid,
+                                     jint consecutive_launch_crashes,
+                                     jboolean auto_detect_ndk_crashes,
+                                     jint _api_level, jboolean is32bit,
+                                     jint send_threads, jint max_breadcrumbs) {
 
   if (!bsg_jni_cache_init(env)) {
     BUGSNAG_LOG("Could not init JNI jni_cache.");
@@ -255,9 +250,7 @@ error:
   free(bugsnag_env);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
-                                                          jobject _this) {
+static void JNI_NativeBridge_addHandledEvent(JNIEnv *env, jobject _this) {
   bsg_environment *bsg_env = request_env_write_lock();
   if (bsg_env == NULL) {
     return;
@@ -270,9 +263,7 @@ Java_com_bugsnag_android_ndk_NativeBridge_addHandledEvent(JNIEnv *env,
   release_env_write_lock();
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_addUnhandledEvent(JNIEnv *env,
-                                                            jobject _this) {
+static void JNI_NativeBridge_addUnhandledEvent(JNIEnv *env, jobject _this) {
   bsg_environment *bsg_env = request_env_write_lock();
   if (bsg_env == NULL) {
     return;
@@ -285,9 +276,11 @@ Java_com_bugsnag_android_ndk_NativeBridge_addUnhandledEvent(JNIEnv *env,
   release_env_write_lock();
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
-    JNIEnv *env, jobject _this, jstring session_id_, jstring start_date_,
-    jint handled_count, jint unhandled_count) {
+static void JNI_NativeBridge_startedSession(JNIEnv *env, jobject _this,
+                                            jstring session_id_,
+                                            jstring start_date_,
+                                            jint handled_count,
+                                            jint unhandled_count) {
   if (session_id_ == NULL) {
     return;
   }
@@ -306,8 +299,7 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_startedSession(
   bsg_safe_release_string_utf_chars(env, start_date_, started_at);
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_pausedSession(
-    JNIEnv *env, jobject _this) {
+static void JNI_NativeBridge_pausedSession(JNIEnv *env, jobject _this) {
   bsg_environment *bsg_env = request_env_write_lock();
   if (bsg_env == NULL) {
     return;
@@ -320,9 +312,10 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_pausedSession(
   release_env_write_lock();
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
-    JNIEnv *env, jobject _this, jstring name_, jint crumb_type,
-    jstring timestamp_, jobject metadata) {
+static void JNI_NativeBridge_addBreadcrumb(JNIEnv *env, jobject _this,
+                                           jstring name_, jint crumb_type,
+                                           jstring timestamp_,
+                                           jobject metadata) {
 
   if (!bsg_jni_cache->initialized) {
     BUGSNAG_LOG("addBreadcrumb failed: JNI cache not initialized.");
@@ -386,10 +379,8 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addBreadcrumb(
   bsg_safe_release_string_utf_chars(env, timestamp_, timestamp);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_updateAppVersion(JNIEnv *env,
-                                                           jobject _this,
-                                                           jstring new_value) {
+static void JNI_NativeBridge_updateAppVersion(JNIEnv *env, jobject _this,
+                                              jstring new_value) {
   char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
@@ -404,10 +395,8 @@ end:
   bsg_safe_release_string_utf_chars(env, new_value, value);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_updateBuildUUID(JNIEnv *env,
-                                                          jobject _this,
-                                                          jstring new_value) {
+static void JNI_NativeBridge_updateBuildUUID(JNIEnv *env, jobject _this,
+                                             jstring new_value) {
   char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
@@ -421,8 +410,8 @@ end:
   bsg_safe_release_string_utf_chars(env, new_value, value);
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateContext(
-    JNIEnv *env, jobject _this, jstring new_value) {
+static void JNI_NativeBridge_updateContext(JNIEnv *env, jobject _this,
+                                           jstring new_value) {
   char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
@@ -439,9 +428,9 @@ end:
   }
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
-    JNIEnv *env, jobject _this, jboolean new_value, jstring activity_) {
+static void JNI_NativeBridge_updateInForeground(JNIEnv *env, jobject _this,
+                                                jboolean new_value,
+                                                jstring activity_) {
   bsg_environment *bsg_env = request_env_write_lock();
   if (bsg_env == NULL) {
     return;
@@ -465,9 +454,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateInForeground(
   }
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_updateIsLaunching(
-    JNIEnv *env, jobject _this, jboolean new_value) {
+static void JNI_NativeBridge_updateIsLaunching(JNIEnv *env, jobject _this,
+                                               jboolean new_value) {
   bsg_environment *bsg_env = request_env_write_lock();
   if (bsg_env == NULL) {
     return;
@@ -477,10 +465,10 @@ Java_com_bugsnag_android_ndk_NativeBridge_updateIsLaunching(
   release_env_write_lock();
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_updateLowMemory(
-    JNIEnv *env, jobject _this, jboolean low_memory,
-    jstring memory_trim_level_description) {
+static void
+JNI_NativeBridge_updateLowMemory(JNIEnv *env, jobject _this,
+                                 jboolean low_memory,
+                                 jstring memory_trim_level_description) {
 
   char *memory_trim_level =
       (char *)bsg_safe_get_string_utf_chars(env, memory_trim_level_description);
@@ -505,10 +493,8 @@ end:
   }
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_updateOrientation(JNIEnv *env,
-                                                            jobject _this,
-                                                            jstring new_value) {
+static void JNI_NativeBridge_updateOrientation(JNIEnv *env, jobject _this,
+                                               jstring new_value) {
   char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
@@ -526,9 +512,8 @@ end:
   }
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_updateReleaseStage(
-    JNIEnv *env, jobject _this, jstring new_value) {
+static void JNI_NativeBridge_updateReleaseStage(JNIEnv *env, jobject _this,
+                                                jstring new_value) {
   char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
@@ -545,8 +530,8 @@ end:
   }
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserId(
-    JNIEnv *env, jobject _this, jstring new_value) {
+static void JNI_NativeBridge_updateUserId(JNIEnv *env, jobject _this,
+                                          jstring new_value) {
   char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
@@ -566,8 +551,8 @@ end:
   }
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateUserName(
-    JNIEnv *env, jobject _this, jstring new_value) {
+static void JNI_NativeBridge_updateUserName(JNIEnv *env, jobject _this,
+                                            jstring new_value) {
   char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
@@ -587,10 +572,8 @@ end:
   }
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_updateUserEmail(JNIEnv *env,
-                                                          jobject _this,
-                                                          jstring new_value) {
+static void JNI_NativeBridge_updateUserEmail(JNIEnv *env, jobject _this,
+                                             jstring new_value) {
   char *value = (char *)bsg_safe_get_string_utf_chars(env, new_value);
   if (value == NULL) {
     return;
@@ -610,9 +593,9 @@ end:
   }
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_addMetadataString(
-    JNIEnv *env, jobject _this, jstring tab_, jstring key_, jstring value_) {
+static void JNI_NativeBridge_addMetadataString(JNIEnv *env, jobject _this,
+                                               jstring tab_, jstring key_,
+                                               jstring value_) {
   char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
   char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
   char *value = (char *)bsg_safe_get_string_utf_chars(env, value_);
@@ -631,9 +614,9 @@ end:
   bsg_safe_release_string_utf_chars(env, value_, value);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_addMetadataDouble(
-    JNIEnv *env, jobject _this, jstring tab_, jstring key_, jdouble value_) {
+static void JNI_NativeBridge_addMetadataDouble(JNIEnv *env, jobject _this,
+                                               jstring tab_, jstring key_,
+                                               jdouble value_) {
   char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
   char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
   if (tab != NULL && key != NULL) {
@@ -650,9 +633,9 @@ end:
   bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_addMetadataBoolean(
-    JNIEnv *env, jobject _this, jstring tab_, jstring key_, jboolean value_) {
+static void JNI_NativeBridge_addMetadataBoolean(JNIEnv *env, jobject _this,
+                                                jstring tab_, jstring key_,
+                                                jboolean value_) {
   char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
   char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
   if (tab != NULL && key != NULL) {
@@ -669,9 +652,9 @@ end:
   bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_addMetadataOpaque(
-    JNIEnv *env, jobject _this, jstring tab_, jstring key_, jstring value_) {
+static void JNI_NativeBridge_addMetadataOpaque(JNIEnv *env, jobject _this,
+                                               jstring tab_, jstring key_,
+                                               jstring value_) {
   char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
   char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
   char *value = (char *)bsg_safe_get_string_utf_chars(env, value_);
@@ -690,10 +673,8 @@ end:
   bsg_safe_release_string_utf_chars(env, value_, value);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_clearMetadataTab(JNIEnv *env,
-                                                           jobject _this,
-                                                           jstring tab_) {
+static void JNI_NativeBridge_clearMetadataTab(JNIEnv *env, jobject _this,
+                                              jstring tab_) {
   char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
   if (tab == NULL) {
     return;
@@ -708,8 +689,8 @@ end:
   bsg_safe_release_string_utf_chars(env, tab_, tab);
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_removeMetadata(
-    JNIEnv *env, jobject _this, jstring tab_, jstring key_) {
+static void JNI_NativeBridge_removeMetadata(JNIEnv *env, jobject _this,
+                                            jstring tab_, jstring key_) {
   char *tab = (char *)bsg_safe_get_string_utf_chars(env, tab_);
   char *key = (char *)bsg_safe_get_string_utf_chars(env, key_);
 
@@ -727,8 +708,8 @@ end:
   bsg_safe_release_string_utf_chars(env, key_, key);
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateMetadata(
-    JNIEnv *env, jobject _this, jobject metadata) {
+static void JNI_NativeBridge_updateMetadata(JNIEnv *env, jobject _this,
+                                            jobject metadata) {
   if (!bsg_jni_cache->initialized) {
     BUGSNAG_LOG("updateMetadata failed: JNI cache not initialized.");
     return;
@@ -742,14 +723,13 @@ JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_updateMetadata(
   release_env_write_lock();
 }
 
-JNIEXPORT jlong JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_getSignalUnwindStackFunction(
-    JNIEnv *env, jobject thiz) {
+static jlong JNI_NativeBridge_getSignalUnwindStackFunction(JNIEnv *env,
+                                                           jobject thiz) {
   return (jlong)bsg_unwind_crash_stack;
 }
 
-JNIEXPORT void JNICALL Java_com_bugsnag_android_ndk_NativeBridge_addFeatureFlag(
-    JNIEnv *env, jobject thiz, jstring name_, jstring variant_) {
+static void JNI_NativeBridge_addFeatureFlag(JNIEnv *env, jobject thiz,
+                                            jstring name_, jstring variant_) {
 
   char *name = (char *)bsg_safe_get_string_utf_chars(env, name_);
   char *variant = (char *)bsg_safe_get_string_utf_chars(env, variant_);
@@ -768,10 +748,8 @@ end:
   bsg_safe_release_string_utf_chars(env, variant_, variant);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_clearFeatureFlag(JNIEnv *env,
-                                                           jobject thiz,
-                                                           jstring name_) {
+static void JNI_NativeBridge_clearFeatureFlag(JNIEnv *env, jobject thiz,
+                                              jstring name_) {
 
   char *name = (char *)bsg_safe_get_string_utf_chars(env, name_);
 
@@ -788,9 +766,7 @@ end:
   bsg_safe_release_string_utf_chars(env, name_, name);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_clearFeatureFlags(JNIEnv *env,
-                                                            jobject thiz) {
+static void JNI_NativeBridge_clearFeatureFlags(JNIEnv *env, jobject thiz) {
   bsg_environment *bsg_env = request_env_write_lock();
   if (bsg_env == NULL) {
     return;
@@ -799,15 +775,12 @@ Java_com_bugsnag_android_ndk_NativeBridge_clearFeatureFlags(JNIEnv *env,
   release_env_write_lock();
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_refreshSymbolTable(JNIEnv *env,
-                                                             jobject thiz) {
+static void JNI_NativeBridge_refreshSymbolTable(JNIEnv *env, jobject thiz) {
   bugsnag_refresh_symbol_table();
 }
 
-JNIEXPORT jobject JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_getCurrentCallbackSetCounts(
-    JNIEnv *env, jobject thiz) {
+static jobject JNI_NativeBridge_getCurrentCallbackSetCounts(JNIEnv *env,
+                                                            jobject thiz) {
 
   if (bsg_global_env == NULL || bsg_jni_cache == NULL) {
     return NULL;
@@ -839,9 +812,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_getCurrentCallbackSetCounts(
   return counts;
 }
 
-JNIEXPORT jobject JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_getCurrentNativeApiCallUsage(
-    JNIEnv *env, jobject thiz) {
+static jobject JNI_NativeBridge_getCurrentNativeApiCallUsage(JNIEnv *env,
+                                                             jobject thiz) {
   if (bsg_global_env == NULL || bsg_jni_cache == NULL) {
     return NULL;
   }
@@ -869,10 +841,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_getCurrentNativeApiCallUsage(
   return map;
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_setStaticJsonData(JNIEnv *env,
-                                                            jobject thiz,
-                                                            jstring data_) {
+static void JNI_NativeBridge_setStaticJsonData(JNIEnv *env, jobject thiz,
+                                               jstring data_) {
   if (bsg_global_env == NULL) {
     return;
   }
@@ -900,10 +870,8 @@ done:
   bsg_safe_release_string_utf_chars(env, data_, data);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_initCallbackCounts(JNIEnv *env,
-                                                             jobject thiz,
-                                                             jobject counts) {
+static void JNI_NativeBridge_initCallbackCounts(JNIEnv *env, jobject thiz,
+                                                jobject counts) {
   jobject entrySet =
       bsg_safe_call_object_method(env, counts, bsg_jni_cache->Map_entrySet);
   jobject iterator =
@@ -925,10 +893,8 @@ Java_com_bugsnag_android_ndk_NativeBridge_initCallbackCounts(JNIEnv *env,
   }
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_notifyAddCallback(JNIEnv *env,
-                                                            jobject thiz,
-                                                            jstring callback_) {
+static void JNI_NativeBridge_notifyAddCallback(JNIEnv *env, jobject thiz,
+                                               jstring callback_) {
   const char *callback = bsg_safe_get_string_utf_chars(env, callback_);
   if (!callback) {
     return;
@@ -944,9 +910,8 @@ end:
   bsg_safe_release_string_utf_chars(env, callback_, callback);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_notifyRemoveCallback(
-    JNIEnv *env, jobject thiz, jstring callback_) {
+static void JNI_NativeBridge_notifyRemoveCallback(JNIEnv *env, jobject thiz,
+                                                  jstring callback_) {
   const char *callback = bsg_safe_get_string_utf_chars(env, callback_);
   if (!callback) {
     return;
@@ -962,10 +927,53 @@ end:
   bsg_safe_release_string_utf_chars(env, callback_, callback);
 }
 
-JNIEXPORT void JNICALL
-Java_com_bugsnag_android_ndk_NativeBridge_setInternalMetricsEnabled(
-    JNIEnv *env, jobject thiz, jboolean enabled) {
+static void JNI_NativeBridge_setInternalMetricsEnabled(JNIEnv *env,
+                                                       jobject thiz,
+                                                       jboolean enabled) {
   bsg_set_internal_metrics_enabled(enabled);
+}
+
+#include "NativeBridge_JNI.h"
+#include "NdkPlugin_JNI.h"
+
+jint JNI_OnLoad(JavaVM *vm, void *reserved) {
+  // export all of the JNI functions and link them to the Java methods
+  JNIEnv *env = NULL;
+  jint result = -1;
+
+  if ((*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_4) != JNI_OK) {
+    goto error;
+  }
+
+  if (env == NULL) {
+    goto error;
+  }
+
+  if (!bsg_jni_cache_init(env)) {
+    BUGSNAG_LOG("Could not init JNI jni_cache.");
+    goto error;
+  }
+
+  result = (*env)->RegisterNatives(env, bsg_jni_cache->NativeBridge,
+                                   NativeBridge_JNIMethods,
+                                   NativeBridge_JNI_METHODS_COUNT);
+  if (result < 0) {
+    BUGSNAG_LOG("Failed to register Bugsnag NativeBridge JNI methods");
+    goto error;
+  }
+
+  result = (*env)->RegisterNatives(env, bsg_jni_cache->NdkPlugin,
+                                   NdkPlugin_JNIMethods,
+                                   NdkPlugin_JNI_METHODS_COUNT);
+  if (result < 0) {
+    BUGSNAG_LOG("Failed to register Bugsnag NdkPlugin JNI methods");
+    goto error;
+  }
+
+  return JNI_VERSION_1_4;
+
+error:
+  return result;
 }
 
 #ifdef __cplusplus

--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.c
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.c
@@ -208,6 +208,9 @@ bool bsg_jni_cache_init(JNIEnv *env) {
 
   CACHE_ENUM_CONSTANT(ErrorType_C, "com/bugsnag/android/ErrorType", "C");
 
+  CACHE_CLASS(NativeBridge, "com/bugsnag/android/ndk/NativeBridge");
+  CACHE_CLASS(NdkPlugin, "com/bugsnag/android/NdkPlugin");
+
   pthread_key_create(&jni_cleanup_key, detach_java_env);
 
   bsg_jni_cache->initialized = true;

--- a/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
+++ b/bugsnag-plugin-android-ndk/src/main/jni/jni_cache.h
@@ -80,6 +80,9 @@ typedef struct {
   jmethodID OpaqueValue_makeSafe;
 
   jobject ErrorType_C;
+
+  jclass NativeBridge;
+  jclass NdkPlugin;
 } bsg_jni_cache_t;
 
 extern bsg_jni_cache_t *const bsg_jni_cache;

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,8 +9,8 @@ repositories {
 
 gradlePlugin {
     plugins {
-        register("bugsnag-ndk-table-plugin") {
-            id = "bugsnag-ndk-table-plugin"
+        register("bugsnag-jni-link-table-plugin") {
+            id = "bugsnag-jni-link-table-plugin"
             implementationClass = "com.bugsnag.android.gradle.JNILinkTablePlugin"
         }
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,8 +4,19 @@ plugins {
 
 repositories {
     mavenCentral()
+    google()
+}
+
+gradlePlugin {
+    plugins {
+        register("bugsnag-ndk-table-plugin") {
+            id = "bugsnag-ndk-table-plugin"
+            implementationClass = "com.bugsnag.android.gradle.JNILinkTablePlugin"
+        }
+    }
 }
 
 dependencies {
     compileOnly(gradleApi())
+    implementation("com.android.tools.build:gradle-api:7.0.4")
 }

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/gradle/GenerateJNILinkTableTransform.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/gradle/GenerateJNILinkTableTransform.kt
@@ -1,0 +1,135 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.api.instrumentation.AsmClassVisitorFactory
+import com.android.build.api.instrumentation.ClassContext
+import com.android.build.api.instrumentation.ClassData
+import com.android.build.api.instrumentation.InstrumentationParameters
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+class GenerateJNILinkTableTransform(
+    api: Int,
+    classVisitor: ClassVisitor?,
+    val outputDirectory: Directory
+) : ClassVisitor(api, classVisitor) {
+
+    private var className: String? = null
+
+    private var nativeMethods: MutableList<JNIMethod> = mutableListOf()
+
+    override fun visit(
+        version: Int,
+        access: Int,
+        name: String?,
+        signature: String?,
+        superName: String?,
+        interfaces: Array<out String>?
+    ) {
+        className = name?.substringAfterLast('/')
+        super.visit(version, access, name, signature, superName, interfaces)
+    }
+
+    override fun visitEnd() {
+        // write the JNI link table for the class to header file
+        className?.let { className ->
+            if (nativeMethods.isNotEmpty()) {
+                generateLinkHeader(className, nativeMethods)
+            }
+        }
+
+        super.visitEnd()
+    }
+
+    private fun generateLinkHeader(className: String, methods: List<JNIMethod>) {
+        val headerFile = outputDirectory.file("${className}_JNI.h").asFile
+        headerFile.printWriter().use { writer ->
+            writer.println("// JNI Link Table for $className")
+            writer.println("#include <jni.h>")
+            writer.println("#ifndef ${className}_JNI_H")
+            writer.println("#define ${className}_JNI_H")
+            writer.println()
+
+            writer.println("#define ${className}_JNI_METHODS_COUNT ${methods.size}")
+
+            writer.println("static const JNINativeMethod ${className}_JNIMethods[] = {");
+            for (i in methods.indices) {
+                val method = methods[i]
+
+                writer.print("    {\"")
+                writer.print(method.name)
+                writer.print("\", \"")
+                writer.print(method.descriptor)
+                writer.print("\", &JNI_")
+                writer.print(className)
+                writer.print('_')
+                writer.print(method.name)
+                writer.print("}")
+
+                if (i < methods.size - 1) {
+                    writer.println(",")
+                } else {
+                    writer.println()
+                }
+            }
+            writer.println("};");
+
+            writer.println()
+            writer.println("#endif // ${className}_JNI_H")
+        }
+    }
+
+    override fun visitMethod(
+        access: Int,
+        name: String?,
+        descriptor: String?,
+        signature: String?,
+        exceptions: Array<out String>?
+    ): MethodVisitor {
+        if (access and Opcodes.ACC_NATIVE != 0 && name != null && descriptor != null) {
+            nativeMethods.add(JNIMethod(name, descriptor))
+        }
+
+        return super.visitMethod(access, name, descriptor, signature, exceptions)
+    }
+
+    private data class JNIMethod(
+        val name: String,
+        val descriptor: String,
+    )
+}
+
+abstract class GenerateJNILinkTableTransformFactory :
+    AsmClassVisitorFactory<GenerateJNILinkTableParameters> {
+    override fun createClassVisitor(
+        classContext: ClassContext,
+        nextClassVisitor: ClassVisitor
+    ): ClassVisitor {
+        return GenerateJNILinkTableTransform(
+            Opcodes.ASM7,
+            nextClassVisitor,
+            parameters.get().outputDirectory.get()
+        )
+    }
+
+    override fun isInstrumentable(classData: ClassData): Boolean {
+        val className = classData.className
+        val packagePrefix = parameters.get().packagePrefix.get()
+
+        // Check if the class is in the specified package
+        return className.startsWith(packagePrefix)
+    }
+}
+
+interface GenerateJNILinkTableParameters : InstrumentationParameters {
+    @get:Input
+    val packagePrefix: Property<String>
+
+    @get:OutputDirectory
+    val outputDirectory: DirectoryProperty
+}

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/gradle/JNILinkTablePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/gradle/JNILinkTablePlugin.kt
@@ -8,7 +8,19 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 
+/**
+ * Generates C header files for use with [RegisterNatives](docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#RegisterNatives)
+ * for the Bugsnag Android SDK. This plugin ensures that the Java/Kotlin classes with native methods
+ * have corresponding C functions as part of the build process. When the headers are included
+ * in the C or C++ code, any missing implementations will cause a build error.
+ */
 class JNILinkTablePlugin : Plugin<Project> {
+    /*
+     * This plugin generates JNI headers for the Bugsnag Android SDK by registering an
+     * identity ASM transformer to AGP. The transformer processes the classes, but does not
+     * modify them. Instead it just captures the native method signatures to generate the headers.
+     */
+
     override fun apply(project: Project) {
         // Create a directory for generated headers
         val generatedHeadersDir = project.layout.buildDirectory.dir("generated/jni-headers")

--- a/buildSrc/src/main/kotlin/com/bugsnag/android/gradle/JNILinkTablePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bugsnag/android/gradle/JNILinkTablePlugin.kt
@@ -1,0 +1,67 @@
+package com.bugsnag.android.gradle
+
+import com.android.build.api.instrumentation.InstrumentationScope
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Variant
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+
+class JNILinkTablePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        // Create a directory for generated headers
+        val generatedHeadersDir = project.layout.buildDirectory.dir("generated/jni-headers")
+
+        // Get the Android components extension
+        val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
+
+        // Configure each variant
+        androidComponents.onVariants { variant ->
+            project.configureVariant(variant, generatedHeadersDir)
+        }
+    }
+
+    private fun Project.configureVariant(
+        variant: Variant,
+        generatedHeadersDir: Provider<Directory>
+    ) {
+        val externalNativeBuild = variant.externalNativeBuild ?: return
+
+        // configure the variant to generate the headers from the class files
+        variant.transformClassesWith(
+            GenerateJNILinkTableTransformFactory::class.java,
+            InstrumentationScope.PROJECT
+        ) { parameters ->
+            parameters.packagePrefix.set("com.bugsnag.android")
+            parameters.outputDirectory.set(generatedHeadersDir)
+        }
+
+        fixTaskOrdering(variant)
+
+        // Get the physical directory
+        val headersDir = generatedHeadersDir.get().asFile
+
+        // Ensure the directory exists
+        headersDir.mkdirs()
+
+        // Configure CMake to include our generated headers directory
+        externalNativeBuild.cFlags.apply {
+            // Add the include directory to the CMake arguments
+            add("-I${headersDir.absolutePath}")
+        }
+    }
+
+    private fun Project.fixTaskOrdering(variant: Variant) {
+        val variantName = variant.name.capitalize()
+        val transformTaskName = "transform${variantName}ClassesWithAsm"
+        // Ensure the CMake task runs after the classes are transformed
+        tasks.whenTaskAdded {
+            when (name) {
+                "buildCMakeDebug", "buildCMakeRelWithDebInfo" -> {
+                    dependsOn(transformTaskName)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal
Avoid lazy-linking the JNI functions in `bugsnag-plugin-android-ndk`.

## Design
This PR introduces a small Gradle plugin to `buildSrc` that generates the JNI natives lists as header files which are `#include`d into `bugsnag_ndk.c`. The plugin means that the Kotlin `external`s and the native code are guaranteed to be in-sync and no new functions can be introduced without their implementation.

Using `JNI_OnLoad` and `RegisterNatives` also helps improve reliability because the entire module will either load, or not load. So we cannot suffer from spurious `LinkError`s when unlinked function cannot be called due to a failed loading of some kind.

## Testing
Manually tested failure modes, and relied on existing tests.