### PR TITLE
Prevent system generated ANRs from being sent in e2e tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -324,6 +324,10 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - label: ':browserstack: ANDROID_16 NDK r21 e2e tests - batch 2'
     depends_on: "fixture-r21"
@@ -356,6 +360,10 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - label: ':bitbar: {{matrix}} NDK r28 e2e tests - batch 1'
     matrix:
@@ -480,6 +488,10 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - label: ':browserstack: ANDROID_16 NDK r28 e2e tests - batch 2'
     depends_on: "fixture-r28"
@@ -512,6 +524,10 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   # If there is a tag present activate a manual publishing step
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -401,6 +401,10 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - label: ':bitbar: {{matrix}} NDK r28 smoke tests'
     matrix:
@@ -555,6 +559,10 @@ steps:
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: 103  # Appium client failure
+          limit: 2
 
   - label: 'Conditionally include device farms/full tests'
     agents:

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
@@ -46,21 +46,7 @@ fun prepareConfig(
         }
     }
 
-    // Do not allow system generated ANRs to be sent to Maze Runner
-    config.addOnError { event ->
-        val error = event.errors.first()
-        val method1 = "android.os.BinderProxy.transact"
-        val method2 = "android.app.IActivityManager\$Stub\$Proxy.handleApplicationCrash"
-        if (error.errorClass.equals("ANR") &&
-            error.stacktrace.any { frame -> frame.method.equals(method1) } &&
-            error.stacktrace.any { frame -> frame.method.equals(method2) }
-            ) {
-            CiLog.info("Filtering system generated ANR")
-            false
-        } else {
-            true
-        }
-    }
+    config.addOnError(filterSystemAnrs)
 
     return config
 }

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/BugsnagConfig.kt
@@ -10,7 +10,6 @@ import com.bugsnag.android.DeliveryStatus
 import com.bugsnag.android.EndpointConfiguration
 import com.bugsnag.android.EventPayload
 import com.bugsnag.android.Logger
-import com.bugsnag.android.OnErrorCallback
 import com.bugsnag.android.Session
 import com.bugsnag.android.createDefaultDelivery
 
@@ -50,9 +49,12 @@ fun prepareConfig(
     // Do not allow system generated ANRs to be sent to Maze Runner
     config.addOnError { event ->
         val error = event.errors.first()
+        val method1 = "android.os.BinderProxy.transact"
+        val method2 = "android.app.IActivityManager\$Stub\$Proxy.handleApplicationCrash"
         if (error.errorClass.equals("ANR") &&
-            error.stacktrace.any { frame -> frame.method.equals("android.os.BinderProxy.transact")} &&
-            error.stacktrace.any { frame -> frame.method.equals("android.app.IActivityManager\$Stub\$Proxy.handleApplicationCrash")}) {
+            error.stacktrace.any { frame -> frame.method.equals(method1) } &&
+            error.stacktrace.any { frame -> frame.method.equals(method2) }
+            ) {
             CiLog.info("Filtering system generated ANR")
             false
         } else {

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationFromManifestScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationFromManifestScenario.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.OnErrorCallback
+import com.bugsnag.android.mazerunner.CiLog
 import java.lang.RuntimeException
 
 internal class LoadConfigurationFromManifestScenario(
@@ -30,6 +31,21 @@ internal class LoadConfigurationFromManifestScenario(
                 true
             }
         )
+        // Do not allow system generated ANRs to be sent to Maze Runner
+        testConfig.addOnError { event ->
+            val error = event.errors.first()
+            val method1 = "android.os.BinderProxy.transact"
+            val method2 = "android.app.IActivityManager\$Stub\$Proxy.handleApplicationCrash"
+            if (error.errorClass.equals("ANR") &&
+                error.stacktrace.any { frame -> frame.method.equals(method1) } &&
+                error.stacktrace.any { frame -> frame.method.equals(method2) }
+            ) {
+                CiLog.info("Filtering system generated ANR")
+                false
+            } else {
+                true
+            }
+        }
         measureBugsnagStartupDuration(this.context, testConfig)
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationFromManifestScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationFromManifestScenario.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.bugsnag.android.OnErrorCallback
-import com.bugsnag.android.mazerunner.CiLog
+import com.bugsnag.android.mazerunner.filterSystemAnrs
 import java.lang.RuntimeException
 
 internal class LoadConfigurationFromManifestScenario(
@@ -31,21 +31,8 @@ internal class LoadConfigurationFromManifestScenario(
                 true
             }
         )
-        // Do not allow system generated ANRs to be sent to Maze Runner
-        testConfig.addOnError { event ->
-            val error = event.errors.first()
-            val method1 = "android.os.BinderProxy.transact"
-            val method2 = "android.app.IActivityManager\$Stub\$Proxy.handleApplicationCrash"
-            if (error.errorClass.equals("ANR") &&
-                error.stacktrace.any { frame -> frame.method.equals(method1) } &&
-                error.stacktrace.any { frame -> frame.method.equals(method2) }
-            ) {
-                CiLog.info("Filtering system generated ANR")
-                false
-            } else {
-                true
-            }
-        }
+        testConfig.addOnError(filterSystemAnrs)
+
         measureBugsnagStartupDuration(this.context, testConfig)
     }
 

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/LoadConfigurationKotlinScenario.kt
@@ -6,7 +6,7 @@ import com.bugsnag.android.Configuration
 import com.bugsnag.android.EndpointConfiguration
 import com.bugsnag.android.OnErrorCallback
 import com.bugsnag.android.ThreadSendPolicy
-import com.bugsnag.android.mazerunner.CiLog
+import com.bugsnag.android.mazerunner.filterSystemAnrs
 import java.lang.RuntimeException
 import java.util.regex.Pattern
 
@@ -46,21 +46,7 @@ internal class LoadConfigurationKotlinScenario(
                 true
             }
         )
-        // Do not allow system generated ANRs to be sent to Maze Runner
-        testConfig.addOnError { event ->
-            val error = event.errors.first()
-            val method1 = "android.os.BinderProxy.transact"
-            val method2 = "android.app.IActivityManager\$Stub\$Proxy.handleApplicationCrash"
-            if (error.errorClass.equals("ANR") &&
-                error.stacktrace.any { frame -> frame.method.equals(method1) } &&
-                error.stacktrace.any { frame -> frame.method.equals(method2) }
-                ) {
-                CiLog.info("Filtering system generated ANR")
-                false
-            } else {
-                true
-            }
-        }
+        testConfig.addOnError(filterSystemAnrs)
 
         measureBugsnagStartupDuration(this.context, testConfig)
     }

--- a/features/full_tests/usage.feature
+++ b/features/full_tests/usage.feature
@@ -18,7 +18,7 @@ Feature: Reporting Errors with usage info
     And the event "usage.callbacks.event_set_user" is true
     And the event "usage.callbacks.ndkOnError" equals 1
     And the event "usage.callbacks.onBreadcrumb" equals 1
-    And the event "usage.callbacks.onError" equals 3
+    And the event "usage.callbacks.onError" equals 4
     And the event "usage.callbacks.onSession" equals 3
 
   Scenario: Report a handled exception with custom configuration and set callbacks, usage disabled
@@ -54,7 +54,7 @@ Feature: Reporting Errors with usage info
     And the event "usage.callbacks.event_set_user" is true
     And the event "usage.callbacks.ndkOnError" equals 1
     And the event "usage.callbacks.onBreadcrumb" equals 3
-    And the event "usage.callbacks.onError" equals 2
+    And the event "usage.callbacks.onError" equals 3
     And the event "usage.callbacks.onSession" equals 2
 
   Scenario: Report an unhandled exception with custom configuration and set callbacks, usage disabled
@@ -89,7 +89,7 @@ Feature: Reporting Errors with usage info
     And the event "usage.config.discardClassesCount" equals 3
     And the event "usage.config.maxPersistedSessions" equals 1000
     And the event "usage.callbacks.onBreadcrumb" equals 1
-    And the event "usage.callbacks.onError" equals 2
+    And the event "usage.callbacks.onError" equals 3
     And the event "usage.callbacks.onSession" equals 4
 
   Scenario: Report a native exception with custom configuration and set callbacks, usage disabled
@@ -124,7 +124,7 @@ Feature: Reporting Errors with usage info
     And the event "usage.config.autoTrackSessions" is false
     And the event "usage.callbacks.ndkOnError" equals 1
     And the event "usage.callbacks.onBreadcrumb" equals 1
-    And the event "usage.callbacks.onError" equals 2
+    And the event "usage.callbacks.onError" equals 3
     And the event "usage.callbacks.onSession" equals 4
     And the event "usage.callbacks.event_set_user" is true
     And the event "usage.callbacks.app_set_binary_arch" is true


### PR DESCRIPTION
## Goal

Fixes a flake in e2e tests where a test scenario expects there to be no errors to be sent, but where a system generated ANR was produced.  There are already ignored by Maze Runner, but the ANR meant that the step `Bugsnag confirms it has no errors to send` was not always satisfied.

## Design

Adds an onError callback for all e2e test scenario configs.

## Testing

Covered by a full CI and inspection of the device logs for any mention of `Filtering system generated ANR`.