### PR TITLE
Only use Buildkite plugins once per step

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1013,7 +1013,6 @@ steps:
           image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/android
           cache-from:
             - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:latest
-      - docker-compose#v4.7.0:
           push:
             - android-common:855461928731.dkr.ecr.us-west-1.amazonaws.com/android:latest
 


### PR DESCRIPTION
## Goal

Only use Buildkie plugins once per step, removing a warning that later steps will be ignored in a future version of the agent.

## Testing

Verified by review only - not easily tested in advance of the next release.