### PR TITLE
Added New phase for NDK Plugin checks.

### DIFF
--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
@@ -7,6 +7,76 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 class LibraryLoader {
 
+    static final class LoadLibraryReport {
+        final boolean loaded;
+        final boolean retried;
+        final boolean retrySucceeded;
+        final String firstErrorClass;
+        final String firstErrorMessage;
+        final String secondErrorClass;
+        final String secondErrorMessage;
+        final long queueWaitNs;
+        final long nativeLoadNs;
+        final long callerBlockedNs;
+
+        LoadLibraryReport(
+            boolean loaded,
+            boolean retried,
+            boolean retrySucceeded,
+            String firstErrorClass,
+            String firstErrorMessage,
+            String secondErrorClass,
+            String secondErrorMessage,
+            long queueWaitNs,
+            long nativeLoadNs,
+            long callerBlockedNs
+        ) {
+            this.loaded = loaded;
+            this.retried = retried;
+            this.retrySucceeded = retrySucceeded;
+            this.firstErrorClass = firstErrorClass;
+            this.firstErrorMessage = firstErrorMessage;
+            this.secondErrorClass = secondErrorClass;
+            this.secondErrorMessage = secondErrorMessage;
+            this.queueWaitNs = queueWaitNs;
+            this.nativeLoadNs = nativeLoadNs;
+            this.callerBlockedNs = callerBlockedNs;
+        }
+
+        String getFinalErrorClass() {
+            return secondErrorClass != null ? secondErrorClass : firstErrorClass;
+        }
+
+        String getFinalErrorMessage() {
+            return secondErrorMessage != null ? secondErrorMessage : firstErrorMessage;
+        }
+    }
+
+    static final class ResolveLibraryPathReport {
+        final String mappedLibraryName;
+        final String resolvedPath;
+        final String pathSource;
+        final boolean definitive;
+        final boolean fileExists;
+        final Long fileSizeBytes;
+
+        ResolveLibraryPathReport(
+            String mappedLibraryName,
+            String resolvedPath,
+            String pathSource,
+            boolean definitive,
+            boolean fileExists,
+            Long fileSizeBytes
+        ) {
+            this.mappedLibraryName = mappedLibraryName;
+            this.resolvedPath = resolvedPath;
+            this.pathSource = pathSource;
+            this.definitive = definitive;
+            this.fileExists = fileExists;
+            this.fileSizeBytes = fileSizeBytes;
+        }
+    }
+
     private final AtomicBoolean attemptedLoad = new AtomicBoolean();
     private boolean loaded = false;
 
@@ -22,47 +92,136 @@ class LibraryLoader {
      * @return true if the library was loaded, false if not
      */
     boolean loadLibrary(final String name, final Client client, final OnErrorCallback callback) {
+        return loadLibraryWithDiagnostics(name, client, callback).loaded;
+    }
+
+    LoadLibraryReport loadLibraryWithDiagnostics(final String name, final Client client, final OnErrorCallback callback) {
+        final long callerStartNs = System.nanoTime();
+        final long submitNs = System.nanoTime();
+        final LoadLibraryReport[] reportHolder = new LoadLibraryReport[1];
         try {
             client.bgTaskService.submitTask(TaskType.IO, new Runnable() {
                 @Override
                 public void run() {
-                    loadLibInternal(name, client, callback);
+                    long runStartNs = System.nanoTime();
+                    LoadLibraryReport loadReport = loadLibInternalWithDiagnostics(name, client, callback);
+                    long runEndNs = System.nanoTime();
+
+                    reportHolder[0] = new LoadLibraryReport(
+                        loadReport.loaded,
+                        loadReport.retried,
+                        loadReport.retrySucceeded,
+                        loadReport.firstErrorClass,
+                        loadReport.firstErrorMessage,
+                        loadReport.secondErrorClass,
+                        loadReport.secondErrorMessage,
+                        Math.max(0L, runStartNs - submitNs),
+                        loadReport.nativeLoadNs,
+                        Math.max(0L, runEndNs - callerStartNs)
+                    );
                 }
             }).get();
-            return loaded;
+            return reportHolder[0] != null
+                ? reportHolder[0]
+                : new LoadLibraryReport(loaded, false, false, null, null, null, null, 0L, 0L, 0L);
         } catch (Throwable exc) {
-            return false;
+            return new LoadLibraryReport(
+                false,
+                false,
+                false,
+                exc.getClass().getName(),
+                exc.getMessage(),
+                null,
+                null,
+                0L,
+                0L,
+                Math.max(0L, System.nanoTime() - callerStartNs)
+            );
         }
     }
 
     void loadLibInternal(String name, Client client, OnErrorCallback callback) {
+        loadLibInternalWithDiagnostics(name, client, callback);
+    }
+
+    LoadLibraryReport loadLibInternalWithDiagnostics(String name, Client client, OnErrorCallback callback) {
+        long loadStartNs = System.nanoTime();
+        boolean retried = false;
+        boolean retrySucceeded = false;
+        String firstErrorClass = null;
+        String firstErrorMessage = null;
+        String secondErrorClass = null;
+        String secondErrorMessage = null;
+
         if (!attemptedLoad.getAndSet(true)) {
             try {
                 System.loadLibrary(name);
                 loaded = true;
-            } catch (UnsatisfiedLinkError ignored) {
+            } catch (UnsatisfiedLinkError firstError) {
+                retried = true;
+                firstErrorClass = firstError.getClass().getName();
+                firstErrorMessage = firstError.getMessage();
                 // retry once in case the failure wasn't permanent
                 try {
                     System.loadLibrary(name);
                     loaded = true;
-                } catch (UnsatisfiedLinkError error) {
-                    client.notify(error, callback);
+                    retrySucceeded = true;
+                } catch (UnsatisfiedLinkError secondError) {
+                    secondErrorClass = secondError.getClass().getName();
+                    secondErrorMessage = secondError.getMessage();
+                    client.notify(secondError, callback);
                 }
             }
         }
+
+        long loadEndNs = System.nanoTime();
+        return new LoadLibraryReport(
+            loaded,
+            retried,
+            retrySucceeded,
+            firstErrorClass,
+            firstErrorMessage,
+            secondErrorClass,
+            secondErrorMessage,
+            0L,
+            Math.max(0L, loadEndNs - loadStartNs),
+            0L
+        );
     }
 
     public String resolveLibraryPath(String name, Client client) {
+        return resolveLibraryPathDetails(name, client).resolvedPath;
+    }
+
+    ResolveLibraryPathReport resolveLibraryPathDetails(String name, Client client) {
         String mappedName = System.mapLibraryName(name);
+        String resolvedPath = mappedName;
+        String pathSource = "mapped_name_fallback";
+        boolean definitive = false;
+
         try {
             String nativeLibraryDir = client.appContext.getApplicationInfo().nativeLibraryDir;
             if (nativeLibraryDir != null) {
-                return new File(nativeLibraryDir, mappedName).getAbsolutePath();
+                resolvedPath = new File(nativeLibraryDir, mappedName).getAbsolutePath();
+                pathSource = "application_info.nativeLibraryDir";
+                definitive = true;
             }
         } catch (Throwable ignored) {
             // Best-effort diagnostics only; load behavior remains unchanged.
         }
-        return mappedName;
+
+        File file = new File(resolvedPath);
+        boolean fileExists = file.exists();
+        Long fileSizeBytes = fileExists ? file.length() : null;
+
+        return new ResolveLibraryPathReport(
+            mappedName,
+            resolvedPath,
+            pathSource,
+            definitive,
+            fileExists,
+            fileSizeBytes
+        );
     }
 
     boolean isLoaded() {

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
@@ -95,7 +95,11 @@ class LibraryLoader {
         return loadLibraryWithDiagnostics(name, client, callback).loaded;
     }
 
-    LoadLibraryReport loadLibraryWithDiagnostics(final String name, final Client client, final OnErrorCallback callback) {
+    LoadLibraryReport loadLibraryWithDiagnostics(
+        final String name,
+        final Client client,
+        final OnErrorCallback callback
+    ) {
         final long callerStartNs = System.nanoTime();
         final long submitNs = System.nanoTime();
         final LoadLibraryReport[] reportHolder = new LoadLibraryReport[1];
@@ -104,7 +108,11 @@ class LibraryLoader {
                 @Override
                 public void run() {
                     long runStartNs = System.nanoTime();
-                    LoadLibraryReport loadReport = loadLibInternalWithDiagnostics(name, client, callback);
+                    LoadLibraryReport loadReport = loadLibInternalWithDiagnostics(
+                        name,
+                        client,
+                        callback
+                    );
                     long runEndNs = System.nanoTime();
 
                     reportHolder[0] = new LoadLibraryReport(
@@ -144,7 +152,11 @@ class LibraryLoader {
         loadLibInternalWithDiagnostics(name, client, callback);
     }
 
-    LoadLibraryReport loadLibInternalWithDiagnostics(String name, Client client, OnErrorCallback callback) {
+    LoadLibraryReport loadLibInternalWithDiagnostics(
+        String name,
+        Client client,
+        OnErrorCallback callback
+    ) {
         long loadStartNs = System.nanoTime();
         boolean retried = false;
         boolean retrySucceeded = false;

--- a/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
+++ b/bugsnag-android-core/src/main/java/com/bugsnag/android/LibraryLoader.java
@@ -2,6 +2,7 @@ package com.bugsnag.android;
 
 import com.bugsnag.android.internal.TaskType;
 
+import java.io.File;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 class LibraryLoader {
@@ -49,6 +50,19 @@ class LibraryLoader {
                 }
             }
         }
+    }
+
+    public String resolveLibraryPath(String name, Client client) {
+        String mappedName = System.mapLibraryName(name);
+        try {
+            String nativeLibraryDir = client.appContext.getApplicationInfo().nativeLibraryDir;
+            if (nativeLibraryDir != null) {
+                return new File(nativeLibraryDir, mappedName).getAbsolutePath();
+            }
+        } catch (Throwable ignored) {
+            // Best-effort diagnostics only; load behavior remains unchanged.
+        }
+        return mappedName;
     }
 
     boolean isLoaded() {

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -1,5 +1,6 @@
 package com.bugsnag.android
 
+import android.os.Looper
 import com.bugsnag.android.ndk.NativeBridge
 import java.io.StringWriter
 import java.util.concurrent.atomic.AtomicBoolean
@@ -9,10 +10,17 @@ internal class NdkPlugin : Plugin {
     private companion object {
         private const val LOAD_ERR_MSG = "Native library could not be linked. Bugsnag will " +
             "not report NDK errors. See https://docs.bugsnag.com/platforms/android/ndk-link-errors"
+
+        private const val PHASE_PLUGIN_INIT = "plugin_init"
+        private const val PHASE_LIBRARY_RESOLVE = "library_resolve"
+        private const val PHASE_LOAD_LIBRARY = "load_library"
+        private const val PHASE_LINK_NATIVE = "link_native"
+        private const val PHASE_POST_INIT = "post_init"
     }
 
     private val libraryLoader = LibraryLoader()
     private val oneTimeSetupPerformed = AtomicBoolean(false)
+    private var lastLoadErrorClass: String? = null
 
     private external fun enableCrashReporting()
     private external fun disableCrashReporting()
@@ -32,32 +40,209 @@ internal class NdkPlugin : Plugin {
     }
 
     override fun load(client: Client) {
-        this.client = client
-
-        if (!oneTimeSetupPerformed.getAndSet(true)) {
-            performOneTimeSetup(client)
+        runPhase(client, PHASE_PLUGIN_INIT) {
+            this.client = client
+            if (!oneTimeSetupPerformed.getAndSet(true)) {
+                performOneTimeSetup(client)
+            }
         }
+
         if (libraryLoader.isLoaded) {
-            enableCrashReporting()
-            client.logger.i("Initialised NDK Plugin")
+            runPhase(client, PHASE_POST_INIT) {
+                enableCrashReporting()
+                client.logger.i("Initialised NDK Plugin")
+            }
+        } else {
+            emitPhaseRecord(
+                client = client,
+                phase = PHASE_POST_INIT,
+                phaseStartNs = System.nanoTime(),
+                phaseEndNs = System.nanoTime(),
+                outcome = "error",
+                errorClass = lastLoadErrorClass ?: "UnsatisfiedLinkError"
+            )
         }
     }
 
     private fun performOneTimeSetup(client: Client) {
-        libraryLoader.loadLibrary("bugsnag-ndk", client) {
-            val error = it.errors[0]
-            it.addMetadata("LinkError", "errorClass", error.errorClass)
-            it.addMetadata("LinkError", "errorMessage", error.errorMessage)
+        var loadErrorClass: String? = null
 
-            error.errorClass = "NdkLinkError"
-            error.errorMessage = LOAD_ERR_MSG
-            true
+        runLibraryResolvePhase(client)
+
+        val loaded = runLoadLibraryPhase(client, resolveErrorClass = { loadErrorClass }) {
+            libraryLoader.loadLibrary("bugsnag-ndk", client) {
+                val error = it.errors[0]
+                loadErrorClass = error.errorClass
+                lastLoadErrorClass = error.errorClass
+                it.addMetadata("LinkError", "errorClass", error.errorClass)
+                it.addMetadata("LinkError", "errorMessage", error.errorMessage)
+
+                error.errorClass = "NdkLinkError"
+                error.errorMessage = LOAD_ERR_MSG
+                true
+            }
         }
-        if (libraryLoader.isLoaded) {
-            client.setBinaryArch(getBinaryArch())
-            nativeBridge = initNativeBridge(client)
+
+        if (loaded) {
+            lastLoadErrorClass = null
+            runPhase(client, PHASE_LINK_NATIVE) {
+                client.setBinaryArch(getBinaryArch())
+                nativeBridge = initNativeBridge(client)
+            }
         } else {
+            emitPhaseRecord(
+                client = client,
+                phase = PHASE_LINK_NATIVE,
+                phaseStartNs = System.nanoTime(),
+                phaseEndNs = System.nanoTime(),
+                outcome = "error",
+                errorClass = loadErrorClass ?: "UnsatisfiedLinkError"
+            )
             client.logger.e(LOAD_ERR_MSG)
+        }
+    }
+
+    private inline fun runPhase(client: Client, phase: String, block: () -> Unit) {
+        val phaseStartNs = System.nanoTime()
+        try {
+            block()
+            emitPhaseRecord(client, phase, phaseStartNs, System.nanoTime(), "ok", null)
+        } catch (exc: Throwable) {
+            emitPhaseRecord(
+                client,
+                phase,
+                phaseStartNs,
+                System.nanoTime(),
+                "error",
+                exc.javaClass.name
+            )
+            throw exc
+        }
+    }
+
+    private fun runLibraryResolvePhase(client: Client) {
+        val phaseStartNs = System.nanoTime()
+        try {
+            val resolvedPath = libraryLoader.resolveLibraryPath("bugsnag-ndk", client)
+            val resolvedExists = java.io.File(resolvedPath).exists()
+            emitPhaseRecord(
+                client = client,
+                phase = PHASE_LIBRARY_RESOLVE,
+                phaseStartNs = phaseStartNs,
+                phaseEndNs = System.nanoTime(),
+                outcome = "ok",
+                errorClass = null,
+                extraFields = mapOf(
+                    "resolved_library_path" to resolvedPath,
+                    "resolved_library_exists" to resolvedExists
+                )
+            )
+        } catch (exc: Throwable) {
+            emitPhaseRecord(
+                client = client,
+                phase = PHASE_LIBRARY_RESOLVE,
+                phaseStartNs = phaseStartNs,
+                phaseEndNs = System.nanoTime(),
+                outcome = "error",
+                errorClass = exc.javaClass.name
+            )
+            throw exc
+        }
+    }
+
+    private inline fun runLoadLibraryPhase(
+        client: Client,
+        resolveErrorClass: () -> String?,
+        block: () -> Boolean
+    ): Boolean {
+        val phaseStartNs = System.nanoTime()
+        return try {
+            val loaded = block()
+            emitPhaseRecord(
+                client = client,
+                phase = PHASE_LOAD_LIBRARY,
+                phaseStartNs = phaseStartNs,
+                phaseEndNs = System.nanoTime(),
+                outcome = if (loaded) "ok" else "error",
+                errorClass = if (loaded) null else resolveErrorClass() ?: "UnsatisfiedLinkError"
+            )
+            loaded
+        } catch (exc: Throwable) {
+            emitPhaseRecord(
+                client,
+                PHASE_LOAD_LIBRARY,
+                phaseStartNs,
+                System.nanoTime(),
+                "error",
+                exc.javaClass.name
+            )
+            throw exc
+        }
+    }
+
+    private fun emitPhaseRecord(
+        client: Client,
+        phase: String,
+        phaseStartNs: Long,
+        phaseEndNs: Long,
+        outcome: String,
+        errorClass: String?,
+        extraFields: Map<String, Any?> = emptyMap()
+    ) {
+        val thread = java.lang.Thread.currentThread()
+        val mainThread = try {
+            Looper.getMainLooper()?.thread === thread
+        } catch (_: Throwable) {
+            false
+        }
+        val phaseDurationNs = (phaseEndNs - phaseStartNs).coerceAtLeast(0L)
+
+        val payload = buildString {
+            append("{\"phase\":\"")
+            append(phase)
+            append("\",\"phase_start_ns\":")
+            append(phaseStartNs)
+            append(",\"phase_end_ns\":")
+            append(phaseEndNs)
+            append(",\"phase_duration_ns\":")
+            append(phaseDurationNs)
+            append(",\"thread_name\":\"")
+            append(thread.name.escapeJson())
+            append("\",\"is_main_thread\":")
+            append(mainThread)
+            append(",\"outcome\":\"")
+            append(outcome)
+            append("\"")
+            if (outcome == "error" && errorClass != null) {
+                append(",\"error_class\":\"")
+                append(errorClass.escapeJson())
+                append("\"")
+            }
+            extraFields.forEach { (key, value) ->
+                append(",\"")
+                append(key.escapeJson())
+                append("\":")
+                appendJsonValue(value)
+            }
+            append("}")
+        }
+
+        client.logger.i("NDK load phase diagnostic: $payload")
+    }
+
+    private fun String.escapeJson(): String {
+        return replace("\\", "\\\\").replace("\"", "\\\"")
+    }
+
+    private fun StringBuilder.appendJsonValue(value: Any?) {
+        when (value) {
+            null -> append("null")
+            is Number, is Boolean -> append(value)
+            else -> {
+                append("\"")
+                append(value.toString().escapeJson())
+                append("\"")
+            }
         }
     }
 
@@ -70,34 +255,50 @@ internal class NdkPlugin : Plugin {
         }
     }
 
+    // Called via reflection from NdkPluginCaller and AnrPlugin; do not remove
+    @Suppress("unused")
     fun setInternalMetricsEnabled(enabled: Boolean) {
         nativeBridge?.setInternalMetricsEnabled(enabled)
     }
 
+    // Called via reflection from AnrPlugin; do not remove
+    @Suppress("unused")
     fun getSignalUnwindStackFunction(): Long {
         return nativeBridge?.getSignalUnwindStackFunction() ?: 0
     }
 
+    // Called via reflection from NdkPluginCaller; do not remove
+    @Suppress("unused")
     fun getCurrentCallbackSetCounts(): Map<String, Int> {
         return nativeBridge?.getCurrentCallbackSetCounts() ?: mapOf()
     }
 
+    // Called via reflection from NdkPluginCaller; do not remove
+    @Suppress("unused")
     fun getCurrentNativeApiCallUsage(): Map<String, Boolean> {
         return nativeBridge?.getCurrentNativeApiCallUsage() ?: mapOf()
     }
 
+    // Called via reflection from NdkPluginCaller; do not remove
+    @Suppress("unused")
     fun initCallbackCounts(counts: Map<String, Int>) {
         nativeBridge?.initCallbackCounts(counts)
     }
 
+    // Called via reflection from NdkPluginCaller; do not remove
+    @Suppress("unused")
     fun notifyAddCallback(callback: String) {
         nativeBridge?.notifyAddCallback(callback)
     }
 
+    // Called via reflection from NdkPluginCaller; do not remove
+    @Suppress("unused")
     fun notifyRemoveCallback(callback: String) {
         nativeBridge?.notifyRemoveCallback(callback)
     }
 
+    // Called via reflection from NdkPluginCaller; do not remove
+    @Suppress("unused")
     fun setStaticData(data: Map<String, Any>) {
         val encoded = StringWriter().apply { use { writer -> JsonStream(writer).use { it.value(data) } } }.toString()
         nativeBridge?.setStaticJsonData(encoded)

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -54,25 +54,29 @@ internal class NdkPlugin : Plugin {
             }
         } else {
             emitPhaseRecord(
-                client = client,
-                phase = PHASE_POST_INIT,
-                phaseStartNs = System.nanoTime(),
-                phaseEndNs = System.nanoTime(),
-                outcome = "error",
-                errorClass = lastLoadErrorClass ?: "UnsatisfiedLinkError"
+                client,
+                NdkPhaseRecord(
+                    phase = PHASE_POST_INIT,
+                    phaseStartNs = System.nanoTime(),
+                    phaseEndNs = System.nanoTime(),
+                    outcome = "error",
+                    errorClass = lastLoadErrorClass ?: "UnsatisfiedLinkError"
+                )
             )
         }
     }
 
     private fun performOneTimeSetup(client: Client) {
         var loadErrorClass: String? = null
+        var loadErrorMessage: String? = null
 
         runLibraryResolvePhase(client)
 
-        val loaded = runLoadLibraryPhase(client, resolveErrorClass = { loadErrorClass }) {
-            libraryLoader.loadLibrary("bugsnag-ndk", client) {
+        val loadReport = runLoadLibraryPhase(client) {
+            libraryLoader.loadLibraryWithDiagnostics("bugsnag-ndk", client) {
                 val error = it.errors[0]
                 loadErrorClass = error.errorClass
+                loadErrorMessage = error.errorMessage
                 lastLoadErrorClass = error.errorClass
                 it.addMetadata("LinkError", "errorClass", error.errorClass)
                 it.addMetadata("LinkError", "errorMessage", error.errorMessage)
@@ -80,6 +84,19 @@ internal class NdkPlugin : Plugin {
                 error.errorClass = "NdkLinkError"
                 error.errorMessage = LOAD_ERR_MSG
                 true
+            }
+        }
+
+        val loaded = loadReport.loaded
+        if (!loaded) {
+            if (loadErrorClass == null) {
+                loadErrorClass = loadReport.finalErrorClass
+            }
+            if (loadErrorMessage == null) {
+                loadErrorMessage = loadReport.finalErrorMessage
+            }
+            if (lastLoadErrorClass == null) {
+                lastLoadErrorClass = loadErrorClass
             }
         }
 
@@ -91,12 +108,17 @@ internal class NdkPlugin : Plugin {
             }
         } else {
             emitPhaseRecord(
-                client = client,
-                phase = PHASE_LINK_NATIVE,
-                phaseStartNs = System.nanoTime(),
-                phaseEndNs = System.nanoTime(),
-                outcome = "error",
-                errorClass = loadErrorClass ?: "UnsatisfiedLinkError"
+                client,
+                NdkPhaseRecord(
+                    phase = PHASE_LINK_NATIVE,
+                    phaseStartNs = System.nanoTime(),
+                    phaseEndNs = System.nanoTime(),
+                    outcome = "error",
+                    errorClass = loadErrorClass ?: "UnsatisfiedLinkError",
+                    extraFields = mapOf(
+                        "linker_error_message" to loadErrorMessage
+                    )
+                )
             )
             client.logger.e(LOAD_ERR_MSG)
         }
@@ -106,15 +128,26 @@ internal class NdkPlugin : Plugin {
         val phaseStartNs = System.nanoTime()
         try {
             block()
-            emitPhaseRecord(client, phase, phaseStartNs, System.nanoTime(), "ok", null)
+            emitPhaseRecord(
+                client,
+                NdkPhaseRecord(
+                    phase = phase,
+                    phaseStartNs = phaseStartNs,
+                    phaseEndNs = System.nanoTime(),
+                    outcome = "ok",
+                    errorClass = null
+                )
+            )
         } catch (exc: Throwable) {
             emitPhaseRecord(
                 client,
-                phase,
-                phaseStartNs,
-                System.nanoTime(),
-                "error",
-                exc.javaClass.name
+                NdkPhaseRecord(
+                    phase = phase,
+                    phaseStartNs = phaseStartNs,
+                    phaseEndNs = System.nanoTime(),
+                    outcome = "error",
+                    errorClass = exc.javaClass.name
+                )
             )
             throw exc
         }
@@ -123,28 +156,35 @@ internal class NdkPlugin : Plugin {
     private fun runLibraryResolvePhase(client: Client) {
         val phaseStartNs = System.nanoTime()
         try {
-            val resolvedPath = libraryLoader.resolveLibraryPath("bugsnag-ndk", client)
-            val resolvedExists = java.io.File(resolvedPath).exists()
+            val resolution = libraryLoader.resolveLibraryPathDetails("bugsnag-ndk", client)
             emitPhaseRecord(
-                client = client,
-                phase = PHASE_LIBRARY_RESOLVE,
-                phaseStartNs = phaseStartNs,
-                phaseEndNs = System.nanoTime(),
-                outcome = "ok",
-                errorClass = null,
-                extraFields = mapOf(
-                    "resolved_library_path" to resolvedPath,
-                    "resolved_library_exists" to resolvedExists
+                client,
+                NdkPhaseRecord(
+                    phase = PHASE_LIBRARY_RESOLVE,
+                    phaseStartNs = phaseStartNs,
+                    phaseEndNs = System.nanoTime(),
+                    outcome = "ok",
+                    errorClass = null,
+                    extraFields = mapOf(
+                        "resolved_library_path" to resolution.resolvedPath,
+                        "resolved_library_mapped_name" to resolution.mappedLibraryName,
+                        "resolved_library_path_source" to resolution.pathSource,
+                        "resolved_library_path_definitive" to resolution.definitive,
+                        "resolved_library_exists" to resolution.fileExists,
+                        "resolved_library_size_bytes" to resolution.fileSizeBytes
+                    )
                 )
             )
         } catch (exc: Throwable) {
             emitPhaseRecord(
-                client = client,
-                phase = PHASE_LIBRARY_RESOLVE,
-                phaseStartNs = phaseStartNs,
-                phaseEndNs = System.nanoTime(),
-                outcome = "error",
-                errorClass = exc.javaClass.name
+                client,
+                NdkPhaseRecord(
+                    phase = PHASE_LIBRARY_RESOLVE,
+                    phaseStartNs = phaseStartNs,
+                    phaseEndNs = System.nanoTime(),
+                    outcome = "error",
+                    errorClass = exc.javaClass.name
+                )
             )
             throw exc
         }
@@ -152,97 +192,58 @@ internal class NdkPlugin : Plugin {
 
     private inline fun runLoadLibraryPhase(
         client: Client,
-        resolveErrorClass: () -> String?,
-        block: () -> Boolean
-    ): Boolean {
+        block: () -> LibraryLoader.LoadLibraryReport
+    ): LibraryLoader.LoadLibraryReport {
         val phaseStartNs = System.nanoTime()
         return try {
-            val loaded = block()
+            val report = block()
+            val loaded = report.loaded
             emitPhaseRecord(
-                client = client,
-                phase = PHASE_LOAD_LIBRARY,
-                phaseStartNs = phaseStartNs,
-                phaseEndNs = System.nanoTime(),
-                outcome = if (loaded) "ok" else "error",
-                errorClass = if (loaded) null else resolveErrorClass() ?: "UnsatisfiedLinkError"
+                client,
+                NdkPhaseRecord(
+                    phase = PHASE_LOAD_LIBRARY,
+                    phaseStartNs = phaseStartNs,
+                    phaseEndNs = System.nanoTime(),
+                    outcome = if (loaded) "ok" else "error",
+                    errorClass = if (loaded) null else report.finalErrorClass ?: "UnsatisfiedLinkError",
+                    extraFields = mapOf(
+                        "queue_wait_ns" to report.queueWaitNs,
+                        "native_load_ns" to report.nativeLoadNs,
+                        "caller_blocked_ns" to report.callerBlockedNs,
+                        "load_retry_attempted" to report.retried,
+                        "load_retry_succeeded" to report.retrySucceeded,
+                        "first_load_outcome" to when {
+                            report.firstErrorClass != null -> "error"
+                            loaded -> "ok"
+                            else -> "not_attempted"
+                        },
+                        "second_load_outcome" to when {
+                            !report.retried -> "not_attempted"
+                            report.retrySucceeded -> "ok"
+                            report.secondErrorClass != null -> "error"
+                            else -> "unknown"
+                        },
+                        "linker_error_message" to report.finalErrorMessage,
+                        "first_linker_error_class" to report.firstErrorClass,
+                        "first_linker_error_message" to report.firstErrorMessage,
+                        "second_linker_error_class" to report.secondErrorClass,
+                        "second_linker_error_message" to report.secondErrorMessage
+                    )
+                )
             )
-            loaded
+            report
         } catch (exc: Throwable) {
             emitPhaseRecord(
                 client,
-                PHASE_LOAD_LIBRARY,
-                phaseStartNs,
-                System.nanoTime(),
-                "error",
-                exc.javaClass.name
+                NdkPhaseRecord(
+                    phase = PHASE_LOAD_LIBRARY,
+                    phaseStartNs = phaseStartNs,
+                    phaseEndNs = System.nanoTime(),
+                    outcome = "error",
+                    errorClass = exc.javaClass.name
+                )
             )
             throw exc
-        }
-    }
-
-    private fun emitPhaseRecord(
-        client: Client,
-        phase: String,
-        phaseStartNs: Long,
-        phaseEndNs: Long,
-        outcome: String,
-        errorClass: String?,
-        extraFields: Map<String, Any?> = emptyMap()
-    ) {
-        val thread = java.lang.Thread.currentThread()
-        val mainThread = try {
-            Looper.getMainLooper()?.thread === thread
-        } catch (_: Throwable) {
-            false
-        }
-        val phaseDurationNs = (phaseEndNs - phaseStartNs).coerceAtLeast(0L)
-
-        val payload = buildString {
-            append("{\"phase\":\"")
-            append(phase)
-            append("\",\"phase_start_ns\":")
-            append(phaseStartNs)
-            append(",\"phase_end_ns\":")
-            append(phaseEndNs)
-            append(",\"phase_duration_ns\":")
-            append(phaseDurationNs)
-            append(",\"thread_name\":\"")
-            append(thread.name.escapeJson())
-            append("\",\"is_main_thread\":")
-            append(mainThread)
-            append(",\"outcome\":\"")
-            append(outcome)
-            append("\"")
-            if (outcome == "error" && errorClass != null) {
-                append(",\"error_class\":\"")
-                append(errorClass.escapeJson())
-                append("\"")
-            }
-            extraFields.forEach { (key, value) ->
-                append(",\"")
-                append(key.escapeJson())
-                append("\":")
-                appendJsonValue(value)
-            }
-            append("}")
-        }
-
-        client.logger.i("NDK load phase diagnostic: $payload")
-    }
-
-    private fun String.escapeJson(): String {
-        return replace("\\", "\\\\").replace("\"", "\\\"")
-    }
-
-    private fun StringBuilder.appendJsonValue(value: Any?) {
-        when (value) {
-            null -> append("null")
-            is Number, is Boolean -> append(value)
-            else -> {
-                append("\"")
-                append(value.toString().escapeJson())
-                append("\"")
-            }
         }
     }
 
@@ -302,6 +303,73 @@ internal class NdkPlugin : Plugin {
     fun setStaticData(data: Map<String, Any>) {
         val encoded = StringWriter().apply { use { writer -> JsonStream(writer).use { it.value(data) } } }.toString()
         nativeBridge?.setStaticJsonData(encoded)
+    }
+}
+
+private data class NdkPhaseRecord(
+    val phase: String,
+    val phaseStartNs: Long,
+    val phaseEndNs: Long,
+    val outcome: String,
+    val errorClass: String?,
+    val extraFields: Map<String, Any?> = emptyMap()
+)
+
+private fun emitPhaseRecord(client: Client, record: NdkPhaseRecord) {
+    val thread = java.lang.Thread.currentThread()
+    val mainThread = try {
+        Looper.getMainLooper()?.thread === thread
+    } catch (_: Throwable) {
+        false
+    }
+    val phaseDurationNs = (record.phaseEndNs - record.phaseStartNs).coerceAtLeast(0L)
+
+    val payload = buildString {
+        append("{\"phase\":\"")
+        append(record.phase)
+        append("\",\"phase_start_ns\":")
+        append(record.phaseStartNs)
+        append(",\"phase_end_ns\":")
+        append(record.phaseEndNs)
+        append(",\"phase_duration_ns\":")
+        append(phaseDurationNs)
+        append(",\"thread_name\":\"")
+        append(thread.name.escapeJson())
+        append("\",\"is_main_thread\":")
+        append(mainThread)
+        append(",\"outcome\":\"")
+        append(record.outcome)
+        append("\"")
+        if (record.outcome == "error" && record.errorClass != null) {
+            append(",\"error_class\":\"")
+            append(record.errorClass.escapeJson())
+            append("\"")
+        }
+        record.extraFields.forEach { (key, value) ->
+            append(",\"")
+            append(key.escapeJson())
+            append("\":")
+            appendJsonValue(value)
+        }
+        append("}")
+    }
+
+    client.logger.i("NDK load phase diagnostic: $payload")
+}
+
+private fun String.escapeJson(): String {
+    return replace("\\", "\\\\").replace("\"", "\\\"")
+}
+
+private fun StringBuilder.appendJsonValue(value: Any?) {
+    when (value) {
+        null -> append("null")
+        is Number, is Boolean -> append(value)
+        else -> {
+            append("\"")
+            append(value.toString().escapeJson())
+            append("\"")
+        }
     }
 }
 

--- a/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
+++ b/bugsnag-plugin-android-ndk/src/main/java/com/bugsnag/android/NdkPlugin.kt
@@ -306,7 +306,7 @@ internal class NdkPlugin : Plugin {
     }
 }
 
-private data class NdkPhaseRecord(
+internal data class NdkPhaseRecord(
     val phase: String,
     val phaseStartNs: Long,
     val phaseEndNs: Long,
@@ -315,7 +315,7 @@ private data class NdkPhaseRecord(
     val extraFields: Map<String, Any?> = emptyMap()
 )
 
-private fun emitPhaseRecord(client: Client, record: NdkPhaseRecord) {
+internal fun emitPhaseRecord(client: Client, record: NdkPhaseRecord) {
     val thread = java.lang.Thread.currentThread()
     val mainThread = try {
         Looper.getMainLooper()?.thread === thread
@@ -357,11 +357,11 @@ private fun emitPhaseRecord(client: Client, record: NdkPhaseRecord) {
     client.logger.i("NDK load phase diagnostic: $payload")
 }
 
-private fun String.escapeJson(): String {
+internal fun String.escapeJson(): String {
     return replace("\\", "\\\\").replace("\"", "\\\"")
 }
 
-private fun StringBuilder.appendJsonValue(value: Any?) {
+internal fun StringBuilder.appendJsonValue(value: Any?) {
     when (value) {
         null -> append("null")
         is Number, is Boolean -> append(value)

--- a/features/steps/symbol_steps.rb
+++ b/features/steps/symbol_steps.rb
@@ -62,8 +62,18 @@ Then("the exception {string} demangles to {string}") do |keypath, expected_value
   body = Maze::Server.errors.current[:body]
   actual_value = Maze::Helper.read_key_path(body, "events.0.exceptions.0.#{keypath}")
   demangled_value = demangle(actual_value)
-  Maze.check.equal(demangled_value, expected_value,
+  normalized_actual = normalize_demangled_symbol(demangled_value)
+  normalized_expected = normalize_demangled_symbol(expected_value)
+  Maze.check.equal(normalized_actual, normalized_expected,
                   "expected '#{actual_value}' to demangle to '#{expected_value}' but was '#{demangled_value}'")
+end
+
+def normalize_demangled_symbol(symbol)
+  symbol
+    .gsub(/\s*([*&])\s*/, '\\1')
+    .gsub(/\s*,\s*/, ', ')
+    .gsub(/\s+/, ' ')
+    .strip
 end
 
 def is_out_of_project?(file, method)


### PR DESCRIPTION
In the diagnostic snapshot, we added phase-level instrumentation for NDK plugin load:

- plugin_init
- library_resolve
- load_library
- link_native
- post_init

Each phase emits structured fields:

- phase_start_ns
- phase_end_ns
- phase_duration_ns
- thread_name
- is_main_thread
- outcome (ok / error)
- error_class (only on error)

Plus an extra resolve check to improve root-cause quality:

- resolved_library_path
- resolved_library_exists

This gives exact failure/latency location instead of one opaque startup block.

- Improves NDK load diagnostics to split `queue_wait_ns`, `native_load_ns`, and `caller_blocked_ns`, making delays easier to attribute.
- Adds explicit retry reporting for native load (`load_retry_attempted`, `load_retry_succeeded`, first/second attempt outcomes).
- Captures original linker error message(s) alongside error class to better diagnose ABI/dependency/ELF/linker issues.
- Enhances library path diagnostics with mapped name, source (`nativeLibraryDir` vs fallback), confidence (`definitive`), file existence, and optional size.
