### PR TITLE
Fix the ErrorType rule & add dontwarn for Thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Fixed the consumer proguard rules for `ErrorType` (affects Kotlin Multiplatform apps), and added a `dontwarn` for apps with compileSdk < 36
+  [#2326](https://github.com/bugsnag/bugsnag-android/pull/2326)
+
 ## 6.19.0 (2025-09-30)
 
 ### Enhancements

--- a/bugsnag-android-core/proguard-rules.pro
+++ b/bugsnag-android-core/proguard-rules.pro
@@ -9,5 +9,6 @@
     public static com.bugsnag.android.Telemetry[] values();
  }
 -keepclassmembers enum com.bugsnag.android.ErrorType {
-    public static com.bugsnag.android.Telemetry[] values();
+    public static com.bugsnag.android.ErrorType[] values();
  }
+-dontwarn com.bugsnag.android.ThreadState


### PR DESCRIPTION
## Goal
Avoid triggering proguard warnings for `Thread.threadId` on apps with `compileSdk < 26`. Also fixed the `ErrorType` proguard rule for Kotlin Multiplatform apps.