### PR TITLE
Added the "remoteConfig" flag to `Event.usage`

### DIFF
--- a/bugsnag-android-core/api/bugsnag-android-core.api
+++ b/bugsnag-android-core/api/bugsnag-android-core.api
@@ -1020,36 +1020,40 @@ public final class com/bugsnag/android/internal/ImmutableConfigKt {
 }
 
 public abstract interface class com/bugsnag/android/internal/InternalMetrics {
+	public abstract fun getRemoteConfigEnabled ()Z
 	public abstract fun notifyAddCallback (Ljava/lang/String;)V
 	public abstract fun notifyRemoveCallback (Ljava/lang/String;)V
 	public abstract fun setBreadcrumbTrimMetrics (II)V
 	public abstract fun setCallbackCounts (Ljava/util/Map;)V
 	public abstract fun setConfigDifferences (Ljava/util/Map;)V
 	public abstract fun setMetadataTrimMetrics (II)V
+	public abstract fun setRemoteConfigEnabled (Z)V
 	public abstract fun toJsonableMap ()Ljava/util/Map;
 }
 
 public final class com/bugsnag/android/internal/InternalMetricsImpl : com/bugsnag/android/internal/InternalMetrics {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getRemoteConfigEnabled ()Z
 	public fun notifyAddCallback (Ljava/lang/String;)V
 	public fun notifyRemoveCallback (Ljava/lang/String;)V
 	public fun setBreadcrumbTrimMetrics (II)V
 	public fun setCallbackCounts (Ljava/util/Map;)V
 	public fun setConfigDifferences (Ljava/util/Map;)V
 	public fun setMetadataTrimMetrics (II)V
+	public fun setRemoteConfigEnabled (Z)V
 	public fun toJsonableMap ()Ljava/util/Map;
 }
 
 public final class com/bugsnag/android/internal/InternalMetricsNoop : com/bugsnag/android/internal/InternalMetrics {
 	public fun <init> ()V
+	public fun getRemoteConfigEnabled ()Z
 	public fun notifyAddCallback (Ljava/lang/String;)V
 	public fun notifyRemoveCallback (Ljava/lang/String;)V
 	public fun setBreadcrumbTrimMetrics (II)V
 	public fun setCallbackCounts (Ljava/util/Map;)V
 	public fun setConfigDifferences (Ljava/util/Map;)V
 	public fun setMetadataTrimMetrics (II)V
+	public fun setRemoteConfigEnabled (Z)V
 	public fun toJsonableMap ()Ljava/util/Map;
 }
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -235,6 +235,10 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
             internalMetrics = new InternalMetricsNoop();
         }
 
+        internalMetrics.setRemoteConfigEnabled(
+                immutableConfig.getEndpoints().getConfiguration() != null
+        );
+
         configDifferences = configuration.impl.getConfigDifferences();
         systemBroadcastReceiver = new SystemBroadcastReceiver(this, logger);
 

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/InternalMetrics.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/InternalMetrics.kt
@@ -20,6 +20,8 @@ interface InternalMetrics {
     fun setMetadataTrimMetrics(stringsTrimmed: Int, charsRemoved: Int)
 
     fun setBreadcrumbTrimMetrics(breadcrumbsRemoved: Int, bytesRemoved: Int)
+
+    var remoteConfigEnabled: Boolean
 }
 
 internal data class TrimMetrics(

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/InternalMetricsNoop.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/internal/InternalMetricsNoop.kt
@@ -1,7 +1,9 @@
 package com.bugsnag.android.internal
 
 class InternalMetricsNoop : InternalMetrics {
-    override fun toJsonableMap(): Map<String, Any> = emptyMap()
+    override var remoteConfigEnabled: Boolean = false
+
+    override fun toJsonableMap(): Map<String, Any> = mapOf("remoteConfig" to remoteConfigEnabled)
     override fun setConfigDifferences(differences: Map<String, Any>) = Unit
     override fun setCallbackCounts(newCallbackCounts: Map<String, Int>) = Unit
     override fun notifyAddCallback(callback: String) = Unit

--- a/bugsnag-android-core/src/test/resources/event_default_redaction.json
+++ b/bugsnag-android-core/src/test/resources/event_default_redaction.json
@@ -17,7 +17,7 @@
   },
   "unhandled": false,
   "exceptions": [],
-  "projectPackages":[
+  "projectPackages": [
     "com.example.foo"
   ],
   "user": {},
@@ -51,6 +51,9 @@
       }
     }
   ],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_redaction.json
+++ b/bugsnag-android-core/src/test/resources/event_redaction.json
@@ -17,7 +17,7 @@
   },
   "unhandled": false,
   "exceptions": [],
-  "projectPackages":[
+  "projectPackages": [
     "com.example.foo"
   ],
   "user": {},
@@ -51,6 +51,9 @@
       }
     }
   ],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_0.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_0.json
@@ -7,7 +7,7 @@
   },
   "unhandled": false,
   "exceptions": [],
-  "projectPackages":[
+  "projectPackages": [
     "com.example.foo"
   ],
   "user": {},
@@ -32,6 +32,9 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_1.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_1.json
@@ -33,6 +33,9 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_2.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_2.json
@@ -33,6 +33,9 @@
   },
   "breadcrumbs": [],
   "groupingHash": "herpderp",
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_3.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_3.json
@@ -32,6 +32,9 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_4.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_4.json
@@ -32,6 +32,9 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": [],
   "session": {

--- a/bugsnag-android-core/src/test/resources/event_serialization_5.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_5.json
@@ -32,6 +32,9 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [
     {
       "id": "5",

--- a/bugsnag-android-core/src/test/resources/event_serialization_6.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_6.json
@@ -58,6 +58,9 @@
       "metaData": {}
     }
   ],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": []
 }

--- a/bugsnag-android-core/src/test/resources/event_serialization_7.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_7.json
@@ -32,6 +32,9 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": [
     {

--- a/bugsnag-android-core/src/test/resources/event_serialization_8.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_8.json
@@ -33,6 +33,9 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": [],
   "correlation": {

--- a/bugsnag-android-core/src/test/resources/event_serialization_9.json
+++ b/bugsnag-android-core/src/test/resources/event_serialization_9.json
@@ -129,6 +129,9 @@
     "time": "1970-01-01T00:00:00.000Z"
   },
   "breadcrumbs": [],
+  "usage": {
+    "remoteConfig": false
+  },
   "threads": [],
   "featureFlags": []
 }

--- a/features/full_tests/remote_config_discard.feature
+++ b/features/full_tests/remote_config_discard.feature
@@ -20,10 +20,13 @@ Feature: Remote config discard rules are applied
     Then the report contains the required fields
     And the event "severity" equals "warning"
     And the event "unhandled" is false
+    And the event "usage.remoteConfig" is true
+
     And I discard the oldest error
     Then the report contains the required fields
     And the event "severity" equals "error"
     And the event "unhandled" is true
+    And the event "usage.remoteConfig" is true
 
   Scenario: Invalid remote config
     When I prepare an error config with:
@@ -42,10 +45,13 @@ Feature: Remote config discard rules are applied
     Then the report contains the required fields
     And the event "severity" equals "warning"
     And the event "unhandled" is false
+    And the event "usage.remoteConfig" is true
+
     And I discard the oldest error
     Then the report contains the required fields
     And the event "severity" equals "error"
     And the event "unhandled" is true
+    And the event "usage.remoteConfig" is true
 
   Scenario: Remote config with ALL_HANDLED rule
     When I prepare an error config with:
@@ -63,6 +69,7 @@ Feature: Remote config discard rules are applied
     Then the report contains the required fields
     And the event "severity" equals "error"
     And the event "unhandled" is true
+    And the event "usage.remoteConfig" is true
 
   Scenario: Remote config with ALL rule
     When I prepare an error config with:
@@ -113,6 +120,7 @@ Feature: Remote config discard rules are applied
     Then the report contains the required fields
     And the event "severity" equals "error"
     And the event "unhandled" is true
+    And the event "usage.remoteConfig" is true
 
   Scenario: Remote config with errorClass HASH discard
     When I prepare an error config with:
@@ -127,3 +135,4 @@ Feature: Remote config discard rules are applied
     And the received errors match:
       | exceptions.0.errorClass    | exceptions.0.message |
       | java.lang.RuntimeException | Handled exception    |
+    And the event "usage.remoteConfig" is true


### PR DESCRIPTION
## Goal
Include the `event.usage.remoteConfig` flag to signal that the SDK is capable of processing the events through remote config rules.

## Testing
Updated tests to assert the existence of the new flag