### PR TITLE
Fix ANR test scenarios for Android 16

### DIFF
--- a/features/full_tests/anr.feature
+++ b/features/full_tests/anr.feature
@@ -8,7 +8,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR triggered in CXX code is captured
     When I run "CXXAnrScenario"
     And I wait for 2 seconds
-    And I press the back button
+    And I cause the ANR dialog to appear
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -24,7 +24,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled
     When I run "CXXAnrNdkDisabledScenario"
     And I wait for 2 seconds
-    And I press the back button
+    And I cause the ANR dialog to appear
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -40,8 +40,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR triggered in JVM loop code is captured
     When I clear any error dialogue
     And I run "JvmAnrLoopScenario"
-    And I wait for 2 seconds
-    And I tap the screen 3 times
+    And I cause the ANR dialog to appear
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -58,7 +57,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
     When I clear any error dialogue
     And I run "JvmAnrSleepScenario"
     And I wait for 2 seconds
-    And I press the back button
+    And I cause the ANR dialog to appear
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -82,7 +81,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR triggered in JVM code is not captured when outside of release stage
     When I run "JvmAnrOutsideReleaseStagesScenario"
     And I wait for 2 seconds
-    And I press the back button
+    And I cause the ANR dialog to appear
     And I wait for 10 seconds
     And I close and relaunch the app after an ANR
     And I configure Bugsnag for "JvmAnrOutsideReleaseStagesScenario"
@@ -95,7 +94,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR not captured with autoDetectAnrs=false
     When I run "AutoDetectAnrsFalseScenario"
     And I wait for 2 seconds
-    And I press the back button
+    And I cause the ANR dialog to appear
     And I wait for 10 seconds
     And I close and relaunch the app after an ANR
     And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
@@ -109,7 +108,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
     When I clear any error dialogue
     And I run "AutoDetectAnrsTrueScenario"
     And I wait for 2 seconds
-    And I press the back button
+    And I cause the ANR dialog to appear
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements

--- a/features/full_tests/anr.feature
+++ b/features/full_tests/anr.feature
@@ -8,7 +8,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR triggered in CXX code is captured
     When I run "CXXAnrScenario"
     And I wait for 2 seconds
-    And I tap the screen 3 times
+    And I press the back button
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -24,7 +24,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR triggered in CXX code is captured even when NDK detection is disabled
     When I run "CXXAnrNdkDisabledScenario"
     And I wait for 2 seconds
-    And I tap the screen 3 times
+    And I press the back button
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -58,7 +58,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
     When I clear any error dialogue
     And I run "JvmAnrSleepScenario"
     And I wait for 2 seconds
-    And I tap the screen 3 times
+    And I press the back button
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "ANR"
@@ -82,7 +82,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR triggered in JVM code is not captured when outside of release stage
     When I run "JvmAnrOutsideReleaseStagesScenario"
     And I wait for 2 seconds
-    And I tap the screen 3 times
+    And I press the back button
     And I wait for 10 seconds
     And I close and relaunch the app after an ANR
     And I configure Bugsnag for "JvmAnrOutsideReleaseStagesScenario"
@@ -95,7 +95,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
   Scenario: ANR not captured with autoDetectAnrs=false
     When I run "AutoDetectAnrsFalseScenario"
     And I wait for 2 seconds
-    And I tap the screen 3 times
+    And I press the back button
     And I wait for 10 seconds
     And I close and relaunch the app after an ANR
     And I configure Bugsnag for "AutoDetectAnrsFalseScenario"
@@ -109,7 +109,7 @@ Feature: ANRs triggered in CXX/JVM code are captured and Switching automatic err
     When I clear any error dialogue
     And I run "AutoDetectAnrsTrueScenario"
     And I wait for 2 seconds
-    And I tap the screen 3 times
+    And I press the back button
     And I wait to receive an error
     Then the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the error payload field "events" is an array with 1 elements

--- a/features/minimal/detect_anr_minimal.feature
+++ b/features/minimal/detect_anr_minimal.feature
@@ -8,8 +8,7 @@ Feature: ANRs triggered in a fixture with only bugsnag-android-core are captured
   Scenario: Triggering ANR does not crash the minimal app
     When I run "JvmAnrMinimalFixtureScenario"
     And I wait for 2 seconds
-    And I press the back button
-    And I wait for 4 seconds
+    And I cause the ANR dialog to appear
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "java.lang.RuntimeException"

--- a/features/minimal/detect_anr_minimal.feature
+++ b/features/minimal/detect_anr_minimal.feature
@@ -8,7 +8,7 @@ Feature: ANRs triggered in a fixture with only bugsnag-android-core are captured
   Scenario: Triggering ANR does not crash the minimal app
     When I run "JvmAnrMinimalFixtureScenario"
     And I wait for 2 seconds
-    And I tap the screen 3 times
+    And I press the back button
     And I wait for 4 seconds
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier

--- a/features/smoke_tests/01_anr.feature
+++ b/features/smoke_tests/01_anr.feature
@@ -10,10 +10,8 @@ Feature: ANR smoke test
     When I set the screen orientation to portrait
     And I clear any error dialogue
     And I run "JvmAnrLoopScenario"
-    And I wait for 1 seconds
-    And I tap the screen 3 times
-    And I wait for 5 seconds
-    And I tap the screen 3 times
+    And I wait for 2 seconds
+    And I cause the ANR dialog to appear
     And I wait to receive an error
 
     # Exception details

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -133,12 +133,8 @@ When("I tap the screen {int} times") do |count|
   }
 end
 
-When("I tap the back-button {int} times") do |count|
-  manager = Maze::Api::Appium::DeviceManager.new
-  (1..count).each { |i|
-    manager.back
-    sleep(0.5)
-  }
+When('I press the back button') do
+  Maze::Api::Appium::DeviceManager.new.back
 end
 
 When("I configure the app to run in the {string} state") do |scenario_mode|

--- a/features/steps/android_steps.rb
+++ b/features/steps/android_steps.rb
@@ -122,6 +122,11 @@ When("I relaunch the app after a crash") do
   manager.activate
 end
 
+When('I cause the ANR dialog to appear') do
+  step 'I tap the screen 3 times'
+  step 'I press the back button'
+end
+
 When("I tap the screen {int} times") do |count|
   (1..count).each { |i|
     begin


### PR DESCRIPTION
## Goal

Fix the ANR scenarios for Android 16, which seemed to be always failing if more than one scenario was included in the run (even though each scenario passed on its own).

## Design

We've used different approaches for prompting the ANR dialog to appear - primarily screen touches or Back Button presses.  While investigating this issues I found that the back button worked for most scenarios For Android > v9, but touches had to be used for Android <= 9.  I also found one scenario that had to use touches even on newer Android versions.

So, the end result here is a combined step to use both approaches for all scenarios and on all Android versions.

## Testing

Covered by a few CI run.