### PR TITLE
Reduce CXXCrashLoopScenario flakes

### DIFF
--- a/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCrashLoopScenario.kt
+++ b/features/fixtures/mazerunner/cxx-scenarios-bugsnag/src/main/java/com/bugsnag/android/mazerunner/scenarios/CXXCrashLoopScenario.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 
+private const val STARTUP_SETTLING_TIME = 500L
+
 /**
  * Triggers a crash loop which Bugsnag allows recovery from.
  */
@@ -35,6 +37,8 @@ internal class CXXCrashLoopScenario(
                 it.consecutiveLaunchCrashes
             )
         }
+
+        Thread.sleep(STARTUP_SETTLING_TIME)
 
         // the last run info allows the scenario to escape from what would otherwise be
         // a crash loop, by conditionally entering a 'safe mode'.


### PR DESCRIPTION
## Goal
Reduce CXXCrashLoopScenario flakes

## Changeset
Added a short delay to the `CXXCrashLoopScenario` to allow things to correctly settle before crashing.

## Testing
Existing testing