### PR TITLE
More RemoteConfig Tests

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/RemoteConfig.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/RemoteConfig.kt
@@ -117,7 +117,7 @@ internal sealed class DiscardRule : JsonStream.Streamable {
         override fun toString(): String = DISCARD_RULE_ALL_HANDLED
     }
 
-    class Hash(
+    data class Hash(
         private val unparsedPaths: List<*>,
         private val matches: Set<String>
     ) : DiscardRule() {

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/remoteconfig/HashDiscardIntegrationTests.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/internal/remoteconfig/HashDiscardIntegrationTests.kt
@@ -1,0 +1,81 @@
+package com.bugsnag.android.internal.remoteconfig
+
+import com.bugsnag.android.DiscardRule
+import com.bugsnag.android.RemoteConfig
+import com.bugsnag.android.internal.JsonCollectionParser
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.util.Date
+
+@RunWith(Parameterized::class)
+internal class HashDiscardIntegrationTests {
+    companion object {
+        @Parameterized.Parameters
+        @JvmStatic
+        fun parameters(): List<HashDiscardFixture> = listOf(
+            HashDiscardFixture("anr01", "anr_config01"),
+            HashDiscardFixture("anr02", "anr_config01"),
+            HashDiscardFixture("anr03", "anr_config01"),
+            HashDiscardFixture("native_crash01", "native_crash_config"),
+            HashDiscardFixture("java_unhandled01", "unhandled_config01"),
+            HashDiscardFixture("java_unhandled01", "unhandled_config02")
+        )
+    }
+
+    @Parameterized.Parameter
+    lateinit var testData: HashDiscardFixture
+
+    private lateinit var remoteConfig: RemoteConfig
+
+    private lateinit var event: Map<String, Any>
+
+    @Before
+    fun loadFixtures() {
+        event = jsonFrom(testData.event)
+
+        remoteConfig = RemoteConfig.fromJsonMap(
+            null,
+            Date(Long.MAX_VALUE),
+            jsonFrom(testData.config)
+        )
+    }
+
+    @Test
+    fun testDiscard() {
+        val hashRule = remoteConfig.discardRules.filterIsInstance<DiscardRule.Hash>().singleOrNull()
+        assertNotNull("there must be exactly 1 HASH rule in the fixture: $testData")
+
+        val shouldDiscard = hashRule!!.shouldDiscardJson(event)
+        assertTrue("expected the payload to be discarded: $testData", shouldDiscard)
+    }
+
+    @Test
+    fun failDiscard() {
+        val hashRule = remoteConfig.discardRules.filterIsInstance<DiscardRule.Hash>().singleOrNull()
+        assertNotNull("there must be exactly 1 HASH rule in the fixture: $testData")
+
+        val modifiedHashRule = hashRule!!.copy(matches = setOf("abc123"))
+
+        val shouldDiscard = modifiedHashRule.shouldDiscardJson(event)
+        assertFalse("expected the payload to be retained: $testData", shouldDiscard)
+    }
+
+    private fun jsonFrom(resource: String): Map<String, Any> {
+        val resourceAsStream = this::class.java.getResourceAsStream("/remoteConfig/$resource.json")
+        requireNotNull(resourceAsStream) { "resource not found: $resource" }
+        @Suppress("UNCHECKED_CAST")
+        return resourceAsStream.use {
+            JsonCollectionParser(it).parse() as Map<String, Any>
+        }
+    }
+
+    data class HashDiscardFixture(
+        val event: String,
+        val config: String
+    )
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/anr01.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/anr01.json
@@ -1,0 +1,1309 @@
+{
+  "context": "ExampleActivity",
+  "metaData": {
+    "app": {
+      "memoryUsage": 4937568,
+      "totalMemory": 9151742,
+      "processName": "com.example.bugsnag.android",
+      "activeScreen": "ExampleActivity",
+      "name": "Bugsnag",
+      "memoryLimit": 201326592,
+      "freeMemory": 4214174,
+      "processImportance": "foreground"
+    },
+    "Custom Data": {
+      "members": [
+        {
+          "Group Members 1": "Adam"
+        },
+        {
+          "Group Members 2": "Alice"
+        }
+      ]
+    },
+    "Last Resume Time": {
+      "Member Last Resume Time": {
+        "Last Resume Time": "2025-10-01T16:07:49.137Z"
+      }
+    },
+    "user": {
+      "age": 31
+    },
+    "device": {
+      "locationStatus": "allowed",
+      "emulator": false,
+      "networkAccess": "cellular",
+      "charging": false,
+      "screenDensity": 2.625,
+      "dpi": 420,
+      "screenResolution": "2424x1080",
+      "brand": "google",
+      "batteryLevel": 1.0
+    }
+  },
+  "severity": "error",
+  "severityReason": {
+    "type": "anrError",
+    "unhandledOverridden": false
+  },
+  "unhandled": true,
+  "exceptions": [
+    {
+      "errorClass": "ANR",
+      "message": " Input dispatching timed out (a411f9d com.example.bugsnag.android/com.example.bugsnag.android.ExampleActivity is not responding. Waited 5000ms for MotionEvent).",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "Java_com_example_bugsnag_android_BaseCrashyActivity_anrFromCXX",
+          "file": "/data/app/~~FqNp5rRUP9jrTIEHzpmUSg==/com.example.bugsnag.android-4FDM8-k0-PbIOI4Hpslbyw==/lib/arm64/libentrypoint.so",
+          "lineNumber": 3344,
+          "frameAddress": "0x78c88a040d10",
+          "symbolAddress": "0x78c88a040d04",
+          "loadAddress": "0x78c88a040000",
+          "type": "c"
+        },
+        {
+          "method": "art_quick_generic_jni_trampoline",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3405056,
+          "frameAddress": "0x78c88df07500",
+          "symbolAddress": "0x78c88df07470",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "art_quick_invoke_stub",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3309972,
+          "frameAddress": "0x78c88def0194",
+          "symbolAddress": "0x78c88deeff30",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter6DoCallILb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtbPNS_6JValueE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 6788052,
+          "frameAddress": "0x78c88e2413d4",
+          "symbolAddress": "0x78c88e240da8",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter20ExecuteSwitchImplCppILb0EEEvPNS0_17SwitchImplContextE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 6063348,
+          "frameAddress": "0x78c88e1904f4",
+          "symbolAddress": "0x78c88e190190",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "ExecuteSwitchImplAsm",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3242632,
+          "frameAddress": "0x78c88dedfa88",
+          "symbolAddress": "0x78c88dedfa80",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "",
+          "file": "",
+          "lineNumber": 753760,
+          "frameAddress": "0x78c851eac060",
+          "symbolAddress": "0x78c851eac060",
+          "loadAddress": "0x78c851df4000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3241096,
+          "frameAddress": "0x78c88dedf488",
+          "symbolAddress": "0x78c88dedf2ec",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter6DoCallILb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtbPNS_6JValueE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 6788540,
+          "frameAddress": "0x78c88e2415bc",
+          "symbolAddress": "0x78c88e240da8",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter20ExecuteSwitchImplCppILb0EEEvPNS0_17SwitchImplContextE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 6063760,
+          "frameAddress": "0x78c88e190690",
+          "symbolAddress": "0x78c88e190190",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "ExecuteSwitchImplAsm",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3242632,
+          "frameAddress": "0x78c88dedfa88",
+          "symbolAddress": "0x78c88dedfa80",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "",
+          "file": "",
+          "lineNumber": 1107180,
+          "frameAddress": "0x78c851f024ec",
+          "symbolAddress": "0x78c851f024ec",
+          "loadAddress": "0x78c851df4000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.__uniq.112435418011751916792819755956732575238.llvm.11186287395527938019",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 2979388,
+          "frameAddress": "0x78c88de9f63c",
+          "symbolAddress": "0x78c88de9f4f0",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "artQuickToInterpreterBridge",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 2977392,
+          "frameAddress": "0x78c88de9ee70",
+          "symbolAddress": "0x78c88de9eaf8",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "art_quick_to_interpreter_bridge",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3405368,
+          "frameAddress": "0x78c88df07638",
+          "symbolAddress": "0x78c88df075e0",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "",
+          "file": "",
+          "lineNumber": 5726140,
+          "frameAddress": "0x48575fbc",
+          "symbolAddress": "0x48575fbc",
+          "loadAddress": "0x48000000",
+          "type": "c"
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ]
+    }
+  ],
+  "projectPackages": [
+    "com.example.bugsnag.android"
+  ],
+  "user": {
+    "id": "123456",
+    "email": "joebloggs@example.com",
+    "name": "Joe Bloggs"
+  },
+  "app": {
+    "binaryArch": "arm64",
+    "buildUUID": "93348f5f102f35a5367ddb5d21a96c6332c638fc",
+    "id": "com.example.bugsnag.android",
+    "releaseStage": "development",
+    "type": "android",
+    "version": "1.0",
+    "versionCode": 1,
+    "duration": 129219,
+    "durationInForeground": 128770,
+    "inForeground": true,
+    "isLaunching": false
+  },
+  "device": {
+    "cpuAbi": [
+      "arm64-v8a"
+    ],
+    "jailbroken": false,
+    "id": "8d2f5aaa-a207-4a00-ae3d-faf5d38768dd",
+    "locale": "en_US",
+    "manufacturer": "Google",
+    "model": "sdk_gphone16k_arm64",
+    "osName": "android",
+    "osVersion": "16",
+    "runtimeVersions": {
+      "androidApiLevel": "36",
+      "osBuild": "BE2A.250530.026.F3 dev-keys"
+    },
+    "totalMemory": 2096365568,
+    "freeDisk": 4640706560,
+    "freeMemory": 291848192,
+    "orientation": "portrait",
+    "time": "2025-10-01T16:09:57.902Z"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "2025-10-01T16:07:48.984Z",
+      "name": "Bugsnag loaded",
+      "type": "state",
+      "metaData": {}
+    },
+    {
+      "timestamp": "2025-10-01T16:07:49.056Z",
+      "name": "ExampleActivity#onCreate()",
+      "type": "state",
+      "metaData": {
+        "hasBundle": false,
+        "action": "android.intent.action.MAIN",
+        "categories": "android.intent.category.LAUNCHER",
+        "flags": "0x10200000",
+        "hasData": false,
+        "hasExtras": false
+      }
+    },
+    {
+      "timestamp": "2025-10-01T16:07:49.135Z",
+      "name": "ExampleActivity#onStart()",
+      "type": "state",
+      "metaData": {
+        "previous": "onCreate()"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T16:07:49.140Z",
+      "name": "ExampleActivity#onResume()",
+      "type": "state",
+      "metaData": {
+        "previous": "onStart()"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T16:07:54.701Z",
+      "name": "java.lang.RuntimeException",
+      "type": "error",
+      "metaData": {
+        "unhandled": "false",
+        "severity": "WARNING",
+        "errorClass": "java.lang.RuntimeException",
+        "message": "Non-Fatal Crash"
+      }
+    }
+  ],
+  "usage": {
+    "config": {
+      "pluginCount": 1,
+      "launchDurationMillis": 5000,
+      "logger": true
+    },
+    "callbacks": {
+      "event_set_context": true,
+      "app_set_is_launching": true,
+      "ndkOnError": 1,
+      "event_set_grouping_discriminator": true
+    }
+  },
+  "threads": [
+    {
+      "id": "2",
+      "name": "main",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ]
+    },
+    {
+      "id": "55",
+      "name": "Signal Catcher",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": []
+    },
+    {
+      "id": "57",
+      "name": "HeapTaskDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": []
+    },
+    {
+      "id": "58",
+      "name": "ReferenceQueueDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 543
+        },
+        {
+          "method": "java.lang.Daemons$ReferenceQueueDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 260
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "59",
+      "name": "FinalizerDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 207
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 228
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 348
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "60",
+      "name": "FinalizerWatchdogDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 543
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded",
+          "file": "Daemons.java",
+          "lineNumber": 481
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 461
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "61",
+      "name": "Jit thread pool worker thread 0",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "62",
+      "name": "binder:4753_1",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "63",
+      "name": "binder:4753_2",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "64",
+      "name": "binder:4753_3",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "65",
+      "name": "binder:4753_4",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "66",
+      "name": "Profile Saver",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "67",
+      "name": "Bugsnag IO thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "72",
+      "name": "bugsnag-anr-collector",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "73",
+      "name": "Bugsnag Error thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "74",
+      "name": "OkHttp ConnectionPool",
+      "type": "android",
+      "state": "TIMED_WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.okhttp.ConnectionPool$1.run",
+          "file": "ConnectionPool.java",
+          "lineNumber": 106
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1156
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "75",
+      "name": "ConscryptStatsLog",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "76",
+      "name": "Bugsnag Session thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "77",
+      "name": "ConnectivityThread",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "78",
+      "name": "RenderThread",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "79",
+      "name": "hwuiTask1",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "80",
+      "name": "hwuiTask0",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "81",
+      "name": "SurfaceSyncGroupTimer",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "84",
+      "name": "Thread-2",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "Java_com_example_bugsnag_android_BaseCrashyActivity_anrFromCXX",
+          "file": "/data/app/~~FqNp5rRUP9jrTIEHzpmUSg==/com.example.bugsnag.android-4FDM8-k0-PbIOI4Hpslbyw==/lib/arm64/libentrypoint.so",
+          "lineNumber": 3344,
+          "frameAddress": "0x78c88a040d10",
+          "symbolAddress": "0x78c88a040d04",
+          "loadAddress": "0x78c88a040000",
+          "type": "c"
+        },
+        {
+          "method": "art_quick_generic_jni_trampoline",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3405056,
+          "frameAddress": "0x78c88df07500",
+          "symbolAddress": "0x78c88df07470",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "art_quick_invoke_stub",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3309972,
+          "frameAddress": "0x78c88def0194",
+          "symbolAddress": "0x78c88deeff30",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter6DoCallILb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtbPNS_6JValueE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 6788052,
+          "frameAddress": "0x78c88e2413d4",
+          "symbolAddress": "0x78c88e240da8",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter20ExecuteSwitchImplCppILb0EEEvPNS0_17SwitchImplContextE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 6063348,
+          "frameAddress": "0x78c88e1904f4",
+          "symbolAddress": "0x78c88e190190",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "ExecuteSwitchImplAsm",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3242632,
+          "frameAddress": "0x78c88dedfa88",
+          "symbolAddress": "0x78c88dedfa80",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "",
+          "file": "",
+          "lineNumber": 753760,
+          "frameAddress": "0x78c851eac060",
+          "symbolAddress": "0x78c851eac060",
+          "loadAddress": "0x78c851df4000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3241096,
+          "frameAddress": "0x78c88dedf488",
+          "symbolAddress": "0x78c88dedf2ec",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter6DoCallILb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtbPNS_6JValueE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 6788540,
+          "frameAddress": "0x78c88e2415bc",
+          "symbolAddress": "0x78c88e240da8",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreter20ExecuteSwitchImplCppILb0EEEvPNS0_17SwitchImplContextE",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 6063760,
+          "frameAddress": "0x78c88e190690",
+          "symbolAddress": "0x78c88e190190",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "ExecuteSwitchImplAsm",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3242632,
+          "frameAddress": "0x78c88dedfa88",
+          "symbolAddress": "0x78c88dedfa80",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "",
+          "file": "",
+          "lineNumber": 1107180,
+          "frameAddress": "0x78c851f024ec",
+          "symbolAddress": "0x78c851f024ec",
+          "loadAddress": "0x78c851df4000",
+          "type": "c"
+        },
+        {
+          "method": "_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.__uniq.112435418011751916792819755956732575238.llvm.11186287395527938019",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 2979388,
+          "frameAddress": "0x78c88de9f63c",
+          "symbolAddress": "0x78c88de9f4f0",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "artQuickToInterpreterBridge",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 2977392,
+          "frameAddress": "0x78c88de9ee70",
+          "symbolAddress": "0x78c88de9eaf8",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "art_quick_to_interpreter_bridge",
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "lineNumber": 3405368,
+          "frameAddress": "0x78c88df07638",
+          "symbolAddress": "0x78c88df075e0",
+          "loadAddress": "0x78c88dbc8000",
+          "type": "c"
+        },
+        {
+          "method": "",
+          "file": "",
+          "lineNumber": 5726140,
+          "frameAddress": "0x48575fbc",
+          "symbolAddress": "0x48575fbc",
+          "loadAddress": "0x48000000",
+          "type": "c"
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ],
+      "errorReportingThread": true
+    }
+  ],
+  "featureFlags": [],
+  "session": {
+    "id": "09a10d4c-ec4a-4276-ba70-aa9fa949a7c9",
+    "startedAt": "2025-10-01T16:07:49.134Z",
+    "events": {
+      "handled": 1,
+      "unhandled": 1
+    }
+  }
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/anr02.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/anr02.json
@@ -1,0 +1,1157 @@
+{
+  "context": "ExampleActivity",
+  "metaData": {
+    "app": {
+      "memoryUsage": 3244416,
+      "totalMemory": 5879805,
+      "processName": "com.example.bugsnag.android",
+      "activeScreen": "ExampleActivity",
+      "name": "Bugsnag",
+      "memoryLimit": 201326592,
+      "freeMemory": 2635389,
+      "processImportance": "foreground"
+    },
+    "Custom Data": {
+      "members": [
+        {
+          "Group Members 1": "Adam"
+        },
+        {
+          "Group Members 2": "Alice"
+        }
+      ]
+    },
+    "Last Resume Time": {
+      "Member Last Resume Time": {
+        "Last Resume Time": "2025-10-02T13:31:33.305Z"
+      }
+    },
+    "user": {
+      "age": 31
+    },
+    "device": {
+      "locationStatus": "allowed",
+      "emulator": false,
+      "networkAccess": "cellular",
+      "charging": false,
+      "screenDensity": 3.0,
+      "dpi": 480,
+      "screenResolution": "2856x1280",
+      "brand": "google",
+      "batteryLevel": 1.0
+    }
+  },
+  "severity": "error",
+  "severityReason": {
+    "type": "anrError",
+    "unhandledOverridden": false
+  },
+  "unhandled": true,
+  "exceptions": [
+    {
+      "errorClass": "ANR",
+      "message": " Input dispatching timed out (38623cd com.example.bugsnag.android/com.example.bugsnag.android.ExampleActivity is not responding. Waited 5000ms for MotionEvent).",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "Java_com_example_bugsnag_android_BaseCrashyActivity_anrFromCXX",
+          "file": "/data/app/~~2ZnIK2112S2YKvMTcQ8OdA==/com.example.bugsnag.android-N5cRmaw7i8x8mZ-NH9EQ0A==/lib/arm64/libentrypoint.so",
+          "lineNumber": 3344,
+          "frameAddress": "0x79b4c4fd10",
+          "symbolAddress": "0x79b4c4fd04",
+          "loadAddress": "0x79b4c4f000",
+          "type": "c"
+        },
+        {
+          "method": "art_jni_trampoline",
+          "file": "/system/framework/arm64/boot.oat",
+          "lineNumber": 2969728,
+          "frameAddress": "0x722bd080",
+          "symbolAddress": "0x722bd010",
+          "loadAddress": "0x71fe8000",
+          "type": "c"
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ]
+    }
+  ],
+  "projectPackages": [
+    "com.example.bugsnag.android"
+  ],
+  "user": {
+    "id": "123456",
+    "email": "joebloggs@example.com",
+    "name": "Joe Bloggs"
+  },
+  "app": {
+    "binaryArch": "arm64",
+    "buildUUID": "c01ed2c6148946c213ef135362059826dceaf96d",
+    "id": "com.example.bugsnag.android",
+    "releaseStage": "production",
+    "type": "android",
+    "version": "1.0",
+    "versionCode": 1,
+    "duration": 33566,
+    "durationInForeground": 33428,
+    "inForeground": true,
+    "isLaunching": false
+  },
+  "device": {
+    "cpuAbi": [
+      "arm64-v8a"
+    ],
+    "jailbroken": false,
+    "id": "6decd824-12fb-4e55-82bd-0cb60dc8d7ad",
+    "locale": "en_US",
+    "manufacturer": "Google",
+    "model": "sdk_gphone64_arm64",
+    "osName": "android",
+    "osVersion": "16",
+    "runtimeVersions": {
+      "androidApiLevel": "36",
+      "osBuild": "BE2A.250530.026.D1"
+    },
+    "totalMemory": 3120066560,
+    "freeDisk": 5260369920,
+    "freeMemory": 1524367360,
+    "orientation": "portrait",
+    "time": "2025-10-02T13:32:06.731Z"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "2025-10-02T13:31:33.284Z",
+      "name": "Bugsnag loaded",
+      "type": "state",
+      "metaData": {}
+    },
+    {
+      "timestamp": "2025-10-02T13:31:33.297Z",
+      "name": "ExampleActivity#onCreate()",
+      "type": "state",
+      "metaData": {
+        "hasBundle": false,
+        "action": "android.intent.action.MAIN",
+        "categories": "android.intent.category.LAUNCHER",
+        "flags": "0x10200000",
+        "hasData": false,
+        "hasExtras": false
+      }
+    },
+    {
+      "timestamp": "2025-10-02T13:31:33.303Z",
+      "name": "ExampleActivity#onStart()",
+      "type": "state",
+      "metaData": {
+        "previous": "onCreate()"
+      }
+    },
+    {
+      "timestamp": "2025-10-02T13:31:33.305Z",
+      "name": "ExampleActivity#onResume()",
+      "type": "state",
+      "metaData": {
+        "previous": "onStart()"
+      }
+    }
+  ],
+  "usage": {
+    "config": {
+      "pluginCount": 1,
+      "persistenceDirectorySet": true,
+      "launchDurationMillis": 5000
+    },
+    "callbacks": {
+      "event_set_context": true,
+      "app_set_is_launching": true,
+      "ndkOnError": 1,
+      "event_set_grouping_discriminator": true
+    }
+  },
+  "threads": [
+    {
+      "id": "2",
+      "name": "main",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ]
+    },
+    {
+      "id": "35",
+      "name": "Signal Catcher",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "36",
+      "name": "HeapTaskDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": []
+    },
+    {
+      "id": "37",
+      "name": "Jit thread pool worker thread 0",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "38",
+      "name": "ReferenceQueueDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 543
+        },
+        {
+          "method": "java.lang.Daemons$ReferenceQueueDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 260
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "39",
+      "name": "FinalizerDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 207
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 228
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 348
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "40",
+      "name": "FinalizerWatchdogDaemon",
+      "type": "android",
+      "state": "TIMED_WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Thread.sleep",
+          "file": "Thread.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Thread.sleep",
+          "file": "Thread.java",
+          "lineNumber": 451
+        },
+        {
+          "method": "java.lang.Thread.sleep",
+          "file": "Thread.java",
+          "lineNumber": 356
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.sleepForNanos",
+          "file": "Daemons.java",
+          "lineNumber": 534
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.waitForProgress",
+          "file": "Daemons.java",
+          "lineNumber": 610
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 465
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "41",
+      "name": "binder:4630_1",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "42",
+      "name": "binder:4630_2",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "43",
+      "name": "binder:4630_3",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "44",
+      "name": "Bugsnag IO thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "46",
+      "name": "Bugsnag Default thread",
+      "type": "android",
+      "state": "TIMED_WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.parkNanos",
+          "file": "LockSupport.java",
+          "lineNumber": 269
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1758
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.poll",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 460
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1081
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "48",
+      "name": "process reaper",
+      "type": "android",
+      "state": "TIMED_WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.parkNanos",
+          "file": "LockSupport.java",
+          "lineNumber": 410
+        },
+        {
+          "method": "java.util.concurrent.LinkedTransferQueue$DualNode.await",
+          "file": "LinkedTransferQueue.java",
+          "lineNumber": 452
+        },
+        {
+          "method": "java.util.concurrent.SynchronousQueue$Transferer.xferLifo",
+          "file": "SynchronousQueue.java",
+          "lineNumber": 194
+        },
+        {
+          "method": "java.util.concurrent.SynchronousQueue.xfer",
+          "file": "SynchronousQueue.java",
+          "lineNumber": 233
+        },
+        {
+          "method": "java.util.concurrent.SynchronousQueue.poll",
+          "file": "SynchronousQueue.java",
+          "lineNumber": 336
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1081
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "49",
+      "name": "bugsnag-anr-collector",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "50",
+      "name": "Bugsnag Error thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "51",
+      "name": "Bugsnag Session thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "52",
+      "name": "ConnectivityThread",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "53",
+      "name": "RenderThread",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "54",
+      "name": "OkHttp ConnectionPool",
+      "type": "android",
+      "state": "TIMED_WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.okhttp.ConnectionPool$1.run",
+          "file": "ConnectionPool.java",
+          "lineNumber": 106
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1156
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "55",
+      "name": "hwuiTask0",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "56",
+      "name": "hwuiTask1",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "57",
+      "name": "SurfaceSyncGroupTimer",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "58",
+      "name": "ConscryptStatsLog",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "59",
+      "name": "binder:4630_4",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "62",
+      "name": "binder:4630_5",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "63",
+      "name": "Thread-2",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "Java_com_example_bugsnag_android_BaseCrashyActivity_anrFromCXX",
+          "file": "/data/app/~~2ZnIK2112S2YKvMTcQ8OdA==/com.example.bugsnag.android-N5cRmaw7i8x8mZ-NH9EQ0A==/lib/arm64/libentrypoint.so",
+          "lineNumber": 3344,
+          "frameAddress": "0x79b4c4fd10",
+          "symbolAddress": "0x79b4c4fd04",
+          "loadAddress": "0x79b4c4f000",
+          "type": "c"
+        },
+        {
+          "method": "art_jni_trampoline",
+          "file": "/system/framework/arm64/boot.oat",
+          "lineNumber": 2969728,
+          "frameAddress": "0x722bd080",
+          "symbolAddress": "0x722bd010",
+          "loadAddress": "0x71fe8000",
+          "type": "c"
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ],
+      "errorReportingThread": true
+    }
+  ],
+  "featureFlags": [],
+  "session": {
+    "id": "d0c6d492-11a8-4beb-a3f7-99146e16da5d",
+    "startedAt": "2025-10-02T13:31:33.303Z",
+    "events": {
+      "handled": 0,
+      "unhandled": 1
+    }
+  }
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/anr03.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/anr03.json
@@ -1,0 +1,1046 @@
+{
+  "context": "ExampleActivity",
+  "metaData": {
+    "app": {
+      "memoryUsage": 3572688,
+      "totalMemory": 6405470,
+      "processName": "com.example.bugsnag.android",
+      "activeScreen": "ExampleActivity",
+      "name": "Bugsnag",
+      "memoryLimit": 201326592,
+      "freeMemory": 2832782,
+      "processImportance": "foreground"
+    },
+    "Custom Data": {
+      "members": [
+        {
+          "Group Members 1": "Adam"
+        },
+        {
+          "Group Members 2": "Alice"
+        }
+      ]
+    },
+    "Last Resume Time": {
+      "Member Last Resume Time": {
+        "Last Resume Time": "2025-10-02T13:32:09.431Z"
+      }
+    },
+    "user": {
+      "age": 31
+    },
+    "device": {
+      "locationStatus": "allowed",
+      "emulator": false,
+      "networkAccess": "cellular",
+      "charging": false,
+      "screenDensity": 3.0,
+      "dpi": 480,
+      "screenResolution": "2856x1280",
+      "brand": "google",
+      "batteryLevel": 1.0
+    }
+  },
+  "severity": "error",
+  "severityReason": {
+    "type": "anrError",
+    "unhandledOverridden": false
+  },
+  "unhandled": true,
+  "exceptions": [
+    {
+      "errorClass": "ANR",
+      "message": " Input dispatching timed out (af0c895 com.example.bugsnag.android/com.example.bugsnag.android.ExampleActivity is not responding. Waited 5000ms for MotionEvent).",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "Java_com_example_bugsnag_android_BaseCrashyActivity_anrFromCXX",
+          "file": "/data/app/~~2ZnIK2112S2YKvMTcQ8OdA==/com.example.bugsnag.android-N5cRmaw7i8x8mZ-NH9EQ0A==/lib/arm64/libentrypoint.so",
+          "lineNumber": 3344,
+          "frameAddress": "0x79b4c44d10",
+          "symbolAddress": "0x79b4c44d04",
+          "loadAddress": "0x79b4c44000",
+          "type": "c"
+        },
+        {
+          "method": "art_jni_trampoline",
+          "file": "/system/framework/arm64/boot.oat",
+          "lineNumber": 2969728,
+          "frameAddress": "0x722bd080",
+          "symbolAddress": "0x722bd010",
+          "loadAddress": "0x71fe8000",
+          "type": "c"
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ]
+    }
+  ],
+  "projectPackages": [
+    "com.example.bugsnag.android"
+  ],
+  "user": {
+    "id": "123456",
+    "email": "joebloggs@example.com",
+    "name": "Joe Bloggs"
+  },
+  "app": {
+    "binaryArch": "arm64",
+    "buildUUID": "c01ed2c6148946c213ef135362059826dceaf96d",
+    "id": "com.example.bugsnag.android",
+    "releaseStage": "production",
+    "type": "android",
+    "version": "1.0",
+    "versionCode": 1,
+    "duration": 114656,
+    "durationInForeground": 114516,
+    "inForeground": true,
+    "isLaunching": false
+  },
+  "device": {
+    "cpuAbi": [
+      "arm64-v8a"
+    ],
+    "jailbroken": false,
+    "id": "6decd824-12fb-4e55-82bd-0cb60dc8d7ad",
+    "locale": "en_US",
+    "manufacturer": "Google",
+    "model": "sdk_gphone64_arm64",
+    "osName": "android",
+    "osVersion": "16",
+    "runtimeVersions": {
+      "androidApiLevel": "36",
+      "osBuild": "BE2A.250530.026.D1"
+    },
+    "totalMemory": 3120066560,
+    "freeDisk": 5260431360,
+    "freeMemory": 1524117504,
+    "orientation": "portrait",
+    "time": "2025-10-02T13:34:03.945Z"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "2025-10-02T13:32:09.404Z",
+      "name": "Bugsnag loaded",
+      "type": "state",
+      "metaData": {}
+    },
+    {
+      "timestamp": "2025-10-02T13:32:09.423Z",
+      "name": "ExampleActivity#onCreate()",
+      "type": "state",
+      "metaData": {
+        "hasBundle": false,
+        "action": "android.intent.action.MAIN",
+        "categories": "android.intent.category.LAUNCHER",
+        "flags": "0x10200000",
+        "hasData": false,
+        "hasExtras": false
+      }
+    },
+    {
+      "timestamp": "2025-10-02T13:32:09.431Z",
+      "name": "ExampleActivity#onStart()",
+      "type": "state",
+      "metaData": {
+        "previous": "onCreate()"
+      }
+    },
+    {
+      "timestamp": "2025-10-02T13:32:09.432Z",
+      "name": "ExampleActivity#onResume()",
+      "type": "state",
+      "metaData": {
+        "previous": "onStart()"
+      }
+    }
+  ],
+  "usage": {
+    "config": {
+      "pluginCount": 1,
+      "persistenceDirectorySet": true,
+      "launchDurationMillis": 5000
+    },
+    "callbacks": {
+      "event_set_context": true,
+      "app_set_is_launching": true,
+      "ndkOnError": 1,
+      "event_set_grouping_discriminator": true
+    }
+  },
+  "threads": [
+    {
+      "id": "2",
+      "name": "main",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ]
+    },
+    {
+      "id": "35",
+      "name": "Signal Catcher",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "36",
+      "name": "HeapTaskDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": []
+    },
+    {
+      "id": "37",
+      "name": "ReferenceQueueDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 543
+        },
+        {
+          "method": "java.lang.Daemons$ReferenceQueueDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 260
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "38",
+      "name": "Jit thread pool worker thread 0",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "39",
+      "name": "FinalizerDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 207
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 228
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 348
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "40",
+      "name": "FinalizerWatchdogDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 543
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded",
+          "file": "Daemons.java",
+          "lineNumber": 481
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 461
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "41",
+      "name": "binder:4735_1",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "42",
+      "name": "binder:4735_2",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "43",
+      "name": "binder:4735_3",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "44",
+      "name": "Bugsnag IO thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "49",
+      "name": "bugsnag-anr-collector",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "50",
+      "name": "Bugsnag Error thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "51",
+      "name": "Bugsnag Session thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "52",
+      "name": "ConnectivityThread",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "53",
+      "name": "OkHttp ConnectionPool",
+      "type": "android",
+      "state": "TIMED_WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.okhttp.ConnectionPool$1.run",
+          "file": "ConnectionPool.java",
+          "lineNumber": 106
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1156
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "54",
+      "name": "RenderThread",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "55",
+      "name": "hwuiTask0",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "56",
+      "name": "hwuiTask1",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "57",
+      "name": "SurfaceSyncGroupTimer",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "58",
+      "name": "ConscryptStatsLog",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "59",
+      "name": "binder:4735_4",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "60",
+      "name": "binder:4735_5",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "63",
+      "name": "Thread-2",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "Java_com_example_bugsnag_android_BaseCrashyActivity_anrFromCXX",
+          "file": "/data/app/~~2ZnIK2112S2YKvMTcQ8OdA==/com.example.bugsnag.android-N5cRmaw7i8x8mZ-NH9EQ0A==/lib/arm64/libentrypoint.so",
+          "lineNumber": 3344,
+          "frameAddress": "0x79b4c44d10",
+          "symbolAddress": "0x79b4c44d04",
+          "loadAddress": "0x79b4c44000",
+          "type": "c"
+        },
+        {
+          "method": "art_jni_trampoline",
+          "file": "/system/framework/arm64/boot.oat",
+          "lineNumber": 2969728,
+          "frameAddress": "0x722bd080",
+          "symbolAddress": "0x722bd010",
+          "loadAddress": "0x71fe8000",
+          "type": "c"
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.anrFromCXX",
+          "file": "SourceFile",
+          "lineNumber": -2,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.u",
+          "file": "SourceFile",
+          "lineNumber": 1,
+          "inProject": true
+        },
+        {
+          "method": "o0.b.onClick",
+          "file": "SourceFile",
+          "lineNumber": 8
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ],
+      "errorReportingThread": true
+    }
+  ],
+  "featureFlags": [],
+  "session": {
+    "id": "481acdea-6c01-41f9-9540-5e8048083c73",
+    "startedAt": "2025-10-02T13:32:09.431Z",
+    "events": {
+      "handled": 0,
+      "unhandled": 1
+    }
+  }
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/anr_config01.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/anr_config01.json
@@ -1,0 +1,83 @@
+{
+  "discardRules": [
+    {
+      "matchType": "HASH",
+      "hash": {
+        "paths": [
+          {
+            "path": "groupingDiscriminator"
+          },
+          {
+            "path": "exceptions.-1.errorClass"
+          },
+          {
+            "path": "exceptions.-1.stacktrace",
+            "pathMode": "FILTER",
+            "filter": {
+              "conditions": [
+                {
+                  "filterPath": {
+                    "path": "type"
+                  },
+                  "matchType": "IS_NULL",
+                  "value": "true"
+                }
+              ],
+              "subPaths": [
+                {
+                  "path": "file"
+                },
+                {
+                  "path": "lineNumber"
+                },
+                {
+                  "path": "method"
+                }
+              ]
+            }
+          },
+          {
+            "path": "exceptions.-1.stacktrace",
+            "pathMode": "FILTER",
+            "filter": {
+              "conditions": [
+                {
+                  "filterPath": {
+                    "path": "type"
+                  },
+                  "matchType": "EQUALS",
+                  "value": "c"
+                },
+                {
+                  "filterPath": {
+                    "path": "method"
+                  },
+                  "matchType": "NOT_EQUALS",
+                  "value": "art_jni_trampoline"
+                }
+              ],
+              "subPaths": [
+                {
+                  "path": "codeIdentifier"
+                },
+                {
+                  "path": "file",
+                  "pathMode": "REGEX",
+                  "regex": "([^/\\\\]+)$"
+                },
+                {
+                  "path": "$",
+                  "pathMode": "RELATIVE_ADDRESS"
+                }
+              ]
+            }
+          }
+        ],
+        "matches": [
+          "7c56591a8b31a7406e9a2623f37c6717b1247b8f",
+          "8fc0643febf25e0ecd734dd485d9bb3ed10e4290"
+        ]
+      }
+    }
+  ]
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/java_unhandled01.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/java_unhandled01.json
@@ -1,0 +1,1368 @@
+{
+  "context": "ExampleActivity",
+  "metaData": {
+    "app": {
+      "memoryUsage": 7942320,
+      "totalMemory": 8862494,
+      "processName": "com.example.bugsnag.android",
+      "activeScreen": "ExampleActivity",
+      "name": "Bugsnag",
+      "memoryLimit": 201326592,
+      "freeMemory": 920174,
+      "processImportance": "foreground"
+    },
+    "Custom Data": {
+      "members": [
+        {
+          "Group Members 1": "Adam"
+        },
+        {
+          "Group Members 2": "Alice"
+        }
+      ]
+    },
+    "Last Resume Time": {
+      "Member Last Resume Time": {
+        "Last Resume Time": "2025-09-30T13:31:39.254Z"
+      }
+    },
+    "user": {
+      "age": 31
+    },
+    "device": {
+      "locationStatus": "allowed",
+      "emulator": false,
+      "networkAccess": "cellular",
+      "charging": false,
+      "screenDensity": 2.625,
+      "dpi": 420,
+      "screenResolution": "2424x1080",
+      "brand": "google",
+      "batteryLevel": 1.0
+    }
+  },
+  "severity": "error",
+  "severityReason": {
+    "type": "unhandledException",
+    "unhandledOverridden": false
+  },
+  "unhandled": true,
+  "exceptions": [
+    {
+      "errorClass": "java.lang.RuntimeException",
+      "message": "Fatal Crash",
+      "type": "android",
+      "stacktrace": [
+        {
+          "method": "com.example.foo.CrashyClass.sendMessage",
+          "file": "CrashyClass.java",
+          "lineNumber": 10
+        },
+        {
+          "method": "com.example.foo.CrashyClass.crash",
+          "file": "CrashyClass.java",
+          "lineNumber": 6
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.crashUnhandled",
+          "file": "BaseCrashyActivity.kt",
+          "lineNumber": 84,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity$$ExternalSyntheticLambda8.onClick",
+          "file": "D8$$SyntheticClass",
+          "lineNumber": 0,
+          "inProject": true
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ]
+    }
+  ],
+  "projectPackages": [
+    "com.example.bugsnag.android"
+  ],
+  "user": {
+    "id": "123456",
+    "email": "joebloggs@example.com",
+    "name": "Joe Bloggs"
+  },
+  "app": {
+    "binaryArch": "arm64",
+    "buildUUID": "6fe37cf5bf085f398d05aebb4f3930e12e3802f0",
+    "id": "com.example.bugsnag.android",
+    "releaseStage": "development",
+    "type": "android",
+    "version": "1.0",
+    "versionCode": 1,
+    "duration": 26469017,
+    "durationInForeground": 26468476,
+    "inForeground": true,
+    "isLaunching": false
+  },
+  "device": {
+    "cpuAbi": [
+      "arm64-v8a"
+    ],
+    "jailbroken": false,
+    "id": "da515088-7506-42e5-a054-bd7946514025",
+    "locale": "en_US",
+    "manufacturer": "Google",
+    "model": "sdk_gphone16k_arm64",
+    "osName": "android",
+    "osVersion": "16",
+    "runtimeVersions": {
+      "androidApiLevel": "36",
+      "osBuild": "BE2A.250530.026.F3 dev-keys"
+    },
+    "totalMemory": 2096365568,
+    "freeDisk": 4626407424,
+    "freeMemory": 262553600,
+    "orientation": "portrait",
+    "time": "2025-10-01T11:23:45.662Z"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "2025-09-30T13:31:39.083Z",
+      "name": "Bugsnag loaded",
+      "type": "state",
+      "metaData": {}
+    },
+    {
+      "timestamp": "2025-09-30T13:31:39.166Z",
+      "name": "ExampleActivity#onCreate()",
+      "type": "state",
+      "metaData": {
+        "hasBundle": false,
+        "action": "android.intent.action.MAIN",
+        "categories": "android.intent.category.LAUNCHER",
+        "flags": "0x10200000",
+        "hasData": false,
+        "hasExtras": false
+      }
+    },
+    {
+      "timestamp": "2025-09-30T13:31:39.250Z",
+      "name": "ExampleActivity#onStart()",
+      "type": "state",
+      "metaData": {
+        "previous": "onCreate()"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T13:31:39.255Z",
+      "name": "ExampleActivity#onResume()",
+      "type": "state",
+      "metaData": {
+        "previous": "onStart()"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T16:39:18.036Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T16:55:27.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T17:10:48.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T17:26:45.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T17:42:13.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T18:00:01.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T18:17:45.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T18:24:05.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T18:41:26.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T18:58:28.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T19:13:40.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T19:29:00.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T19:44:53.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T20:01:55.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T20:19:20.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T20:34:55.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T20:50:27.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T21:06:30.010Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T21:23:52.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T21:40:29.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T21:56:34.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T22:14:16.009Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T22:32:04.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T22:48:04.009Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T23:04:03.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T23:20:07.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T23:36:37.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T23:52:51.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T00:08:03.009Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T00:25:24.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T00:42:15.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T00:58:22.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T01:14:04.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T01:31:41.010Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T01:48:03.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T02:03:50.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T02:11:41.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T02:27:53.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T02:43:00.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T02:54:27.004Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T03:10:41.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T03:26:43.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T03:43:52.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T04:00:51.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T04:12:42.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T04:28:19.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T04:43:36.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T04:59:14.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T05:13:43.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T05:30:28.003Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T05:46:26.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T06:03:07.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T06:14:44.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T06:32:26.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T06:32:27.352Z",
+      "name": "Connectivity changed",
+      "type": "state",
+      "metaData": {
+        "hasConnection": true,
+        "networkState": "unknown"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T06:48:51.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T06:59:28.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-10-01T07:02:18.623Z",
+      "name": "Connectivity changed",
+      "type": "state",
+      "metaData": {
+        "hasConnection": true,
+        "networkState": "unknown"
+      }
+    }
+  ],
+  "usage": {
+    "config": {
+      "pluginCount": 1,
+      "launchDurationMillis": 5000,
+      "logger": true
+    },
+    "callbacks": {
+      "event_set_context": true,
+      "app_set_is_launching": true,
+      "ndkOnError": 1,
+      "event_set_grouping_discriminator": true
+    }
+  },
+  "threads": [
+    {
+      "id": "2",
+      "name": "main",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "com.example.foo.CrashyClass.sendMessage",
+          "file": "CrashyClass.java",
+          "lineNumber": 10
+        },
+        {
+          "method": "com.example.foo.CrashyClass.crash",
+          "file": "CrashyClass.java",
+          "lineNumber": 6
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity.crashUnhandled",
+          "file": "BaseCrashyActivity.kt",
+          "lineNumber": 84,
+          "inProject": true
+        },
+        {
+          "method": "com.example.bugsnag.android.BaseCrashyActivity$$ExternalSyntheticLambda8.onClick",
+          "file": "D8$$SyntheticClass",
+          "lineNumber": 0,
+          "inProject": true
+        },
+        {
+          "method": "android.view.View.performClick",
+          "file": "View.java",
+          "lineNumber": 8083
+        },
+        {
+          "method": "android.view.View.performClickInternal",
+          "file": "View.java",
+          "lineNumber": 8060
+        },
+        {
+          "method": "android.view.View.-$$Nest$mperformClickInternal",
+          "file": "Unknown",
+          "lineNumber": 0
+        },
+        {
+          "method": "android.view.View$PerformClick.run",
+          "file": "View.java",
+          "lineNumber": 31549
+        },
+        {
+          "method": "android.os.Handler.handleCallback",
+          "file": "Handler.java",
+          "lineNumber": 995
+        },
+        {
+          "method": "android.os.Handler.dispatchMessage",
+          "file": "Handler.java",
+          "lineNumber": 103
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 248
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.app.ActivityThread.main",
+          "file": "ActivityThread.java",
+          "lineNumber": 9067
+        },
+        {
+          "method": "java.lang.reflect.Method.invoke",
+          "file": "Method.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run",
+          "file": "RuntimeInit.java",
+          "lineNumber": 593
+        },
+        {
+          "method": "com.android.internal.os.ZygoteInit.main",
+          "file": "ZygoteInit.java",
+          "lineNumber": 932
+        }
+      ],
+      "errorReportingThread": true
+    },
+    {
+      "id": "55",
+      "name": "Signal Catcher",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": []
+    },
+    {
+      "id": "57",
+      "name": "Jit thread pool worker thread 0",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "58",
+      "name": "HeapTaskDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": []
+    },
+    {
+      "id": "59",
+      "name": "ReferenceQueueDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 543
+        },
+        {
+          "method": "java.lang.Daemons$ReferenceQueueDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 260
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "60",
+      "name": "FinalizerDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 207
+        },
+        {
+          "method": "java.lang.ref.ReferenceQueue.remove",
+          "file": "ReferenceQueue.java",
+          "lineNumber": 228
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 348
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "61",
+      "name": "FinalizerWatchdogDaemon",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 405
+        },
+        {
+          "method": "java.lang.Object.wait",
+          "file": "Object.java",
+          "lineNumber": 543
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.sleepUntilNeeded",
+          "file": "Daemons.java",
+          "lineNumber": 481
+        },
+        {
+          "method": "java.lang.Daemons$FinalizerWatchdogDaemon.runInternal",
+          "file": "Daemons.java",
+          "lineNumber": 461
+        },
+        {
+          "method": "java.lang.Daemons$Daemon.run",
+          "file": "Daemons.java",
+          "lineNumber": 132
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "62",
+      "name": "binder:32157_1",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "63",
+      "name": "binder:32157_2",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "64",
+      "name": "binder:32157_3",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "65",
+      "name": "binder:32157_4",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "66",
+      "name": "Profile Saver",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "67",
+      "name": "Bugsnag IO thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "73",
+      "name": "bugsnag-anr-collector",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "74",
+      "name": "Bugsnag Error thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "75",
+      "name": "ConscryptStatsLog",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "76",
+      "name": "Bugsnag Session thread",
+      "type": "android",
+      "state": "WAITING",
+      "stacktrace": [
+        {
+          "method": "jdk.internal.misc.Unsafe.park",
+          "file": "Unsafe.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "java.util.concurrent.locks.LockSupport.park",
+          "file": "LockSupport.java",
+          "lineNumber": 371
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 519
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.unmanagedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3805
+        },
+        {
+          "method": "java.util.concurrent.ForkJoinPool.managedBlock",
+          "file": "ForkJoinPool.java",
+          "lineNumber": 3746
+        },
+        {
+          "method": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await",
+          "file": "AbstractQueuedSynchronizer.java",
+          "lineNumber": 1707
+        },
+        {
+          "method": "java.util.concurrent.LinkedBlockingQueue.take",
+          "file": "LinkedBlockingQueue.java",
+          "lineNumber": 435
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.getTask",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1082
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor.runWorker",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 1142
+        },
+        {
+          "method": "java.util.concurrent.ThreadPoolExecutor$Worker.run",
+          "file": "ThreadPoolExecutor.java",
+          "lineNumber": 651
+        },
+        {
+          "method": "java.lang.Thread.run",
+          "file": "Thread.java",
+          "lineNumber": 1119
+        }
+      ]
+    },
+    {
+      "id": "77",
+      "name": "ConnectivityThread",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    },
+    {
+      "id": "78",
+      "name": "RenderThread",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "79",
+      "name": "hwuiTask0",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "80",
+      "name": "hwuiTask1",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": []
+    },
+    {
+      "id": "81",
+      "name": "SurfaceSyncGroupTimer",
+      "type": "android",
+      "state": "RUNNABLE",
+      "stacktrace": [
+        {
+          "method": "android.os.MessageQueue.nativePollOnce",
+          "file": "MessageQueue.java",
+          "lineNumber": -2
+        },
+        {
+          "method": "android.os.MessageQueue.nextLegacy",
+          "file": "MessageQueue.java",
+          "lineNumber": 913
+        },
+        {
+          "method": "android.os.MessageQueue.next",
+          "file": "MessageQueue.java",
+          "lineNumber": 1025
+        },
+        {
+          "method": "android.os.Looper.loopOnce",
+          "file": "Looper.java",
+          "lineNumber": 196
+        },
+        {
+          "method": "android.os.Looper.loop",
+          "file": "Looper.java",
+          "lineNumber": 338
+        },
+        {
+          "method": "android.os.HandlerThread.run",
+          "file": "HandlerThread.java",
+          "lineNumber": 85
+        }
+      ]
+    }
+  ],
+  "featureFlags": [],
+  "session": {
+    "id": "e3858a57-6a8b-40f7-9f02-02f8b040bd3f",
+    "startedAt": "2025-09-30T13:31:39.249Z",
+    "events": {
+      "handled": 0,
+      "unhandled": 1
+    }
+  }
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/native_crash01.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/native_crash01.json
@@ -1,0 +1,982 @@
+{
+  "context": "ExampleActivity",
+  "metaData": {
+    "app": {
+      "name": "Bugsnag",
+      "processName": "com.example.bugsnag.android",
+      "memoryLimit": 201326592,
+      "lowMemory": false,
+      "memoryTrimLevel": "None"
+    },
+    "device": {
+      "brand": "google",
+      "dpi": 420,
+      "emulator": false,
+      "locationStatus": "allowed",
+      "networkAccess": "cellular",
+      "screenDensity": 2.625,
+      "screenResolution": "2424x1080"
+    },
+    "user": {
+      "age": 31
+    },
+    "Custom Data": {
+      "members": [
+        {
+          "Group Members 1": "Adam"
+        },
+        {
+          "Group Members 2": "Alice"
+        }
+      ]
+    },
+    "Last Resume Time": {
+      "Member Last Resume Time": {
+        "Last Resume Time": "2025-09-29T14:20:48.156Z"
+      }
+    },
+    "Native": {
+      "field": "value",
+      "field": true
+    }
+  },
+  "severity": "error",
+  "unhandled": true,
+  "severityReason": {
+    "unhandledOverridden": false,
+    "type": "signal",
+    "attributes": {
+      "signalType": "SIGSEGV"
+    }
+  },
+  "exceptions": [
+    {
+      "errorClass": "SIGSEGV",
+      "message": "Segmentation violation (invalid memory reference)",
+      "type": "c",
+      "stacktrace": [
+        {
+          "frameAddress": "0x78c88a180cb0",
+          "symbolAddress": "0x78c88a180c9c",
+          "loadAddress": "0x78c88a180000",
+          "lineNumber": 3248,
+          "isPC": true,
+          "file": "/data/app/~~7zddDSBFN9PPk6EBEwzt6g==/com.example.bugsnag.android-QJUs-bOLyJzCWVpT4IUjzA==/lib/arm64/libentrypoint.so",
+          "method": "crash_write_read_only",
+          "codeIdentifier": "3d33ca9c27cb3a0b28fcab56252e46bc080cea06"
+        },
+        {
+          "frameAddress": "0x78c88a180db8",
+          "symbolAddress": "0x78c88a180da4",
+          "loadAddress": "0x78c88a180000",
+          "lineNumber": 3512,
+          "file": "/data/app/~~7zddDSBFN9PPk6EBEwzt6g==/com.example.bugsnag.android-QJUs-bOLyJzCWVpT4IUjzA==/lib/arm64/libentrypoint.so",
+          "method": "Java_com_example_bugsnag_android_BaseCrashyActivity_crashFromCXX",
+          "codeIdentifier": "3d33ca9c27cb3a0b28fcab56252e46bc080cea06"
+        },
+        {
+          "frameAddress": "0x78c88df07500",
+          "symbolAddress": "0x78c88df07470",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 3405056,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "art_quick_generic_jni_trampoline",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88def0194",
+          "symbolAddress": "0x78c88deeff30",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 3309972,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "art_quick_invoke_stub",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88e2413d4",
+          "symbolAddress": "0x78c88e240da8",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 6788052,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreter6DoCallILb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtbPNS_6JValueE",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88e1904f4",
+          "symbolAddress": "0x78c88e190190",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 6063348,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreter20ExecuteSwitchImplCppILb0EEEvPNS0_17SwitchImplContextE",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88dedfa88",
+          "symbolAddress": "0x78c88dedfa80",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 3242632,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "ExecuteSwitchImplAsm",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78cb581d9d74",
+          "symbolAddress": "0x78cb581d9d74",
+          "loadAddress": "0x78cb581d8000",
+          "lineNumber": 7540,
+          "method": "0x78cb581d9d74"
+        },
+        {
+          "frameAddress": "0x78c88dedf488",
+          "symbolAddress": "0x78c88dedf2ec",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 3241096,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88e2415bc",
+          "symbolAddress": "0x78c88e240da8",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 6788540,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreter6DoCallILb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtbPNS_6JValueE",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88e190690",
+          "symbolAddress": "0x78c88e190190",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 6063760,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreter20ExecuteSwitchImplCppILb0EEEvPNS0_17SwitchImplContextE",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88dedfa88",
+          "symbolAddress": "0x78c88dedfa80",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 3242632,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "ExecuteSwitchImplAsm",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78cb581d99d0",
+          "symbolAddress": "0x78cb581d99d0",
+          "loadAddress": "0x78cb581d8000",
+          "lineNumber": 6608,
+          "method": "0x78cb581d99d0"
+        },
+        {
+          "frameAddress": "0x78c88dedf488",
+          "symbolAddress": "0x78c88dedf2ec",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 3241096,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreter33ArtInterpreterToInterpreterBridgeEPNS_6ThreadERKNS_20CodeItemDataAccessorEPNS_11ShadowFrameEPNS_6JValueE",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88e2415bc",
+          "symbolAddress": "0x78c88e240da8",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 6788540,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreter6DoCallILb0EEEbPNS_9ArtMethodEPNS_6ThreadERNS_11ShadowFrameEPKNS_11InstructionEtbPNS_6JValueE",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88e190690",
+          "symbolAddress": "0x78c88e190190",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 6063760,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreter20ExecuteSwitchImplCppILb0EEEvPNS0_17SwitchImplContextE",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88dedfa88",
+          "symbolAddress": "0x78c88dedfa80",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 3242632,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "ExecuteSwitchImplAsm",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78cb581d9640",
+          "symbolAddress": "0x78cb581d9640",
+          "loadAddress": "0x78cb581d8000",
+          "lineNumber": 5696,
+          "method": "0x78cb581d9640"
+        },
+        {
+          "frameAddress": "0x78c88de9f63c",
+          "symbolAddress": "0x78c88de9f4f0",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 2979388,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "_ZN3art11interpreterL7ExecuteEPNS_6ThreadERKNS_20CodeItemDataAccessorERNS_11ShadowFrameENS_6JValueEbb.__uniq.112435418011751916792819755956732575238.llvm.11186287395527938019",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88de9ee70",
+          "symbolAddress": "0x78c88de9eaf8",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 2977392,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "artQuickToInterpreterBridge",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x78c88df07638",
+          "symbolAddress": "0x78c88df075e0",
+          "loadAddress": "0x78c88dbc8000",
+          "lineNumber": 3405368,
+          "file": "/apex/com.android.art/lib64/libart.so",
+          "method": "art_quick_to_interpreter_bridge",
+          "codeIdentifier": "b229f9d1b6196afaae086f29f029f907"
+        },
+        {
+          "frameAddress": "0x485df07c",
+          "symbolAddress": "0x485df07c",
+          "loadAddress": "0x48000000",
+          "lineNumber": 6156412,
+          "method": "0x485df07c"
+        }
+      ]
+    }
+  ],
+  "user": {
+    "id": "999999",
+    "name": "j@ex.co",
+    "email": "ndk override"
+  },
+  "app": {
+    "version": "1.0",
+    "id": "com.example.bugsnag.android",
+    "type": "android",
+    "releaseStage": "development",
+    "versionCode": 1,
+    "buildUUID": "6fe37cf5bf085f398d05aebb4f3930e12e3802f0",
+    "binaryArch": "arm64",
+    "duration": 83447119,
+    "durationInForeground": 83446000,
+    "inForeground": true,
+    "isLaunching": false
+  },
+  "device": {
+    "osName": "android",
+    "id": "da515088-7506-42e5-a054-bd7946514025",
+    "locale": "en_US",
+    "osVersion": "16",
+    "manufacturer": "Google",
+    "model": "sdk_gphone16k_arm64",
+    "orientation": "portrait",
+    "runtimeVersions": {
+      "androidApiLevel": 36,
+      "osBuild": "BE2A.250530.026.F3 dev-keys"
+    },
+    "cpuAbi": [
+      "arm64-v8a"
+    ],
+    "totalMemory": 2096365568,
+    "jailbroken": false,
+    "time": "2025-09-30T13:31:34Z"
+  },
+  "breadcrumbs": [
+    {
+      "timestamp": "2025-09-29T14:20:47.974Z",
+      "name": "Bugsnag loaded",
+      "type": "state"
+    },
+    {
+      "timestamp": "2025-09-29T14:20:48.068Z",
+      "name": "ExampleActivity#onCreate()",
+      "type": "state",
+      "metaData": {
+        "hasBundle": false,
+        "action": "android.intent.action.MAIN",
+        "categories": "android.intent.category.LAUNCHER",
+        "flags": "0x10000000",
+        "hasData": false,
+        "hasExtras": false
+      }
+    },
+    {
+      "timestamp": "2025-09-29T14:20:48.153Z",
+      "name": "ExampleActivity#onStart()",
+      "type": "state",
+      "metaData": {
+        "previous": "onCreate()"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T14:20:48.157Z",
+      "name": "ExampleActivity#onResume()",
+      "type": "state",
+      "metaData": {
+        "previous": "onStart()"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T14:21:25.651Z",
+      "name": "java.lang.RuntimeException",
+      "type": "error",
+      "metaData": {
+        "unhandled": "false",
+        "severity": "WARNING",
+        "errorClass": "java.lang.RuntimeException",
+        "message": "Non-Fatal Crash"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T16:58:35.051Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T17:14:49.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T17:31:42.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T17:48:45.004Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T18:02:22.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T18:20:11.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T18:36:57.010Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T18:42:12.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T18:58:37.004Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T19:16:28.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T19:31:54.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T19:47:03.010Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T20:03:09.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T20:19:29.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T20:36:43.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T20:54:03.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T21:11:56.004Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T21:27:03.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T21:42:36.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T21:59:51.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T22:15:18.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T22:30:31.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T22:48:23.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T23:04:20.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T23:21:29.015Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T23:39:17.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-29T23:54:50.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T00:11:58.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T00:28:22.004Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T00:43:27.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T00:59:58.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T01:17:56.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T01:34:43.010Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T01:49:47.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T02:07:32.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T02:15:23.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T02:29:12.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T02:44:32.004Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T03:02:28.008Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T03:18:27.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T03:34:34.012Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T03:51:03.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T03:51:05.607Z",
+      "name": "Connectivity changed",
+      "type": "state",
+      "metaData": {
+        "hasConnection": true,
+        "networkState": "unknown"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T04:06:13.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T04:23:48.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T04:30:13.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T04:46:29.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T05:02:28.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T05:18:49.004Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T05:31:14.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T05:48:36.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T06:06:26.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T06:23:20.007Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T06:32:15.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T06:50:18.006Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T07:05:28.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    },
+    {
+      "timestamp": "2025-09-30T07:08:55.005Z",
+      "name": "TIME_SET",
+      "type": "state",
+      "metaData": {
+        "Intent Action": "android.intent.action.TIME_SET"
+      }
+    }
+  ],
+  "usage": {
+    "callbacks": {
+      "ndkOnError": 1,
+      "app_set_is_launching": true,
+      "event_add_metadata_bool": true,
+      "event_add_metadata_string": true,
+      "event_set_context": true,
+      "event_set_user": true,
+      "event_set_grouping_discriminator": true
+    },
+    "config": {
+      "pluginCount": 1,
+      "launchDurationMillis": 5000,
+      "logger": true
+    }
+  },
+  "threads": [
+    {
+      "id": "29630",
+      "errorReportingThread": true,
+      "name": "bugsnag.android",
+      "state": "running",
+      "type": "c"
+    },
+    {
+      "id": "29632",
+      "name": "Signal Catcher",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29633",
+      "name": "perfetto_hprof_",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29634",
+      "name": "ADB-JDWP Connec",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29635",
+      "name": "Jit thread pool",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29636",
+      "name": "HeapTaskDaemon",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29637",
+      "name": "ReferenceQueueD",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29638",
+      "name": "FinalizerDaemon",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29639",
+      "name": "FinalizerWatchd",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29640",
+      "name": "binder:29630_1",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29641",
+      "name": "binder:29630_2",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29642",
+      "name": "binder:29630_3",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29644",
+      "name": "Profile Saver",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29645",
+      "name": "Bugsnag IO thre",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29651",
+      "name": "bugsnag-anr-col",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29652",
+      "name": "bugsnag.android",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29653",
+      "name": "Bugsnag Error t",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29654",
+      "name": "Bugsnag Session",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29655",
+      "name": "ConnectivityThr",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29656",
+      "name": "RenderThread",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29661",
+      "name": "TracingMuxer",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29662",
+      "name": "hwuiTask0",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29663",
+      "name": "hwuiTask1",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29666",
+      "name": "SurfaceSyncGrou",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29667",
+      "name": "ConscryptStatsL",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29668",
+      "name": "binder:29630_4",
+      "state": "sleeping",
+      "type": "c"
+    },
+    {
+      "id": "29669",
+      "name": "binder:29630_4",
+      "state": "sleeping",
+      "type": "c"
+    }
+  ],
+  "session": {
+    "id": "0fb86691-8499-4549-a25d-c4b9178e6d5a",
+    "startedAt": "2025-09-29T14:20:48.149Z",
+    "events": {
+      "handled": 1,
+      "unhandled": 1
+    }
+  }
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/native_crash_config.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/native_crash_config.json
@@ -1,0 +1,32 @@
+{
+  "discardRules": [
+    {
+      "matchType": "HASH",
+      "hash": {
+        "paths": [
+          {
+            "path": "groupingDiscriminator"
+          },
+          {
+            "path": "exceptions.-1.errorClass"
+          },
+          {
+            "path": "exceptions.-1.stacktrace.*.codeIdentifier"
+          },
+          {
+            "path": "exceptions.-1.stacktrace.*.file",
+            "pathMode": "REGEX",
+            "regex": "([^/\\\\]+)$"
+          },
+          {
+            "path": "exceptions.-1.stacktrace.*",
+            "pathMode": "RELATIVE_ADDRESS"
+          }
+        ],
+        "matches": [
+          "4351b6c1394121e80d782cabf93b85f99487c53b"
+        ]
+      }
+    }
+  ]
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/unhandled_config01.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/unhandled_config01.json
@@ -1,0 +1,29 @@
+{
+  "discardRules": [
+    {
+      "matchType": "HASH",
+      "hash": {
+        "paths": [
+          {
+            "path": "groupingDiscriminator"
+          },
+          {
+            "path": "exceptions.-1.errorClass"
+          },
+          {
+            "path": "exceptions.-1.stacktrace.*.file"
+          },
+          {
+            "path": "exceptions.-1.stacktrace.*.lineNumber"
+          },
+          {
+            "path": "exceptions.-1.stacktrace.*.method"
+          }
+        ],
+        "matches": [
+          "5e0c627bac494a834b6b3a2c3f5d2d1c3f7a9a80"
+        ]
+      }
+    }
+  ]
+}

--- a/bugsnag-android-core/src/test/resources/remoteConfig/unhandled_config02.json
+++ b/bugsnag-android-core/src/test/resources/remoteConfig/unhandled_config02.json
@@ -1,0 +1,23 @@
+{
+  "discardRules": [
+    {
+      "matchType": "HASH",
+      "hash": {
+        "paths": [
+          {
+            "path": "groupingDiscriminator"
+          },
+          {
+            "path": "exceptions.-1.errorClass"
+          },
+          {
+            "path": "context"
+          }
+        ],
+        "matches": [
+          "f19387b136de58677e86d8ca97a54c68cb1e1532"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Goal
More integration-style tests for `DiscardRule.Hash` based remote config.

## Design
Used real test fixtures and config with a parameterized JUnit test. The test checks that the config marks the specific errors for discard, but only if the hashes do indeed match (modifying the hash causes the exact same rule to mark the error "retained" instead of discarded).