### PR TITLE
Add ErrorCaptureOptions.CAPTURE_ALL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## TBD
 
+### Enhancements
+
+* Added `ErrorCaptureOptions.CAPTURE_ALL` field to more easily change only the captured metadata when specifying `ErrorOptions`
+  [#2358](https://github.com/bugsnag/bugsnag-android/pull/2358)
+
 ### Bug fixes
 
 * Synthesized ANRs from the exitinfo plugin will now include the user details (captured when they are synthesized)

--- a/bugsnag-android-core/api/bugsnag-android-core.api
+++ b/bugsnag-android-core/api/bugsnag-android-core.api
@@ -358,6 +358,7 @@ public class com/bugsnag/android/Error : com/bugsnag/android/JsonStream$Streamab
 }
 
 public final class com/bugsnag/android/ErrorCaptureOptions {
+	public static final field CAPTURE_ALL I
 	public static final field CAPTURE_BREADCRUMBS I
 	public static final field CAPTURE_FEATURE_FLAGS I
 	public static final field CAPTURE_STACKTRACE I

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorOptions.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ErrorOptions.kt
@@ -56,6 +56,13 @@ class ErrorCaptureOptions(
         const val CAPTURE_THREADS = 8
         const val CAPTURE_USER = 16
 
+        const val CAPTURE_ALL =
+            CAPTURE_STACKTRACE or
+                CAPTURE_BREADCRUMBS or
+                CAPTURE_FEATURE_FLAGS or
+                CAPTURE_THREADS or
+                CAPTURE_USER
+
         /**
          * A convenience method to capture only selected event fields using a bit-mask of field
          * names (a mask of [CAPTURE_STACKTRACE], [CAPTURE_BREADCRUMBS], etc.).

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorCaptureOptionsTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ErrorCaptureOptionsTest.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import com.bugsnag.android.ErrorCaptureOptions.Companion.CAPTURE_ALL
 import com.bugsnag.android.ErrorCaptureOptions.Companion.CAPTURE_BREADCRUMBS
 import com.bugsnag.android.ErrorCaptureOptions.Companion.CAPTURE_FEATURE_FLAGS
 import com.bugsnag.android.ErrorCaptureOptions.Companion.CAPTURE_STACKTRACE
@@ -98,5 +99,16 @@ class ErrorCaptureOptionsTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun testCaptureAll() {
+        val options = ErrorCaptureOptions.captureOnly(CAPTURE_ALL)
+        assertTrue("breadcrumbs", options.breadcrumbs)
+        assertTrue("featureFlags", options.featureFlags)
+        assertTrue("stacktrace", options.stacktrace)
+        assertTrue("threads", options.threads)
+        assertTrue("user", options.user)
+        assertNull(options.metadata)
     }
 }


### PR DESCRIPTION
## Goal
Simplify the use of `ErrorCaptureOptions.captureOnly` when only the metadata capturing needs to change.

## Design
Added a new `CAPTURE_ALL` flag that has all field bits set. This can also be used as a base to "exclude" specific fields from being captured rather than the current "include" behaviour of `captureOnly`

## Testing
New unit test introduced