### PR TITLE
Do not report `lowMemory` or `memoryTrimLevel` when not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* `memoryTrimLevel` and `lowMemory` will not be reported when they are not set (newer versions of Android do not set these values)
+  [#2237](https://github.com/bugsnag/bugsnag-android/pull/2237)
+
 ## 6.16.0 (2025-07-31)
 
 ### Changes

--- a/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
+++ b/bugsnag-android-core/src/androidTest/java/com/bugsnag/android/ClientTest.java
@@ -171,14 +171,12 @@ public class ClientTest {
     public void testAppDataMetadata() {
         client = generateClient();
         Map<String, Object> app = client.getAppDataCollector().getAppDataMetadata();
-        assertEquals(11, app.size());
+        assertEquals(9, app.size());
         assertEquals("Bugsnag Android Tests", app.get("name"));
         assertEquals("com.bugsnag.android.core.test", app.get("processName"));
         assertNotNull(app.get("memoryUsage"));
         assertTrue(app.containsKey("activeScreen"));
         assertTrue(app.containsKey("installerPackage"));
-        assertNotNull(app.get("lowMemory"));
-        assertNotNull(app.get("memoryTrimLevel"));
     }
 
     @Test

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/AppDataCollector.kt
@@ -109,9 +109,14 @@ internal class AppDataCollector(
         val map = HashMap<String, Any?>()
         map["name"] = appName
         map["activeScreen"] = sessionTracker.get().contextActivity
-        map["lowMemory"] = memoryTrimState.isLowMemory
-        map["memoryTrimLevel"] = memoryTrimState.trimLevelDescription
         map["processImportance"] = getProcessImportance()
+
+        // only report the memory trim/low memory state if it has been captured
+        // more recent Android versions will not report these
+        if (memoryTrimState.memoryTrimLevel != null) {
+            map["lowMemory"] = memoryTrimState.isLowMemory
+            map["memoryTrimLevel"] = memoryTrimState.trimLevelDescription
+        }
 
         populateRuntimeMemoryMetadata(map)
 

--- a/bugsnag-android-core/src/test/resources/app_meta_data_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/app_meta_data_serialization_0.json
@@ -1,6 +1,6 @@
 {
-  "memoryTrimLevel": "None",
+  "memoryTrimLevel": "Moderate",
   "activeScreen": "MyActivity",
   "name": "MyApp",
-  "lowMemory": false
+  "lowMemory": true
 }

--- a/bugsnag-android-core/src/test/resources/app_meta_data_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/app_meta_data_serialization_1.json
@@ -1,0 +1,4 @@
+{
+  "activeScreen": "MyActivity",
+  "name": "MyApp"
+}

--- a/features/smoke_tests/02_handled.feature
+++ b/features/smoke_tests/02_handled.feature
@@ -51,8 +51,6 @@ Feature: Handled smoke tests
     And the error payload field "events.0.metaData.app.freeMemory" is an integer
     And the error payload field "events.0.metaData.app.memoryLimit" is greater than 0
     And the event "metaData.app.name" equals "MazeRunner"
-    And the event "metaData.app.lowMemory" is false
-    And the event "metaData.app.memoryTrimLevel" equals "None"
 
     # Device data
     And the error payload field "events.0.device.cpuAbi" is a non-empty array

--- a/features/smoke_tests/04_unhandled.feature
+++ b/features/smoke_tests/04_unhandled.feature
@@ -53,7 +53,6 @@ Feature: Unhandled smoke tests
 
     # Metadata
     And the event "metaData.app.name" equals "MazeRunner"
-    And the event "metaData.app.lowMemory" is false
     And the event "metaData.TestData.password" equals "[REDACTED]"
 
     # Device data


### PR DESCRIPTION
## Goal
Stop reporting the `app.lowMemory` and `app.memoryTrimLevel` attributes when they are not reported by the OS. Newer versions of Android have deprecated these callbacks, and removing the attributes (unless the callbacks have been triggered) reduces the amount of metadata and noise.

## Testing
Updated existing unit tests and end-to-end tests.