### PR TITLE
Move Android 7 ANR tests to BitBar

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -230,14 +230,13 @@ steps:
     concurrency_group: 'bitbar'
     concurrency_method: eager
 
-
-  - label: ':browserstack: Android 7 NDK r19 end-to-end tests - ANRs'
+  - label: ':bitbar: Android 7 NDK r19 end-to-end tests - ANRs'
     depends_on: "fixture-r19"
     timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
-          - "build/bs-fixture-r19-url.txt"
+          - "build/fixture-r19-url.txt"
           - "build/fixture-r19/*"
         upload:
           - "maze_output/failed/**/*"
@@ -248,9 +247,11 @@ steps:
         service-ports: true
         command:
           - "features/full_tests/anr.feature"
-          - "--app=@build/bs-fixture-r19-url.txt"
+          - "--app=@build/fixture-r19-url.txt"
           - "--appium-version=1.22.0"
-          - "--farm=bs"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
           - "--device=ANDROID_7"
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
@@ -258,8 +259,8 @@ steps:
         branch: "^main|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
+    concurrency: 25
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 8 NDK r19 end-to-end tests - batch 1'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -140,13 +140,13 @@ steps:
     concurrency_group: 'bitbar'
     concurrency_method: eager
 
-  - label: ':browserstack: Android 7 NDK r19 ANR smoke tests'
+  - label: ':bitbar: Android 7 NDK r19 ANR smoke tests'
     depends_on: "fixture-r19"
     timeout_in_minutes: 30
     plugins:
       artifacts#v1.9.0:
         download:
-          - "build/bs-fixture-r19-url.txt"
+          - "build/fixture-r19-url.txt"
           - "build/fixture-r19/*"
         upload:
           - "maze_output/failed/**/*"
@@ -157,9 +157,11 @@ steps:
         service-ports: true
         command:
           - "features/smoke_tests/01_anr.feature"
-          - "--app=@build/bs-fixture-r19-url.txt"
+          - "--app=@build/fixture-r19-url.txt"
           - "--appium-version=1.22.0"
-          - "--farm=bs"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--farm=bb"
           - "--device=ANDROID_7"
       test-collector#v1.10.2:
         files: "reports/TEST-*.xml"
@@ -167,8 +169,8 @@ steps:
         branch: "^main|next$$"
     env:
       TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r19"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
+    concurrency: 25
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: Android 8 NDK r19 smoke tests'


### PR DESCRIPTION
## Goal

BrowserStack are removing the last of their Android 7 devices, so moving the ANR tests to BitBar.

## Design

The ANR tests had been moved to BS in the past due to problems running them on on BB (I forget why exactly), but so far they are running well.  For now I have kept the ANR scenarios in their own Buildkite job as they do tend to be flakier, but in principle we may be able to reunite them with the bulk of the tests in future.

## Testing

Covered by a full CI run.