### PR TITLE
Update compileSdk to 35

### DIFF
--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/MemoryTrimTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/MemoryTrimTest.java
@@ -34,6 +34,7 @@ public class MemoryTrimTest {
     ArgumentCaptor<ComponentCallbacks> componentCallbacksCaptor;
 
     @Test
+    @SuppressWarnings("deprecation")
     public void onLowMemoryEvent() {
         when(context.getApplicationContext()).thenReturn(context);
         doNothing().when(context).registerComponentCallbacks(any());

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientComponentCallbacks.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientComponentCallbacks.kt
@@ -19,9 +19,11 @@ internal class ClientComponentCallbacks(
     }
 
     override fun onTrimMemory(level: Int) {
+        @Suppress("DEPRECATION")
         memoryCallback(level >= ComponentCallbacks2.TRIM_MEMORY_COMPLETE, level)
     }
 
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onLowMemory() {
         memoryCallback(true, null)
     }

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/MemoryTrimState.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/MemoryTrimState.kt
@@ -27,6 +27,7 @@ internal class MemoryTrimState : BaseObservable() {
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun descriptionFor(memoryTrimLevel: Int?) = when (memoryTrimLevel) {
         null -> "None"
         ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> "Complete"

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientComponentCallbacksMemoryCallbackTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientComponentCallbacksMemoryCallbackTest.kt
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 
+@Suppress("DEPRECATION")
 @RunWith(MockitoJUnitRunner::class)
 class ClientComponentCallbacksMemoryCallbackTest {
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/MemoryTrimStateTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/MemoryTrimStateTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
+@Suppress("DEPRECATION")
 internal class MemoryTrimStateTest {
 
     lateinit var memoryTrimState: MemoryTrimState

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/UpdateMemoryTrimLevelTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/UpdateMemoryTrimLevelTest.kt
@@ -10,6 +10,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@Suppress("DEPRECATION")
 internal class UpdateMemoryTrimLevelTest {
 
     lateinit var memoryTrimState: MemoryTrimState

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,5 +26,3 @@ POM_DESCRIPTION=Official Bugsnag notifier for Android applications
 POM_URL=https://bugsnag.com
 android.useAndroidX=true
 android.enableJetifier=true
-# remove this when AGP version is upgraded
-android.aapt2Version=8.6.1-11315950


### PR DESCRIPTION
## Goal
Bump the compileSdk to 35

## Changes
Added `@Suppress("DEPRECATION")` annotations to the appropriate classes & functions where we call API that is no longer supported (but may still be used on older devices).

## Testing
Relied on existing tests