### PR TITLE
gradle/wrapper-validation-action: bump to v4.4.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           submodules: recursive
-      - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 #v3.5.0
+      - uses: gradle/actions/wrapper-validation@017a9effdb900e5b5b2fddfb590a105619dca3c3 #v4.4.2
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 #v5.0.0
         with:


### PR DESCRIPTION
## Goal
Bump the Gradle wrapper validation GitHub Action to the latest version

## Testing
Temporarily included this branch in the GH Actions and verified that they pass as expected.