### PR TITLE
Release v6.26.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162 #v4.32.5
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -83,6 +83,6 @@ jobs:
           ./gradlew --no-daemon assemble
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 #v4.32.5
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e #v4.32.4
+        uses: github/codeql-action/init@c793b717bc78562f491db7b0e93a3a178b099162 #v4.32.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -83,6 +83,6 @@ jobs:
           ./gradlew --no-daemon assemble
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e #v4.32.4
+        uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 #v4.32.5
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
           java-version: 17
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
+        uses: android-actions/setup-android@651bceb6f9ca583f16b8d75b62c36ded2ae6fc9c # v4.0.0
         with:
           packages: 'cmake;3.22.1'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: recursive
-      - uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c #v5.0.2
+      - uses: gradle/actions/wrapper-validation@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f #v6.0.1
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,7 +68,7 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: results.sarif
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,7 +68,7 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+        uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
         with:
           sarif_file: results.sarif
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,4 +77,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      - uses: gradle/actions/wrapper-validation@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## TBD
+## 6.26.0 (2026-04-07)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Build UUIDs derived from dex file signatures no longer block NDK startup, reducing the overall startup time.
   [#2401](https://github.com/bugsnag/bugsnag-android/pull/2401)
+* The `AppHangPlugin` can now be configured to log breadcrumbs for "near hang" situations where the app pauses for long enough to be noticeable but not long enough to warrant a full AppHang report
+  [#2402](https://github.com/bugsnag/bugsnag-android/pull/2402)
 
 ## 6.25.0 (2026-03-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## TBD
+
+### Enhancements
+
+* Build UUIDs derived from dex file signatures no longer block NDK startup, reducing the overall startup time.
+  [#2401](https://github.com/bugsnag/bugsnag-android/pull/2401)
+
 ## 6.25.0 (2026-03-02)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/App.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/App.kt
@@ -50,7 +50,8 @@ open class App internal constructor(
     var versionCode: Number?
 ) : JsonStream.Streamable {
 
-    private var buildUuidProvider: Provider<String?>? = buildUuid
+    @get:JvmName("getBuildUuidProvider\$internal")
+    internal var buildUuidProvider: Provider<String?>? = buildUuid
 
     var buildUuid: String? = null
         get() = field ?: buildUuidProvider?.getOrNull()

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Bugsnag.java
@@ -14,8 +14,10 @@ import java.util.Set;
  * Static access to a Bugsnag Client, the easiest way to use Bugsnag in your Android app.
  * For example:
  * <p>
+ * <pre>{@code
  * Bugsnag.start(this, "your-api-key");
  * Bugsnag.notify(new RuntimeException("something broke!"));
+ * }</pre>
  *
  * @see Client
  */
@@ -72,7 +74,7 @@ public final class Bugsnag {
     /**
      * Returns true if one of the <code>start</code> methods have been has been called and
      * so Bugsnag is initialized; false if <code>start</code> has not been called and the
-     * other methods will throw IllegalStateException.
+     * other methods will throw {@code IllegalStateException}.
      */
     public static boolean isStarted() {
         return client != null;
@@ -149,12 +151,12 @@ public final class Bugsnag {
      * <p>
      * For example:
      * <p>
-     * Bugsnag.addOnError(new OnErrorCallback() {
-     * public boolean run(Event event) {
-     * event.setSeverity(Severity.INFO);
-     * return true;
-     * }
-     * })
+     * <pre>{@code
+     * Bugsnag.addOnError((Event event) -> {
+     *     event.setSeverity(Severity.INFO);
+     *     return true;
+     * });
+     * }</pre>
      *
      * @param onError a callback to run before sending errors to Bugsnag
      * @see OnErrorCallback
@@ -181,11 +183,11 @@ public final class Bugsnag {
      * <p>
      * For example:
      * <p>
-     * Bugsnag.onBreadcrumb(new OnBreadcrumbCallback() {
-     * public boolean run(Breadcrumb breadcrumb) {
-     * return false; // ignore the breadcrumb
-     * }
-     * })
+     * <pre>{@code
+     * Bugsnag.onBreadcrumb((Breadcrumb breadcrumb) -> {
+     *     return false; // ignore the breadcrumb
+     * });
+     * }</pre>
      *
      * @param onBreadcrumb a callback to run before a breadcrumb is captured
      * @see OnBreadcrumbCallback
@@ -212,11 +214,11 @@ public final class Bugsnag {
      * <p>
      * For example:
      * <p>
-     * Bugsnag.onSession(new OnSessionCallback() {
-     * public boolean run(Session session) {
-     * return false; // ignore the session
-     * }
-     * })
+     * <pre>{@code
+     * Bugsnag.onSession((Session session) -> {
+     *     return false; // ignore the session
+     * });
+     * }</pre>
      *
      * @param onSession a callback to run before a session is captured
      * @see OnSessionCallback

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Client.java
@@ -427,6 +427,25 @@ public class Client implements MetadataAware, CallbackAware, UserAware, FeatureF
         clientObservable.postNdkInstall(immutableConfig, lastRunInfoPath, crashes);
         syncInitialState();
         clientObservable.postNdkDeliverPending();
+
+        // If the buildUuid is still being computed (DexBuildIdGenerator running on IO thread),
+        // schedule a deferred SynchronizeState so the NDK layer picks up the value once ready.
+        Provider<String> buildUuid = immutableConfig.getBuildUuid();
+        if (buildUuid != null && !buildUuid.isComplete()) {
+            try {
+                bgTaskService.submitTask(TaskType.IO, new Runnable() {
+                    @Override
+                    public void run() {
+                        // This blocks on the IO thread until dex generation finishes,
+                        // then syncs the result to the NDK layer.
+                        immutableConfig.getBuildUuid().getOrNull();
+                        clientObservable.postSynchronizeState();
+                    }
+                });
+            } catch (RejectedExecutionException exc) {
+                logger.w("Failed to schedule deferred NDK build UUID sync", exc);
+            }
+        }
     }
 
     private boolean setupNdkDirectory() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/ClientObservable.kt
@@ -18,7 +18,8 @@ internal class ClientObservable : BaseObservable() {
                 conf.apiKey,
                 conf.enabledErrorTypes.ndkCrashes,
                 conf.appVersion,
-                conf.buildUuid?.getOrNull(),
+                if (conf.buildUuid?.isComplete == true) conf.buildUuid.getOrNull()
+                else null,
                 conf.releaseStage,
                 lastRunInfoPath,
                 consecutiveLaunchCrashes,

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -104,7 +104,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * If you would like to distinguish between errors that happen in different stages of the
      * application release process (development, production, etc) you can set the releaseStage
      * that is reported to Bugsnag.
-     *
+     * <p>
      * If you are running a debug build, we'll automatically set this to "development",
      * otherwise it is set to "production". You can control whether events are sent for
      * specific release stages using the enabledReleaseStages option.
@@ -118,7 +118,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * If you would like to distinguish between errors that happen in different stages of the
      * application release process (development, production, etc) you can set the releaseStage
      * that is reported to Bugsnag.
-     *
+     * <p>
      * If you are running a debug build, we'll automatically set this to "development",
      * otherwise it is set to "production". You can control whether events are sent for
      * specific release stages using the enabledReleaseStages option.
@@ -130,7 +130,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Controls whether we should capture and serialize the state of all threads at the time
      * of an error.
-     *
+     * <p>
      * By default sendThreads is set to Thread.ThreadSendPolicy.ALWAYS. This can be set to
      * Thread.ThreadSendPolicy.NEVER to disable or Thread.ThreadSendPolicy.UNHANDLED_ONLY
      * to only do so for unhandled errors.
@@ -143,7 +143,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Controls whether we should capture and serialize the state of all threads at the time
      * of an error.
-     *
+     * <p>
      * By default sendThreads is set to Thread.ThreadSendPolicy.ALWAYS. This can be set to
      * Thread.ThreadSendPolicy.NEVER to disable or Thread.ThreadSendPolicy.UNHANDLED_ONLY
      * to only do so for unhandled errors.
@@ -158,7 +158,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Set whether or not Bugsnag should persist user information between application sessions.
-     *
+     * <p>
      * If enabled then any user information set will be re-used until the user information is
      * removed manually by calling {@link Bugsnag#setUser(String, String, String)}
      * with null arguments.
@@ -169,7 +169,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Set whether or not Bugsnag should persist user information between application sessions.
-     *
+     * <p>
      * If enabled then any user information set will be re-used until the user information is
      * removed manually by calling {@link Bugsnag#setUser(String, String, String)}
      * with null arguments.
@@ -180,7 +180,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Set whether or not Bugsnag should generate an anonymous ID and persist it in local storage
-     *
+     * <p>
      * If disabled, any device ID that has been persisted will not be retrieved, and no new
      * device ID will be generated or stored
      */
@@ -190,7 +190,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Set whether or not Bugsnag should generate an anonymous ID and persist it in local storage
-     *
+     * <p>
      * If disabled, any device ID that has been persisted will not be retrieved, and no new
      * device ID will be generated or stored
      */
@@ -238,7 +238,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets whether or not Bugsnag should send crashes synchronously that occurred during
      * the application's launch period. By default this behavior is enabled.
-     *
+     * <p>
      * See {@link #setLaunchDurationMillis(long)}
      */
     public boolean getSendLaunchCrashesSynchronously() {
@@ -248,7 +248,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets whether or not Bugsnag should send crashes synchronously that occurred during
      * the application's launch period. By default this behavior is enabled.
-     *
+     * <p>
      * See {@link #setLaunchDurationMillis(long)}
      */
     public void setSendLaunchCrashesSynchronously(boolean sendLaunchCrashesSynchronously) {
@@ -259,7 +259,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * Sets the threshold in milliseconds for an uncaught error to be considered as a crash on
      * launch. If a crash is detected on launch, Bugsnag will attempt to send the most recent
      * event synchronously.
-     *
+     * <p>
      * By default, this value is set at 5,000ms. Setting the value to 0 will count all crashes
      * as launch crashes until markLaunchCompleted() is called.
      */
@@ -271,7 +271,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * Sets the threshold in milliseconds for an uncaught error to be considered as a crash on
      * launch. If a crash is detected on launch, Bugsnag will attempt to send the most recent
      * event synchronously.
-     *
+     * <p>
      * By default, this value is set at 5,000ms. Setting the value to 0 will count all crashes
      * as launch crashes until markLaunchCompleted() is called.
      */
@@ -288,7 +288,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets whether or not Bugsnag should automatically capture and report User sessions whenever
      * the app enters the foreground.
-     *
+     * <p>
      * By default this behavior is enabled.
      */
     public boolean getAutoTrackSessions() {
@@ -298,7 +298,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets whether or not Bugsnag should automatically capture and report User sessions whenever
      * the app enters the foreground.
-     *
+     * <p>
      * By default this behavior is enabled.
      */
     public void setAutoTrackSessions(boolean autoTrackSessions) {
@@ -329,7 +329,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * If you want to disable automatic detection of all errors, you can set this property to false.
      * By default this property is true.
-     *
+     * <p>
      * Setting autoDetectErrors to false will disable all automatic errors, regardless of the
      * error types enabled by enabledErrorTypes
      */
@@ -340,7 +340,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * If you want to disable automatic detection of all errors, you can set this property to false.
      * By default this property is true.
-     *
+     * <p>
      * Setting autoDetectErrors to false will disable all automatic errors, regardless of the
      * error types enabled by enabledErrorTypes
      */
@@ -352,10 +352,10 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * If your app's codebase contains different entry-points/processes, but reports to a single
      * Bugsnag project, you might want to add information denoting the type of process the error
      * came from.
-     *
+     * <p>
      * This information can be used in the dashboard to filter errors and to determine whether
      * an error is limited to a subset of appTypes.
-     *
+     * <p>
      * By default, this value is set to 'android'.
      */
     @Nullable
@@ -367,10 +367,10 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * If your app's codebase contains different entry-points/processes, but reports to a single
      * Bugsnag project, you might want to add information denoting the type of process the error
      * came from.
-     *
+     * <p>
      * This information can be used in the dashboard to filter errors and to determine whether
      * an error is limited to a subset of appTypes.
-     *
+     * <p>
      * By default, this value is set to 'android'.
      */
     public void setAppType(@Nullable String appType) {
@@ -380,7 +380,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * By default, the notifier's log messages will be logged using android.util.Log
      * with a "Bugsnag" tag unless the releaseStage is "production".
-     *
+     * <p>
      * To override this behavior, an alternative instance can be provided that implements the
      * Logger interface.
      */
@@ -392,7 +392,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * By default, the notifier's log messages will be logged using android.util.Log
      * with a "Bugsnag" tag unless the releaseStage is "production".
-     *
+     * <p>
      * To override this behavior, an alternative instance can be provided that implements the
      * Logger interface.
      */
@@ -404,18 +404,18 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * The Delivery implementation used to make network calls to the Bugsnag
      * <a href="https://docs.bugsnag.com/api/error-reporting/">Error Reporting</a> and
      * <a href="https://docs.bugsnag.com/api/sessions/">Sessions API</a>.
-     *
+     * <p>
      * This may be useful if you have requirements such as certificate pinning and rotation,
      * which are not supported by the default implementation.
-     *
+     * <p>
      * To provide custom delivery functionality, create a class which implements the Delivery
      * interface. Please note that request bodies must match the structure specified in the
      * <a href="https://docs.bugsnag.com/api/error-reporting/">Error Reporting</a> and
      * <a href="https://docs.bugsnag.com/api/sessions/">Sessions API</a> documentation.
-     *
+     * <p>
      * You can use the return type from the deliver functions to control the strategy for
      * retrying the transmission at a later date.
-     *
+     * <p>
      * If DeliveryStatus.UNDELIVERED is returned, the notifier will automatically cache
      * the payload and trigger delivery later on. Otherwise, if either DeliveryStatus.DELIVERED
      * or DeliveryStatus.FAILURE is returned the notifier will removed any cached payload
@@ -430,22 +430,22 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * The Delivery implementation used to make network calls to the Bugsnag
      * <a href="https://docs.bugsnag.com/api/error-reporting/">Error Reporting</a> and
      * <a href="https://docs.bugsnag.com/api/sessions/">Sessions API</a>.
-     *
+     * <p>
      * This may be useful if you have requirements such as certificate pinning and rotation,
      * which are not supported by the default implementation.
-     *
+     * <p>
      * To provide custom delivery functionality, create a class which implements the Delivery
      * interface. Please note that request bodies must match the structure specified in the
      * <a href="https://docs.bugsnag.com/api/error-reporting/">Error Reporting</a> and
      * <a href="https://docs.bugsnag.com/api/sessions/">Sessions API</a> documentation.
-     *
+     * <p>
      * You can use the return type from the deliver functions to control the strategy for
      * retrying the transmission at a later date.
-     *
-     * If DeliveryStatus.UNDELIVERED is returned, the notifier will automatically cache
-     * the payload and trigger delivery later on. Otherwise, if either DeliveryStatus.DELIVERED
-     * or DeliveryStatus.FAILURE is returned the notifier will removed any cached payload
-     * and no further delivery will be attempted.
+     * <p>
+     * If {@link DeliveryStatus#UNDELIVERED} is returned, the notifier will automatically cache
+     * the payload and trigger delivery later on. Otherwise, if either
+     * {@link DeliveryStatus#DELIVERED} or {@link DeliveryStatus#FAILURE} is returned the notifier
+     * will remove any cached payload and no further delivery will be attempted.
      */
     public void setDelivery(@NonNull Delivery delivery) {
         if (delivery != null) {
@@ -456,9 +456,10 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Set the endpoints to send data to. By default we'll send error reports to
-     * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
-     * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoints.
+     * Set the endpoints to send data to. By default, we'll send error reports to
+     * {@code https://notify.bugsnag.com}, and sessions to {@code https://sessions.bugsnag.com},
+     * but you can override this if you are using Bugsnag Enterprise to point to your own
+     * Bugsnag endpoints.
      */
     @NonNull
     public EndpointConfiguration getEndpoints() {
@@ -466,9 +467,10 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Set the endpoints to send data to. By default we'll send error reports to
-     * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
-     * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoints.
+     * Set the endpoints to send data to. By default, we'll send error reports to
+     * {@code https://notify.bugsnag.com}, and sessions to {@code https://sessions.bugsnag.com},
+     * but you can override this if you are using Bugsnag Enterprise to point to your own
+     * Bugsnag endpoints.
      */
     public void setEndpoints(@NonNull EndpointConfiguration endpoints) {
         if (endpoints != null) {
@@ -481,7 +483,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets the maximum number of breadcrumbs which will be stored. Once the threshold is reached,
      * the oldest breadcrumbs will be deleted.
-     *
+     * <p>
      * By default, 100 breadcrumbs are stored: this can be amended up to a maximum of 500.
      */
     public int getMaxBreadcrumbs() {
@@ -491,7 +493,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets the maximum number of breadcrumbs which will be stored. Once the threshold is reached,
      * the oldest breadcrumbs will be deleted.
-     *
+     * <p>
      * By default, 100 breadcrumbs are stored: this can be amended up to a maximum of 500.
      */
     public void setMaxBreadcrumbs(@IntRange(from = 0, to = 500) int maxBreadcrumbs) {
@@ -507,7 +509,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets the maximum number of persisted events which will be stored. Once the threshold is
      * reached, the oldest event will be deleted.
-     *
+     * <p>
      * By default, 32 events are persisted.
      */
     public int getMaxPersistedEvents() {
@@ -517,7 +519,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets the maximum number of persisted events which will be stored. Once the threshold is
      * reached, the oldest event will be deleted.
-     *
+     * <p>
      * By default, 32 events are persisted.
      */
     public void setMaxPersistedEvents(@IntRange(from = 0) int maxPersistedEvents) {
@@ -533,7 +535,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Gets the maximum number of threads that will be reported with an event. Once the threshold is
      * reached, all remaining threads will be omitted.
-     *
+     * <p>
      * By default, up to 200 threads are reported.
      */
     public int getMaxReportedThreads() {
@@ -543,7 +545,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets the maximum number of threads that will be reported with an event. Once the threshold is
      * reached, all remaining threads will be omitted.
-     *
+     * <p>
      * By default, up to 200 threads are reported.
      */
     public void setMaxReportedThreads(@IntRange(from = 0) int maxReportedThreads) {
@@ -584,7 +586,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets the maximum number of persisted sessions which will be stored. Once the threshold is
      * reached, the oldest session will be deleted.
-     *
+     * <p>
      * By default, 128 sessions are persisted.
      */
     public int getMaxPersistedSessions() {
@@ -594,7 +596,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets the maximum number of persisted sessions which will be stored. Once the threshold is
      * reached, the oldest session will be deleted.
-     *
+     * <p>
      * By default, 128 sessions are persisted.
      */
     public void setMaxPersistedSessions(@IntRange(from = 0) int maxPersistedSessions) {
@@ -610,7 +612,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Gets the maximum string length in any metadata field. Once the threshold is
      * reached in a particular string, all excess characters will be deleted.
-     *
+     * <p>
      * By default, the limit is 10,000.
      */
     public int getMaxStringValueLength() {
@@ -620,7 +622,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Sets the maximum string length in any metadata field. Once the threshold is
      * reached in a particular string, all excess characters will be deleted.
-     *
+     * <p>
      * By default, the limit is 10,000.
      */
     public void setMaxStringValueLength(@IntRange(from = 0) int maxStringValueLength) {
@@ -636,7 +638,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Bugsnag uses the concept of "contexts" to help display and group your errors. Contexts
      * represent what was happening in your application at the time an error occurs.
-     *
+     * <p>
      * In an android app the "context" is automatically set as the foreground Activity.
      * If you would like to set this value manually, you should alter this property.
      */
@@ -648,7 +650,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Bugsnag uses the concept of "contexts" to help display and group your errors. Contexts
      * represent what was happening in your application at the time an error occurs.
-     *
+     * <p>
      * In an android app the "context" is automatically set as the foreground Activity.
      * If you would like to set this value manually, you should alter this property.
      */
@@ -661,7 +663,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * sending them to Bugsnag. Use this if you want to ensure you don't send
      * sensitive data such as passwords, and credit card numbers to our
      * servers. Any keys which contain these strings will be filtered.
-     *
+     * <p>
      * By default, redactedKeys is set to "password"
      */
     @NonNull
@@ -674,7 +676,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * sending them to Bugsnag. Use this if you want to ensure you don't send
      * sensitive data such as passwords, and credit card numbers to our
      * servers. Any keys which contain these strings will be filtered.
-     *
+     * <p>
      * By default, redactedKeys is set to "password"
      */
     public void setRedactedKeys(@NonNull Set<Pattern> redactedKeys) {
@@ -730,9 +732,9 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * activity lifecycle events and system intents. To amend this behavior,
      * override the enabled breadcrumb types. All breadcrumbs can be disabled by providing an
      * empty set.
-     *
+     * <p>
      * The following breadcrumb types can be enabled:
-     *
+     * <p>
      * - Captured errors: left when an error event is sent to the Bugsnag API.
      * - Manual breadcrumbs: left via the Bugsnag.leaveBreadcrumb function.
      * - Navigation changes: left for Activity Lifecycle events to track the user's journey in
@@ -751,9 +753,9 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * activity lifecycle events and system intents. To amend this behavior,
      * override the enabled breadcrumb types. All breadcrumbs can be disabled by providing an
      * empty set.
-     *
+     * <p>
      * The following breadcrumb types can be enabled:
-     *
+     * <p>
      * - Captured errors: left when an error event is sent to the Bugsnag API.
      * - Manual breadcrumbs: left via the Bugsnag.leaveBreadcrumb function.
      * - Navigation changes: left for Activity Lifecycle events to track the user's journey in
@@ -773,9 +775,9 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Set which telemetry will be sent to Bugsnag. By default, all telemetry is enabled.
-     *
+     * <p>
      * The following telemetry can be enabled:
-     *
+     * <p>
      * - internal errors: Errors in the Bugsnag SDK itself.
      */
     public void setTelemetry(@NonNull Set<Telemetry> telemetry) {
@@ -791,7 +793,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * running application. We mark stacktrace lines as in-project if they
      * originate from any of these packages and this allows us to improve
      * the visual display of the stacktrace on the dashboard.
-     *
+     * <p>
      * By default, projectPackages is set to be the package you called Bugsnag.start from.
      */
     @NonNull
@@ -804,7 +806,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * running application. We mark stacktrace lines as in-project if they
      * originate from any of these packages and this allows us to improve
      * the visual display of the stacktrace on the dashboard.
-     *
+     * <p>
      * By default, projectPackages is set to be the package you called Bugsnag.start from.
      */
     public void setProjectPackages(@NonNull Set<String> projectPackages) {
@@ -818,21 +820,22 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Add a "on error" callback, to execute code at the point where an error report is
      * captured in Bugsnag.
-     *
+     * <p>
      * You can use this to add or modify information attached to an Event
      * before it is sent to your dashboard. You can also return
-     * <code>false</code> from any callback to prevent delivery. "on error"
+     * {@code false} from any callback to prevent delivery. "on error"
      * callbacks do not run before reports generated in the event
      * of immediate app termination from crashes in C/C++ code.
-     *
+     * <p>
      * For example:
-     *
+     * <pre>{@code
      * Bugsnag.addOnError(new OnErrorCallback() {
-     * public boolean run(Event event) {
-     * event.setSeverity(Severity.INFO);
-     * return true;
-     * }
-     * })
+     *     public boolean onError(Event event) {
+     *         event.setSeverity(Severity.INFO);
+     *         return true;
+     *     }
+     * });
+     * }</pre>
      *
      * @param onError a callback to run before sending errors to Bugsnag
      * @see OnErrorCallback
@@ -848,6 +851,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Removes a previously added "on error" callback
+     *
      * @param onError the callback to remove
      */
     @Override
@@ -862,17 +866,18 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Add an "on breadcrumb" callback, to execute code before every
      * breadcrumb captured by Bugsnag.
-     *
+     * <p>
      * You can use this to modify breadcrumbs before they are stored by Bugsnag.
-     * You can also return <code>false</code> from any callback to ignore a breadcrumb.
-     *
+     * You can also return {@code false} from any callback to ignore a breadcrumb.
+     * <p>
      * For example:
-     *
+     * <pre>{@code
      * Bugsnag.onBreadcrumb(new OnBreadcrumbCallback() {
-     * public boolean run(Breadcrumb breadcrumb) {
-     * return false; // ignore the breadcrumb
-     * }
-     * })
+     *     public boolean run(Breadcrumb breadcrumb) {
+     *         return false; // ignore the breadcrumb
+     *     }
+     * });
+     * }</pre>
      *
      * @param onBreadcrumb a callback to run before a breadcrumb is captured
      * @see OnBreadcrumbCallback
@@ -888,6 +893,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Removes a previously added "on breadcrumb" callback
+     *
      * @param onBreadcrumb the callback to remove
      */
     @Override
@@ -902,17 +908,18 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Add an "on session" callback, to execute code before every
      * session captured by Bugsnag.
-     *
+     * <p>
      * You can use this to modify sessions before they are stored by Bugsnag.
-     * You can also return <code>false</code> from any callback to ignore a session.
-     *
+     * You can also return {@code false} from any callback to ignore a session.
+     * <p>
      * For example:
-     *
+     * <pre>{@code
      * Bugsnag.onSession(new OnSessionCallback() {
-     * public boolean run(Session session) {
-     * return false; // ignore the session
-     * }
-     * })
+     *     public boolean onSession(Session session) {
+     *         return false; // ignore the session
+     *     }
+     * });
+     * }</pre>
      *
      * @param onSession a callback to run before a session is captured
      * @see OnSessionCallback
@@ -928,6 +935,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Removes a previously added "on session" callback
+     *
      * @param onSession the callback to remove
      */
     @Override
@@ -942,7 +950,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     /**
      * Add a callback which will be invoked prior to an event being delivered
      * to Bugsnag. The callback can be used to modify events or cancel
-     * delivering the event altogether by returning <code>false</code>. Note
+     * delivering the event altogether by returning {@code false}. Note
      * that the callback may be invoked in the current or a subsequent app
      * launch depending on whether the app terminated prior to delivering the
      * event.
@@ -1134,19 +1142,21 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * Whether Bugsnag should try to send crashing errors prior to app termination.
-     *
+     * <p>
      * Delivery will only be attempted for uncaught Java / Kotlin exceptions or errors, and
      * while in progress will block the crashing thread for up to 3 seconds.
-     *
+     * <p>
      * Delivery on crash should be considered unreliable due to the necessary short timeout and
      * potential for generating "errors on errors".
-     *
+     * <p>
      * Use of this feature is discouraged because it:
-     * - may cause Application Not Responding (ANR) errors on-top of existing crashes
-     * - will result in duplicate errors in your Dashboard when errors are not detected as sent
-     *   before termination
-     * - may prevent other error handlers from detecting or reporting a crash
-     *
+     * <ul>
+     * <li>may cause Application Not Responding (ANR) errors on-top of existing crashes</li>
+     * <li>will result in duplicate errors in your Dashboard when errors are not detected as sent
+     * before termination</li>
+     * <li>may prevent other error handlers from detecting or reporting a crash</li>
+     * </ul>
+     * <p>
      * By default this value is {@code false}.
      *
      * @param attemptDeliveryOnCrash {@code true} if Bugsnag should try to send crashing errors

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java
@@ -102,7 +102,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * If you would like to distinguish between errors that happen in different stages of the
-     * application release process (development, production, etc) you can set the releaseStage
+     * application release process (development, production, etc.) you can set the releaseStage
      * that is reported to Bugsnag.
      * <p>
      * If you are running a debug build, we'll automatically set this to "development",
@@ -116,7 +116,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
 
     /**
      * If you would like to distinguish between errors that happen in different stages of the
-     * application release process (development, production, etc) you can set the releaseStage
+     * application release process (development, production, etc.) you can set the releaseStage
      * that is reported to Bugsnag.
      * <p>
      * If you are running a debug build, we'll automatically set this to "development",
@@ -168,7 +168,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Set whether or not Bugsnag should persist user information between application sessions.
+     * Set whether Bugsnag should persist user information between application sessions.
      * <p>
      * If enabled then any user information set will be re-used until the user information is
      * removed manually by calling {@link Bugsnag#setUser(String, String, String)}
@@ -179,7 +179,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Set whether or not Bugsnag should generate an anonymous ID and persist it in local storage
+     * Set whether Bugsnag should generate an anonymous ID and persist it in local storage
      * <p>
      * If disabled, any device ID that has been persisted will not be retrieved, and no new
      * device ID will be generated or stored
@@ -189,7 +189,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Set whether or not Bugsnag should generate an anonymous ID and persist it in local storage
+     * Set whether Bugsnag should generate an anonymous ID and persist it in local storage
      * <p>
      * If disabled, any device ID that has been persisted will not be retrieved, and no new
      * device ID will be generated or stored
@@ -226,7 +226,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * The persistenceDirectory also stores user information if {@link #getPersistUser()} has been
      * set to true.
      * <p/>
-     * By default, bugsnag sets the persistenceDirectory to {@link Context#getCacheDir()}.
+     * By default, Bugsnag sets the persistenceDirectory to {@link Context#getCacheDir()}.
      * <p/>
      * If the persistenceDirectory is changed between application launches, no attempt will be made
      * to deliver events or sessions cached in the previous location.
@@ -236,7 +236,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Sets whether or not Bugsnag should send crashes synchronously that occurred during
+     * Sets whether Bugsnag should send crashes synchronously that occurred during
      * the application's launch period. By default this behavior is enabled.
      * <p>
      * See {@link #setLaunchDurationMillis(long)}
@@ -246,10 +246,10 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Sets whether or not Bugsnag should send crashes synchronously that occurred during
+     * Sets whether Bugsnag should send crashes synchronously that occurred during
      * the application's launch period. By default this behavior is enabled.
      * <p>
-     * See {@link #setLaunchDurationMillis(long)}
+     * @see #setLaunchDurationMillis(long)
      */
     public void setSendLaunchCrashesSynchronously(boolean sendLaunchCrashesSynchronously) {
         impl.setSendLaunchCrashesSynchronously(sendLaunchCrashesSynchronously);
@@ -261,7 +261,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * event synchronously.
      * <p>
      * By default, this value is set at 5,000ms. Setting the value to 0 will count all crashes
-     * as launch crashes until markLaunchCompleted() is called.
+     * as launch crashes until {@link Bugsnag#markLaunchCompleted()} is called.
      */
     public long getLaunchDurationMillis() {
         return impl.getLaunchDurationMillis();
@@ -286,7 +286,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Sets whether or not Bugsnag should automatically capture and report User sessions whenever
+     * Sets whether Bugsnag should automatically capture and report User sessions whenever
      * the app enters the foreground.
      * <p>
      * By default this behavior is enabled.
@@ -296,7 +296,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Sets whether or not Bugsnag should automatically capture and report User sessions whenever
+     * Sets whether Bugsnag should automatically capture and report User sessions whenever
      * the app enters the foreground.
      * <p>
      * By default this behavior is enabled.
@@ -416,10 +416,10 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * You can use the return type from the deliver functions to control the strategy for
      * retrying the transmission at a later date.
      * <p>
-     * If DeliveryStatus.UNDELIVERED is returned, the notifier will automatically cache
-     * the payload and trigger delivery later on. Otherwise, if either DeliveryStatus.DELIVERED
-     * or DeliveryStatus.FAILURE is returned the notifier will removed any cached payload
-     * and no further delivery will be attempted.
+     * If {@link DeliveryStatus#UNDELIVERED} is returned, the notifier will automatically cache
+     * the payload and trigger delivery later on. Otherwise, if either
+     * {@link DeliveryStatus#DELIVERED} or {@link DeliveryStatus#FAILURE} is returned the notifier
+     * will remove any cached payload and no further delivery will be attempted.
      */
     @NonNull
     public Delivery getDelivery() {
@@ -734,14 +734,15 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * empty set.
      * <p>
      * The following breadcrumb types can be enabled:
-     * <p>
-     * - Captured errors: left when an error event is sent to the Bugsnag API.
-     * - Manual breadcrumbs: left via the Bugsnag.leaveBreadcrumb function.
-     * - Navigation changes: left for Activity Lifecycle events to track the user's journey in
-     * the app.
-     * - State changes: state breadcrumbs are left for system broadcast events. For example:
-     * battery warnings, airplane mode, etc.
-     * - User interaction: left when the user performs certain system operations.
+     * <ul>
+     * <li>Captured errors: left when an error event is sent to the Bugsnag API.</li>
+     * <li>Manual breadcrumbs: left via the Bugsnag.leaveBreadcrumb function.</li>
+     * <li>Navigation changes: left for Activity Lifecycle events to track the user's journey in
+     * the app.</li>
+     * <li>State changes: state breadcrumbs are left for system broadcast events. For example:
+     * battery warnings, airplane mode, etc.</li>
+     * <li>User interaction: left when the user performs certain system operations.</li>
+     * </ul>
      */
     @Nullable
     public Set<BreadcrumbType> getEnabledBreadcrumbTypes() {
@@ -755,14 +756,15 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * empty set.
      * <p>
      * The following breadcrumb types can be enabled:
-     * <p>
-     * - Captured errors: left when an error event is sent to the Bugsnag API.
-     * - Manual breadcrumbs: left via the Bugsnag.leaveBreadcrumb function.
-     * - Navigation changes: left for Activity Lifecycle events to track the user's journey in
-     * the app.
-     * - State changes: state breadcrumbs are left for system broadcast events. For example:
-     * battery warnings, airplane mode, etc.
-     * - User interaction: left when the user performs certain system operations.
+     * <ul>
+     * <li>Captured errors: left when an error event is sent to the Bugsnag API.</li>
+     * <li>Manual breadcrumbs: left via the Bugsnag.leaveBreadcrumb function.</li>
+     * <li>Navigation changes: left for Activity Lifecycle events to track the user's journey in
+     * the app.</li>
+     * <li>State changes: state breadcrumbs are left for system broadcast events. For example:
+     * battery warnings, airplane mode, etc.</li>
+     * <li>User interaction: left when the user performs certain system operations.</li>
+     * </ul>
      */
     public void setEnabledBreadcrumbTypes(@Nullable Set<BreadcrumbType> enabledBreadcrumbTypes) {
         impl.setEnabledBreadcrumbTypes(enabledBreadcrumbTypes);
@@ -778,7 +780,10 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * <p>
      * The following telemetry can be enabled:
      * <p>
-     * - internal errors: Errors in the Bugsnag SDK itself.
+     * <ul>
+     * <li>internal errors: Errors in the Bugsnag SDK itself</li>
+     * <li>usage: Differences from the default configuration</li>
+     * </ul>
      */
     public void setTelemetry(@NonNull Set<Telemetry> telemetry) {
         if (telemetry != null) {
@@ -794,7 +799,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * originate from any of these packages and this allows us to improve
      * the visual display of the stacktrace on the dashboard.
      * <p>
-     * By default, projectPackages is set to be the package you called Bugsnag.start from.
+     * By default, projectPackages is set to be the package you called {@link Bugsnag#start} from.
      */
     @NonNull
     public Set<String> getProjectPackages() {
@@ -807,7 +812,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * originate from any of these packages and this allows us to improve
      * the visual display of the stacktrace on the dashboard.
      * <p>
-     * By default, projectPackages is set to be the package you called Bugsnag.start from.
+     * By default, projectPackages is set to be the package you called {@link Bugsnag#start} from.
      */
     public void setProjectPackages(@NonNull Set<String> projectPackages) {
         if (CollectionUtils.containsNullElements(projectPackages)) {
@@ -818,7 +823,7 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
     }
 
     /**
-     * Add a "on error" callback, to execute code at the point where an error report is
+     * Add an "on error" callback, to execute code at the point where an error report is
      * captured in Bugsnag.
      * <p>
      * You can use this to add or modify information attached to an Event
@@ -829,11 +834,9 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * <p>
      * For example:
      * <pre>{@code
-     * Bugsnag.addOnError(new OnErrorCallback() {
-     *     public boolean onError(Event event) {
-     *         event.setSeverity(Severity.INFO);
-     *         return true;
-     *     }
+     * Bugsnag.addOnError((event) -> {
+     *     event.setSeverity(Severity.INFO);
+     *     return true;
      * });
      * }</pre>
      *
@@ -872,10 +875,8 @@ public class Configuration implements CallbackAware, MetadataAware, UserAware, F
      * <p>
      * For example:
      * <pre>{@code
-     * Bugsnag.onBreadcrumb(new OnBreadcrumbCallback() {
-     *     public boolean run(Breadcrumb breadcrumb) {
-     *         return false; // ignore the breadcrumb
-     *     }
+     * Bugsnag.addOnBreadcrumb((breadcrumb) -> {
+     *     return false; // ignore the breadcrumb
      * });
      * }</pre>
      *

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/NativeInterface.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import com.bugsnag.android.internal.ImmutableConfig;
 import com.bugsnag.android.internal.JsonHelper;
+import com.bugsnag.android.internal.dag.Provider;
 
 import android.annotation.SuppressLint;
 
@@ -114,14 +115,20 @@ public class NativeInterface {
     @NonNull
     @SuppressWarnings("unused")
     public static Map<String, Object> getApp() {
-        HashMap<String, Object> data = new HashMap<>();
         AppDataCollector source = getClient().getAppDataCollector();
         AppWithState app = source.generateAppWithState();
+
+        Provider<String> buildUuidProvider = app.getBuildUuidProvider$internal();
+        String buildUuid = buildUuidProvider != null && buildUuidProvider.isComplete()
+                ? buildUuidProvider.getOrNull()
+                : null;
+
+        HashMap<String, Object> data = new HashMap<>();
         data.put("version", app.getVersion());
         data.put("releaseStage", app.getReleaseStage());
         data.put("id", app.getId());
         data.put("type", app.getType());
-        data.put("buildUUID", app.getBuildUuid());
+        data.put("buildUUID", buildUuid);
         data.put("duration", app.getDuration());
         data.put("durationInForeground", app.getDurationInForeground());
         data.put("versionCode", app.getVersionCode());

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/Notifier.kt
@@ -7,7 +7,7 @@ import java.io.IOException
  */
 class Notifier @JvmOverloads constructor(
     var name: String = "Android Bugsnag Notifier",
-    var version: String = "6.25.0",
+    var version: String = "6.26.0",
     var url: String = "https://bugsnag.com"
 ) : JsonStream.Streamable {
 

--- a/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientObservableTest.kt
+++ b/bugsnag-android-core/src/test/java/com/bugsnag/android/ClientObservableTest.kt
@@ -1,7 +1,11 @@
 package com.bugsnag.android
 
 import com.bugsnag.android.internal.StateObserver
+import com.bugsnag.android.internal.convertToImmutableConfig
+import com.bugsnag.android.internal.dag.RunnableProvider
+import com.bugsnag.android.internal.dag.ValueProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -22,12 +26,61 @@ class ClientObservableTest {
 
     @Test
     fun postNdkInstall() {
-        clientObservable.postNdkInstall(BugsnagTestUtils.generateImmutableConfig(), "/foo", 0)
         clientObservable.addObserver(
             StateObserver {
                 assertTrue(it is StateEvent.Install)
             }
         )
+        clientObservable.postNdkInstall(BugsnagTestUtils.generateImmutableConfig(), "/foo", 0)
+    }
+
+    @Test
+    fun postNdkInstallBuildUuidNull() {
+        // When buildUuid is null, Install event should have null buildUuid
+        val config = BugsnagTestUtils.generateImmutableConfig()
+        var installEvent: StateEvent.Install? = null
+        clientObservable.addObserver {
+            if (it is StateEvent.Install) installEvent = it
+        }
+        clientObservable.postNdkInstall(config, "/foo", 0)
+        assertNull(installEvent?.buildUuid)
+    }
+
+    @Test
+    fun postNdkInstallBuildUuidComplete() {
+        // When buildUuid is a ValueProvider (already complete), Install should include it
+        val config = convertToImmutableConfig(
+            BugsnagTestUtils.generateConfiguration(),
+            ValueProvider("test-uuid")
+        )
+        var installEvent: StateEvent.Install? = null
+        clientObservable.addObserver(
+            StateObserver {
+                if (it is StateEvent.Install) installEvent = it
+            }
+        )
+        clientObservable.postNdkInstall(config, "/foo", 0)
+        assertEquals("test-uuid", installEvent?.buildUuid)
+    }
+
+    @Test
+    fun postNdkInstallBuildUuidPending() {
+        // When buildUuid is a pending RunnableProvider, Install should have null buildUuid
+        val pendingProvider = object : RunnableProvider<String?>() {
+            override fun invoke(): String? = "deferred-uuid"
+        }
+        val config = convertToImmutableConfig(
+            BugsnagTestUtils.generateConfiguration(),
+            pendingProvider
+        )
+        var installEvent: StateEvent.Install? = null
+        clientObservable.addObserver(
+            StateObserver {
+                if (it is StateEvent.Install) installEvent = it
+            }
+        )
+        clientObservable.postNdkInstall(config, "/foo", 0)
+        assertNull(installEvent?.buildUuid)
     }
 
     @Test

--- a/bugsnag-plugin-android-apphang/api/bugsnag-plugin-android-apphang.api
+++ b/bugsnag-plugin-android-apphang/api/bugsnag-plugin-android-apphang.api
@@ -1,14 +1,16 @@
 public final class com/bugsnag/android/AppHangConfiguration {
 	public fun <init> ()V
-	public fun <init> (JLandroid/os/Looper;Ljava/lang/Long;JJ)V
-	public synthetic fun <init> (JLandroid/os/Looper;Ljava/lang/Long;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JLandroid/os/Looper;Ljava/lang/Long;JJJ)V
+	public synthetic fun <init> (JLandroid/os/Looper;Ljava/lang/Long;JJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAppHangCooldownMillis ()J
 	public final fun getAppHangThresholdMillis ()J
+	public final fun getNearHangThresholdMillis ()J
 	public final fun getStackSamplingIntervalMillis ()J
 	public final fun getStackSamplingThresholdMillis ()Ljava/lang/Long;
 	public final fun getWatchedLooper ()Landroid/os/Looper;
 	public final fun setAppHangCooldownMillis (J)V
 	public final fun setAppHangThresholdMillis (J)V
+	public final fun setNearHangThresholdMillis (J)V
 	public final fun setStackSamplingIntervalMillis (J)V
 	public final fun setStackSamplingThresholdMillis (Ljava/lang/Long;)V
 	public final fun setWatchedLooper (Landroid/os/Looper;)V

--- a/bugsnag-plugin-android-apphang/detekt-baseline.xml
+++ b/bugsnag-plugin-android-apphang/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>LongParameterList:LooperMonitorThread.kt$LooperMonitorThread$( watchedLooper: Looper, private val appHangThresholdMillis: Long, private val appHangCooldownMillis: Long, private val samplingThresholdMillis: Long, private val samplingRateMillis: Long, private val nearHangThresholdMillis: Long, private val onAppHangDetected: (timeSinceLastHeartbeat: Long, ThreadSampler?) -> Unit, private val onNearHangDetected: (pauseTime: Long, ThreadSampler?) -> Unit )</ID>
     <ID>LoopWithTooManyJumpStatements:LooperMonitorThread.kt$LooperMonitorThread$while</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/bugsnag-plugin-android-apphang/src/androidTest/java/com/bugsnag/android/LooperMonitorThreadTest.kt
+++ b/bugsnag-plugin-android-apphang/src/androidTest/java/com/bugsnag/android/LooperMonitorThreadTest.kt
@@ -53,25 +53,6 @@ class LooperMonitorThreadTest {
     }
 
     @Test
-    fun testBelowThresholdEvents() {
-        val countDownLatch = CountDownLatch(10)
-        val task = object : Runnable {
-            override fun run() {
-                JThread.sleep(APP_HANG_THRESHOLD / 2)
-                countDownLatch.countDown()
-
-                if (countDownLatch.count > 0) {
-                    handler.postDelayed(this, 1L)
-                }
-            }
-        }
-        handler.postDelayed(task, 1)
-
-        countDownLatch.await()
-        assertEquals("no AppHangs expected", 0, appHangCount)
-    }
-
-    @Test
     fun appHang() {
         val countDownLatch = CountDownLatch(1)
         handler.postDelayed({

--- a/bugsnag-plugin-android-apphang/src/androidTest/java/com/bugsnag/android/LooperMonitorThreadTest.kt
+++ b/bugsnag-plugin-android-apphang/src/androidTest/java/com/bugsnag/android/LooperMonitorThreadTest.kt
@@ -10,8 +10,9 @@ import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.lang.Thread as JThread
 
-private const val APP_HANG_THRESHOLD = 200L
-private const val COOLDOWN_TIME = 800L
+private const val NEAR_HANG_THRESHOLD = 250L
+private const val APP_HANG_THRESHOLD = NEAR_HANG_THRESHOLD * 2
+private const val COOLDOWN_TIME = 1000L
 
 class LooperMonitorThreadTest {
     private lateinit var handlerThread: HandlerThread
@@ -19,6 +20,7 @@ class LooperMonitorThreadTest {
     private lateinit var handler: Handler
 
     private var appHangCount = 0
+    private var nearHangCount = 0
 
     @Before
     fun setup() {
@@ -34,7 +36,9 @@ class LooperMonitorThreadTest {
             appHangCooldownMillis = COOLDOWN_TIME,
             samplingThresholdMillis = 0,
             samplingRateMillis = 0,
-            onAppHangDetected = { _, _ -> appHangCount++ }
+            nearHangThresholdMillis = NEAR_HANG_THRESHOLD,
+            onAppHangDetected = { _, _ -> appHangCount++ },
+            onNearHangDetected = { _, _ -> nearHangCount++ }
         )
 
         monitorThread.startMonitoring()
@@ -50,6 +54,30 @@ class LooperMonitorThreadTest {
     fun testIdleHandlerThread() {
         JThread.sleep(APP_HANG_THRESHOLD * 5)
         assertEquals("no AppHangs expected", 0, appHangCount)
+    }
+
+    @Test
+    fun testBelowThresholdEvents() {
+        val nearHangTotal = 10
+        val countDownLatch = CountDownLatch(nearHangTotal)
+        val task = object : Runnable {
+            override fun run() {
+                JThread.sleep(NEAR_HANG_THRESHOLD)
+                countDownLatch.countDown()
+
+                if (countDownLatch.count > 0) {
+                    handler.postDelayed(this, 1L)
+                }
+            }
+        }
+
+        handler.postDelayed(task, 1)
+
+        countDownLatch.await()
+        // Allow the monitor thread to wake up and detect the final near-hang
+        JThread.sleep(APP_HANG_THRESHOLD)
+        assertEquals("no AppHangs expected", 0, appHangCount)
+        assertEquals("$nearHangTotal NearHangs expected", nearHangTotal, nearHangCount)
     }
 
     @Test

--- a/bugsnag-plugin-android-apphang/src/androidTest/java/com/bugsnag/android/SequentialAppHangsTest.kt
+++ b/bugsnag-plugin-android-apphang/src/androidTest/java/com/bugsnag/android/SequentialAppHangsTest.kt
@@ -37,7 +37,9 @@ class SequentialAppHangsTest {
             appHangCooldownMillis = 0L, // No cooldown
             samplingThresholdMillis = 0,
             samplingRateMillis = 0,
-            onAppHangDetected = { _, _ -> appHangCount++ }
+            nearHangThresholdMillis = 0L, // No near hangs
+            onAppHangDetected = { _, _ -> appHangCount++ },
+            onNearHangDetected = { _, _ -> }
         )
 
         monitorThread.startMonitoring()

--- a/bugsnag-plugin-android-apphang/src/androidTest/java/com/bugsnag/android/SequentialAppHangsTest.kt
+++ b/bugsnag-plugin-android-apphang/src/androidTest/java/com/bugsnag/android/SequentialAppHangsTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.lang.Thread as JThread
 
-private const val APP_HANG_THRESHOLD = 200L
+private const val APP_HANG_THRESHOLD = 500L
 
 /**
  * Tests for LooperMonitorThread without cooldown period configured.
@@ -60,7 +60,7 @@ class SequentialAppHangsTest {
         val countDownLatch = CountDownLatch(10)
         val task = object : Runnable {
             override fun run() {
-                JThread.sleep((APP_HANG_THRESHOLD / 2) - 10)
+                JThread.sleep(APP_HANG_THRESHOLD * 3 / 4)
                 countDownLatch.countDown()
 
                 if (countDownLatch.count > 0) {

--- a/bugsnag-plugin-android-apphang/src/main/java/com/bugsnag/android/AppHangConfiguration.kt
+++ b/bugsnag-plugin-android-apphang/src/main/java/com/bugsnag/android/AppHangConfiguration.kt
@@ -61,6 +61,14 @@ class AppHangConfiguration(
      * Set to 0 (default) to disable the cooldown period and report all detected AppHangs.
      */
     var appHangCooldownMillis: Long = 0L,
+    /**
+     * The minimum pause duration in milliseconds that will leave a "near hang" breadcrumb.
+     * When the monitored thread is unresponsive for at least this long (but less than
+     * [appHangThresholdMillis]), a breadcrumb will be recorded.
+     *
+     * Set to 0 (default) to disable near-hang breadcrumbs.
+     */
+    var nearHangThresholdMillis: Long = 0L
 ) {
     constructor() : this(DEFAULT_APP_HANG_THRESHOLD)
 

--- a/bugsnag-plugin-android-apphang/src/main/java/com/bugsnag/android/BugsnagAppHangPlugin.kt
+++ b/bugsnag-plugin-android-apphang/src/main/java/com/bugsnag/android/BugsnagAppHangPlugin.kt
@@ -11,9 +11,13 @@ class BugsnagAppHangPlugin @JvmOverloads constructor(
     configuration: AppHangConfiguration = AppHangConfiguration()
 ) : Plugin {
     private val appHangThresholdMillis = configuration.appHangThresholdMillis
+    private val appHangCooldownMillis = configuration.appHangCooldownMillis
+
+    private val nearHangThresholdMillis = configuration.nearHangThresholdMillis
+
     private val samplingThresholdMillis = configuration.stackSamplingThresholdMillis ?: 0
     private val samplingRateMillis = configuration.stackSamplingIntervalMillis
-    private val appHangCooldownMillis = configuration.appHangCooldownMillis
+
     private val watchedLooper = configuration.watchedLooper
 
     private var client: Client? = null
@@ -61,19 +65,43 @@ class BugsnagAppHangPlugin @JvmOverloads constructor(
         }
     }
 
+    private fun reportNearHang(pauseTime: Long) {
+        if (nearHangThresholdMillis <= 0) {
+            return
+        }
+
+        client?.leaveAutoBreadcrumb(
+            "Near Hang Detected",
+            BreadcrumbType.STATE,
+            mapOf("pauseTimeMs" to "${pauseTime}ms")
+        )
+    }
+
     @VisibleForTesting
     internal fun startMonitoring() {
         if (monitorThread != null) {
             return
         }
 
+        val safeSamplingThresholdMillis =
+            if (samplingThresholdMillis in 1..appHangThresholdMillis) samplingThresholdMillis
+            else 0
+
+        val safeSamplingRateMillis =
+            if (samplingRateMillis in 1..appHangThresholdMillis) samplingRateMillis
+            else 0
+
         monitorThread = LooperMonitorThread(
-            watchedLooper,
-            appHangThresholdMillis,
-            appHangCooldownMillis,
-            if (samplingThresholdMillis in 1..appHangThresholdMillis) samplingThresholdMillis else 0,
-            if (samplingRateMillis in 1..appHangThresholdMillis) samplingRateMillis else 0,
-            this::reportAppHang
+            watchedLooper = watchedLooper,
+            appHangThresholdMillis = appHangThresholdMillis,
+            appHangCooldownMillis = appHangCooldownMillis,
+            samplingThresholdMillis = safeSamplingThresholdMillis,
+            samplingRateMillis = safeSamplingRateMillis,
+            nearHangThresholdMillis = nearHangThresholdMillis,
+            onAppHangDetected = this::reportAppHang,
+            onNearHangDetected = { timeSinceLastHeartbeat, _ ->
+                reportNearHang(timeSinceLastHeartbeat)
+            }
         )
 
         monitorThread?.startMonitoring()

--- a/bugsnag-plugin-android-apphang/src/main/java/com/bugsnag/android/internal/LooperMonitorThread.kt
+++ b/bugsnag-plugin-android-apphang/src/main/java/com/bugsnag/android/internal/LooperMonitorThread.kt
@@ -11,7 +11,9 @@ internal class LooperMonitorThread(
     private val appHangCooldownMillis: Long,
     private val samplingThresholdMillis: Long,
     private val samplingRateMillis: Long,
-    private val onAppHangDetected: (timeSinceLastHeartbeat: Long, ThreadSampler?) -> Unit
+    private val nearHangThresholdMillis: Long,
+    private val onAppHangDetected: (timeSinceLastHeartbeat: Long, ThreadSampler?) -> Unit,
+    private val onNearHangDetected: (pauseTime: Long, ThreadSampler?) -> Unit
 ) : Thread("Bugsnag AppHang Monitor: ${watchedLooper.thread.name}") {
     private val handler: Handler = Handler(watchedLooper)
 
@@ -19,9 +21,12 @@ internal class LooperMonitorThread(
         if (isSamplingEnabled) ThreadSampler(watchedLooper.thread)
         else null
 
-    private val heartbeatInterval =
-        if (isSamplingEnabled) samplingThresholdMillis / 2
-        else appHangThresholdMillis / 2
+    private val heartbeatInterval: Long = run {
+        var min = appHangThresholdMillis
+        if (samplingThresholdMillis in 1 until min) min = samplingThresholdMillis
+        if (nearHangThresholdMillis in 1 until min) min = nearHangThresholdMillis
+        min / 2
+    }
 
     @Volatile
     private var lastStackSampleTimestamp = 0L
@@ -34,6 +39,9 @@ internal class LooperMonitorThread(
 
     @Volatile
     private var isAppHangDetected = false
+
+    @Volatile
+    private var lastPauseDuration = 0L
 
     private var lastHeartbeatPostTimestamp = 0L
 
@@ -78,7 +86,6 @@ internal class LooperMonitorThread(
         }
 
         isAppHangDetected = true
-        lastReportedHangTimestamp = currentTime
         onAppHangDetected(timeSinceLastHeartbeat, threadSampler)
         return true
     }
@@ -135,6 +142,19 @@ internal class LooperMonitorThread(
                     reportAppHang(now, timeSinceHeartbeat)
                 }
             } else {
+                // range is not always strictly 1>lastPauseDuration so we use <=
+                @Suppress("ConvertTwoComparisonsToRangeCheck")
+                // recovered — use the pause duration captured by the heartbeat callback
+                if (nearHangThresholdMillis > 1 &&
+                    nearHangThresholdMillis <= lastPauseDuration &&
+                    lastPauseDuration < appHangThresholdMillis
+                ) {
+                    onNearHangDetected(lastPauseDuration, threadSampler)
+                }
+
+                if (isAppHangDetected) {
+                    lastReportedHangTimestamp = currentTime()
+                }
                 isAppHangDetected = false
                 threadSampler?.resetSampling()
                 lastStackSampleTimestamp = 0L
@@ -203,7 +223,15 @@ internal class LooperMonitorThread(
 
     private inner class Heartbeat : Runnable {
         override fun run() {
-            lastHeartbeatTimestamp = currentTime()
+            val now = currentTime()
+            val previousHeartbeatTimestamp = lastHeartbeatTimestamp
+            lastHeartbeatTimestamp = now
+            lastPauseDuration =
+                if (previousHeartbeatTimestamp > 0L) {
+                    now - previousHeartbeatTimestamp
+                } else {
+                    0L
+                }
         }
 
         override fun toString(): String {

--- a/bugsnag-plugin-android-okhttp/README.md
+++ b/bugsnag-plugin-android-okhttp/README.md
@@ -1,10 +1,14 @@
 # bugsnag-plugin-android-okhttp
 
-This module captures a breadcrumb for each network request made by OkHttp.
+This module instruments OkHttp network requests, capturing them as breadcrumbs and/or errors
+in Bugsnag.
 
 ## High-level Overview
 
-The module has a `compileOnly` dependency on OkHttp 4 and implements the `Plugin` and `EventListener`
-interfaces. The user should install the plugin while initializing Bugsnag and creating an
-`OkHttpClient`, and OkHttp's callbacks will then be used to automatically capture breadcrumbs
-for each request.
+`BugsnagOkHttp` is the main entry point. It provides a builder-style API to configure which HTTP
+status codes should be reported as errors, request/response body capture limits, breadcrumb logging,
+and request/response callbacks. Call `createInterceptor()` to produce an OkHttp `Interceptor` and
+add it to your `OkHttpClient` via `addInterceptor`.
+
+`OkHttpDelivery` is an OkHttp-backed `Delivery` implementation that can be used to deliver Bugsnag
+event and session payloads using your own `OkHttpClient`.

--- a/examples/sdk-app-example/gradle/libs.versions.toml
+++ b/examples/sdk-app-example/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 activityCompose = "1.8.0"
 agp = "8.10.0"
 appcompat = "1.6.1"
-bugsnag-android = "6.25.0"
+bugsnag-android = "6.26.0"
 bugsnag-gradle = "0.4.0"
 composeBom = "2024.09.00"
 coreKtx = "1.16.0"

--- a/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppHangPluginScenario.kt
+++ b/features/fixtures/mazerunner/jvm-scenarios/src/main/java/com/bugsnag/android/mazerunner/scenarios/AppHangPluginScenario.kt
@@ -8,6 +8,8 @@ import com.bugsnag.android.BugsnagAppHangPlugin
 import com.bugsnag.android.Configuration
 import kotlin.system.exitProcess
 
+private const val HEADROOM = 10L
+private const val NEAR_HANG_THRESHOLD = 800L
 private const val APP_HANG_THRESHOLD = 1000L
 private const val APP_HANG_THRESHOLD3 = APP_HANG_THRESHOLD * 3L
 
@@ -20,7 +22,10 @@ class AppHangPluginScenario(
         config.enabledErrorTypes.anrs = false
         config.addPlugin(
             BugsnagAppHangPlugin(
-                AppHangConfiguration(appHangThresholdMillis = APP_HANG_THRESHOLD)
+                AppHangConfiguration(
+                    appHangThresholdMillis = APP_HANG_THRESHOLD,
+                    nearHangThresholdMillis = NEAR_HANG_THRESHOLD
+                )
             )
         )
     }
@@ -28,12 +33,20 @@ class AppHangPluginScenario(
     override fun startScenario() {
         super.startScenario()
 
-        Handler(Looper.getMainLooper()).postDelayed(
+        val handler = Handler(Looper.getMainLooper())
+        handler.postDelayed(
             Runnable {
-                Thread.sleep(APP_HANG_THRESHOLD3)
-                exitProcess(0)
+                Thread.sleep(NEAR_HANG_THRESHOLD + HEADROOM)
+
+                handler.postDelayed(
+                    Runnable {
+                        Thread.sleep(APP_HANG_THRESHOLD3)
+                        exitProcess(0)
+                    },
+                    HEADROOM
+                )
             },
-            1
+            HEADROOM
         )
     }
 }

--- a/features/full_tests/apphang_plugin.feature
+++ b/features/full_tests/apphang_plugin.feature
@@ -8,6 +8,7 @@ Feature: AppHang Plugin
     Then I wait to receive an error
     And the error is valid for the error reporting API version "4.0" for the "Android Bugsnag Notifier" notifier
     And the exception "errorClass" equals "AppHang"
+    And the event has a "state" breadcrumb named "Near Hang Detected"
 
   Scenario: StackSampling reports cause of AppHang
     When I run "SampledAppHangScenario"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx4096m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
-VERSION_NAME=6.25.0
+VERSION_NAME=6.26.0
 GROUP=com.bugsnag
 POM_SCM_URL=https://github.com/bugsnag/bugsnag-android
 POM_SCM_CONNECTION=scm:git@github.com:bugsnag/bugsnag-android.git


### PR DESCRIPTION
### Enhancements

* Build UUIDs derived from dex file signatures no longer block NDK startup, reducing the overall startup time.
  [#2401](https://github.com/bugsnag/bugsnag-android/pull/2401)
* The `AppHangPlugin` can now be configured to log breadcrumbs for "near hang" situations where the app pauses for long enough to be noticeable but not long enough to warrant a full AppHang report
  [#2402](https://github.com/bugsnag/bugsnag-android/pull/2402)