### PR TITLE
fix threadCollectionTimeLimitMillis default milliseconds comment

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -567,7 +567,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Sets the maximum time for collecting threads and traces.
-     * By default, up to 500 milliseconds are reported.
+     * By default, up to 5000 milliseconds are reported.
      */
     public void setThreadCollectionTimeLimitMillis(
             @IntRange(from = 0) long threadCollectionTimeLimitMillis


### PR DESCRIPTION
A customer has pointed out that the comment specifies the default as 500 milliseconds when it is actually 5000 milliseconds