### PR TITLE
Fix: Enable fortify source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.27.0 (2026-07-15)
+
+### Enhancements
+
+* **Security Hardening**: Enabled `_FORTIFY_SOURCE=2` and stack protector (`-fstack-protector-all`) for all native libraries (`libbugsnag-ndk.so`, `libbugsnag-plugin-android-anr.so`, `libbugsnag-root-detection.so`) to improve runtime buffer overflow detection.
+
 ## 6.26.0 (2026-04-07)
 
 ### Enhancements

--- a/bugsnag-android-core/src/main/CMakeLists.txt
+++ b/bugsnag-android-core/src/main/CMakeLists.txt
@@ -14,6 +14,6 @@ set(EXTRA_LINK_FLAGS "-Wl,-z,max-page-size=16384")
 set_target_properties(
         bugsnag-root-detection
         PROPERTIES
-        COMPILE_OPTIONS -Werror -Wall -pedantic
+        COMPILE_OPTIONS -Werror -Wall -pedantic -D_FORTIFY_SOURCE=2 -fstack-protector-all
         LINK_FLAGS "${EXTRA_LINK_FLAGS}"
 )

--- a/bugsnag-plugin-android-anr/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-anr/src/main/CMakeLists.txt
@@ -22,6 +22,6 @@ target_link_libraries( # Specifies the target library.
 set_target_properties(
         bugsnag-plugin-android-anr
         PROPERTIES
-        COMPILE_OPTIONS -Werror -Wall -pedantic
+        COMPILE_OPTIONS -Werror -Wall -pedantic -D_FORTIFY_SOURCE=2 -fstack-protector-all
         LINK_FLAGS "${EXTRA_LINK_FLAGS}"
 )

--- a/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
+++ b/bugsnag-plugin-android-ndk/src/main/CMakeLists.txt
@@ -50,7 +50,7 @@ set(EXTRA_LINK_FLAGS "-Wl,-z,max-page-size=16384,--version-script=${CMAKE_CURREN
 set_target_properties(
         bugsnag-ndk
         PROPERTIES
-        COMPILE_OPTIONS -Werror -Wall -pedantic
+        COMPILE_OPTIONS -Werror -Wall -pedantic -D_FORTIFY_SOURCE=2 -fstack-protector-all
         LINK_FLAGS "${EXTRA_LINK_FLAGS}"
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED YES


### PR DESCRIPTION
* **Security Hardening**: Enabled `_FORTIFY_SOURCE=2` and stack protector (`-fstack-protector-all`) for all native libraries (`libbugsnag-ndk.so`, `libbugsnag-plugin-android-anr.so`, `libbugsnag-root-detection.so`) to improve runtime buffer overflow detection.
