### PR TITLE
Fix reported loadAddress for system libs in NDK errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Handle edge-cases to reduce the changes of duplicate ANR reporting from `bugsnag-plugin-android-exitinfo` when `reportUnmatchedANR = true && disableProcessStateSummaryOverride = true`
   [#2235](https://github.com/bugsnag/bugsnag-android/pull/2235)
+* Correct the reporting of the loadAddress for native system libraries and JIT frames
+  [#2244](https://github.com/bugsnag/bugsnag-android/pull/2244)
 
 ## 6.16.0 (2025-07-31)
 

--- a/features/smoke_tests/04_unhandled.feature
+++ b/features/smoke_tests/04_unhandled.feature
@@ -123,6 +123,7 @@ Feature: Unhandled smoke tests
     # Stacktrace validation
     And the error payload field "events.0.exceptions.0.stacktrace" is a non-empty array
     And the event stacktrace identifies the program counter
+    And the event stacktrace has valid addresses
     And the event "exceptions.0.stacktrace.0.method" is not null
     And the event "exceptions.0.stacktrace.0.file" is not null
     And the error payload field "events.0.exceptions.0.stacktrace.0.frameAddress" is not null
@@ -250,6 +251,7 @@ Feature: Unhandled smoke tests
       | magicstacks::middle()                                                         | CXXExceptionSmokeScenario.cpp | 16 |
       | magicstacks::start()                                                          | CXXExceptionSmokeScenario.cpp | 18 |
       | Java_com_bugsnag_android_mazerunner_scenarios_CXXExceptionSmokeScenario_crash | CXXExceptionSmokeScenario.cpp | 25 |
+    And the event stacktrace has valid addresses
 
     # App data
     And the event binary arch field is valid


### PR DESCRIPTION
## Goal
Correct the `loadAddress` based on the mapped offset so that the `frameAddress - loadAddress == relPC`.

## Changeset
When a valid map offset is reported by the unwinder, subtract it from the reported `loadAddress` so that the reported address is the expected value. The only observed offset maps have been system libraries (such as `libart.so`) but there are likely others that may have had the wrong `loadAddress` reported.

In order to retain `frameAddress` being the raw PC while `lineNumber` remains the reported relative PC (`rel_pc`) we need to adjust the `loadAddress` so that `frameAddress - loadAddress == lineNumber` (or rather `pc - load_addr == rel_pc`). The `rel_pc` is typically calculated as:
```c
pc - map_info->start() + load_bias_ + map_info->elf_offset();
```
where `elf_offset` is `elf_offset == offset - elf_start_offset`.

However: the `load_bias` for a JITsym frame is `7fffffffffffffff` which ruins these calculations, so when calculating the `loadAddress` we check the total offset applied won't cause an underflow.

## Testing
- Added a frameAddress / lineNumber validation check to the Mazerunner smoke tests.
- Manually checked against various crash types.