### PR TITLE
Move Android 16 tests to BitBar

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -50,7 +50,9 @@ steps:
     plugins:
       artifacts#v1.9.0:
         download: "build/fixture-minimal.apk"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: maze-runner
         run: maze-runner
@@ -74,6 +76,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -85,7 +89,9 @@ steps:
         download:
           - "build/fixture-debug.apk"
           - "build/fixture-debug/*"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: maze-runner
         run: maze-runner
@@ -112,6 +118,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -128,6 +136,7 @@ steps:
           - "build/fixture-r19/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -155,6 +164,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -171,6 +182,7 @@ steps:
           - "build/fixture-r19/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -198,6 +210,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -210,6 +224,7 @@ steps:
       - "ANDROID_13"
       - "ANDROID_14"
       - "ANDROID_15"
+      - "ANDROID_16"
     depends_on: "fixture-r21"
     timeout_in_minutes: 60
     plugins:
@@ -219,6 +234,7 @@ steps:
           - "build/fixture-r21/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -244,6 +260,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -256,6 +274,7 @@ steps:
       - "ANDROID_13"
       - "ANDROID_14"
       - "ANDROID_15"
+      - "ANDROID_16"
     depends_on: "fixture-r21"
     timeout_in_minutes: 60
     plugins:
@@ -265,6 +284,7 @@ steps:
           - "build/fixture-r21/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -290,79 +310,9 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':browserstack: ANDROID_16 NDK r21 e2e tests - batch 1'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_16"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: 103  # Appium client failure
-          limit: 2
-
-  - label: ':browserstack: ANDROID_16 NDK r21 e2e tests - batch 2'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_16"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: 103  # Appium client failure
           limit: 2
 
   - label: ':bitbar: {{matrix}} NDK r28 e2e tests - batch 1'
@@ -374,6 +324,7 @@ steps:
       - "ANDROID_13"
       - "ANDROID_14"
       - "ANDROID_15"
+      - "ANDROID_16"
     depends_on: "fixture-r28"
     timeout_in_minutes: 60
     plugins:
@@ -383,6 +334,7 @@ steps:
           - "build/fixture-r28/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -408,6 +360,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -420,6 +374,7 @@ steps:
       - "ANDROID_13"
       - "ANDROID_14"
       - "ANDROID_15"
+      - "ANDROID_16"
     depends_on: "fixture-r28"
     timeout_in_minutes: 60
     plugins:
@@ -429,6 +384,7 @@ steps:
           - "build/fixture-r28/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -454,79 +410,9 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':browserstack: ANDROID_16 NDK r28 e2e tests - batch 1'
-    depends_on: "fixture-r28"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r28-url.txt"
-          - "build/fixture-r28/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^a-m].*.feature"
-          - "--app=@build/bs-fixture-r28-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_16"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r28"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: 103  # Appium client failure
-          limit: 2
-
-  - label: ':browserstack: ANDROID_16 NDK r28 e2e tests - batch 2'
-    depends_on: "fixture-r28"
-    timeout_in_minutes: 60
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r28-url.txt"
-          - "build/fixture-r28/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/full_tests"
-          - "--exclude=features/full_tests/[^n-z].*.feature"
-          - "--app=@build/bs-fixture-r28-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_16"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r28"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: 103  # Appium client failure
           limit: 2
 
   # If there is a tag present activate a manual publishing step

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -144,6 +144,7 @@ steps:
           - "build/fixture-r19/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -170,6 +171,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -187,6 +190,7 @@ steps:
           - "build/fixture-r21/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -211,6 +215,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -225,6 +231,7 @@ steps:
           - "build/fixture-r21/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -249,6 +256,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -263,6 +272,7 @@ steps:
           - "build/fixture-r21/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -288,6 +298,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -302,6 +314,7 @@ steps:
           - "build/fixture-r21/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -327,6 +340,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -335,6 +350,7 @@ steps:
       - "ANDROID_13"
       - "ANDROID_14"
       - "ANDROID_15"
+      - "ANDROID_16"
     depends_on: "fixture-r21"
     timeout_in_minutes: 30
     plugins:
@@ -344,6 +360,7 @@ steps:
           - "build/fixture-r21/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -368,42 +385,9 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
-        - exit_status: 103  # Appium session failed
+        - exit_status: -1  # Agent was lost
           limit: 2
-
-  - label: ':browserstack: ANDROID_16 NDK r21 smoke tests'
-    depends_on: "fixture-r21"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r21-url.txt"
-          - "build/fixture-r21/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--app=@build/bs-fixture-r21-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_16"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r21"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: 103  # Appium client failure
+        - exit_status: 103  # Appium session failed
           limit: 2
 
   - label: ':bitbar: {{matrix}} NDK r28 smoke tests'
@@ -415,6 +399,7 @@ steps:
       - "ANDROID_13"
       - "ANDROID_14"
       - "ANDROID_15"
+      - "ANDROID_16"
     depends_on: "fixture-r28"
     timeout_in_minutes: 30
     plugins:
@@ -424,6 +409,7 @@ steps:
           - "build/fixture-r28/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -448,6 +434,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -462,6 +450,7 @@ steps:
           - "build/fixture-r28/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -487,6 +476,8 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
         - exit_status: 103  # Appium session failed
           limit: 2
 
@@ -501,6 +492,7 @@ steps:
           - "build/fixture-r28/*"
         upload:
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
           - "maze_output/metrics.csv"
       docker-compose#v4.7.0:
         pull: maze-runner
@@ -526,42 +518,9 @@ steps:
     concurrency_method: eager
     retry:
       automatic:
-        - exit_status: 103  # Appium session failed
+        - exit_status: -1  # Agent was lost
           limit: 2
-
-  - label: ':browserstack: ANDROID_16 NDK r28 smoke tests'
-    depends_on: "fixture-r28"
-    timeout_in_minutes: 30
-    plugins:
-      artifacts#v1.9.0:
-        download:
-          - "build/bs-fixture-r28-url.txt"
-          - "build/fixture-r28/*"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/metrics.csv"
-      docker-compose#v4.7.0:
-        pull: maze-runner
-        run: maze-runner
-        service-ports: true
-        command:
-          - "features/smoke_tests"
-          - "--app=@build/bs-fixture-r28-url.txt"
-          - "--appium-version=1.22.0"
-          - "--farm=bs"
-          - "--device=ANDROID_16"
-      test-collector#v1.10.2:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^main|next$$"
-    env:
-      TEST_FIXTURE_SYMBOL_DIR: "build/fixture-r28"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: 103  # Appium client failure
+        - exit_status: 103  # Appium session failed
           limit: 2
 
   - label: 'Conditionally include device farms/full tests'


### PR DESCRIPTION
## Goal

Move Android 16 tests to BitBar.

## Changeset

I've also made a couple of general improvements:
- Auto retry for lost Buildkite agents
- Always upload maze_output.zip

## Testing

Covered by a full CI run.