### PR TITLE
Simple path implementation for JSON data extraction

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/json/JsonCollectionPath.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/json/JsonCollectionPath.kt
@@ -1,0 +1,130 @@
+package com.bugsnag.android.internal.json
+
+/**
+ * A simple path implementation similar to json path, but much simpler. The notation is strictly
+ * dot (`'.'`) separated and does not support name escaping. Paths are parsed from strings and
+ * can be efficiently evaluated any number of times once parsed, and are thread safe.
+ *
+ * Paths are in the form `"property.0.-1.*.value"` where `'*'` is a wildcard match, `0` is the
+ * first item of an array (or a property named `"0"`) and `-1` is the last element in an array (or
+ * a property named `"-1"`). Null values or non-existent values are skipped.
+ */
+internal class JsonCollectionPath private constructor(
+    private val root: PathNode,
+    private val path: String
+) {
+    /**
+     * Extract all of the selected values from the given JSON object stored in the given `Map`.
+     */
+    fun extractFrom(json: Map<String, *>): List<Any> {
+        val out = ArrayList<Any>()
+        root.visit(json, out::add)
+        return out
+    }
+
+    override fun toString(): String {
+        return path
+    }
+
+    companion object {
+        val IDENTITY_PATH = JsonCollectionPath(PathNode.TerminalNode, "")
+
+        fun fromString(path: String): JsonCollectionPath {
+            if (path.isEmpty()) {
+                return IDENTITY_PATH
+            }
+
+            val segments = path.split('.')
+                .reversed() // we build the path backwards
+
+            var node: PathNode = PathNode.TerminalNode
+            segments.forEach { segment ->
+                node = segment.toPathNode(node)
+            }
+
+            return JsonCollectionPath(node, path)
+        }
+
+        private fun String.toPathNode(next: PathNode): PathNode {
+            if (this == "*") {
+                return PathNode.Wildcard(next)
+            }
+
+            val index = this.toIntOrNull()
+            if (index != null) {
+                return if (index < 0) {
+                    PathNode.NegativeIndex(index, next)
+                } else {
+                    PathNode.PositiveIndex(index, next)
+                }
+            }
+
+            return PathNode.Property(this, next)
+        }
+    }
+
+    private sealed class PathNode {
+        abstract fun visit(element: Any, collector: (Any) -> Unit)
+
+        abstract class NonTerminalPathNode(protected val next: PathNode) : PathNode()
+
+        class Property(val name: String, next: PathNode) : NonTerminalPathNode(next) {
+            override fun visit(element: Any, collector: (Any) -> Unit) {
+                if (element is Map<*, *>) {
+                    element[name]?.let { next.visit(it, collector) }
+                }
+            }
+
+            override fun toString(): String = name
+        }
+
+        class Wildcard(next: PathNode) : NonTerminalPathNode(next) {
+            override fun visit(element: Any, collector: (Any) -> Unit) {
+                if (element is Iterable<*>) {
+                    element.forEach { item ->
+                        item?.let { next.visit(it, collector) }
+                    }
+                } else if (element is Map<*, *>) {
+                    element.values.forEach { item ->
+                        item?.let { next.visit(it, collector) }
+                    }
+                }
+            }
+        }
+
+        abstract class IndexPathNode(
+            protected val index: Int,
+            next: PathNode
+        ) : NonTerminalPathNode(next) {
+            protected abstract fun normalisedIndex(list: List<*>): Int
+
+            override fun visit(element: Any, collector: (Any) -> Unit) {
+                if (element is List<*>) {
+                    val normalised = normalisedIndex(element)
+                    element.getOrNull(normalised)?.let { next.visit(it, collector) }
+                } else if (element is Map<*, *>) {
+                    val value = element[index.toString()]
+                    value?.let { next.visit(it, collector) }
+                }
+            }
+        }
+
+        class PositiveIndex(index: Int, next: PathNode) : IndexPathNode(index, next) {
+            override fun normalisedIndex(list: List<*>): Int {
+                return index
+            }
+        }
+
+        class NegativeIndex(index: Int, next: PathNode) : IndexPathNode(index, next) {
+            override fun normalisedIndex(list: List<*>): Int {
+                return list.size + index
+            }
+        }
+
+        object TerminalNode : PathNode() {
+            override fun visit(element: Any, collector: (Any) -> Unit) {
+                collector(element)
+            }
+        }
+    }
+}

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/json/JsonCollectionPathTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/json/JsonCollectionPathTest.kt
@@ -1,0 +1,102 @@
+package com.bugsnag.android.internal.json
+
+import com.bugsnag.android.internal.JsonCollectionParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+internal class JsonCollectionPathTest {
+    @Test
+    fun extractLastArrayElement() {
+        val extracted = extractPathFromResource(
+            "metaData.structuralTests.arrayTests.nested.*.-1",
+            "event_serialization_9.json"
+        )
+
+        assertEquals(
+            listOf(2L, listOf(4L, 5L), listOf(7L, listOf(8L, 9L))),
+            extracted
+        )
+    }
+
+    @Test
+    fun extractFirstArrayElement() {
+        val extracted = extractPathFromResource(
+            "metaData.structuralTests.arrayTests.nested.*.0",
+            "event_serialization_9.json"
+        )
+
+        assertEquals(
+            listOf(1L, 3L, 6L),
+            extracted
+        )
+    }
+
+    @Test
+    fun nonExistentPropertyPath() {
+        val extracted = extractPathFromResource(
+            "metaData.structuralTests.arrayTests.noValueHere",
+            "event_serialization_9.json"
+        )
+
+        assertEquals(0, extracted.size)
+    }
+
+    @Test
+    fun nonExistentNumericPath() {
+        val extracted = extractPathFromResource(
+            "metaData.structuralTests.arrayTests.0",
+            "event_serialization_9.json"
+        )
+
+        assertEquals(0, extracted.size)
+    }
+
+    @Test
+    fun nonExistentNegativeNumericPath() {
+        val extracted = extractPathFromResource(
+            "metaData.structuralTests.arrayTests.-1",
+            "event_serialization_9.json"
+        )
+
+        assertEquals(0, extracted.size)
+    }
+
+    @Test
+    fun numericMapKeys() {
+        val numberKeys = extractPathFromResource("metaData.numbers.0", "path_fixture.json")
+        assertEquals(listOf("naught"), numberKeys)
+    }
+
+    @Test
+    fun wildcardArrayElements() {
+        val numberKeys =
+            extractPathFromResource("metaData.arrayOfObjects.*.name", "path_fixture.json")
+        assertEquals(listOf("one", "two", "three"), numberKeys)
+    }
+
+    @Test
+    fun wildcardObjectProperties() {
+        val numberKeys = extractPathFromResource("metaData.numbers.*", "path_fixture.json")
+        assertEquals(listOf("naught", "one", "two", "three"), numberKeys)
+    }
+
+    @Test
+    fun toStringReturnsPath() {
+        val path = "name.string.more words are here.0.-1.*.*.*.\uD83D\uDE00\uD83D\uDE03\uD83D\uDE04"
+        val json = JsonCollectionPath.fromString(path)
+
+        assertEquals(path, json.toString())
+    }
+
+    private fun extractPathFromResource(path: String, resource: String): List<Any> {
+        val json = JsonCollectionParser(this::class.java.getResourceAsStream("/$resource")!!)
+            .parse()
+
+        val collectionPath = JsonCollectionPath.fromString(path)
+        assertNotNull("path failed to parse: '$path'", collectionPath)
+
+        @Suppress("UNCHECKED_CAST")
+        return collectionPath.extractFrom(json as Map<String, *>)
+    }
+}

--- a/bugsnag-android-core/src/test/resources/path_fixture.json
+++ b/bugsnag-android-core/src/test/resources/path_fixture.json
@@ -1,0 +1,21 @@
+{
+  "metaData": {
+    "numbers": {
+      "0": "naught",
+      "1": "one",
+      "2": "two",
+      "3": "three"
+    },
+    "arrayOfObjects": [
+      {
+        "name": "one"
+      },
+      {
+        "name": "two"
+      },
+      {
+        "name": "three"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Goal
Enable the next phase of our remote SDK configuration with a simple data extractor.

## Design
The new `JsonCollectionPath` class implements the parsing of the path into nodes, and encapsulates the data extraction.

Calling `JsonCollectionPath.fromString` splits the string on the dot (`'.'`) character and then builds a chain of `PathNode` objects based on each unit of the path:

- `'*'` becomes a `WildcardNode` and matches all elements in an array, and all values in an object
- Positive integers become `PositiveIndex` objects and attempt to match the numbered element of an array. If asked to match against an object (`Map`) the index is treated as a property name
- Negative integers become `NegativeIndex` objects and attempt to match an element from the end of an array (`-1` is the last element, `-2` is the second-from-last, and so-on). If asked to match against an object (`Map`) the index is treated as a property name (verbatim)
- All other strings are treated as a property name for a JSON object (`Map`) and will not match anything else.

## Testing
New unit tests introduced.