### PR TITLE
Add User info to synthesized ANR events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Bug fixes
+
+* Synthesized ANRs from the exitinfo plugin will now include the user details (captured when they are synthesized)
+  [#2352](https://github.com/bugsnag/bugsnag-android/pull/2352)
+
 ## 6.20.0 (2025-12-03)
 
 ### Enhancements

--- a/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/InternalHooks.java
+++ b/bugsnag-plugin-android-exitinfo/src/main/java/com/bugsnag/android/InternalHooks.java
@@ -42,9 +42,11 @@ class InternalHooks {
             }
 
             Event event = NativeInterface.createEmptyEvent();
+            User user = client.getUser();
             event.setDevice(deviceDataCollector.generateHistoricDeviceWithState(exitInfoTimeStamp));
             event.setApp(appDataCollector.generateHistoricAppWithState());
             event.updateSeverityReason(SeverityReason.REASON_ANR);
+            event.setUser(user.getId(), user.getEmail(), user.getName());
             return event;
         } catch (Exception ex) {
             return null;
@@ -66,9 +68,11 @@ class InternalHooks {
             }
 
             Event event = NativeInterface.createEmptyEvent();
+            User user = client.getUser();
             event.setDevice(deviceDataCollector.generateHistoricDeviceWithState(exitInfoTimeStamp));
             event.setApp(appDataCollector.generateHistoricAppWithState());
             event.updateSeverityReason(SeverityReason.REASON_SIGNAL);
+            event.setUser(user.getId(), user.getEmail(), user.getName());
             return event;
         } catch (Exception ex) {
             return null;


### PR DESCRIPTION
## Goal
Included User information to synthesized ANRs generated by the `exitinfo` plugin.

## Changeset
When the `exitinfo` plugin generates a synthesized ANR (one reported in `ApplicationExitInfo` but not captured by the `bugsnag-plugin-android-anr` module), the current (at time the event is synthesized) `User` is now added to the `Event`.

## Testing
Manually tested